### PR TITLE
fix(ci): satisfy rustfmt and clippy on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
+  test-status:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - run: echo "All matrix test jobs passed"
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/m1nd-core/tests/retrobuilder_stress.rs
+++ b/m1nd-core/tests/retrobuilder_stress.rs
@@ -197,10 +197,19 @@ fn stress_taint_all_entry_points() {
     };
     let result = TaintEngine::analyze(&g, &entries, &config).unwrap();
     let elapsed = t.elapsed();
-    eprintln!("[STRESS TAINT] {} entry points on real graph: risk={:.3}, reached={}, leaks={}, elapsed={:.1}ms",
-        entries.len(), result.risk_score, result.summary.total_nodes_reached, result.summary.leaks_found,
-        elapsed.as_secs_f64() * 1000.0);
-    assert!(elapsed.as_secs() < 180, "Should complete within 180s (CI), took {:?}", elapsed);
+    eprintln!(
+        "[STRESS TAINT] {} entry points on real graph: risk={:.3}, reached={}, leaks={}, elapsed={:.1}ms",
+        entries.len(),
+        result.risk_score,
+        result.summary.total_nodes_reached,
+        result.summary.leaks_found,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    assert!(
+        elapsed.as_secs() < 180,
+        "Should complete within 180s (CI), took {:?}",
+        elapsed
+    );
 }
 
 #[test]

--- a/m1nd-ingest/src/bibtex_adapter.rs
+++ b/m1nd-ingest/src/bibtex_adapter.rs
@@ -195,9 +195,7 @@ fn parse_fields(chars: &[char]) -> Vec<(String, String)> {
             read_quoted_value(remaining)
         } else {
             // Bare value (number or macro)
-            let end = remaining
-                .find(|c: char| c == ',' || c == '}')
-                .unwrap_or(remaining.len());
+            let end = remaining.find([',', '}']).unwrap_or(remaining.len());
             let val = remaining[..end].trim().to_string();
             let rest = if end < remaining.len() {
                 &remaining[end..]
@@ -254,8 +252,7 @@ fn read_quoted_value(s: &str) -> (String, &str) {
 }
 
 fn clean_bibtex_value(s: &str) -> String {
-    s.replace('{', "")
-        .replace('}', "")
+    s.replace(['{', '}'], "")
         .replace('\n', " ")
         .replace("  ", " ")
         .trim()

--- a/m1nd-ingest/src/cross_domain.rs
+++ b/m1nd-ingest/src/cross_domain.rs
@@ -97,15 +97,13 @@ impl CrossDomainResolver {
 
             // Index by identifier type
             let eid = &node.external_id;
-            if eid.starts_with("doi::") {
-                let doi = &eid[5..];
+            if let Some(doi) = eid.strip_prefix("doi::") {
                 doi_to_ids
                     .entry(doi.to_lowercase())
                     .or_default()
                     .push(eid.clone());
             }
-            if eid.starts_with("pmid::") {
-                let pmid = &eid[6..];
+            if let Some(pmid) = eid.strip_prefix("pmid::") {
                 pmid_to_ids
                     .entry(pmid.to_string())
                     .or_default()

--- a/m1nd-ingest/src/crossref_adapter.rs
+++ b/m1nd-ingest/src/crossref_adapter.rs
@@ -476,7 +476,7 @@ fn build_graph(prefix: &str, records: &[CrossRefRecord]) -> (Graph, u64, u64) {
             // Create stub node for referenced DOI if doesn't exist
             if graph.resolve_id(&ref_id).is_none() {
                 let ref_label = format!("DOI: {}", ref_doi);
-                let ref_tags = vec![format!("doi:{}", ref_doi), "stub:true".to_string()];
+                let ref_tags = [format!("doi:{}", ref_doi), "stub:true".to_string()];
                 let tag_refs: Vec<&str> = ref_tags.iter().map(String::as_str).collect();
                 if graph
                     .add_node(&ref_id, &ref_label, NodeType::Module, &tag_refs, 0.0, 0.0)

--- a/m1nd-ingest/src/jats_adapter.rs
+++ b/m1nd-ingest/src/jats_adapter.rs
@@ -192,15 +192,19 @@ impl JatsArticleAdapter {
                     match name.as_str() {
                         // ── PubMed NLM format ──
                         "PubmedArticle" => {
-                            let mut rec = ArticleRecord::default();
-                            rec.format = ArticleFormat::PubMedNlm;
+                            let rec = ArticleRecord {
+                                format: ArticleFormat::PubMedNlm,
+                                ..ArticleRecord::default()
+                            };
                             current = Some(rec);
                         }
                         // ── JATS format ──
                         "article" => {
                             if current.is_none() {
-                                let mut rec = ArticleRecord::default();
-                                rec.format = ArticleFormat::Jats;
+                                let rec = ArticleRecord {
+                                    format: ArticleFormat::Jats,
+                                    ..ArticleRecord::default()
+                                };
                                 current = Some(rec);
                             }
                         }

--- a/m1nd-ingest/tests/connectome_integration.rs
+++ b/m1nd-ingest/tests/connectome_integration.rs
@@ -12,9 +12,9 @@
 //! After ingestion, all three domains share DOI identifiers that the
 //! CrossDomainResolver can bridge.
 
+use m1nd_ingest::bibtex_adapter::BibTexAdapter;
 use m1nd_ingest::crossref_adapter::CrossRefAdapter;
 use m1nd_ingest::rfc_adapter::RfcAdapter;
-use m1nd_ingest::bibtex_adapter::BibTexAdapter;
 use m1nd_ingest::IngestAdapter;
 use std::collections::HashSet;
 
@@ -149,9 +149,7 @@ fn three_domain_connectome_shares_dois() {
         .unwrap();
 
     let bibtex_adapter = BibTexAdapter::new(None);
-    let (bibtex_graph, bibtex_stats) = bibtex_adapter
-        .ingest(&dir.join("references.bib"))
-        .unwrap();
+    let (bibtex_graph, bibtex_stats) = bibtex_adapter.ingest(&dir.join("references.bib")).unwrap();
 
     // Verify each adapter produced nodes
     assert!(rfc_stats.nodes_created > 0, "RFC should produce nodes");
@@ -234,15 +232,15 @@ fn three_domain_connectome_shares_dois() {
     );
 
     // Count total domains with connectable DOIs
-    let rfc_has_shared = rfc_dois.iter().any(|d| {
-        crossref_dois.contains(d) || bibtex_dois.contains(d)
-    });
-    let crossref_has_shared = crossref_dois.iter().any(|d| {
-        rfc_dois.contains(d) || bibtex_dois.contains(d)
-    });
-    let bibtex_has_shared = bibtex_dois.iter().any(|d| {
-        rfc_dois.contains(d) || crossref_dois.contains(d)
-    });
+    let rfc_has_shared = rfc_dois
+        .iter()
+        .any(|d| crossref_dois.contains(d) || bibtex_dois.contains(d));
+    let crossref_has_shared = crossref_dois
+        .iter()
+        .any(|d| rfc_dois.contains(d) || bibtex_dois.contains(d));
+    let bibtex_has_shared = bibtex_dois
+        .iter()
+        .any(|d| rfc_dois.contains(d) || crossref_dois.contains(d));
 
     let connected_domains = [rfc_has_shared, crossref_has_shared, bibtex_has_shared]
         .iter()

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -23,9 +23,7 @@ use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
 
 use crate::http_types::SubgraphQuery;
-use crate::server::{
-    dispatch_tool, tool_schemas, McpConfig,
-};
+use crate::server::{dispatch_tool, tool_schemas, McpConfig};
 use crate::session::{ApplyBatchProgressSink, SessionState};
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix rustfmt drift in tests and HTTP server imports
- resolve clippy warnings in ingest adapters
- restore local CI parity for fmt and clippy

## Validation
- cargo fmt --check
- cargo clippy --workspace -- -D warnings