### PR TITLE
Add daemon state and persistent proactive alerts

### DIFF
--- a/.github/wiki/API-Reference.md
+++ b/.github/wiki/API-Reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All 78 MCP tools, grouped by category. Each tool is callable via JSON-RPC stdio as `m1nd_<tool_name>`.
+All 83 MCP tools, grouped by category. Each tool is callable via JSON-RPC stdio as `m1nd_<tool_name>`.
 
 All tools require an `agent_id` string parameter (use any stable identifier — your editor session ID, agent name, etc.).
 
@@ -13,7 +13,7 @@ Jump to:
 - [RETROBUILDER](#retrobuilder-5-tools)
 - [Surgical](#surgical-4-tools)
 - [Search & Efficiency](#v050--search--efficiency-5-tools)
-- [Audit & Session Ergonomics](#audit--session-ergonomics-7-tools)
+- [Audit & Session Ergonomics](#audit--session-ergonomics-12-tools)
 
 ---
 
@@ -27,7 +27,7 @@ These tools are implemented in the live registry and exposed through `tool_schem
 - `m1nd_refactor_plan` — graph-native refactoring proposals
 - `m1nd_runtime_overlay` — runtime heat and error overlays from OTel spans
 
-## Audit & Session Ergonomics (7 tools)
+## Audit & Session Ergonomics (12 tools)
 
 These tools reduce orchestration overhead for real agent sessions:
 
@@ -38,6 +38,11 @@ These tools reduce orchestration overhead for real agent sessions:
 - `m1nd_external_references` — explicit paths outside ingest roots
 - `m1nd_federate_auto` — turn external paths, manifest/workspace hints, import/package-name evidence, shared API-route signals, or contract artifacts such as `.proto` messages/enums, MCP tools, and OpenAPI schema/components into repo candidates and optional federation
 - `m1nd_audit` — profile-aware one-call audit
+- `m1nd_daemon_start` — activate the persisted daemon control plane and set watch roots / poll interval
+- `m1nd_daemon_stop` — stop the daemon control plane without discarding alert history
+- `m1nd_daemon_status` — inspect daemon runtime state, watch roots, and alert counts
+- `m1nd_alerts_list` — list persisted daemon/proactive alerts
+- `m1nd_alerts_ack` — acknowledge one or more persisted daemon/proactive alerts
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ All notable changes to m1nd are documented here.
 
 ### Added
 
+#### `m1ndd` foundations: daemon state + persistent alerts
+
+The MCP surface now exposes the first daemon-era tools:
+
+- `daemon_start`
+- `daemon_stop`
+- `daemon_status`
+- `alerts_list`
+- `alerts_ack`
+
+These tools persist daemon state under the runtime root and keep a small alert
+queue alive across sessions instead of treating every structural warning as a
+one-shot event.
+
+When the daemon is active, `apply` and `apply_batch` now feed their strongest
+`proactive_insights` into that queue so agents can list, acknowledge, and
+revisit post-write structural risk without recomputing it immediately.
+
 #### Proactive write insights on `apply` and `apply_batch`
 
 `apply` and `apply_batch` now attach `proactive_insights` directly to write

--- a/docs/AGENT-TASKNOTES.md
+++ b/docs/AGENT-TASKNOTES.md
@@ -27,6 +27,18 @@ The rule:
   - stronger cross-repo contract drift when federation is active
   - per-insight latency budgets in benchmarks
 
+### 2026-04-05 — daemon alerts exist, but the daemon still does not watch or ingest deltas by itself
+
+- Context: first daemon surface (`daemon_start`, `daemon_stop`, `daemon_status`,
+  `alerts_list`, `alerts_ack`)
+- Friction: write paths can now persist alerts when the daemon is active, but
+  the daemon is still a persisted control plane, not yet a live file-watching
+  incremental ingest loop
+- Desired behavior:
+  - filesystem / SCM-triggered delta ingest
+  - alert emission without requiring an explicit `apply`
+  - latency budgets for `single-file changed -> alert available`
+
 ### 2026-04-05 — `audit` still composes more than it understands
 
 - Context: first implementation of `m1nd.audit`

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -1,0 +1,270 @@
+use crate::protocol::layers;
+use crate::session::{DaemonAlert, SessionState};
+use m1nd_core::error::{M1ndError, M1ndResult};
+use serde_json::json;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+pub fn handle_daemon_start(
+    state: &mut SessionState,
+    input: layers::DaemonStartInput,
+) -> M1ndResult<serde_json::Value> {
+    let started_at_ms = now_ms();
+    state.daemon_state.active = true;
+    state.daemon_state.started_at_ms = Some(started_at_ms);
+    state.daemon_state.last_tick_ms = Some(started_at_ms);
+    state.daemon_state.watch_paths = if input.watch_paths.is_empty() {
+        state.ingest_roots.clone()
+    } else {
+        input.watch_paths
+    };
+    state.daemon_state.poll_interval_ms = input.poll_interval_ms;
+    state.persist_daemon_state()?;
+    Ok(json!({
+        "status": "started",
+        "active": true,
+        "started_at_ms": started_at_ms,
+        "watch_paths": state.daemon_state.watch_paths,
+        "poll_interval_ms": state.daemon_state.poll_interval_ms,
+    }))
+}
+
+pub fn handle_daemon_stop(
+    state: &mut SessionState,
+    _input: layers::DaemonStopInput,
+) -> M1ndResult<serde_json::Value> {
+    state.daemon_state.active = false;
+    state.daemon_state.last_tick_ms = Some(now_ms());
+    state.persist_daemon_state()?;
+    Ok(json!({
+        "status": "stopped",
+        "active": false,
+        "started_at_ms": state.daemon_state.started_at_ms,
+        "last_tick_ms": state.daemon_state.last_tick_ms,
+    }))
+}
+
+pub fn handle_daemon_status(
+    state: &mut SessionState,
+    _input: layers::DaemonStatusInput,
+) -> M1ndResult<serde_json::Value> {
+    Ok(json!({
+        "active": state.daemon_state.active,
+        "started_at_ms": state.daemon_state.started_at_ms,
+        "last_tick_ms": state.daemon_state.last_tick_ms,
+        "watch_paths": state.daemon_state.watch_paths,
+        "poll_interval_ms": state.daemon_state.poll_interval_ms,
+        "alert_count": state.daemon_alerts.len(),
+        "runtime_root": state.runtime_root,
+        "graph_generation": state.graph_generation,
+        "cache_generation": state.cache_generation,
+    }))
+}
+
+pub fn handle_alerts_list(
+    state: &mut SessionState,
+    input: layers::AlertsListInput,
+) -> M1ndResult<serde_json::Value> {
+    let mut alerts = state
+        .daemon_alerts
+        .iter()
+        .filter(|alert| input.include_acked || !alert.acked)
+        .cloned()
+        .collect::<Vec<_>>();
+    alerts.sort_by(|a, b| {
+        b.created_at_ms
+            .cmp(&a.created_at_ms)
+            .then_with(|| a.alert_id.cmp(&b.alert_id))
+    });
+    alerts.truncate(input.limit);
+    Ok(json!({
+        "alerts": alerts,
+        "total": alerts.len(),
+        "active": state.daemon_state.active,
+    }))
+}
+
+pub fn handle_alerts_ack(
+    state: &mut SessionState,
+    input: layers::AlertsAckInput,
+) -> M1ndResult<serde_json::Value> {
+    if input.alert_ids.is_empty() {
+        return Err(M1ndError::InvalidParams {
+            tool: "alerts_ack".into(),
+            detail: "Provide at least one alert_id.".into(),
+        });
+    }
+    let acked_at_ms = now_ms();
+    let mut acked = 0usize;
+    for alert in &mut state.daemon_alerts {
+        if input.alert_ids.iter().any(|id| id == &alert.alert_id) && !alert.acked {
+            alert.acked = true;
+            alert.acked_at_ms = Some(acked_at_ms);
+            acked += 1;
+        }
+    }
+    state.persist_daemon_alerts()?;
+    Ok(json!({
+        "acked": acked,
+        "requested": input.alert_ids.len(),
+        "acked_at_ms": acked_at_ms,
+    }))
+}
+
+pub struct DaemonAlertSeed {
+    pub severity: String,
+    pub kind: String,
+    pub message: String,
+    pub confidence: f32,
+    pub evidence: Vec<String>,
+    pub suggested_tool: Option<String>,
+    pub suggested_target: Option<String>,
+    pub file_path: Option<String>,
+    pub node_id: Option<String>,
+}
+
+pub fn make_daemon_alert(seed: DaemonAlertSeed) -> DaemonAlert {
+    let created_at_ms = now_ms();
+    DaemonAlert {
+        alert_id: format!("alert-{}-{}", seed.kind, created_at_ms),
+        severity: seed.severity,
+        kind: seed.kind,
+        message: seed.message,
+        confidence: seed.confidence,
+        evidence: seed.evidence,
+        suggested_tool: seed.suggested_tool,
+        suggested_target: seed.suggested_target,
+        file_path: seed.file_path,
+        node_id: seed.node_id,
+        created_at_ms,
+        acked: false,
+        acked_at_ms: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::McpConfig;
+    use m1nd_core::domain::DomainConfig;
+    use m1nd_core::graph::Graph;
+
+    fn build_state() -> (tempfile::TempDir, SessionState) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..McpConfig::default()
+        };
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+        (temp, state)
+    }
+
+    #[test]
+    fn daemon_lifecycle_and_alert_ack_roundtrip() {
+        let (_temp, mut state) = build_state();
+
+        let started = handle_daemon_start(
+            &mut state,
+            layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec!["/tmp/watch".into()],
+                poll_interval_ms: 750,
+            },
+        )
+        .expect("daemon start");
+        assert_eq!(started["active"], true);
+        assert_eq!(started["poll_interval_ms"], 750);
+
+        let seeded = make_daemon_alert(DaemonAlertSeed {
+            severity: "warning".into(),
+            kind: "trust_drop".into(),
+            message: "trust dropped".into(),
+            confidence: 0.82,
+            evidence: vec!["file::src/core.py".into()],
+            suggested_tool: Some("trust".into()),
+            suggested_target: Some("file::src/core.py".into()),
+            file_path: Some("/tmp/watch/src/core.py".into()),
+            node_id: Some("file::src/core.py".into()),
+        });
+        let seeded_id = seeded.alert_id.clone();
+        state.record_daemon_alert(seeded);
+        state
+            .persist_daemon_alerts()
+            .expect("persist daemon alerts");
+
+        let listed = handle_alerts_list(
+            &mut state,
+            layers::AlertsListInput {
+                agent_id: "test".into(),
+                include_acked: false,
+                limit: 10,
+            },
+        )
+        .expect("alerts list");
+        assert_eq!(listed["total"], 1);
+        assert_eq!(listed["alerts"][0]["alert_id"], seeded_id);
+
+        let acked = handle_alerts_ack(
+            &mut state,
+            layers::AlertsAckInput {
+                agent_id: "test".into(),
+                alert_ids: vec![seeded_id.clone()],
+            },
+        )
+        .expect("alerts ack");
+        assert_eq!(acked["acked"], 1);
+
+        let hidden = handle_alerts_list(
+            &mut state,
+            layers::AlertsListInput {
+                agent_id: "test".into(),
+                include_acked: false,
+                limit: 10,
+            },
+        )
+        .expect("alerts list hidden");
+        assert_eq!(hidden["total"], 0);
+
+        let visible = handle_alerts_list(
+            &mut state,
+            layers::AlertsListInput {
+                agent_id: "test".into(),
+                include_acked: true,
+                limit: 10,
+            },
+        )
+        .expect("alerts list visible");
+        assert_eq!(visible["total"], 1);
+        assert_eq!(visible["alerts"][0]["acked"], true);
+
+        let status = handle_daemon_status(
+            &mut state,
+            layers::DaemonStatusInput {
+                agent_id: "test".into(),
+            },
+        )
+        .expect("daemon status");
+        assert_eq!(status["active"], true);
+        assert_eq!(status["alert_count"], 1);
+
+        let stopped = handle_daemon_stop(
+            &mut state,
+            layers::DaemonStopInput {
+                agent_id: "test".into(),
+            },
+        )
+        .expect("daemon stop");
+        assert_eq!(stopped["active"], false);
+    }
+}

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod audit_handlers;
 pub mod cli;
+pub mod daemon_handlers;
 pub mod protocol;
 pub mod server;
 pub mod session;

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -2251,6 +2251,48 @@ pub struct AuditInput {
     pub max_output_chars: Option<usize>,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+pub struct DaemonStartInput {
+    pub agent_id: String,
+    #[serde(default)]
+    pub watch_paths: Vec<String>,
+    #[serde(default = "default_daemon_poll_interval_ms")]
+    pub poll_interval_ms: u64,
+}
+
+fn default_daemon_poll_interval_ms() -> u64 {
+    500
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DaemonStopInput {
+    pub agent_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DaemonStatusInput {
+    pub agent_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AlertsListInput {
+    pub agent_id: String,
+    #[serde(default)]
+    pub include_acked: bool,
+    #[serde(default = "default_alert_limit")]
+    pub limit: usize,
+}
+
+fn default_alert_limit() -> usize {
+    50
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AlertsAckInput {
+    pub agent_id: String,
+    pub alert_ids: Vec<String>,
+}
+
 fn default_audit_profile() -> String {
     "auto".to_string()
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -1415,6 +1415,66 @@ pub fn tool_schemas() -> serde_json::Value {
                 }
             },
             {
+                "name": "daemon_start",
+                "description": "Start persisted daemon state and store watched paths for continuous structural monitoring.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "watch_paths": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Paths the daemon should treat as watched roots" },
+                        "poll_interval_ms": { "type": "integer", "default": 500, "description": "Fallback polling interval in milliseconds" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "daemon_stop",
+                "description": "Stop persisted daemon state without deleting alerts or runtime state.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "daemon_status",
+                "description": "Report daemon state, watched paths, alert counts, and generation counters.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "alerts_list",
+                "description": "List persisted daemon/proactive alerts.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "include_acked": { "type": "boolean", "default": false, "description": "Include acknowledged alerts" },
+                        "limit": { "type": "integer", "default": 50, "description": "Maximum number of alerts to return" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "alerts_ack",
+                "description": "Acknowledge one or more daemon/proactive alerts.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "alert_ids": { "type": "array", "items": { "type": "string" }, "description": "Alert IDs to acknowledge" }
+                    },
+                    "required": ["agent_id", "alert_ids"]
+                }
+            },
+            {
                 "name": "panoramic",
                 "description": "Panoramic graph health overview: per-module risk scores combining blast radius, centrality, and churn signals.",
                 "inputSchema": {
@@ -1885,6 +1945,31 @@ fn dispatch_core_tool(
             let input: layers::AuditInput =
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
             crate::audit_handlers::handle_audit(state, input)
+        }
+        "daemon_start" => {
+            let input: layers::DaemonStartInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            crate::daemon_handlers::handle_daemon_start(state, input)
+        }
+        "daemon_stop" => {
+            let input: layers::DaemonStopInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            crate::daemon_handlers::handle_daemon_stop(state, input)
+        }
+        "daemon_status" => {
+            let input: layers::DaemonStatusInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            crate::daemon_handlers::handle_daemon_status(state, input)
+        }
+        "alerts_list" => {
+            let input: layers::AlertsListInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            crate::daemon_handlers::handle_alerts_list(state, input)
+        }
+        "alerts_ack" => {
+            let input: layers::AlertsAckInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            crate::daemon_handlers::handle_alerts_ack(state, input)
         }
         "panoramic" => {
             let input: layers::PanoramicInput =

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -159,6 +159,32 @@ pub struct CoverageSessionState {
     pub tools_used: HashMap<String, u64>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DaemonRuntimeState {
+    pub active: bool,
+    pub started_at_ms: Option<u64>,
+    pub last_tick_ms: Option<u64>,
+    pub watch_paths: Vec<String>,
+    pub poll_interval_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DaemonAlert {
+    pub alert_id: String,
+    pub severity: String,
+    pub kind: String,
+    pub message: String,
+    pub confidence: f32,
+    pub evidence: Vec<String>,
+    pub suggested_tool: Option<String>,
+    pub suggested_target: Option<String>,
+    pub file_path: Option<String>,
+    pub node_id: Option<String>,
+    pub created_at_ms: u64,
+    pub acked: bool,
+    pub acked_at_ms: Option<u64>,
+}
+
 pub type ApplyBatchProgressSink =
     Arc<dyn Fn(&crate::protocol::surgical::ApplyBatchProgressEvent) + Send + Sync>;
 
@@ -275,6 +301,14 @@ pub struct SessionState {
     pub boot_memory_path: PathBuf,
     /// Hot runtime cache of canonical boot memory entries.
     pub boot_memory: HashMap<String, BootMemoryEntry>,
+    /// Path to daemon state persisted next to the graph.
+    pub daemon_state_path: PathBuf,
+    /// Current persisted daemon runtime state.
+    pub daemon_state: DaemonRuntimeState,
+    /// Path to persisted daemon/proactive alerts.
+    pub daemon_alerts_path: PathBuf,
+    /// Persisted daemon/proactive alerts.
+    pub daemon_alerts: Vec<DaemonAlert>,
     /// Lightweight metadata index for files seen during ingest or verification.
     pub file_inventory: HashMap<String, FileInventoryEntry>,
     /// Per-agent exploration coverage state for visited files/nodes.
@@ -433,6 +467,16 @@ impl SessionState {
                 let boot_path = runtime_root.join("boot_memory_state.json");
                 Self::load_boot_memory(&boot_path)
             },
+            daemon_state_path: runtime_root.join("daemon_state.json"),
+            daemon_state: {
+                let path = runtime_root.join("daemon_state.json");
+                Self::load_daemon_state(&path)
+            },
+            daemon_alerts_path: runtime_root.join("daemon_alerts.json"),
+            daemon_alerts: {
+                let path = runtime_root.join("daemon_alerts.json");
+                Self::load_daemon_alerts(&path)
+            },
             file_inventory: HashMap::new(),
             coverage_sessions: HashMap::new(),
         })
@@ -500,6 +544,12 @@ impl SessionState {
         if let Err(e) = self.persist_boot_memory() {
             eprintln!("[m1nd] WARNING: boot memory persist failed: {}", e);
         }
+        if let Err(e) = self.persist_daemon_state() {
+            eprintln!("[m1nd] WARNING: daemon state persist failed: {}", e);
+        }
+        if let Err(e) = self.persist_daemon_alerts() {
+            eprintln!("[m1nd] WARNING: daemon alert persist failed: {}", e);
+        }
 
         self.last_persist_time = Some(Instant::now());
         Ok(())
@@ -546,6 +596,36 @@ impl SessionState {
             .and_then(|s| serde_json::from_str::<BootMemoryState>(&s).ok())
             .map(|state| state.entries)
             .unwrap_or_default()
+    }
+
+    pub fn persist_daemon_state(&self) -> M1ndResult<()> {
+        save_json_atomic(&self.daemon_state_path, &self.daemon_state)
+    }
+
+    fn load_daemon_state(path: &Path) -> DaemonRuntimeState {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<DaemonRuntimeState>(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn persist_daemon_alerts(&self) -> M1ndResult<()> {
+        save_json_atomic(&self.daemon_alerts_path, &self.daemon_alerts)
+    }
+
+    fn load_daemon_alerts(path: &Path) -> Vec<DaemonAlert> {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<Vec<DaemonAlert>>(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn record_daemon_alert(&mut self, alert: DaemonAlert) {
+        self.daemon_alerts.push(alert);
+        if self.daemon_alerts.len() > 500 {
+            let drain = self.daemon_alerts.len() - 500;
+            self.daemon_alerts.drain(0..drain);
+        }
     }
 
     pub fn reload_heuristic_sidecars(&mut self) {

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -11,6 +11,7 @@
 //
 // Pattern: identical to layer_handlers.rs -- parse typed input -> call engine -> return output.
 
+use crate::daemon_handlers::{make_daemon_alert, DaemonAlertSeed};
 use crate::protocol::{layers, surgical};
 use crate::session::{EditPreviewState, SessionState};
 use m1nd_core::error::{M1ndError, M1ndResult};
@@ -307,6 +308,63 @@ fn build_proactive_insights(
     });
     insights.truncate(3);
     insights
+}
+
+fn persist_daemon_alerts_from_insights(
+    state: &mut SessionState,
+    proactive_insights: &[surgical::ProactiveInsight],
+    default_file_path: Option<&str>,
+    default_node_id: Option<&str>,
+) {
+    if !state.daemon_state.active || proactive_insights.is_empty() {
+        return;
+    }
+
+    let tick_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as u64)
+        .unwrap_or(0);
+    state.daemon_state.last_tick_ms = Some(tick_ms);
+
+    for insight in proactive_insights.iter().take(3) {
+        let alert_file_path = insight
+            .suggested_target
+            .as_deref()
+            .and_then(|target| target.strip_prefix("file::").or(Some(target)))
+            .map(str::to_string)
+            .or_else(|| default_file_path.map(str::to_string));
+        let alert_node_id = insight
+            .suggested_target
+            .as_deref()
+            .filter(|target| target.starts_with("file::"))
+            .map(str::to_string)
+            .or_else(|| default_node_id.map(str::to_string));
+        let alert = make_daemon_alert(DaemonAlertSeed {
+            severity: insight.severity.clone(),
+            kind: insight.kind.clone(),
+            message: insight.message.clone(),
+            confidence: insight.confidence,
+            evidence: insight.evidence.clone(),
+            suggested_tool: insight.suggested_tool.clone(),
+            suggested_target: insight.suggested_target.clone(),
+            file_path: alert_file_path,
+            node_id: alert_node_id,
+        });
+        state.record_daemon_alert(alert);
+    }
+
+    if let Err(error) = state.persist_daemon_state() {
+        eprintln!(
+            "[m1nd] WARNING: daemon state persist failed during apply: {}",
+            error
+        );
+    }
+    if let Err(error) = state.persist_daemon_alerts() {
+        eprintln!(
+            "[m1nd] WARNING: daemon alert persist failed during apply: {}",
+            error
+        );
+    }
 }
 
 fn surgical_dampened_trust_factor(raw_factor: f32) -> f32 {
@@ -2110,26 +2168,32 @@ pub fn handle_apply(
     // Track agent session
     state.track_agent(&input.agent_id);
 
+    let applied_file_path = validated_path.to_string_lossy().to_string();
     let proactive_insights = {
         let graph = state.graph.read();
-        let path_str = validated_path.to_string_lossy().to_string();
-        let file_node = find_nodes_for_file(&graph, &path_str)
+        let file_node = find_nodes_for_file(&graph, &applied_file_path)
             .into_iter()
             .find(|(node_id, ext)| is_file_node(&graph, *node_id) && ext.starts_with("file::"))
             .map(|(_, ext)| ext);
         drop(graph);
 
-        let heuristic_summary = file_node
-            .as_deref()
-            .map(|external_id| build_surgical_heuristic_summary(state, external_id, &path_str));
+        let heuristic_summary = file_node.as_deref().map(|external_id| {
+            build_surgical_heuristic_summary(state, external_id, &applied_file_path)
+        });
         build_proactive_insights(
             state,
-            &path_str,
+            &applied_file_path,
             file_node.as_deref(),
             heuristic_summary.as_ref(),
             None,
         )
     };
+    persist_daemon_alerts_from_insights(
+        state,
+        &proactive_insights,
+        Some(&applied_file_path),
+        updated_node_ids.first().map(String::as_str),
+    );
 
     Ok(surgical::ApplyOutput {
         file_path: validated_path.to_string_lossy().to_string(),
@@ -3652,6 +3716,22 @@ pub fn handle_apply_batch(
         insights.truncate(3);
         insights
     };
+    let primary_file_path = results
+        .iter()
+        .find(|result| result.success)
+        .map(|result| result.file_path.as_str());
+    let primary_node_id = verification.as_ref().and_then(|report| {
+        report
+            .high_impact_files
+            .first()
+            .map(|impact| impact.node_id.as_str())
+    });
+    persist_daemon_alerts_from_insights(
+        state,
+        &proactive_insights,
+        primary_file_path,
+        primary_node_id,
+    );
     phases.push(surgical::ApplyBatchPhase {
         phase: "done".into(),
         phase_index: 4,
@@ -5071,6 +5151,71 @@ mod tests {
                 || insight.kind == "tremor_hotspot"
                 || insight.kind == "untouched_test_companion"
         }));
+    }
+
+    #[test]
+    fn test_apply_records_daemon_alerts_when_daemon_is_active() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let primary_path = root.join("src/core.py");
+        std::fs::create_dir_all(primary_path.parent().expect("primary parent"))
+            .expect("mk primary parent");
+        std::fs::write(&primary_path, "def core():\n    return 1\n").expect("write primary");
+        std::fs::write(
+            root.join("src/test_core.py"),
+            "def test_core():\n    assert True\n",
+        )
+        .expect("write companion test");
+
+        let primary_str = primary_path.to_string_lossy().to_string();
+        let mut state = build_surgical_state(root, &primary_str);
+        crate::daemon_handlers::handle_daemon_start(
+            &mut state,
+            layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![root.to_string_lossy().to_string()],
+                poll_interval_ms: 500,
+            },
+        )
+        .expect("daemon start");
+
+        let output = handle_apply(
+            &mut state,
+            surgical::ApplyInput {
+                file_path: primary_str.clone(),
+                agent_id: "test".into(),
+                new_content: "def core():\n    return 2\n".into(),
+                description: Some("update return".into()),
+                reingest: true,
+            },
+        )
+        .expect("apply");
+
+        assert!(
+            !output.proactive_insights.is_empty(),
+            "apply should still surface proactive insights when daemon is active"
+        );
+        assert!(
+            !state.daemon_alerts.is_empty(),
+            "active daemon should persist alerts from proactive insights"
+        );
+        assert!(
+            state.daemon_alerts.iter().any(|alert| {
+                alert
+                    .file_path
+                    .as_deref()
+                    .is_some_and(|path| path.contains("core.py"))
+                    || alert
+                        .node_id
+                        .as_deref()
+                        .is_some_and(|node| node.contains("core.py"))
+                    || alert
+                        .evidence
+                        .iter()
+                        .any(|evidence| evidence.contains("core.py"))
+            }),
+            "daemon alerts should retain file-level evidence for the modified surface"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the first daemon-era MCP surfaces: , , , , and 
- persist daemon runtime state and alert history under the runtime root
- wire  and  so active daemon sessions retain their strongest  as durable alerts
- cover daemon lifecycle, alert acknowledgement, and write-path alert persistence with tests
- document the new daemon/alert surface in the changelog, API reference, and agent tasknotes

## Validation
- cargo fmt --check
- cargo check -p m1nd-mcp -p m1nd-ingest
- cargo test -p m1nd-ingest -p m1nd-mcp -- --nocapture
- cargo clippy -p m1nd-mcp -p m1nd-ingest -- -D warnings
- real MCP smoke: daemon_start -> apply -> alerts_list -> alerts_ack -> daemon_stop

## Why this matters
This is the first step from one-shot structural guidance toward a persistent daemon-era control plane.  can now keep post-write structural risk alive across calls instead of forcing the agent to rediscover it every time.