### PR TITLE
Run daemon ticks during idle server time

### DIFF
--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -275,11 +275,23 @@ pub fn handle_daemon_tick(
                 sha256: entry.sha256.clone(),
             },
         );
+        let proactive_insights = crate::surgical_handlers::daemon_proactive_insights_for_file(
+            state,
+            &entry.file_path,
+            None,
+        );
+        crate::surgical_handlers::persist_daemon_alerts_from_insights(
+            state,
+            &proactive_insights,
+            Some(&entry.file_path),
+            Some(&entry.external_id),
+        );
         ingested_files.push(json!({
             "file_path": entry.file_path,
             "external_id": entry.external_id,
             "nodes_created": ingest_result.get("nodes_created").cloned().unwrap_or(json!(0)),
             "edges_created": ingest_result.get("edges_created").cloned().unwrap_or(json!(0)),
+            "proactive_insight_kinds": proactive_insights.iter().map(|insight| insight.kind.clone()).collect::<Vec<_>>(),
         }));
     }
 
@@ -592,6 +604,100 @@ mod tests {
         assert!(ticked["ingested_files"][0]["file_path"]
             .as_str()
             .is_some_and(|path| path.ends_with("src/core.py")));
+    }
+
+    #[test]
+    fn daemon_tick_surfaces_proactive_alerts_for_risky_changed_file() {
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo src");
+        let file_path = repo.join("src/core.py");
+        std::fs::write(&file_path, "def core():\n    return 1\n").expect("write file");
+        std::fs::write(
+            repo.join("src/test_core.py"),
+            "def test_core():\n    assert True\n",
+        )
+        .expect("write companion test");
+
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: repo.to_string_lossy().to_string(),
+                agent_id: "test".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+            },
+        )
+        .expect("initial ingest");
+
+        handle_daemon_start(
+            &mut state,
+            layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![repo.to_string_lossy().to_string()],
+                poll_interval_ms: 500,
+            },
+        )
+        .expect("daemon start");
+
+        state
+            .trust_ledger
+            .record_defect(&format!("file::{}", file_path.to_string_lossy()), 100.0);
+        state
+            .trust_ledger
+            .record_defect(&format!("file::{}", file_path.to_string_lossy()), 200.0);
+        state.tremor_registry.record_observation(
+            &format!("file::{}", file_path.to_string_lossy()),
+            1.0,
+            4,
+            300.0,
+        );
+        state.tremor_registry.record_observation(
+            &format!("file::{}", file_path.to_string_lossy()),
+            1.1,
+            4,
+            400.0,
+        );
+        state.tremor_registry.record_observation(
+            &format!("file::{}", file_path.to_string_lossy()),
+            1.2,
+            4,
+            500.0,
+        );
+
+        std::fs::write(&file_path, "def core():\n    return 3\n").expect("rewrite file");
+
+        let ticked = handle_daemon_tick(
+            &mut state,
+            layers::DaemonTickInput {
+                agent_id: "test".into(),
+                max_files: 8,
+            },
+        )
+        .expect("risky changed tick");
+        let kinds = ticked["ingested_files"][0]["proactive_insight_kinds"]
+            .as_array()
+            .expect("proactive insight kinds");
+        assert!(
+            kinds.iter().any(|value| {
+                value.as_str() == Some("trust_drop")
+                    || value.as_str() == Some("tremor_hotspot")
+                    || value.as_str() == Some("untouched_test_companion")
+            }),
+            "daemon tick should surface the same proactive heuristics as write paths"
+        );
+        assert!(
+            state.daemon_alerts.iter().any(|alert| {
+                alert.kind == "trust_drop"
+                    || alert.kind == "tremor_hotspot"
+                    || alert.kind == "untouched_test_companion"
+            }),
+            "daemon tick should persist heuristic alerts for risky changed files"
+        );
     }
 
     #[test]

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -13,6 +13,7 @@ use m1nd_core::domain::DomainConfig;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use std::io::{BufRead, Read, Write};
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
 // MCP protocol instructions — injected into initialize response so agents
@@ -2118,6 +2119,25 @@ fn dispatch_core_tool(
     }
 }
 
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn should_autotick_daemon(tool_name: &str) -> bool {
+    !matches!(
+        tool_name,
+        "daemon_start"
+            | "daemon_stop"
+            | "daemon_status"
+            | "daemon_tick"
+            | "alerts_list"
+            | "alerts_ack"
+    )
+}
+
 /// Dispatch perspective tools (12 tools).
 fn dispatch_perspective_tool(
     state: &mut SessionState,
@@ -2537,6 +2557,21 @@ impl McpServer {
                 // Track agent session from arguments
                 if let Some(agent_id) = arguments.get("agent_id").and_then(|v| v.as_str()) {
                     self.state.track_agent(agent_id);
+                    if self.state.daemon_state.active
+                        && should_autotick_daemon(tool_name)
+                        && self.state.daemon_state.last_tick_ms.is_some_and(|last| {
+                            now_ms().saturating_sub(last)
+                                >= self.state.daemon_state.poll_interval_ms
+                        })
+                    {
+                        let _ = crate::daemon_handlers::handle_daemon_tick(
+                            &mut self.state,
+                            layers::DaemonTickInput {
+                                agent_id: agent_id.to_string(),
+                                max_files: 32,
+                            },
+                        );
+                    }
                 }
 
                 // MCP spec: tool execution errors -> isError content, not JSON-RPC errors
@@ -2594,7 +2629,7 @@ impl McpServer {
 
 #[cfg(test)]
 mod tests {
-    use super::tool_schemas;
+    use super::{should_autotick_daemon, tool_schemas};
 
     #[test]
     fn tool_schemas_expose_new_audit_surface_and_retrobuilder_tools() {
@@ -2620,11 +2655,36 @@ mod tests {
             "external_references",
             "federate_auto",
             "audit",
+            "daemon_start",
+            "daemon_stop",
+            "daemon_status",
+            "daemon_tick",
+            "alerts_list",
+            "alerts_ack",
         ] {
             assert!(
                 names.iter().any(|name| name == expected),
                 "tool_schemas should expose {expected}"
             );
         }
+    }
+
+    #[test]
+    fn autotick_skips_daemon_control_tools() {
+        for skipped in [
+            "daemon_start",
+            "daemon_stop",
+            "daemon_status",
+            "daemon_tick",
+            "alerts_list",
+            "alerts_ack",
+        ] {
+            assert!(
+                !should_autotick_daemon(skipped),
+                "autotick should skip {skipped}"
+            );
+        }
+        assert!(should_autotick_daemon("search"));
+        assert!(should_autotick_daemon("apply"));
     }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -13,6 +13,9 @@ use m1nd_core::domain::DomainConfig;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use std::io::{BufRead, Read, Write};
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
@@ -2138,6 +2141,27 @@ fn should_autotick_daemon(tool_name: &str) -> bool {
     )
 }
 
+fn background_tick_if_due(state: &mut SessionState) {
+    if !state.daemon_state.active || state.daemon_state.poll_interval_ms == 0 {
+        return;
+    }
+    let due = state
+        .daemon_state
+        .last_tick_ms
+        .is_none_or(|last| now_ms().saturating_sub(last) >= state.daemon_state.poll_interval_ms);
+    if !due {
+        return;
+    }
+
+    let _ = crate::daemon_handlers::handle_daemon_tick(
+        state,
+        layers::DaemonTickInput {
+            agent_id: "daemon".into(),
+            max_files: 32,
+        },
+    );
+}
+
 /// Dispatch perspective tools (12 tools).
 fn dispatch_perspective_tool(
     state: &mut SessionState,
@@ -2427,17 +2451,50 @@ impl McpServer {
     /// Main event loop: read JSON-RPC from stdin, dispatch, write response to stdout.
     /// Blocks until EOF or shutdown signal.
     pub fn serve(&mut self) -> M1ndResult<()> {
-        let stdin = std::io::stdin();
         let stdout = std::io::stdout();
-        let mut reader = stdin.lock();
         let mut writer = stdout.lock();
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            loop {
+                let next = read_request_payload(&mut reader);
+                match next {
+                    Ok(Some(value)) => {
+                        if tx.send(Some(value)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        let _ = tx.send(None);
+                        break;
+                    }
+                    Err(_) => {
+                        let _ = tx.send(None);
+                        break;
+                    }
+                }
+            }
+        });
 
         loop {
-            let (payload, transport_mode) = match read_request_payload(&mut reader) {
-                Ok(Some(value)) => value,
-                Ok(None) => break,
-                Err(_) => break,
+            let daemon_wait = if self.state.daemon_state.active {
+                self.state.daemon_state.poll_interval_ms.clamp(25, 1000)
+            } else {
+                1000
             };
+
+            let (payload, transport_mode) =
+                match rx.recv_timeout(Duration::from_millis(daemon_wait)) {
+                    Ok(Some(value)) => value,
+                    Ok(None) => break,
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        background_tick_if_due(&mut self.state);
+                        continue;
+                    }
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                };
             let trimmed = payload.trim();
             if trimmed.is_empty() {
                 continue;
@@ -2629,7 +2686,26 @@ impl McpServer {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_autotick_daemon, tool_schemas};
+    use super::{background_tick_if_due, should_autotick_daemon, tool_schemas};
+    use crate::server::McpConfig;
+    use crate::session::SessionState;
+    use m1nd_core::domain::DomainConfig;
+    use m1nd_core::graph::Graph;
+
+    fn build_state() -> (tempfile::TempDir, SessionState) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..McpConfig::default()
+        };
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+        (temp, state)
+    }
 
     #[test]
     fn tool_schemas_expose_new_audit_surface_and_retrobuilder_tools() {
@@ -2686,5 +2762,71 @@ mod tests {
         }
         assert!(should_autotick_daemon("search"));
         assert!(should_autotick_daemon("apply"));
+    }
+
+    #[test]
+    fn background_tick_runs_when_daemon_is_due() {
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo src");
+        let file_path = repo.join("src/core.py");
+        std::fs::write(&file_path, "def core():\n    return 1\n").expect("write file");
+
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: repo.to_string_lossy().to_string(),
+                agent_id: "test".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+            },
+        )
+        .expect("initial ingest");
+
+        crate::daemon_handlers::handle_daemon_start(
+            &mut state,
+            crate::protocol::layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![repo.to_string_lossy().to_string()],
+                poll_interval_ms: 25,
+            },
+        )
+        .expect("daemon start");
+
+        std::fs::write(&file_path, "def core():\n    return 9\n").expect("rewrite file");
+        state.daemon_state.last_tick_ms = Some(0);
+
+        background_tick_if_due(&mut state);
+
+        let hit = crate::search_handlers::handle_search(
+            &mut state,
+            crate::protocol::layers::SearchInput {
+                query: "return 9".into(),
+                agent_id: "test".into(),
+                mode: crate::protocol::layers::SearchMode::Literal,
+                scope: None,
+                filename_pattern: None,
+                top_k: 5,
+                case_sensitive: false,
+                context_lines: 0,
+                invert: false,
+                count_only: false,
+                multiline: false,
+                auto_ingest: false,
+                max_output_chars: None,
+            },
+        )
+        .expect("search after background tick");
+
+        assert!(
+            hit.results
+                .iter()
+                .any(|result| { result.matched_line.contains("return 9") }),
+            "background tick should refresh the graph before the next explicit tool call"
+        );
     }
 }

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -310,7 +310,31 @@ fn build_proactive_insights(
     insights
 }
 
-fn persist_daemon_alerts_from_insights(
+pub(crate) fn daemon_proactive_insights_for_file(
+    state: &SessionState,
+    file_path: &str,
+    verification: Option<&surgical::VerificationReport>,
+) -> Vec<surgical::ProactiveInsight> {
+    let graph = state.graph.read();
+    let file_node = find_nodes_for_file(&graph, file_path)
+        .into_iter()
+        .find(|(node_id, ext)| is_file_node(&graph, *node_id) && ext.starts_with("file::"))
+        .map(|(_, ext)| ext);
+    drop(graph);
+
+    let heuristic_summary = file_node
+        .as_deref()
+        .map(|external_id| build_surgical_heuristic_summary(state, external_id, file_path));
+    build_proactive_insights(
+        state,
+        file_path,
+        file_node.as_deref(),
+        heuristic_summary.as_ref(),
+        verification,
+    )
+}
+
+pub(crate) fn persist_daemon_alerts_from_insights(
     state: &mut SessionState,
     proactive_insights: &[surgical::ProactiveInsight],
     default_file_path: Option<&str>,
@@ -2169,25 +2193,7 @@ pub fn handle_apply(
     state.track_agent(&input.agent_id);
 
     let applied_file_path = validated_path.to_string_lossy().to_string();
-    let proactive_insights = {
-        let graph = state.graph.read();
-        let file_node = find_nodes_for_file(&graph, &applied_file_path)
-            .into_iter()
-            .find(|(node_id, ext)| is_file_node(&graph, *node_id) && ext.starts_with("file::"))
-            .map(|(_, ext)| ext);
-        drop(graph);
-
-        let heuristic_summary = file_node.as_deref().map(|external_id| {
-            build_surgical_heuristic_summary(state, external_id, &applied_file_path)
-        });
-        build_proactive_insights(
-            state,
-            &applied_file_path,
-            file_node.as_deref(),
-            heuristic_summary.as_ref(),
-            None,
-        )
-    };
+    let proactive_insights = daemon_proactive_insights_for_file(state, &applied_file_path, None);
     persist_daemon_alerts_from_insights(
         state,
         &proactive_insights,


### PR DESCRIPTION
## Summary
- move stdin reading onto a helper thread so the main serve loop can wake on timeouts
- run daemon ticks during idle periods when the daemon is active and overdue
- keep the implementation transport-agnostic and in-process, without introducing OS-specific watcher dependencies yet
- add coverage proving background ticking refreshes the graph before the next explicit tool call

## Validation
- cargo fmt --check
- cargo check -p m1nd-mcp -p m1nd-ingest
- cargo test -p m1nd-ingest -p m1nd-mcp -- --nocapture
- cargo clippy -p m1nd-mcp -p m1nd-ingest -- -D warnings
- real MCP smoke with idle wait before `daemon_status` / `search`

## Why this matters
This is the first real autonomous background behavior in the server loop. The daemon can now keep watched roots fresh even when the agent is idle, which is a meaningful category shift from opportunistic autotick-on-traffic.
