### PR TITLE
Expose daemon tick metrics in daemon_status

### DIFF
--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -153,6 +153,11 @@ pub fn handle_daemon_start(
     state.daemon_state.watch_paths = watch_paths;
     state.daemon_state.poll_interval_ms = input.poll_interval_ms;
     state.daemon_state.tracked_files = tracked_files_from_inventory(&initial_inventory);
+    state.daemon_state.tick_count = 0;
+    state.daemon_state.last_tick_duration_ms = None;
+    state.daemon_state.last_tick_changed_files = 0;
+    state.daemon_state.last_tick_deleted_files = 0;
+    state.daemon_state.last_tick_alerts_emitted = 0;
     state.persist_daemon_state()?;
     Ok(json!({
         "status": "started",
@@ -191,6 +196,11 @@ pub fn handle_daemon_status(
         "poll_interval_ms": state.daemon_state.poll_interval_ms,
         "alert_count": state.daemon_alerts.len(),
         "tracked_files": state.daemon_state.tracked_files.len(),
+        "tick_count": state.daemon_state.tick_count,
+        "last_tick_duration_ms": state.daemon_state.last_tick_duration_ms,
+        "last_tick_changed_files": state.daemon_state.last_tick_changed_files,
+        "last_tick_deleted_files": state.daemon_state.last_tick_deleted_files,
+        "last_tick_alerts_emitted": state.daemon_state.last_tick_alerts_emitted,
         "runtime_root": state.runtime_root,
         "graph_generation": state.graph_generation,
         "cache_generation": state.cache_generation,
@@ -201,6 +211,7 @@ pub fn handle_daemon_tick(
     state: &mut SessionState,
     input: layers::DaemonTickInput,
 ) -> M1ndResult<serde_json::Value> {
+    let start = std::time::Instant::now();
     if !state.daemon_state.active {
         return Err(M1ndError::InvalidParams {
             tool: "daemon_tick".into(),
@@ -250,6 +261,7 @@ pub fn handle_daemon_tick(
     changed_entries.truncate(input.max_files);
 
     let mut ingested_files = Vec::new();
+    let mut heuristic_alerts_emitted = 0usize;
     for entry in &changed_entries {
         let ingest_result = crate::tools::handle_ingest(
             state,
@@ -280,7 +292,7 @@ pub fn handle_daemon_tick(
             &entry.file_path,
             None,
         );
-        crate::surgical_handlers::persist_daemon_alerts_from_insights(
+        heuristic_alerts_emitted += crate::surgical_handlers::persist_daemon_alerts_from_insights(
             state,
             &proactive_insights,
             Some(&entry.file_path),
@@ -323,6 +335,12 @@ pub fn handle_daemon_tick(
 
     let tick_ms = now_ms();
     state.daemon_state.last_tick_ms = Some(tick_ms);
+    state.daemon_state.tick_count = state.daemon_state.tick_count.saturating_add(1);
+    state.daemon_state.last_tick_duration_ms = Some(start.elapsed().as_secs_f64() * 1000.0);
+    state.daemon_state.last_tick_changed_files = changed_entries.len();
+    state.daemon_state.last_tick_deleted_files = deleted_entries.len();
+    state.daemon_state.last_tick_alerts_emitted =
+        emitted_alert_ids.len() + heuristic_alerts_emitted;
     state.persist_daemon_state()?;
     state.persist_daemon_alerts()?;
 
@@ -338,7 +356,7 @@ pub fn handle_daemon_tick(
             "file_path": entry.file_path,
             "external_id": entry.external_id,
         })).collect::<Vec<_>>(),
-        "alerts_emitted": emitted_alert_ids.len(),
+        "alerts_emitted": emitted_alert_ids.len() + heuristic_alerts_emitted,
         "alert_ids": emitted_alert_ids,
     }))
 }
@@ -533,6 +551,7 @@ mod tests {
         .expect("daemon status");
         assert_eq!(status["active"], true);
         assert_eq!(status["alert_count"], 1);
+        assert_eq!(status["tick_count"], 0);
 
         let stopped = handle_daemon_stop(
             &mut state,
@@ -604,6 +623,16 @@ mod tests {
         assert!(ticked["ingested_files"][0]["file_path"]
             .as_str()
             .is_some_and(|path| path.ends_with("src/core.py")));
+        let status = handle_daemon_status(
+            &mut state,
+            layers::DaemonStatusInput {
+                agent_id: "test".into(),
+            },
+        )
+        .expect("daemon status after tick");
+        assert_eq!(status["tick_count"], 2);
+        assert_eq!(status["last_tick_changed_files"], 1);
+        assert_eq!(status["last_tick_deleted_files"], 0);
     }
 
     #[test]
@@ -698,6 +727,18 @@ mod tests {
             }),
             "daemon tick should persist heuristic alerts for risky changed files"
         );
+        let status = handle_daemon_status(
+            &mut state,
+            layers::DaemonStatusInput {
+                agent_id: "test".into(),
+            },
+        )
+        .expect("daemon status after risky tick");
+        assert_eq!(status["last_tick_changed_files"], 1);
+        assert!(
+            status["last_tick_alerts_emitted"].as_u64().unwrap_or(0) >= 1,
+            "risky daemon tick should emit at least one alert"
+        );
     }
 
     #[test]
@@ -749,5 +790,15 @@ mod tests {
             .daemon_alerts
             .iter()
             .any(|alert| alert.kind == "graph_vs_disk_drift"));
+        let status = handle_daemon_status(
+            &mut state,
+            layers::DaemonStatusInput {
+                agent_id: "test".into(),
+            },
+        )
+        .expect("daemon status after delete tick");
+        assert_eq!(status["last_tick_deleted_files"], 1);
+        assert_eq!(status["last_tick_alerts_emitted"], 1);
+        assert!(status["last_tick_duration_ms"].as_f64().is_some());
     }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -13,6 +13,9 @@ use m1nd_core::domain::DomainConfig;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use std::io::{BufRead, Read, Write};
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
@@ -2138,6 +2141,27 @@ fn should_autotick_daemon(tool_name: &str) -> bool {
     )
 }
 
+fn background_tick_if_due(state: &mut SessionState) {
+    if !state.daemon_state.active || state.daemon_state.poll_interval_ms == 0 {
+        return;
+    }
+    let due = state
+        .daemon_state
+        .last_tick_ms
+        .is_none_or(|last| now_ms().saturating_sub(last) >= state.daemon_state.poll_interval_ms);
+    if !due {
+        return;
+    }
+
+    let _ = crate::daemon_handlers::handle_daemon_tick(
+        state,
+        layers::DaemonTickInput {
+            agent_id: "daemon".into(),
+            max_files: 32,
+        },
+    );
+}
+
 /// Dispatch perspective tools (12 tools).
 fn dispatch_perspective_tool(
     state: &mut SessionState,
@@ -2427,17 +2451,50 @@ impl McpServer {
     /// Main event loop: read JSON-RPC from stdin, dispatch, write response to stdout.
     /// Blocks until EOF or shutdown signal.
     pub fn serve(&mut self) -> M1ndResult<()> {
-        let stdin = std::io::stdin();
         let stdout = std::io::stdout();
-        let mut reader = stdin.lock();
         let mut writer = stdout.lock();
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            loop {
+                let next = read_request_payload(&mut reader);
+                match next {
+                    Ok(Some(value)) => {
+                        if tx.send(Some(value)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        let _ = tx.send(None);
+                        break;
+                    }
+                    Err(_) => {
+                        let _ = tx.send(None);
+                        break;
+                    }
+                }
+            }
+        });
 
         loop {
-            let (payload, transport_mode) = match read_request_payload(&mut reader) {
-                Ok(Some(value)) => value,
-                Ok(None) => break,
-                Err(_) => break,
+            let daemon_wait = if self.state.daemon_state.active {
+                self.state.daemon_state.poll_interval_ms.clamp(25, 1000)
+            } else {
+                1000
             };
+
+            let (payload, transport_mode) =
+                match rx.recv_timeout(Duration::from_millis(daemon_wait)) {
+                    Ok(Some(value)) => value,
+                    Ok(None) => break,
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        background_tick_if_due(&mut self.state);
+                        continue;
+                    }
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                };
             let trimmed = payload.trim();
             if trimmed.is_empty() {
                 continue;
@@ -2629,7 +2686,26 @@ impl McpServer {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_autotick_daemon, tool_schemas};
+    use super::{background_tick_if_due, should_autotick_daemon, tool_schemas};
+    use crate::server::McpConfig;
+    use crate::session::SessionState;
+    use m1nd_core::domain::DomainConfig;
+    use m1nd_core::graph::Graph;
+
+    fn build_state() -> (tempfile::TempDir, SessionState) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..McpConfig::default()
+        };
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+        (temp, state)
+    }
 
     #[test]
     fn tool_schemas_expose_new_audit_surface_and_retrobuilder_tools() {
@@ -2686,5 +2762,71 @@ mod tests {
         }
         assert!(should_autotick_daemon("search"));
         assert!(should_autotick_daemon("apply"));
+    }
+
+    #[test]
+    fn background_tick_runs_when_daemon_is_due() {
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo src");
+        let file_path = repo.join("src/core.py");
+        std::fs::write(&file_path, "def core():\n    return 1\n").expect("write file");
+
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: repo.to_string_lossy().to_string(),
+                agent_id: "test".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+            },
+        )
+        .expect("initial ingest");
+
+        crate::daemon_handlers::handle_daemon_start(
+            &mut state,
+            crate::protocol::layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![repo.to_string_lossy().to_string()],
+                poll_interval_ms: 25,
+            },
+        )
+        .expect("daemon start");
+
+        std::fs::write(&file_path, "def core():\n    return 9\n").expect("rewrite file");
+        state.daemon_state.last_tick_ms = Some(0);
+
+        background_tick_if_due(&mut state);
+
+        let hit = crate::search_handlers::handle_search(
+            &mut state,
+            crate::protocol::layers::SearchInput {
+                query: "return 9".into(),
+                agent_id: "test".into(),
+                mode: crate::protocol::layers::SearchMode::Literal,
+                scope: None,
+                filename_pattern: None,
+                top_k: 5,
+                case_sensitive: false,
+                context_lines: 0,
+                invert: false,
+                count_only: false,
+                multiline: false,
+                auto_ingest: false,
+                max_output_chars: None,
+            },
+        )
+        .expect("search after background tick");
+
+        assert!(
+            hit.results
+                .iter()
+                .any(|result| { result.matched_line.contains("return 9") }),
+            "background tick should refresh the graph before the next explicit tool call"
+        );
     }
 }

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -167,6 +167,11 @@ pub struct DaemonRuntimeState {
     pub watch_paths: Vec<String>,
     pub poll_interval_ms: u64,
     pub tracked_files: HashMap<String, DaemonTrackedFile>,
+    pub tick_count: u64,
+    pub last_tick_duration_ms: Option<f64>,
+    pub last_tick_changed_files: usize,
+    pub last_tick_deleted_files: usize,
+    pub last_tick_alerts_emitted: usize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -339,9 +339,9 @@ pub(crate) fn persist_daemon_alerts_from_insights(
     proactive_insights: &[surgical::ProactiveInsight],
     default_file_path: Option<&str>,
     default_node_id: Option<&str>,
-) {
+) -> usize {
     if !state.daemon_state.active || proactive_insights.is_empty() {
-        return;
+        return 0;
     }
 
     let tick_ms = SystemTime::now()
@@ -350,6 +350,7 @@ pub(crate) fn persist_daemon_alerts_from_insights(
         .unwrap_or(0);
     state.daemon_state.last_tick_ms = Some(tick_ms);
 
+    let emitted_count = proactive_insights.iter().take(3).count();
     for insight in proactive_insights.iter().take(3) {
         let alert_file_path = insight
             .suggested_target
@@ -389,6 +390,7 @@ pub(crate) fn persist_daemon_alerts_from_insights(
             error
         );
     }
+    emitted_count
 }
 
 fn surgical_dampened_trust_factor(raw_factor: f32) -> f32 {
@@ -2194,7 +2196,7 @@ pub fn handle_apply(
 
     let applied_file_path = validated_path.to_string_lossy().to_string();
     let proactive_insights = daemon_proactive_insights_for_file(state, &applied_file_path, None);
-    persist_daemon_alerts_from_insights(
+    let _ = persist_daemon_alerts_from_insights(
         state,
         &proactive_insights,
         Some(&applied_file_path),
@@ -3732,7 +3734,7 @@ pub fn handle_apply_batch(
             .first()
             .map(|impact| impact.node_id.as_str())
     });
-    persist_daemon_alerts_from_insights(
+    let _ = persist_daemon_alerts_from_insights(
         state,
         &proactive_insights,
         primary_file_path,


### PR DESCRIPTION
## Summary
- extend `daemon_status` with tick metrics: count, duration, changed/deleted file counts, and emitted alert count
- update daemon bookkeeping so those metrics reflect both deletion drift and heuristic drift alerts
- keep daemon observability in the existing status surface instead of adding a separate metrics tool

## Validation
- cargo fmt --check
- cargo check -p m1nd-mcp -p m1nd-ingest
- cargo test -p m1nd-mcp daemon_ -- --nocapture
- cargo clippy -p m1nd-mcp -p m1nd-ingest -- -D warnings
- MCP smoke for `daemon_status` metric fields

## Why this matters
This closes the current daemon phase with inspectability. The daemon is now not only autonomous enough to tick in the background, but observable enough for agents and humans to trust what it is doing.
