### PR TITLE
Add adaptive backoff to the daemon scheduler

### DIFF
--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -158,6 +158,8 @@ pub fn handle_daemon_start(
     state.daemon_state.last_tick_changed_files = 0;
     state.daemon_state.last_tick_deleted_files = 0;
     state.daemon_state.last_tick_alerts_emitted = 0;
+    state.daemon_state.idle_streak = 0;
+    state.daemon_state.max_backoff_multiplier = 8;
     state.persist_daemon_state()?;
     Ok(json!({
         "status": "started",
@@ -198,6 +200,14 @@ pub fn handle_daemon_status(
         None
     };
     let overdue_ms = next_tick_due_ms.map(|due| now.saturating_sub(due));
+    let effective_poll_interval_ms = state.daemon_state.poll_interval_ms.saturating_mul(
+        2u64.pow(
+            state
+                .daemon_state
+                .idle_streak
+                .min(state.daemon_state.max_backoff_multiplier.saturating_sub(1)),
+        ),
+    );
     Ok(json!({
         "active": state.daemon_state.active,
         "started_at_ms": state.daemon_state.started_at_ms,
@@ -206,6 +216,7 @@ pub fn handle_daemon_status(
         "overdue_ms": overdue_ms,
         "watch_paths": state.daemon_state.watch_paths,
         "poll_interval_ms": state.daemon_state.poll_interval_ms,
+        "effective_poll_interval_ms": effective_poll_interval_ms,
         "alert_count": state.daemon_alerts.len(),
         "tracked_files": state.daemon_state.tracked_files.len(),
         "tick_count": state.daemon_state.tick_count,
@@ -213,6 +224,8 @@ pub fn handle_daemon_status(
         "last_tick_changed_files": state.daemon_state.last_tick_changed_files,
         "last_tick_deleted_files": state.daemon_state.last_tick_deleted_files,
         "last_tick_alerts_emitted": state.daemon_state.last_tick_alerts_emitted,
+        "idle_streak": state.daemon_state.idle_streak,
+        "max_backoff_multiplier": state.daemon_state.max_backoff_multiplier,
         "runtime_root": state.runtime_root,
         "graph_generation": state.graph_generation,
         "cache_generation": state.cache_generation,
@@ -346,13 +359,18 @@ pub fn handle_daemon_tick(
     }
 
     let tick_ms = now_ms();
+    let emitted_alerts_total = emitted_alert_ids.len() + heuristic_alerts_emitted;
     state.daemon_state.last_tick_ms = Some(tick_ms);
     state.daemon_state.tick_count = state.daemon_state.tick_count.saturating_add(1);
     state.daemon_state.last_tick_duration_ms = Some(start.elapsed().as_secs_f64() * 1000.0);
     state.daemon_state.last_tick_changed_files = changed_entries.len();
     state.daemon_state.last_tick_deleted_files = deleted_entries.len();
-    state.daemon_state.last_tick_alerts_emitted =
-        emitted_alert_ids.len() + heuristic_alerts_emitted;
+    state.daemon_state.last_tick_alerts_emitted = emitted_alerts_total;
+    if changed_entries.is_empty() && deleted_entries.is_empty() && emitted_alerts_total == 0 {
+        state.daemon_state.idle_streak = state.daemon_state.idle_streak.saturating_add(1);
+    } else {
+        state.daemon_state.idle_streak = 0;
+    }
     state.persist_daemon_state()?;
     state.persist_daemon_alerts()?;
 
@@ -368,7 +386,7 @@ pub fn handle_daemon_tick(
             "file_path": entry.file_path,
             "external_id": entry.external_id,
         })).collect::<Vec<_>>(),
-        "alerts_emitted": emitted_alert_ids.len() + heuristic_alerts_emitted,
+        "alerts_emitted": emitted_alerts_total,
         "alert_ids": emitted_alert_ids,
     }))
 }
@@ -566,6 +584,7 @@ mod tests {
         assert_eq!(status["tick_count"], 0);
         assert!(status["next_tick_due_ms"].as_u64().is_some());
         assert_eq!(status["overdue_ms"], 0);
+        assert_eq!(status["idle_streak"], 0);
 
         let stopped = handle_daemon_stop(
             &mut state,
@@ -648,6 +667,7 @@ mod tests {
         assert_eq!(status["last_tick_changed_files"], 1);
         assert_eq!(status["last_tick_deleted_files"], 0);
         assert!(status["next_tick_due_ms"].as_u64().is_some());
+        assert_eq!(status["idle_streak"], 0);
     }
 
     #[test]
@@ -754,6 +774,7 @@ mod tests {
             status["last_tick_alerts_emitted"].as_u64().unwrap_or(0) >= 1,
             "risky daemon tick should emit at least one alert"
         );
+        assert_eq!(status["idle_streak"], 0);
     }
 
     #[test]
@@ -816,5 +837,6 @@ mod tests {
         assert_eq!(status["last_tick_alerts_emitted"], 1);
         assert!(status["last_tick_duration_ms"].as_f64().is_some());
         assert!(status["next_tick_due_ms"].as_u64().is_some());
+        assert_eq!(status["idle_streak"], 0);
     }
 }

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -188,10 +188,22 @@ pub fn handle_daemon_status(
     state: &mut SessionState,
     _input: layers::DaemonStatusInput,
 ) -> M1ndResult<serde_json::Value> {
+    let now = now_ms();
+    let next_tick_due_ms = if state.daemon_state.active && state.daemon_state.poll_interval_ms > 0 {
+        state
+            .daemon_state
+            .last_tick_ms
+            .map(|last| last.saturating_add(state.daemon_state.poll_interval_ms))
+    } else {
+        None
+    };
+    let overdue_ms = next_tick_due_ms.map(|due| now.saturating_sub(due));
     Ok(json!({
         "active": state.daemon_state.active,
         "started_at_ms": state.daemon_state.started_at_ms,
         "last_tick_ms": state.daemon_state.last_tick_ms,
+        "next_tick_due_ms": next_tick_due_ms,
+        "overdue_ms": overdue_ms,
         "watch_paths": state.daemon_state.watch_paths,
         "poll_interval_ms": state.daemon_state.poll_interval_ms,
         "alert_count": state.daemon_alerts.len(),
@@ -552,6 +564,8 @@ mod tests {
         assert_eq!(status["active"], true);
         assert_eq!(status["alert_count"], 1);
         assert_eq!(status["tick_count"], 0);
+        assert!(status["next_tick_due_ms"].as_u64().is_some());
+        assert_eq!(status["overdue_ms"], 0);
 
         let stopped = handle_daemon_stop(
             &mut state,
@@ -633,6 +647,7 @@ mod tests {
         assert_eq!(status["tick_count"], 2);
         assert_eq!(status["last_tick_changed_files"], 1);
         assert_eq!(status["last_tick_deleted_files"], 0);
+        assert!(status["next_tick_due_ms"].as_u64().is_some());
     }
 
     #[test]
@@ -800,5 +815,6 @@ mod tests {
         assert_eq!(status["last_tick_deleted_files"], 1);
         assert_eq!(status["last_tick_alerts_emitted"], 1);
         assert!(status["last_tick_duration_ms"].as_f64().is_some());
+        assert!(status["next_tick_due_ms"].as_u64().is_some());
     }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -2162,6 +2162,31 @@ fn background_tick_if_due(state: &mut SessionState) {
     );
 }
 
+fn daemon_wait_duration_ms(state: &SessionState) -> u64 {
+    if !state.daemon_state.active {
+        return 1000;
+    }
+    if state.daemon_state.poll_interval_ms == 0 {
+        return 1000;
+    }
+
+    match state.daemon_state.last_tick_ms {
+        Some(last_tick_ms) => {
+            let elapsed = now_ms().saturating_sub(last_tick_ms);
+            if elapsed >= state.daemon_state.poll_interval_ms {
+                25
+            } else {
+                state
+                    .daemon_state
+                    .poll_interval_ms
+                    .saturating_sub(elapsed)
+                    .clamp(25, 1000)
+            }
+        }
+        None => 25,
+    }
+}
+
 /// Dispatch perspective tools (12 tools).
 fn dispatch_perspective_tool(
     state: &mut SessionState,
@@ -2479,22 +2504,17 @@ impl McpServer {
         });
 
         loop {
-            let daemon_wait = if self.state.daemon_state.active {
-                self.state.daemon_state.poll_interval_ms.clamp(25, 1000)
-            } else {
-                1000
+            let (payload, transport_mode) = match rx
+                .recv_timeout(Duration::from_millis(daemon_wait_duration_ms(&self.state)))
+            {
+                Ok(Some(value)) => value,
+                Ok(None) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    background_tick_if_due(&mut self.state);
+                    continue;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
             };
-
-            let (payload, transport_mode) =
-                match rx.recv_timeout(Duration::from_millis(daemon_wait)) {
-                    Ok(Some(value)) => value,
-                    Ok(None) => break,
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        background_tick_if_due(&mut self.state);
-                        continue;
-                    }
-                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                };
             let trimmed = payload.trim();
             if trimmed.is_empty() {
                 continue;
@@ -2686,7 +2706,9 @@ impl McpServer {
 
 #[cfg(test)]
 mod tests {
-    use super::{background_tick_if_due, should_autotick_daemon, tool_schemas};
+    use super::{
+        background_tick_if_due, daemon_wait_duration_ms, should_autotick_daemon, tool_schemas,
+    };
     use crate::server::McpConfig;
     use crate::session::SessionState;
     use m1nd_core::domain::DomainConfig;
@@ -2828,5 +2850,23 @@ mod tests {
                 .any(|result| { result.matched_line.contains("return 9") }),
             "background tick should refresh the graph before the next explicit tool call"
         );
+    }
+
+    #[test]
+    fn daemon_wait_duration_uses_remaining_time_until_next_tick() {
+        let (_temp, mut state) = build_state();
+        state.daemon_state.active = true;
+        state.daemon_state.poll_interval_ms = 500;
+        state.daemon_state.last_tick_ms = Some(super::now_ms().saturating_sub(125));
+
+        let wait_ms = daemon_wait_duration_ms(&state);
+        assert!(
+            (300..=400).contains(&wait_ms),
+            "remaining wait should be close to the poll interval remainder"
+        );
+
+        state.daemon_state.last_tick_ms = Some(0);
+        let overdue_wait_ms = daemon_wait_duration_ms(&state);
+        assert_eq!(overdue_wait_ms, 25);
     }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -2170,15 +2170,23 @@ fn daemon_wait_duration_ms(state: &SessionState) -> u64 {
         return 1000;
     }
 
+    let exponent = state
+        .daemon_state
+        .idle_streak
+        .min(state.daemon_state.max_backoff_multiplier.saturating_sub(1));
+    let effective_poll_interval_ms = state
+        .daemon_state
+        .poll_interval_ms
+        .saturating_mul(2u64.pow(exponent))
+        .clamp(25, 10_000);
+
     match state.daemon_state.last_tick_ms {
         Some(last_tick_ms) => {
             let elapsed = now_ms().saturating_sub(last_tick_ms);
-            if elapsed >= state.daemon_state.poll_interval_ms {
+            if elapsed >= effective_poll_interval_ms {
                 25
             } else {
-                state
-                    .daemon_state
-                    .poll_interval_ms
+                effective_poll_interval_ms
                     .saturating_sub(elapsed)
                     .clamp(25, 1000)
             }
@@ -2868,5 +2876,21 @@ mod tests {
         state.daemon_state.last_tick_ms = Some(0);
         let overdue_wait_ms = daemon_wait_duration_ms(&state);
         assert_eq!(overdue_wait_ms, 25);
+    }
+
+    #[test]
+    fn daemon_wait_duration_expands_with_idle_backoff() {
+        let (_temp, mut state) = build_state();
+        state.daemon_state.active = true;
+        state.daemon_state.poll_interval_ms = 200;
+        state.daemon_state.last_tick_ms = Some(super::now_ms());
+        state.daemon_state.idle_streak = 2;
+        state.daemon_state.max_backoff_multiplier = 8;
+
+        let wait_ms = daemon_wait_duration_ms(&state);
+        assert!(
+            (700..=800).contains(&wait_ms),
+            "idle streak should expand effective wait close to 4x the base interval"
+        );
     }
 }

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -172,6 +172,8 @@ pub struct DaemonRuntimeState {
     pub last_tick_changed_files: usize,
     pub last_tick_deleted_files: usize,
     pub last_tick_alerts_emitted: usize,
+    pub idle_streak: u32,
+    pub max_backoff_multiplier: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add idle-streak tracking and adaptive poll backoff to the daemon scheduler
- expose `effective_poll_interval_ms` and `idle_streak` in `daemon_status`
- keep `next_tick_due_ms` / `overdue_ms` aligned with the effective scheduler interval

## Validation
- cargo fmt --check
- cargo check -p m1nd-mcp -p m1nd-ingest
- cargo test -p m1nd-mcp daemon_ -- --nocapture
- cargo clippy -p m1nd-mcp -p m1nd-ingest -- -D warnings
- MCP smoke for `effective_poll_interval_ms` / `idle_streak` / `next_tick_due_ms` / `overdue_ms`

## Why this matters
This makes the daemon scheduler materially smarter before native watcher dependencies arrive. The daemon now backs off when the workspace is quiet, while still exposing exactly when it plans to wake up next.
