### PR TITLE
feat: add native OpenClaw fast path for m1nd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "m1nd-openclaw"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "m1nd-mcp",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["m1nd-core", "m1nd-ingest", "m1nd-mcp"]
+members = ["m1nd-core", "m1nd-ingest", "m1nd-mcp", "m1nd-openclaw"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/docs/OPENCLAW-NATIVE-FASTPATH.md
+++ b/docs/OPENCLAW-NATIVE-FASTPATH.md
@@ -1,0 +1,279 @@
+# OpenClaw Native Fast Path for m1nd
+
+## Why this exists
+
+`m1nd-mcp` is the universal transport surface.
+It is correct for Codex, Claude, Cursor, Windsurf, and any generic MCP client.
+
+It is not the lowest-latency path for OpenClaw.
+
+In the current local setup, the graph engine is fast, but the transport stack adds avoidable cost:
+
+- subprocess spawn
+- stdio framing
+- JSON-RPC encode/decode
+- bridge CLI overhead (`mcporter`)
+- optional GUI boot attempts in non-UI flows
+
+Measured locally on this machine:
+
+- `m1nd_cli.py health`: ~148 ms average
+- `mcporter -> m1nd.health`: ~522 ms average
+- `m1nd_cli.py search(literal)`: ~777 ms average
+- `mcporter -> m1nd.search(literal)`: ~994 ms average
+
+That means the bridge layer is currently adding roughly 200-400 ms of avoidable latency per call.
+
+Observed with the new native Unix-socket bridge scaffold on the same machine:
+
+- `m1nd-openclaw` + loaded `SISTEMA` graph (`16122` nodes / `42338` edges)
+- `health` roundtrip overhead: ~`0.23 ms` average over 5 calls
+- warm samples landed between ~`0.07 ms` and `0.11 ms`
+
+That is already well below the original sub-30 ms target and leaves room for future binary/shared-memory upgrades on larger payload tools.
+
+## Target
+
+OpenClaw should have a native `m1nd` fast lane with overhead closer to **single-digit milliseconds** than to hundreds of milliseconds.
+
+The design goal is:
+
+- keep MCP for everyone else
+- give OpenClaw a native transport
+- keep one hot `SessionState`
+- avoid process spawn on every request
+
+## Transport decision
+
+### Chosen direction
+
+Use a **persistent Unix domain socket control plane** now, with a design that can later adopt a **shared-memory data plane** for very large responses.
+
+Why:
+
+- UDS on the same machine is dramatically faster than stdio subprocess hops
+- the implementation cost is much lower than jumping straight to a full custom shared-memory RPC stack
+- it keeps the bridge operational quickly while preserving a future upgrade path
+
+### Frontier donors considered
+
+#### 1. `iceoryx2`
+
+- GitHub: [eclipse-iceoryx/iceoryx2](https://github.com/eclipse-iceoryx/iceoryx2)
+- Docs: [docs.rs/iceoryx2](https://docs.rs/iceoryx2/latest/iceoryx2/)
+
+Why it matters:
+
+- zero-copy IPC
+- request/response pattern
+- excellent for giant payloads and ultra-low-latency local transport
+
+Status in this plan:
+
+- **Phase 2 candidate**
+- strongest donor for large-response transport once the OpenClaw native lane is proven
+
+#### 2. Cap'n Proto RPC
+
+- GitHub: [capnproto/capnproto-rust](https://github.com/capnproto/capnproto-rust)
+
+Why it matters:
+
+- strongly typed RPC
+- compact binary messages
+- excellent long-term protocol discipline
+
+Why not first:
+
+- more protocol machinery than we need to prove the fast path
+- lower immediate delivery speed than a direct UDS bridge
+
+#### 3. `tarpc`
+
+- Docs: [docs.rs/tarpc](https://docs.rs/tarpc/latest/tarpc/)
+
+Why it matters:
+
+- fast Rust RPC
+- simpler than full MCP
+
+Why not first:
+
+- still introduces an RPC framework layer we do not strictly need
+- direct UDS request/response is easier to wire into `SessionState`
+
+## Architecture
+
+### Canonical shape
+
+1. `m1nd-mcp`
+   - universal MCP surface
+   - stdio + HTTP/UI
+   - stays public and stable
+
+2. `m1nd-openclaw`
+   - native low-latency bridge
+   - persistent daemon
+   - OpenClaw-only fast path
+
+3. OpenClaw adapter
+   - prefers native bridge when available
+   - falls back to MCP when needed
+
+### Fast path
+
+OpenClaw request:
+
+```text
+OpenClaw -> Unix socket -> m1nd-openclaw -> dispatch_tool(SessionState) -> response
+```
+
+No subprocess spawn per call.
+No JSON-RPC envelope.
+No GUI boot.
+No `mcporter` in the hot path.
+
+### Data plane upgrade
+
+For large payload tools such as:
+
+- `surgical_context_v2`
+- `apply_batch`
+- `perspective_routes`
+- `report`
+
+the bridge can later evolve to:
+
+- UDS control plane for metadata and coordination
+- `iceoryx2` shared-memory payload blocks for large response bodies
+
+That gives us:
+
+- low handshake overhead
+- low copy overhead
+- better scaling on giant graph/context payloads
+
+## Protocol
+
+Current scaffold request:
+
+```json
+{
+  "id": "req-1",
+  "tool": "search",
+  "arguments": {
+    "agent_id": "openclaw",
+    "query": "m1nd_cli.py",
+    "mode": "literal",
+    "top_k": 3
+  }
+}
+```
+
+Current scaffold response:
+
+```json
+{
+  "id": "req-1",
+  "ok": true,
+  "result": { "...": "tool response" },
+  "elapsed_ms": 3.1
+}
+```
+
+## Hot-path tool set
+
+These should be first-class in the native lane:
+
+- `health`
+- `search`
+- `seek`
+- `view`
+- `impact`
+- `why`
+- `surgical_context_v2`
+- `apply`
+- `apply_batch`
+- `symbol_splice`
+
+## Operational surfaces added in this patch
+
+### Daemon
+
+- [`scripts/macos/m1nd-openclaw-bridge.sh`](/Users/cosmophonix/SISTEMA/m1nd/scripts/macos/m1nd-openclaw-bridge.sh)
+- [`scripts/macos/ai.m1nd.openclaw-bridge.plist`](/Users/cosmophonix/SISTEMA/m1nd/scripts/macos/ai.m1nd.openclaw-bridge.plist)
+
+### Client
+
+- [`scripts/macos/m1nd-openclaw-call.sh`](/Users/cosmophonix/SISTEMA/m1nd/scripts/macos/m1nd-openclaw-call.sh)
+- binary: `target/release/m1nd-openclaw-client`
+
+### Example local flow
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.m1nd.openclaw-bridge.plist
+/Users/cosmophonix/SISTEMA/m1nd/scripts/macos/m1nd-openclaw-call.sh \
+  health \
+  '{"agent_id":"openclaw"}'
+```
+
+## Patch choices in this repo
+
+This patch introduces:
+
+1. `m1nd-openclaw`
+   - a new crate in the workspace
+   - persistent Unix-socket daemon
+   - direct calls into `dispatch_tool`
+
+2. `m1nd-openclaw-client`
+   - a tiny CLI client for the native socket bridge
+   - immediate consumption point for OpenClaw-side wrappers, skills, or future runtime adapters
+   - lets OpenClaw avoid `mcporter` in the hot path without needing the full native plugin patch on day one
+
+3. OpenClaw-side immediate optimization
+   - `mcporter` config should pass `--no-gui` when using stdio
+   - one dedicated HTTP/UI instance should remain separate
+
+## Why this is the right first patch
+
+Because it creates a native lane **inside the m1nd repo** without breaking MCP compatibility.
+
+That means:
+
+- the public product stays MCP-native
+- OpenClaw gets a privileged integration
+- the fastest path lives close to the graph instead of in an external wrapper
+
+## Next steps
+
+### Phase 1
+
+- wire OpenClaw to call the Unix socket bridge directly
+- keep MCP as fallback
+- benchmark overhead against `mcporter`
+
+Immediate command shape:
+
+```bash
+m1nd-openclaw-client health '{"agent_id":"openclaw"}'
+m1nd-openclaw-client search '{"agent_id":"openclaw","query":"websocket","mode":"literal","top_k":5}'
+```
+
+### Phase 2
+
+- add request multiplexing and pooled worker scheduling
+- add optional binary framing
+- classify hot vs cold tools
+
+### Phase 3
+
+- add `iceoryx2` payload lanes for very large result sets
+- keep UDS as control plane
+
+## Success criteria
+
+- `health` bridge overhead under 10 ms
+- `search` bridge overhead under 5-15 ms beyond raw tool execution
+- zero process spawn per request
+- OpenClaw can prefer native bridge automatically

--- a/m1nd-openclaw/Cargo.toml
+++ b/m1nd-openclaw/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "m1nd-openclaw"
+version = "0.1.0"
+edition = "2021"
+description = "Native low-latency OpenClaw bridge for m1nd"
+license = "MIT"
+repository = "https://github.com/maxkle1nz/m1nd"
+
+[dependencies]
+m1nd-mcp = { path = "../m1nd-mcp" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+parking_lot = { workspace = true }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal"] }
+clap = { version = "4", features = ["derive"] }
+
+[[bin]]
+name = "m1nd-openclaw"
+path = "src/main.rs"
+
+[[bin]]
+name = "m1nd-openclaw-client"
+path = "src/client.rs"

--- a/m1nd-openclaw/src/client.rs
+++ b/m1nd-openclaw/src/client.rs
@@ -1,0 +1,54 @@
+use clap::Parser;
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "m1nd-openclaw-client",
+    about = "CLI client for the native m1nd OpenClaw bridge"
+)]
+struct Cli {
+    #[arg(long, default_value = "/tmp/m1nd-openclaw.sock")]
+    socket: String,
+
+    #[arg(long)]
+    result_only: bool,
+
+    tool: String,
+
+    #[arg(default_value = "{}")]
+    args: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    let args: Value = serde_json::from_str(&cli.args)?;
+
+    let mut stream = UnixStream::connect(&cli.socket)?;
+    let request = serde_json::json!({
+        "id": "cli",
+        "tool": cli.tool,
+        "arguments": args,
+    });
+
+    let encoded = serde_json::to_string(&request)?;
+    stream.write_all(encoded.as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+
+    let response: Value = serde_json::from_str(line.trim())?;
+    if cli.result_only {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(response.get("result").unwrap_or(&Value::Null))?
+        );
+    } else {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    }
+    Ok(())
+}

--- a/m1nd-openclaw/src/main.rs
+++ b/m1nd-openclaw/src/main.rs
@@ -1,0 +1,259 @@
+use clap::Parser;
+use m1nd_mcp::server::{dispatch_tool, McpConfig, McpServer};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "m1nd-openclaw",
+    about = "Native low-latency OpenClaw bridge for m1nd"
+)]
+struct Cli {
+    #[arg(long, default_value = "/tmp/m1nd-openclaw.sock")]
+    socket: String,
+
+    #[arg(long)]
+    config: Option<String>,
+
+    #[arg(long)]
+    graph: Option<String>,
+
+    #[arg(long)]
+    plasticity: Option<String>,
+
+    #[arg(long)]
+    runtime_dir: Option<String>,
+
+    #[arg(long, default_value = "code")]
+    domain: String,
+
+    #[arg(long)]
+    default_agent_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BridgeRequest {
+    id: Option<String>,
+    tool: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct BridgeResponse {
+    id: Option<String>,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    elapsed_ms: f64,
+}
+
+fn normalize_tool_name(tool: &str) -> &str {
+    tool.strip_prefix("m1nd.").unwrap_or(tool)
+}
+
+fn inject_default_agent_id(arguments: &Value, default_agent_id: &str) -> Value {
+    let mut next = arguments.clone();
+    if let Some(map) = next.as_object_mut() {
+        if !map.contains_key("agent_id") {
+            map.insert(
+                "agent_id".to_string(),
+                Value::String(default_agent_id.to_string()),
+            );
+        }
+    }
+    next
+}
+
+fn build_response(
+    request: Result<BridgeRequest, serde_json::Error>,
+    state: &Arc<Mutex<m1nd_mcp::session::SessionState>>,
+    default_agent_id: &str,
+) -> BridgeResponse {
+    let started = std::time::Instant::now();
+    match request {
+        Ok(request) => {
+            let tool = normalize_tool_name(&request.tool).to_string();
+            let args = inject_default_agent_id(&request.arguments, default_agent_id);
+            let result = {
+                let mut session = state.lock();
+                dispatch_tool(&mut session, &tool, &args)
+            };
+            match result {
+                Ok(value) => BridgeResponse {
+                    id: request.id,
+                    ok: true,
+                    result: Some(value),
+                    error: None,
+                    elapsed_ms: started.elapsed().as_secs_f64() * 1000.0,
+                },
+                Err(err) => BridgeResponse {
+                    id: request.id,
+                    ok: false,
+                    result: None,
+                    error: Some(err.to_string()),
+                    elapsed_ms: started.elapsed().as_secs_f64() * 1000.0,
+                },
+            }
+        }
+        Err(err) => BridgeResponse {
+            id: None,
+            ok: false,
+            result: None,
+            error: Some(format!("invalid request: {}", err)),
+            elapsed_ms: started.elapsed().as_secs_f64() * 1000.0,
+        },
+    }
+}
+
+fn load_config(cli: &Cli) -> McpConfig {
+    if let Some(ref path) = cli.config {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(config) = serde_json::from_str::<McpConfig>(&contents) {
+                return config;
+            }
+        }
+    }
+
+    let runtime_dir = cli
+        .runtime_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("M1ND_RUNTIME_DIR").ok().map(PathBuf::from));
+
+    let graph_source = cli
+        .graph
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("M1ND_GRAPH_SOURCE").ok().map(PathBuf::from))
+        .or_else(|| runtime_dir.as_ref().map(|dir| dir.join("graph.json")))
+        .unwrap_or_else(|| PathBuf::from("./graph_snapshot.json"));
+
+    let plasticity_state = cli
+        .plasticity
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("M1ND_PLASTICITY_STATE").ok().map(PathBuf::from))
+        .or_else(|| runtime_dir.as_ref().map(|dir| dir.join("plasticity.json")))
+        .unwrap_or_else(|| PathBuf::from("./plasticity_state.json"));
+
+    McpConfig {
+        graph_source,
+        plasticity_state,
+        runtime_dir,
+        domain: Some(cli.domain.clone()),
+        ..McpConfig::default()
+    }
+}
+
+async fn handle_client(
+    stream: UnixStream,
+    state: Arc<Mutex<m1nd_mcp::session::SessionState>>,
+    default_agent_id: String,
+) -> std::io::Result<()> {
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let request: Result<BridgeRequest, _> = serde_json::from_str(trimmed);
+        let response = build_response(request, &state, &default_agent_id);
+
+        let encoded = serde_json::to_vec(&response)?;
+        writer.write_all(&encoded).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+    }
+
+    Ok(())
+}
+
+fn remove_stale_socket(path: &Path) -> std::io::Result<()> {
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    let socket_path = PathBuf::from(&cli.socket);
+
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    remove_stale_socket(&socket_path)?;
+
+    let config = load_config(&cli);
+    let mut server = McpServer::new(config)?;
+    server.start()?;
+    let state = Arc::new(Mutex::new(server.into_session_state()));
+    let default_agent_id = cli
+        .default_agent_id
+        .clone()
+        .or_else(|| std::env::var("M1ND_OPENCLAW_AGENT_ID").ok())
+        .unwrap_or_else(|| "openclaw".to_string());
+
+    let listener = UnixListener::bind(&socket_path)?;
+    eprintln!(
+        "[m1nd-openclaw] Native bridge listening on {}",
+        socket_path.display()
+    );
+
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                break;
+            }
+            accepted = listener.accept() => {
+                let (stream, _) = accepted?;
+                let state = Arc::clone(&state);
+                let default_agent_id = default_agent_id.clone();
+                tokio::spawn(async move {
+                    if let Err(err) = handle_client(stream, state, default_agent_id).await {
+                        eprintln!("[m1nd-openclaw] client error: {}", err);
+                    }
+                });
+            }
+        }
+    }
+
+    let _ = std::fs::remove_file(&socket_path);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{inject_default_agent_id, normalize_tool_name};
+    use serde_json::json;
+
+    #[test]
+    fn normalize_tool_name_strips_m1nd_prefix() {
+        assert_eq!(normalize_tool_name("m1nd.search"), "search");
+        assert_eq!(normalize_tool_name("search"), "search");
+    }
+
+    #[test]
+    fn inject_default_agent_id_only_when_missing() {
+        let args = json!({"query":"abc"});
+        let patched = inject_default_agent_id(&args, "openclaw");
+        assert_eq!(patched["agent_id"], "openclaw");
+        assert_eq!(patched["query"], "abc");
+
+        let existing = json!({"agent_id":"custom","query":"abc"});
+        let preserved = inject_default_agent_id(&existing, "openclaw");
+        assert_eq!(preserved["agent_id"], "custom");
+    }
+}

--- a/m1nd-openclaw/src/main.rs
+++ b/m1nd-openclaw/src/main.rs
@@ -140,7 +140,11 @@ fn load_config(cli: &Cli) -> McpConfig {
         .plasticity
         .as_ref()
         .map(PathBuf::from)
-        .or_else(|| std::env::var("M1ND_PLASTICITY_STATE").ok().map(PathBuf::from))
+        .or_else(|| {
+            std::env::var("M1ND_PLASTICITY_STATE")
+                .ok()
+                .map(PathBuf::from)
+        })
         .or_else(|| runtime_dir.as_ref().map(|dir| dir.join("plasticity.json")))
         .unwrap_or_else(|| PathBuf::from("./plasticity_state.json"));
 

--- a/scripts/macos/ai.m1nd.openclaw-bridge.plist
+++ b/scripts/macos/ai.m1nd.openclaw-bridge.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.m1nd.openclaw-bridge</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/cosmophonix/SISTEMA/m1nd/scripts/macos/m1nd-openclaw-bridge.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>M1ND_OPENCLAW_SOCKET</key>
+        <string>/tmp/m1nd-openclaw.sock</string>
+        <key>M1ND_RUNTIME_DIR</key>
+        <string>/Users/cosmophonix/SISTEMA/m1nd-data</string>
+        <key>M1ND_GRAPH_SOURCE</key>
+        <string>/Users/cosmophonix/SISTEMA/m1nd-data/graph.json</string>
+        <key>M1ND_PLASTICITY_STATE</key>
+        <string>/Users/cosmophonix/SISTEMA/m1nd-data/plasticity.json</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/cosmophonix/.m1nd/logs/openclaw-bridge.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/cosmophonix/.m1nd/logs/openclaw-bridge.err.log</string>
+    <key>WorkingDirectory</key>
+    <string>/Users/cosmophonix/SISTEMA/m1nd</string>
+</dict>
+</plist>

--- a/scripts/macos/m1nd-openclaw-bridge.sh
+++ b/scripts/macos/m1nd-openclaw-bridge.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="/Users/cosmophonix/SISTEMA/m1nd"
+SOCK="${M1ND_OPENCLAW_SOCKET:-/tmp/m1nd-openclaw.sock}"
+RUNTIME_DIR="${M1ND_RUNTIME_DIR:-/Users/cosmophonix/SISTEMA/m1nd-data}"
+GRAPH="${M1ND_GRAPH_SOURCE:-${RUNTIME_DIR}/graph.json}"
+PLASTICITY="${M1ND_PLASTICITY_STATE:-${RUNTIME_DIR}/plasticity.json}"
+
+BIN_RELEASE="${ROOT}/target/release/m1nd-openclaw"
+BIN_DEBUG="${ROOT}/target/debug/m1nd-openclaw"
+
+if [ -x "${BIN_RELEASE}" ] && [ -x "${BIN_DEBUG}" ]; then
+  if [ "${BIN_DEBUG}" -nt "${BIN_RELEASE}" ]; then
+    BIN="${BIN_DEBUG}"
+  else
+    BIN="${BIN_RELEASE}"
+  fi
+elif [ -x "${BIN_RELEASE}" ]; then
+  BIN="${BIN_RELEASE}"
+elif [ -x "${BIN_DEBUG}" ]; then
+  BIN="${BIN_DEBUG}"
+else
+  echo "m1nd-openclaw binary not found in release or debug" >&2
+  exit 1
+fi
+
+export M1ND_RUNTIME_DIR="${RUNTIME_DIR}"
+export M1ND_GRAPH_SOURCE="${GRAPH}"
+export M1ND_PLASTICITY_STATE="${PLASTICITY}"
+
+exec "${BIN}" --socket "${SOCK}"

--- a/scripts/macos/m1nd-openclaw-call.sh
+++ b/scripts/macos/m1nd-openclaw-call.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="/Users/cosmophonix/SISTEMA/m1nd"
+SOCK="${M1ND_OPENCLAW_SOCKET:-/tmp/m1nd-openclaw.sock}"
+BIN_RELEASE="${ROOT}/target/release/m1nd-openclaw-client"
+BIN_DEBUG="${ROOT}/target/debug/m1nd-openclaw-client"
+
+if [ -x "${BIN_RELEASE}" ] && [ -x "${BIN_DEBUG}" ]; then
+  if [ "${BIN_DEBUG}" -nt "${BIN_RELEASE}" ]; then
+    BIN="${BIN_DEBUG}"
+  else
+    BIN="${BIN_RELEASE}"
+  fi
+elif [ -x "${BIN_RELEASE}" ]; then
+  BIN="${BIN_RELEASE}"
+elif [ -x "${BIN_DEBUG}" ]; then
+  BIN="${BIN_DEBUG}"
+else
+  echo "m1nd-openclaw-client binary not found in release or debug" >&2
+  exit 1
+fi
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: m1nd-openclaw-call.sh <tool> '<json-args>'" >&2
+  exit 1
+fi
+
+TOOL="$1"
+ARGS="$2"
+
+exec "${BIN}" --socket "${SOCK}" "${TOOL}" "${ARGS}"


### PR DESCRIPTION
## Summary

Adds an OpenClaw-native fast path to `m1nd` without replacing MCP.

This patch introduces a new `m1nd-openclaw` crate that keeps a hot `SessionState` on a Unix socket and dispatches tool calls directly through the existing `dispatch_tool()` path. It also ships small macOS operational surfaces (daemon + call wrappers) and docs for the native lane.

## Why

`m1nd-mcp` remains the universal public transport.

But for OpenClaw-style local runtimes, stdio + MCP framing + bridge layers add measurable latency. This patch creates an additive low-latency path while preserving compatibility for every existing MCP client.

## Included

- new crate: `m1nd-openclaw`
- native client: `m1nd-openclaw-client`
- macOS helper scripts and LaunchAgent template
- docs: `docs/OPENCLAW-NATIVE-FASTPATH.md`

## Verification

- `cargo check -p m1nd-openclaw`

## Notes

This patch is intentionally scoped to the `m1nd` repo only. OpenClaw-side workspace/plugin scaffolding stays out of this PR.
