### PR TITLE
Port universal l1ght ingest into the canonical m1nd engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "quick-xml",
  "rayon",
  "regex",
+ "serde",
  "serde_json",
  "tree-sitter",
  "tree-sitter-bash",

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -42,6 +42,7 @@ tier2 = [
 
 [dependencies]
 m1nd-core = { path = "../m1nd-core", version = "0.7.0" }
+serde = { workspace = true }
 regex = "1"
 walkdir = "2"
 rayon = "1.10"

--- a/m1nd-ingest/src/canonical.rs
+++ b/m1nd-ingest/src/canonical.rs
@@ -1,0 +1,292 @@
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    NativeLight,
+    NativeArticle,
+    NativeBibtex,
+    NativeCrossref,
+    NativeRfc,
+    NativePatent,
+    Markdown,
+    Text,
+    Html,
+    Pdf,
+    Docx,
+    Pptx,
+    Xlsx,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfidenceLevel {
+    Explicit,
+    #[default]
+    Parsed,
+    Inferred,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentBlockKind {
+    Heading,
+    Paragraph,
+    ListItem,
+    Code,
+    Quote,
+    Table,
+    Link,
+    Text,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentSectionKind {
+    Overview,
+    Api,
+    Constraints,
+    Tests,
+    Rollout,
+    Reference,
+    Appendix,
+    #[default]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentEntityKind {
+    Symbol,
+    FilePath,
+    ToolId,
+    CitationId,
+    CodeRef,
+    NamedTerm,
+    TestName,
+    #[default]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DocumentClaimKind {
+    Requirement,
+    Invariant,
+    Warning,
+    Decision,
+    TestExpectation,
+    Capability,
+    #[default]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimModality {
+    Must,
+    Should,
+    May,
+    Is,
+    #[default]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentMetadata {
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+    pub authors: Vec<String>,
+    pub doi: Option<String>,
+    pub published_at: Option<String>,
+    pub language: Option<String>,
+    pub extra: std::collections::HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct ProvenanceSpan {
+    pub line_start: Option<u32>,
+    pub line_end: Option<u32>,
+    pub excerpt: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentSpan {
+    pub text: String,
+    pub kind: String,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentBlock {
+    pub block_id: String,
+    pub kind: DocumentBlockKind,
+    pub text: String,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub spans: Vec<DocumentSpan>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentSection {
+    pub section_id: String,
+    pub heading: String,
+    pub level: u8,
+    #[serde(default)]
+    pub kind: DocumentSectionKind,
+    #[serde(default)]
+    pub parent_section_id: Option<String>,
+    pub blocks: Vec<DocumentBlock>,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentTableCell {
+    pub text: String,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentTableRow {
+    pub cells: Vec<DocumentTableCell>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentTable {
+    pub table_id: String,
+    pub headers: Vec<String>,
+    pub rows: Vec<DocumentTableRow>,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentLink {
+    pub label: String,
+    pub target: String,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentCitation {
+    pub label: String,
+    pub target: String,
+    #[serde(default)]
+    pub citation_kind: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub authors: Vec<String>,
+    #[serde(default)]
+    pub venue: Option<String>,
+    #[serde(default)]
+    pub year: Option<String>,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentEntityCandidate {
+    pub label: String,
+    pub kind: DocumentEntityKind,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentClaimCandidate {
+    pub claim_id: String,
+    pub label: String,
+    #[serde(default)]
+    pub kind: DocumentClaimKind,
+    #[serde(default)]
+    pub modality: ClaimModality,
+    #[serde(default)]
+    pub subject: Option<String>,
+    #[serde(default)]
+    pub predicate: Option<String>,
+    #[serde(default)]
+    pub object: Option<String>,
+    #[serde(default)]
+    pub negated: bool,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentCodeCandidate {
+    pub label: String,
+    pub candidate_kind: DocumentEntityKind,
+    pub confidence: ConfidenceLevel,
+    pub provenance: ProvenanceSpan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CanonicalDocument {
+    pub doc_id: String,
+    pub source_path: String,
+    pub source_kind: SourceKind,
+    pub detected_type: String,
+    pub producer: String,
+    pub content_hash: String,
+    pub title: String,
+    pub plain_text: String,
+    pub metadata: DocumentMetadata,
+    pub sections: Vec<DocumentSection>,
+    #[serde(default)]
+    pub tables: Vec<DocumentTable>,
+    pub links: Vec<DocumentLink>,
+    pub citations: Vec<DocumentCitation>,
+    pub entities: Vec<DocumentEntityCandidate>,
+    pub claims: Vec<DocumentClaimCandidate>,
+    #[serde(default)]
+    pub code_candidates: Vec<DocumentCodeCandidate>,
+    pub confidence: ConfidenceLevel,
+    #[serde(default)]
+    pub structured_origin: serde_json::Value,
+}
+
+pub fn short_hash(input: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    input.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+pub fn short_hash_bytes(input: &[u8]) -> String {
+    let mut hasher = DefaultHasher::new();
+    input.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+pub fn source_key(source_path: &str) -> String {
+    short_hash(source_path)
+}
+
+pub fn source_kind_from_extension(path: &Path) -> SourceKind {
+    match path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("md" | "markdown") => SourceKind::Markdown,
+        Some("txt" | "rst" | "adoc") => SourceKind::Text,
+        Some("html" | "htm") => SourceKind::Html,
+        Some("pdf") => SourceKind::Pdf,
+        Some("docx") => SourceKind::Docx,
+        Some("pptx") => SourceKind::Pptx,
+        Some("xlsx") => SourceKind::Xlsx,
+        _ => SourceKind::Unknown,
+    }
+}

--- a/m1nd-ingest/src/document_router.rs
+++ b/m1nd-ingest/src/document_router.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     BibTexAdapter, CrossRefAdapter, IngestAdapter, JatsArticleAdapter, L1ghtIngestAdapter,
-    PatentIngestAdapter, RfcAdapter,
+    PatentIngestAdapter, RfcAdapter, UniversalIngestAdapter,
 };
 use std::path::Path;
 
@@ -25,6 +25,8 @@ pub enum DocumentFormat {
     BibTeX,
     /// L1GHT protocol Markdown
     L1ght,
+    /// Universal document lane
+    Universal,
     /// Source code or unknown format
     Code,
 }
@@ -38,6 +40,7 @@ impl std::fmt::Display for DocumentFormat {
             Self::CrossRef => write!(f, "crossref"),
             Self::BibTeX => write!(f, "bibtex"),
             Self::L1ght => write!(f, "light"),
+            Self::Universal => write!(f, "universal"),
             Self::Code => write!(f, "code"),
         }
     }
@@ -74,7 +77,20 @@ impl DocumentRouter {
                     );
                 }
             }
-            return (DocumentFormat::Code, None);
+            return (
+                DocumentFormat::Universal,
+                Some(Box::new(UniversalIngestAdapter::new(None))),
+            );
+        }
+
+        if matches!(
+            ext.as_str(),
+            "txt" | "rst" | "adoc" | "html" | "htm" | "pdf" | "docx" | "pptx" | "xlsx"
+        ) {
+            return (
+                DocumentFormat::Universal,
+                Some(Box::new(UniversalIngestAdapter::new(None))),
+            );
         }
 
         // XML — inspect content header
@@ -152,7 +168,7 @@ impl DocumentRouter {
             return Self::detect(root);
         }
 
-        let mut counts = [0u32; 6]; // Patent, Article, BibTeX, L1ght, Rfc, CrossRef
+        let mut counts = [0u32; 7]; // Patent, Article, BibTeX, L1ght, Rfc, CrossRef, Universal
 
         for entry in walkdir::WalkDir::new(root)
             .max_depth(3)
@@ -169,6 +185,7 @@ impl DocumentRouter {
                 DocumentFormat::L1ght => counts[3] += 1,
                 DocumentFormat::Rfc => counts[4] += 1,
                 DocumentFormat::CrossRef => counts[5] += 1,
+                DocumentFormat::Universal => counts[6] += 1,
                 DocumentFormat::Code => {}
             }
         }
@@ -206,6 +223,10 @@ impl DocumentRouter {
             5 => (
                 DocumentFormat::CrossRef,
                 Some(Box::new(CrossRefAdapter::new(None))),
+            ),
+            6 => (
+                DocumentFormat::Universal,
+                Some(Box::new(UniversalIngestAdapter::new(None))),
             ),
             _ => (DocumentFormat::Code, None),
         }
@@ -290,6 +311,21 @@ mod tests {
         .unwrap();
         let (fmt, adapter) = DocumentRouter::detect(&dir.join("work.json"));
         assert_eq!(fmt, DocumentFormat::CrossRef);
+        assert!(adapter.is_some());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detects_universal_markdown_without_l1ght() {
+        let dir = std::env::temp_dir().join("router-universal-md");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("notes.md"),
+            "# Overview\n\nTokenValidator appears here.\n",
+        )
+        .unwrap();
+        let (fmt, adapter) = DocumentRouter::detect(&dir.join("notes.md"));
+        assert_eq!(fmt, DocumentFormat::Universal);
         assert!(adapter.is_some());
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/m1nd-ingest/src/lib.rs
+++ b/m1nd-ingest/src/lib.rs
@@ -7,6 +7,7 @@ use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
 
 pub mod bibtex_adapter;
+pub mod canonical;
 pub mod cargo_workspace;
 pub mod cross_domain;
 pub mod cross_file;
@@ -22,6 +23,7 @@ pub mod merge;
 pub mod patent_adapter;
 pub mod resolve;
 pub mod rfc_adapter;
+pub mod universal_adapter;
 pub mod walker;
 
 pub use bibtex_adapter::BibTexAdapter;
@@ -30,6 +32,14 @@ pub use jats_adapter::JatsArticleAdapter;
 pub use l1ght_adapter::L1ghtIngestAdapter;
 pub use patent_adapter::PatentIngestAdapter;
 pub use rfc_adapter::RfcAdapter;
+pub use universal_adapter::{ProviderAvailability, UniversalIngestAdapter, UniversalIngestBundle};
+
+pub(crate) fn extension_of(path: &Path) -> String {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default()
+}
 
 fn is_valid_relative_file_path(rel_path: &str) -> bool {
     let trimmed = rel_path.trim();
@@ -49,6 +59,21 @@ fn build_file_external_id(rel_path: &str) -> Option<String> {
     }
 
     Some(format!("file::{}", trimmed))
+}
+
+pub(crate) fn relative_source_path(root: &Path, path: &Path) -> String {
+    if root.is_file() {
+        return path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.to_string())
+            .unwrap_or_else(|| path.to_string_lossy().replace('\\', "/"));
+    }
+
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 fn is_valid_external_id(external_id: &str) -> bool {

--- a/m1nd-ingest/src/merge.rs
+++ b/m1nd-ingest/src/merge.rs
@@ -1,6 +1,7 @@
 use m1nd_core::error::M1ndResult;
 use m1nd_core::graph::{Graph, NodeProvenanceInput};
 use m1nd_core::types::{EdgeDirection, EdgeIdx, NodeId};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -17,6 +18,22 @@ struct EdgeRecord {
     key: EdgeKey,
     weight: f32,
     causal_strength: f32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ClaimedEdgeKey {
+    pub source: String,
+    pub target: String,
+    pub relation: String,
+    pub direction: u8,
+    pub inhibitory: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct SourceClaims {
+    pub source_hint: Option<String>,
+    pub node_ids: Vec<String>,
+    pub edges: Vec<ClaimedEdgeKey>,
 }
 
 fn is_valid_relative_file_path(rel_path: &str) -> bool {
@@ -84,6 +101,26 @@ fn canonical_edge_key(
     }
 }
 
+fn edge_key_to_claimed(key: &EdgeKey) -> ClaimedEdgeKey {
+    ClaimedEdgeKey {
+        source: key.source.clone(),
+        target: key.target.clone(),
+        relation: key.relation.clone(),
+        direction: key.direction,
+        inhibitory: key.inhibitory,
+    }
+}
+
+fn claimed_to_edge_key(key: &ClaimedEdgeKey) -> EdgeKey {
+    EdgeKey {
+        source: key.source.clone(),
+        target: key.target.clone(),
+        relation: key.relation.clone(),
+        direction: key.direction,
+        inhibitory: key.inhibitory,
+    }
+}
+
 fn merge_tags(existing: &[String], incoming: &[String]) -> Vec<String> {
     let mut merged = Vec::with_capacity(existing.len() + incoming.len());
     let mut seen = HashSet::new();
@@ -136,6 +173,172 @@ fn collect_edges(graph: &Graph) -> (Vec<EdgeRecord>, u64) {
     }
 
     (out, skipped_invalid_edges)
+}
+
+pub fn collect_source_claims(graph: &Graph) -> SourceClaims {
+    let node_ids = node_external_ids(graph);
+    let mut claims = SourceClaims::default();
+    let mut claimed_nodes = HashSet::new();
+    let mut claimed_edges = HashSet::new();
+
+    for (idx, external_id) in node_ids.iter().enumerate() {
+        if !is_valid_external_id(external_id) {
+            continue;
+        }
+
+        let provenance = graph.resolve_node_provenance(NodeId::new(idx as u32));
+        if provenance.canonical {
+            if claims.source_hint.is_none() {
+                claims.source_hint = provenance.source_path.clone();
+            }
+            if claimed_nodes.insert(external_id.clone()) {
+                claims.node_ids.push(external_id.clone());
+            }
+        }
+    }
+
+    let (edges, _) = collect_edges(graph);
+    for record in edges {
+        let claimed = edge_key_to_claimed(&record.key);
+        if claimed_edges.insert(claimed.clone()) {
+            claims.edges.push(claimed);
+        }
+    }
+
+    claims
+}
+
+pub fn prune_source_claims(
+    base: &Graph,
+    target_source: &str,
+    claims_by_source: &HashMap<String, SourceClaims>,
+) -> M1ndResult<Graph> {
+    let Some(target_claims) = claims_by_source.get(target_source) else {
+        return merge_graphs(&Graph::new(), base);
+    };
+
+    let mut node_claim_counts: HashMap<&str, usize> = HashMap::new();
+    let mut edge_claim_counts: HashMap<ClaimedEdgeKey, usize> = HashMap::new();
+
+    for (source, claims) in claims_by_source {
+        if source == target_source {
+            continue;
+        }
+        for node_id in &claims.node_ids {
+            *node_claim_counts.entry(node_id.as_str()).or_insert(0) += 1;
+        }
+        for edge in &claims.edges {
+            *edge_claim_counts.entry(edge.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let removed_node_ids: HashSet<String> = target_claims
+        .node_ids
+        .iter()
+        .filter(|node_id| !node_claim_counts.contains_key(node_id.as_str()))
+        .cloned()
+        .collect();
+    let removed_edge_keys: HashSet<EdgeKey> = target_claims
+        .edges
+        .iter()
+        .filter(|edge| !edge_claim_counts.contains_key(*edge))
+        .map(claimed_to_edge_key)
+        .collect();
+
+    let base_ids = node_external_ids(base);
+    let mut pruned = Graph::with_capacity(base.num_nodes() as usize, base.num_edges());
+    let mut retained_node_ids = HashSet::new();
+
+    for (idx, external_id) in base_ids.iter().enumerate() {
+        if !is_valid_external_id(external_id) || removed_node_ids.contains(external_id) {
+            continue;
+        }
+
+        let label = base.strings.resolve(base.nodes.label[idx]).to_string();
+        let tags: Vec<String> = base.nodes.tags[idx]
+            .iter()
+            .map(|&tag| base.strings.resolve(tag).to_string())
+            .collect();
+        let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+        let node_id = pruned.add_node(
+            external_id,
+            &label,
+            base.nodes.node_type[idx],
+            &tag_refs,
+            base.nodes.last_modified[idx],
+            base.nodes.change_frequency[idx].get(),
+        )?;
+        let provenance = base.resolve_node_provenance(NodeId::new(idx as u32));
+        pruned.set_node_provenance(
+            node_id,
+            NodeProvenanceInput {
+                source_path: provenance.source_path.as_deref(),
+                line_start: provenance.line_start,
+                line_end: provenance.line_end,
+                excerpt: provenance.excerpt.as_deref(),
+                namespace: provenance.namespace.as_deref(),
+                canonical: provenance.canonical,
+            },
+        );
+        retained_node_ids.insert(external_id.clone());
+    }
+
+    for src in 0..base.num_nodes() as usize {
+        let src_ext = &base_ids[src];
+        if !retained_node_ids.contains(src_ext) {
+            continue;
+        }
+
+        for edge_idx in base.csr.out_range(NodeId::new(src as u32)) {
+            let target = base.csr.targets[edge_idx].as_usize();
+            let tgt_ext = &base_ids[target];
+            if !retained_node_ids.contains(tgt_ext) {
+                continue;
+            }
+
+            let direction = base.csr.directions[edge_idx];
+            if direction == EdgeDirection::Bidirectional && src > target {
+                continue;
+            }
+
+            let relation = base
+                .strings
+                .resolve(base.csr.relations[edge_idx])
+                .to_string();
+            let edge_key = canonical_edge_key(
+                src_ext,
+                tgt_ext,
+                &relation,
+                direction,
+                base.csr.inhibitory[edge_idx],
+            );
+            if removed_edge_keys.contains(&edge_key) {
+                continue;
+            }
+
+            let source = pruned
+                .resolve_id(src_ext)
+                .expect("retained source node must exist");
+            let target = pruned
+                .resolve_id(tgt_ext)
+                .expect("retained target node must exist");
+            pruned.add_edge(
+                source,
+                target,
+                &relation,
+                base.csr.read_weight(EdgeIdx::new(edge_idx as u32)),
+                direction,
+                base.csr.inhibitory[edge_idx],
+                base.csr.causal_strengths[edge_idx],
+            )?;
+        }
+    }
+
+    if pruned.num_nodes() > 0 {
+        pruned.finalize()?;
+    }
+
+    Ok(pruned)
 }
 
 pub fn merge_graphs(base: &Graph, overlay: &Graph) -> M1ndResult<Graph> {

--- a/m1nd-ingest/src/universal_adapter.rs
+++ b/m1nd-ingest/src/universal_adapter.rs
@@ -1,0 +1,1515 @@
+use crate::canonical::{
+    short_hash, short_hash_bytes, source_kind_from_extension, CanonicalDocument, ClaimModality,
+    ConfidenceLevel, DocumentBlock, DocumentBlockKind, DocumentCitation, DocumentClaimCandidate,
+    DocumentClaimKind, DocumentCodeCandidate, DocumentEntityCandidate, DocumentEntityKind,
+    DocumentLink, DocumentMetadata, DocumentSection, DocumentSectionKind, DocumentSpan,
+    DocumentTable, DocumentTableCell, DocumentTableRow, ProvenanceSpan, SourceKind,
+};
+use crate::{extension_of, relative_source_path};
+use crate::{
+    BibTexAdapter, CrossRefAdapter, IngestAdapter, IngestStats, JatsArticleAdapter,
+    L1ghtIngestAdapter, PatentIngestAdapter, RfcAdapter,
+};
+use m1nd_core::error::{M1ndError, M1ndResult};
+use m1nd_core::graph::{Graph, NodeProvenanceInput};
+use m1nd_core::types::{EdgeDirection, FiniteF32, NodeType};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use walkdir::WalkDir;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct ProviderAvailability {
+    pub magika: bool,
+    pub docling: bool,
+    pub markitdown: bool,
+    pub trafilatura: bool,
+    pub grobid: bool,
+    pub marker: bool,
+    pub mineru: bool,
+}
+
+pub struct UniversalIngestBundle {
+    pub graph: Graph,
+    pub stats: IngestStats,
+    pub documents: Vec<CanonicalDocument>,
+}
+
+pub struct UniversalIngestAdapter {
+    namespace: String,
+}
+
+impl UniversalIngestAdapter {
+    pub fn new(namespace: Option<String>) -> Self {
+        Self {
+            namespace: namespace.unwrap_or_else(|| "universal".to_string()),
+        }
+    }
+
+    pub fn provider_availability() -> ProviderAvailability {
+        ProviderAvailability {
+            magika: python_module_available("magika"),
+            docling: python_module_available("docling"),
+            markitdown: python_module_available("markitdown"),
+            trafilatura: python_module_available("trafilatura"),
+            grobid: grobid_configured(),
+            marker: command_available("marker"),
+            mineru: command_available("mineru"),
+        }
+    }
+
+    pub fn provider_python_command() -> String {
+        provider_python()
+    }
+
+    pub fn can_handle_path(path: &Path) -> bool {
+        let ext = extension_of(path);
+        matches!(
+            ext.as_str(),
+            "md" | "markdown"
+                | "txt"
+                | "rst"
+                | "adoc"
+                | "html"
+                | "htm"
+                | "pdf"
+                | "docx"
+                | "pptx"
+                | "xlsx"
+                | "xml"
+                | "nxml"
+                | "json"
+                | "bib"
+                | "bibtex"
+        )
+    }
+
+    pub fn ingest_bundle(&self, root: &Path) -> M1ndResult<UniversalIngestBundle> {
+        let start = std::time::Instant::now();
+        let mut stats = IngestStats::default();
+        let files = collect_candidate_files(root);
+        stats.files_scanned = files.len() as u64;
+
+        let mut documents = Vec::new();
+        for path in files {
+            if let Some(document) = self.canonicalize_path(root, &path)? {
+                stats.files_parsed += 1;
+                documents.push(document);
+            }
+        }
+
+        let graph = graphify_documents(&documents, &self.namespace)?;
+        stats.nodes_created = graph.num_nodes() as u64;
+        stats.edges_created = graph.num_edges() as u64;
+        stats.elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        Ok(UniversalIngestBundle {
+            graph,
+            stats,
+            documents,
+        })
+    }
+
+    fn canonicalize_path(&self, root: &Path, path: &Path) -> M1ndResult<Option<CanonicalDocument>> {
+        let rel_path = relative_source_path(root, path);
+        let source_kind = source_kind_from_extension(path);
+        let availability = Self::provider_availability();
+        let bytes = fs::read(path).map_err(|error| M1ndError::InvalidParams {
+            tool: "universal_ingest".into(),
+            detail: format!("failed to read {}: {}", path.display(), error),
+        })?;
+        let source_text = String::from_utf8_lossy(&bytes).to_string();
+
+        let mut document = match source_kind {
+            SourceKind::Markdown | SourceKind::Text => {
+                canonicalize_plain_text(&rel_path, source_kind, "universal:internal", &source_text)
+            }
+            SourceKind::Html => {
+                if availability.trafilatura {
+                    canonicalize_html_with_fallback(
+                        &rel_path,
+                        "universal:trafilatura",
+                        "universal:internal-html",
+                        trafilatura_extract(path).as_deref().unwrap_or(&source_text),
+                    )
+                } else if availability.docling {
+                    let extracted = docling_extract(path);
+                    canonicalize_html_with_fallback(
+                        &rel_path,
+                        "universal:docling",
+                        "universal:internal-html",
+                        extracted.as_deref().unwrap_or(&source_text),
+                    )
+                } else {
+                    canonicalize_html_with_fallback(
+                        &rel_path,
+                        "universal:internal-html",
+                        "universal:internal-html",
+                        &source_text,
+                    )
+                }
+            }
+            SourceKind::Pdf | SourceKind::Docx | SourceKind::Pptx | SourceKind::Xlsx => {
+                if availability.docling || availability.markitdown {
+                    let extracted = if matches!(source_kind, SourceKind::Pdf) && availability.grobid
+                    {
+                        grobid_extract(path)
+                    } else if availability.docling {
+                        docling_extract(path)
+                    } else if availability.markitdown {
+                        markitdown_extract(path)
+                    } else {
+                        None
+                    };
+                    canonicalize_binary_placeholder(
+                        &rel_path,
+                        source_kind.clone(),
+                        if matches!(source_kind, SourceKind::Pdf) && availability.grobid {
+                            "universal:grobid"
+                        } else if availability.docling {
+                            "universal:docling"
+                        } else {
+                            "universal:markitdown"
+                        },
+                        extracted.as_deref().unwrap_or(&source_text),
+                    )
+                } else {
+                    return Ok(None);
+                }
+            }
+            SourceKind::Unknown => {
+                if let Some(native) =
+                    self.wrap_native_document(root, path, &rel_path, &source_text)?
+                {
+                    native
+                } else {
+                    return Ok(None);
+                }
+            }
+            _ => return Ok(None),
+        };
+        document.content_hash = short_hash_bytes(&bytes);
+
+        Ok(Some(document))
+    }
+
+    fn wrap_native_document(
+        &self,
+        _root: &Path,
+        path: &Path,
+        rel_path: &str,
+        source_text: &str,
+    ) -> M1ndResult<Option<CanonicalDocument>> {
+        let ext = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_ascii_lowercase())
+            .unwrap_or_default();
+        let native_kind = if matches!(ext.as_str(), "md" | "markdown")
+            && L1ghtIngestAdapter::looks_like_l1ght(source_text)
+        {
+            Some(SourceKind::NativeLight)
+        } else if matches!(ext.as_str(), "bib" | "bibtex") {
+            Some(SourceKind::NativeBibtex)
+        } else if matches!(ext.as_str(), "xml" | "nxml") {
+            if source_text.contains("<PubmedArticle")
+                || source_text.contains("<PubmedArticleSet")
+                || source_text.contains("NLM//DTD")
+                || (source_text.contains("<article") && source_text.contains("dtd-version"))
+            {
+                Some(SourceKind::NativeArticle)
+            } else if source_text.contains("<rfc ") || source_text.contains("<rfc>") {
+                Some(SourceKind::NativeRfc)
+            } else if source_text.contains("<us-patent-grant")
+                || source_text.contains("<us-patent-application")
+                || source_text.contains("<ep-patent-document")
+            {
+                Some(SourceKind::NativePatent)
+            } else {
+                None
+            }
+        } else if ext == "json"
+            && source_text.contains("\"DOI\"")
+            && source_text.contains("\"publisher\"")
+            && source_text.contains("\"type\"")
+        {
+            Some(SourceKind::NativeCrossref)
+        } else {
+            None
+        };
+
+        let Some(native_kind) = native_kind else {
+            return Ok(None);
+        };
+
+        Ok(Some(canonicalize_plain_text(
+            rel_path,
+            native_kind,
+            "universal:native-wrap",
+            source_text,
+        )))
+    }
+}
+
+impl IngestAdapter for UniversalIngestAdapter {
+    fn domain(&self) -> &str {
+        "universal"
+    }
+
+    fn ingest(&self, root: &Path) -> M1ndResult<(Graph, IngestStats)> {
+        let bundle = self.ingest_bundle(root)?;
+        Ok((bundle.graph, bundle.stats))
+    }
+}
+
+fn python_module_available(module_name: &str) -> bool {
+    let output = Command::new(provider_python())
+        .arg("-c")
+        .arg(format!("import importlib.util; print('1' if importlib.util.find_spec('{module_name}') else '0')"))
+        .output();
+    matches!(output, Ok(result) if String::from_utf8_lossy(&result.stdout).trim() == "1")
+}
+
+fn command_available(name: &str) -> bool {
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!("command -v {} >/dev/null 2>&1", name))
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn grobid_configured() -> bool {
+    std::env::var("M1ND_GROBID_URL")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+}
+
+fn python_inline(script: &str, arg: &Path) -> Option<String> {
+    let output = Command::new(provider_python())
+        .arg("-c")
+        .arg(script)
+        .arg(arg)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn provider_python() -> String {
+    std::env::var("M1ND_PROVIDER_PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+pub fn provider_python_command() -> String {
+    provider_python()
+}
+
+fn docling_extract(path: &Path) -> Option<String> {
+    python_inline(
+        r#"
+import sys
+from docling.document_converter import DocumentConverter
+converter = DocumentConverter()
+result = converter.convert(sys.argv[1])
+doc = getattr(result, 'document', None)
+if doc is not None and hasattr(doc, 'export_to_markdown'):
+    text = doc.export_to_markdown()
+    if text:
+        print(text)
+"#,
+        path,
+    )
+}
+
+fn trafilatura_extract(path: &Path) -> Option<String> {
+    python_inline(
+        r#"
+import sys, pathlib, trafilatura
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding='utf-8', errors='ignore')
+extracted = trafilatura.extract(text, output_format='markdown', include_links=True, include_tables=True)
+if extracted:
+    print(extracted)
+"#,
+        path,
+    )
+}
+
+fn markitdown_extract(path: &Path) -> Option<String> {
+    python_inline(
+        r#"
+import sys
+from markitdown import MarkItDown
+md = MarkItDown()
+result = md.convert(sys.argv[1])
+text = getattr(result, 'text_content', None) or getattr(result, 'markdown', None) or str(result)
+if text:
+    print(text)
+"#,
+        path,
+    )
+}
+
+fn grobid_extract(path: &Path) -> Option<String> {
+    let url = std::env::var("M1ND_GROBID_URL").ok()?;
+    let script = format!(
+        r#"
+import sys, requests
+path = sys.argv[1]
+url = {url_repr}.rstrip('/') + '/api/processFulltextDocument'
+with open(path, 'rb') as fh:
+    resp = requests.post(url, files={{'input': fh}}, timeout=30)
+resp.raise_for_status()
+text = resp.text.strip()
+if text:
+    print(text)
+"#,
+        url_repr = serde_json::to_string(&url).ok()?
+    );
+    python_inline(&script, path)
+}
+
+fn collect_candidate_files(root: &Path) -> Vec<PathBuf> {
+    if root.is_file() {
+        return vec![root.to_path_buf()];
+    }
+
+    WalkDir::new(root)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| entry.into_path())
+        .collect()
+}
+
+fn slugify(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut prev_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn content_hash(input: &str) -> String {
+    short_hash(input)
+}
+
+fn default_title(source_path: &str, plain_text: &str) -> String {
+    plain_text
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.trim_start_matches('#').trim().to_string())
+        .filter(|line| !line.is_empty())
+        .unwrap_or_else(|| {
+            Path::new(source_path)
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or(source_path)
+                .to_string()
+        })
+}
+
+fn section_id(source_path: &str, heading: &str, index: usize) -> String {
+    format!(
+        "section::{}::{}-{}",
+        short_hash(source_path),
+        slugify(heading),
+        index
+    )
+}
+
+fn block_id(source_path: &str, heading: &str, index: usize) -> String {
+    format!(
+        "block::{}::{}-{}",
+        short_hash(source_path),
+        slugify(heading),
+        index
+    )
+}
+
+fn claim_id(source_path: &str, label: &str, index: usize) -> String {
+    format!(
+        "claim::{}::{}-{}",
+        short_hash(source_path),
+        slugify(label),
+        index
+    )
+}
+
+fn classify_section_kind(heading: &str) -> DocumentSectionKind {
+    let lower = heading.to_ascii_lowercase();
+    if lower.contains("api") || lower.contains("contract") || lower.contains("interface") {
+        DocumentSectionKind::Api
+    } else if lower.contains("constraint") || lower.contains("invariant") || lower.contains("guard")
+    {
+        DocumentSectionKind::Constraints
+    } else if lower.contains("test") || lower.contains("verification") {
+        DocumentSectionKind::Tests
+    } else if lower.contains("rollout") || lower.contains("migration") {
+        DocumentSectionKind::Rollout
+    } else if lower.contains("reference") || lower.contains("bibliography") {
+        DocumentSectionKind::Reference
+    } else if lower.contains("appendix") {
+        DocumentSectionKind::Appendix
+    } else if lower.contains("overview")
+        || lower.contains("introduction")
+        || lower.contains("summary")
+    {
+        DocumentSectionKind::Overview
+    } else {
+        DocumentSectionKind::Unknown
+    }
+}
+
+fn classify_entity_kind(label: &str) -> DocumentEntityKind {
+    if label.contains("m1nd.") {
+        DocumentEntityKind::ToolId
+    } else if label.contains('/')
+        || label.contains(".rs")
+        || label.contains(".py")
+        || label.contains(".ts")
+        || label.contains(".md")
+    {
+        DocumentEntityKind::FilePath
+    } else if label.contains("::") || label.contains('.') {
+        DocumentEntityKind::Symbol
+    } else if label.to_ascii_lowercase().contains("test") {
+        DocumentEntityKind::TestName
+    } else {
+        DocumentEntityKind::NamedTerm
+    }
+}
+
+fn classify_claim(line: &str) -> (DocumentClaimKind, ClaimModality, bool) {
+    let lower = line.to_ascii_lowercase();
+    let modality = if lower.contains(" must ") || lower.starts_with("must ") {
+        ClaimModality::Must
+    } else if lower.contains(" should ") || lower.starts_with("should ") {
+        ClaimModality::Should
+    } else if lower.contains(" may ") || lower.starts_with("may ") {
+        ClaimModality::May
+    } else if lower.contains(" is ") || lower.starts_with("is ") {
+        ClaimModality::Is
+    } else {
+        ClaimModality::Unknown
+    };
+    let negated = lower.contains(" not ") || lower.contains(" no ");
+    let kind = if lower.contains("warning") || lower.contains("danger") || lower.contains("risk") {
+        DocumentClaimKind::Warning
+    } else if lower.contains("test") || lower.contains("assert") || lower.contains("expect") {
+        DocumentClaimKind::TestExpectation
+    } else if matches!(modality, ClaimModality::Must | ClaimModality::Should) {
+        DocumentClaimKind::Requirement
+    } else if lower.contains("decision") || lower.contains("we choose") || lower.contains("chosen")
+    {
+        DocumentClaimKind::Decision
+    } else if lower.contains("always") || lower.contains("never") || lower.contains("invariant") {
+        DocumentClaimKind::Invariant
+    } else if lower.contains("can ") || lower.contains("supports") || lower.contains("capability") {
+        DocumentClaimKind::Capability
+    } else {
+        DocumentClaimKind::Unknown
+    };
+    (kind, modality, negated)
+}
+
+fn canonicalize_plain_text(
+    source_path: &str,
+    source_kind: SourceKind,
+    producer: &str,
+    raw_text: &str,
+) -> CanonicalDocument {
+    let heading_re = Regex::new(r"^(#{1,6})\s+(.+?)\s*$").unwrap();
+    let link_re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
+    let doi_re = Regex::new(r"(10\.\d{4,9}/[-._;()/:A-Za-z0-9]+)").unwrap();
+    let code_ref_re = Regex::new(r"`([^`]+)`").unwrap();
+    let entity_re = Regex::new(r"\b([A-Z][A-Za-z0-9_.:-]{3,})\b").unwrap();
+
+    let mut sections = Vec::new();
+    let mut links = Vec::new();
+    let mut citations = Vec::new();
+    let mut entities = Vec::new();
+    let mut claims = Vec::new();
+    let mut code_candidates = Vec::new();
+    let mut tables = Vec::new();
+    let mut current_heading = "Document".to_string();
+    let mut current_level = 1u8;
+    let mut current_parent_section_id: Option<String> = None;
+    let mut current_blocks = Vec::new();
+    let mut section_index = 0usize;
+    let mut block_index = 0usize;
+    let mut claim_index = 0usize;
+    let mut seen_entities = HashSet::new();
+    let mut seen_links = HashSet::new();
+    let mut seen_citations = HashSet::new();
+    let mut seen_code_candidates = HashSet::new();
+    let mut section_stack: Vec<(u8, String)> = Vec::new();
+    let mut in_code_block = false;
+    let mut code_lang: Option<String> = None;
+
+    let mut flush_section = |sections: &mut Vec<DocumentSection>,
+                             current_heading: &mut String,
+                             current_level: &mut u8,
+                             current_parent_section_id: &mut Option<String>,
+                             current_blocks: &mut Vec<DocumentBlock>,
+                             section_index: &mut usize| {
+        if current_blocks.is_empty() {
+            return;
+        }
+        *section_index += 1;
+        sections.push(DocumentSection {
+            section_id: section_id(source_path, current_heading, *section_index),
+            heading: current_heading.clone(),
+            level: *current_level,
+            kind: classify_section_kind(current_heading),
+            parent_section_id: current_parent_section_id.clone(),
+            blocks: std::mem::take(current_blocks),
+            provenance: ProvenanceSpan {
+                line_start: None,
+                line_end: None,
+                excerpt: Some(current_heading.clone()),
+            },
+        });
+    };
+
+    for (idx, line) in raw_text.lines().enumerate() {
+        let line_no = idx as u32 + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(caps) = heading_re.captures(trimmed) {
+            flush_section(
+                &mut sections,
+                &mut current_heading,
+                &mut current_level,
+                &mut current_parent_section_id,
+                &mut current_blocks,
+                &mut section_index,
+            );
+            current_heading = caps.get(2).unwrap().as_str().trim().to_string();
+            current_level = caps.get(1).unwrap().as_str().len() as u8;
+            while section_stack
+                .last()
+                .is_some_and(|(level, _)| *level >= current_level)
+            {
+                section_stack.pop();
+            }
+            current_parent_section_id = section_stack.last().map(|(_, id)| id.clone());
+            section_stack.push((
+                current_level,
+                section_id(source_path, &current_heading, section_index + 1),
+            ));
+            continue;
+        }
+
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            code_lang = trimmed
+                .strip_prefix("```")
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| value.to_string());
+        }
+
+        let is_table_line = trimmed.contains('|')
+            && trimmed.matches('|').count() >= 2
+            && !trimmed.starts_with("http");
+        if is_table_line {
+            let cells = trimmed
+                .trim_matches('|')
+                .split('|')
+                .map(|cell| DocumentTableCell {
+                    text: cell.trim().to_string(),
+                    provenance: ProvenanceSpan {
+                        line_start: Some(line_no),
+                        line_end: Some(line_no),
+                        excerpt: Some(trimmed.to_string()),
+                    },
+                })
+                .collect::<Vec<_>>();
+            let table_id = format!("table::{}::{}", short_hash(source_path), tables.len() + 1);
+            let headers = if tables.last().is_none() {
+                cells.iter().map(|cell| cell.text.clone()).collect()
+            } else {
+                Vec::new()
+            };
+            tables.push(DocumentTable {
+                table_id,
+                headers,
+                rows: vec![DocumentTableRow { cells }],
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan {
+                    line_start: Some(line_no),
+                    line_end: Some(line_no),
+                    excerpt: Some(trimmed.to_string()),
+                },
+            });
+        }
+
+        let kind = if in_code_block {
+            DocumentBlockKind::Code
+        } else if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+            DocumentBlockKind::ListItem
+        } else if trimmed.starts_with('>') {
+            DocumentBlockKind::Quote
+        } else if is_table_line {
+            DocumentBlockKind::Table
+        } else {
+            DocumentBlockKind::Paragraph
+        };
+
+        let mut spans = Vec::new();
+        block_index += 1;
+        current_blocks.push(DocumentBlock {
+            block_id: block_id(source_path, &current_heading, block_index),
+            kind,
+            text: trimmed.to_string(),
+            confidence: ConfidenceLevel::Parsed,
+            provenance: ProvenanceSpan {
+                line_start: Some(line_no),
+                line_end: Some(line_no),
+                excerpt: Some(trimmed.chars().take(200).collect()),
+            },
+            language: code_lang.clone().filter(|_| in_code_block),
+            spans: Vec::new(),
+        });
+
+        for caps in link_re.captures_iter(trimmed) {
+            let label = caps.get(1).unwrap().as_str().to_string();
+            let target = caps.get(2).unwrap().as_str().to_string();
+            let key = format!("{label}|{target}");
+            if seen_links.insert(key) {
+                links.push(DocumentLink {
+                    label,
+                    target: target.clone(),
+                    confidence: ConfidenceLevel::Parsed,
+                    provenance: ProvenanceSpan {
+                        line_start: Some(line_no),
+                        line_end: Some(line_no),
+                        excerpt: Some(trimmed.to_string()),
+                    },
+                });
+            }
+            spans.push(DocumentSpan {
+                text: target,
+                kind: "link".into(),
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan {
+                    line_start: Some(line_no),
+                    line_end: Some(line_no),
+                    excerpt: Some(trimmed.to_string()),
+                },
+            });
+        }
+
+        for caps in doi_re.captures_iter(trimmed) {
+            let target = caps.get(1).unwrap().as_str().to_string();
+            if seen_citations.insert(target.clone()) {
+                citations.push(DocumentCitation {
+                    label: target.clone(),
+                    target: target.clone(),
+                    citation_kind: "paper".into(),
+                    title: None,
+                    authors: Vec::new(),
+                    venue: None,
+                    year: None,
+                    confidence: ConfidenceLevel::Parsed,
+                    provenance: ProvenanceSpan {
+                        line_start: Some(line_no),
+                        line_end: Some(line_no),
+                        excerpt: Some(trimmed.to_string()),
+                    },
+                });
+            }
+            spans.push(DocumentSpan {
+                text: target,
+                kind: "doi".into(),
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan {
+                    line_start: Some(line_no),
+                    line_end: Some(line_no),
+                    excerpt: Some(trimmed.to_string()),
+                },
+            });
+        }
+
+        for caps in code_ref_re.captures_iter(trimmed) {
+            let label = caps.get(1).unwrap().as_str().trim().to_string();
+            if !label.is_empty() && seen_entities.insert(label.clone()) {
+                entities.push(DocumentEntityCandidate {
+                    label: label.clone(),
+                    kind: DocumentEntityKind::CodeRef,
+                    aliases: Vec::new(),
+                    confidence: ConfidenceLevel::Parsed,
+                    provenance: ProvenanceSpan {
+                        line_start: Some(line_no),
+                        line_end: Some(line_no),
+                        excerpt: Some(trimmed.to_string()),
+                    },
+                });
+            }
+            if !label.is_empty() && seen_code_candidates.insert(label.clone()) {
+                code_candidates.push(DocumentCodeCandidate {
+                    label: label.clone(),
+                    candidate_kind: classify_entity_kind(&label),
+                    confidence: ConfidenceLevel::Parsed,
+                    provenance: ProvenanceSpan {
+                        line_start: Some(line_no),
+                        line_end: Some(line_no),
+                        excerpt: Some(trimmed.to_string()),
+                    },
+                });
+            }
+            spans.push(DocumentSpan {
+                text: label,
+                kind: "code_ref".into(),
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan {
+                    line_start: Some(line_no),
+                    line_end: Some(line_no),
+                    excerpt: Some(trimmed.to_string()),
+                },
+            });
+        }
+
+        for caps in entity_re.captures_iter(trimmed) {
+            let label = caps.get(1).unwrap().as_str().trim().to_string();
+            if seen_entities.insert(label.clone()) {
+                entities.push(DocumentEntityCandidate {
+                    label,
+                    kind: classify_entity_kind(caps.get(1).unwrap().as_str().trim()),
+                    aliases: Vec::new(),
+                    confidence: ConfidenceLevel::Inferred,
+                    provenance: ProvenanceSpan {
+                        line_start: Some(line_no),
+                        line_end: Some(line_no),
+                        excerpt: Some(trimmed.to_string()),
+                    },
+                });
+            }
+        }
+
+        if trimmed.ends_with('.') && trimmed.len() > 20 {
+            claim_index += 1;
+            let (kind, modality, negated) = classify_claim(trimmed);
+            let subject = code_ref_re
+                .captures(trimmed)
+                .and_then(|caps| caps.get(1).map(|m| m.as_str().trim().to_string()))
+                .or_else(|| {
+                    entity_re
+                        .captures(trimmed)
+                        .and_then(|caps| caps.get(1).map(|m| m.as_str().trim().to_string()))
+                });
+            let predicate = match modality {
+                ClaimModality::Must => Some("must".to_string()),
+                ClaimModality::Should => Some("should".to_string()),
+                ClaimModality::May => Some("may".to_string()),
+                ClaimModality::Is => Some("is".to_string()),
+                ClaimModality::Unknown => None,
+            };
+            let object = predicate.as_ref().and_then(|verb| {
+                let needle = format!(" {} ", verb);
+                trimmed
+                    .to_ascii_lowercase()
+                    .find(&needle)
+                    .map(|idx| {
+                        trimmed[idx + needle.len()..]
+                            .trim_end_matches('.')
+                            .trim()
+                            .to_string()
+                    })
+                    .filter(|value| !value.is_empty())
+            });
+            claims.push(DocumentClaimCandidate {
+                claim_id: claim_id(source_path, trimmed, claim_index),
+                label: trimmed.to_string(),
+                kind,
+                modality,
+                subject,
+                predicate,
+                object,
+                negated,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan {
+                    line_start: Some(line_no),
+                    line_end: Some(line_no),
+                    excerpt: Some(trimmed.to_string()),
+                },
+            });
+        }
+
+        if let Some(last) = current_blocks.last_mut() {
+            last.spans = spans;
+        }
+    }
+
+    flush_section(
+        &mut sections,
+        &mut current_heading,
+        &mut current_level,
+        &mut current_parent_section_id,
+        &mut current_blocks,
+        &mut section_index,
+    );
+
+    let title = default_title(source_path, raw_text);
+    let mut metadata = DocumentMetadata {
+        title: Some(title.clone()),
+        ..Default::default()
+    };
+    if let Some(first) = citations.first() {
+        metadata.doi = Some(first.target.clone());
+    }
+
+    CanonicalDocument {
+        doc_id: format!("canon::{}", short_hash(source_path)),
+        source_path: source_path.to_string(),
+        source_kind: source_kind.clone(),
+        detected_type: match source_kind {
+            SourceKind::Markdown => "markdown".into(),
+            SourceKind::Text => "text".into(),
+            SourceKind::Html => "html".into(),
+            SourceKind::NativeLight => "light".into(),
+            SourceKind::NativeArticle => "article".into(),
+            SourceKind::NativeBibtex => "bibtex".into(),
+            SourceKind::NativeCrossref => "crossref".into(),
+            SourceKind::NativeRfc => "rfc".into(),
+            SourceKind::NativePatent => "patent".into(),
+            other => format!("{:?}", other).to_lowercase(),
+        },
+        producer: producer.to_string(),
+        content_hash: content_hash(raw_text),
+        title,
+        plain_text: raw_text.to_string(),
+        metadata,
+        sections,
+        tables,
+        links,
+        citations,
+        entities,
+        claims,
+        code_candidates,
+        confidence: ConfidenceLevel::Parsed,
+        structured_origin: serde_json::json!({ "producer": producer }),
+    }
+}
+
+fn strip_html_tags(input: &str) -> String {
+    let tag_re = Regex::new(r"<[^>]+>").unwrap();
+    let heading_re = Regex::new(r"(?i)<h([1-6])[^>]*>(.*?)</h[1-6]>").unwrap();
+    let mut text = input.to_string();
+    for caps in heading_re.captures_iter(input) {
+        let level = caps.get(1).unwrap().as_str();
+        let body = tag_re.replace_all(caps.get(2).unwrap().as_str(), "");
+        text = text.replace(
+            caps.get(0).unwrap().as_str(),
+            &format!(
+                "\n{} {}\n",
+                "#".repeat(level.parse::<usize>().unwrap_or(1)),
+                body.trim()
+            ),
+        );
+    }
+    tag_re.replace_all(&text, " ").to_string()
+}
+
+fn canonicalize_html_with_fallback(
+    source_path: &str,
+    producer: &str,
+    fallback_producer: &str,
+    raw_text: &str,
+) -> CanonicalDocument {
+    let text = strip_html_tags(raw_text);
+    let producer = if text.trim().is_empty() {
+        fallback_producer
+    } else {
+        producer
+    };
+    canonicalize_plain_text(source_path, SourceKind::Html, producer, &text)
+}
+
+fn canonicalize_binary_placeholder(
+    source_path: &str,
+    source_kind: SourceKind,
+    producer: &str,
+    source_text: &str,
+) -> CanonicalDocument {
+    let fallback = format!(
+        "# Imported Document\n\nSource: {}\n\nThis document was detected and reserved for optional provider-based canonicalization.\n",
+        source_path
+    );
+    let text = if source_text.trim().is_empty() {
+        fallback
+    } else {
+        source_text.to_string()
+    };
+    canonicalize_plain_text(source_path, source_kind, producer, &text)
+}
+
+pub fn graphify_documents(documents: &[CanonicalDocument], namespace: &str) -> M1ndResult<Graph> {
+    let mut graph = Graph::with_capacity(documents.len() * 24, documents.len() * 48);
+    let mut entity_nodes = HashSet::new();
+    let mut citation_nodes = HashSet::new();
+    let mut binding_nodes = HashSet::new();
+
+    for document in documents {
+        let doc_id = format!("universal::{}::doc::{}", namespace, document.doc_id);
+        let doc_tags = [
+            "universal".to_string(),
+            format!("universal:type:{}", document.detected_type),
+            format!("namespace:{}", namespace),
+            format!("producer:{}", document.producer),
+        ];
+        let doc_tag_refs: Vec<&str> = doc_tags.iter().map(String::as_str).collect();
+        let doc_node = graph.add_node(
+            &doc_id,
+            &document.title,
+            NodeType::File,
+            &doc_tag_refs,
+            0.0,
+            0.5,
+        )?;
+        graph.set_node_provenance(
+            doc_node,
+            NodeProvenanceInput {
+                source_path: Some(&document.source_path),
+                excerpt: Some(&document.title),
+                namespace: Some(namespace),
+                canonical: true,
+                ..Default::default()
+            },
+        );
+
+        for section in &document.sections {
+            let section_id = format!("universal::{}::{}", namespace, section.section_id);
+            let section_tags = [
+                "universal".to_string(),
+                "universal:section".to_string(),
+                format!("section:kind:{:?}", section.kind).to_lowercase(),
+            ];
+            let section_refs: Vec<&str> = section_tags.iter().map(String::as_str).collect();
+            let section_node = graph.add_node(
+                &section_id,
+                &section.heading,
+                NodeType::Module,
+                &section_refs,
+                0.0,
+                0.4,
+            )?;
+            graph.set_node_provenance(
+                section_node,
+                NodeProvenanceInput {
+                    source_path: Some(&document.source_path),
+                    line_start: section.provenance.line_start,
+                    line_end: section.provenance.line_end,
+                    excerpt: section.provenance.excerpt.as_deref(),
+                    namespace: Some(namespace),
+                    canonical: true,
+                },
+            );
+            graph.add_edge(
+                doc_node,
+                section_node,
+                "contains_section",
+                FiniteF32::ONE,
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.8),
+            )?;
+            if let Some(parent_id) = &section.parent_section_id {
+                let graph_parent_id = format!("universal::{}::{}", namespace, parent_id);
+                if let Some(parent_node) = graph.resolve_id(&graph_parent_id) {
+                    graph.add_edge(
+                        section_node,
+                        parent_node,
+                        "subsection_of",
+                        FiniteF32::new(0.7),
+                        EdgeDirection::Forward,
+                        false,
+                        FiniteF32::new(0.5),
+                    )?;
+                }
+            }
+
+            for block in &section.blocks {
+                let block_node_id = format!("universal::{}::{}", namespace, block.block_id);
+                let (node_type, relation, kind_tag) = match block.kind {
+                    DocumentBlockKind::Code => {
+                        (NodeType::Module, "contains_code", "universal:code")
+                    }
+                    DocumentBlockKind::Table => {
+                        (NodeType::System, "contains_table", "universal:table")
+                    }
+                    _ => (NodeType::Concept, "contains_block", "universal:block"),
+                };
+                let block_tags = [
+                    "universal".to_string(),
+                    kind_tag.to_string(),
+                    format!("confidence:{:?}", block.confidence).to_lowercase(),
+                ];
+                let block_refs: Vec<&str> = block_tags.iter().map(String::as_str).collect();
+                let block_node = graph.add_node(
+                    &block_node_id,
+                    &block.text.chars().take(80).collect::<String>(),
+                    node_type,
+                    &block_refs,
+                    0.0,
+                    0.3,
+                )?;
+                graph.set_node_provenance(
+                    block_node,
+                    NodeProvenanceInput {
+                        source_path: Some(&document.source_path),
+                        line_start: block.provenance.line_start,
+                        line_end: block.provenance.line_end,
+                        excerpt: block.provenance.excerpt.as_deref(),
+                        namespace: Some(namespace),
+                        canonical: true,
+                    },
+                );
+                graph.add_edge(
+                    section_node,
+                    block_node,
+                    relation,
+                    FiniteF32::new(0.9),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.6),
+                )?;
+            }
+        }
+
+        for table in &document.tables {
+            let table_id = format!("universal::{}::{}", namespace, table.table_id);
+            let table_tags = ["universal", "universal:table"];
+            let table_node = graph.add_node(
+                &table_id,
+                &format!("Table {}", table.table_id),
+                NodeType::System,
+                &table_tags,
+                0.0,
+                0.35,
+            )?;
+            graph.set_node_provenance(
+                table_node,
+                NodeProvenanceInput {
+                    source_path: Some(&document.source_path),
+                    line_start: table.provenance.line_start,
+                    line_end: table.provenance.line_end,
+                    excerpt: table.provenance.excerpt.as_deref(),
+                    namespace: Some(namespace),
+                    canonical: true,
+                },
+            );
+            graph.add_edge(
+                doc_node,
+                table_node,
+                "contains_table",
+                FiniteF32::new(0.85),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.6),
+            )?;
+        }
+
+        for entity in &document.entities {
+            let entity_id = format!(
+                "universal::{}::entity::{}",
+                namespace,
+                slugify(&entity.label)
+            );
+            if entity_nodes.insert(entity_id.clone()) {
+                let tags = [
+                    "universal".to_string(),
+                    format!("entity:kind:{:?}", entity.kind).to_lowercase(),
+                    format!("confidence:{:?}", entity.confidence).to_lowercase(),
+                ];
+                let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+                let entity_node = graph.add_node(
+                    &entity_id,
+                    &entity.label,
+                    NodeType::Concept,
+                    &tag_refs,
+                    0.0,
+                    0.35,
+                )?;
+                graph.set_node_provenance(
+                    entity_node,
+                    NodeProvenanceInput {
+                        source_path: Some(&document.source_path),
+                        line_start: entity.provenance.line_start,
+                        line_end: entity.provenance.line_end,
+                        excerpt: entity.provenance.excerpt.as_deref(),
+                        namespace: Some(namespace),
+                        canonical: true,
+                    },
+                );
+            }
+
+            if let Some(entity_node) = graph.resolve_id(&entity_id) {
+                graph.add_edge(
+                    doc_node,
+                    entity_node,
+                    "declares_entity",
+                    FiniteF32::new(0.9),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.7),
+                )?;
+            }
+        }
+
+        for citation in &document.citations {
+            let citation_id = format!(
+                "universal::{}::citation::{}",
+                namespace,
+                slugify(&citation.target)
+            );
+            if citation_nodes.insert(citation_id.clone()) {
+                let tags = [
+                    "universal".to_string(),
+                    "universal:citation".to_string(),
+                    format!("target:{}", citation.target),
+                ];
+                let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+                let citation_node = graph.add_node(
+                    &citation_id,
+                    &citation.label,
+                    NodeType::Reference,
+                    &tag_refs,
+                    0.0,
+                    0.25,
+                )?;
+                graph.set_node_provenance(
+                    citation_node,
+                    NodeProvenanceInput {
+                        source_path: Some(&document.source_path),
+                        line_start: citation.provenance.line_start,
+                        line_end: citation.provenance.line_end,
+                        excerpt: citation.provenance.excerpt.as_deref(),
+                        namespace: Some(namespace),
+                        canonical: true,
+                    },
+                );
+            }
+            if let Some(citation_node) = graph.resolve_id(&citation_id) {
+                graph.add_edge(
+                    doc_node,
+                    citation_node,
+                    "references",
+                    FiniteF32::new(0.8),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.6),
+                )?;
+            }
+        }
+
+        for link in &document.links {
+            let link_id = format!("universal::{}::link::{}", namespace, slugify(&link.target));
+            if graph.resolve_id(&link_id).is_none() {
+                let tags = ["universal".to_string(), "universal:link".to_string()];
+                let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+                let link_node = graph.add_node(
+                    &link_id,
+                    &link.label,
+                    NodeType::Reference,
+                    &tag_refs,
+                    0.0,
+                    0.2,
+                )?;
+                graph.set_node_provenance(
+                    link_node,
+                    NodeProvenanceInput {
+                        source_path: Some(&document.source_path),
+                        line_start: link.provenance.line_start,
+                        line_end: link.provenance.line_end,
+                        excerpt: link.provenance.excerpt.as_deref(),
+                        namespace: Some(namespace),
+                        canonical: true,
+                    },
+                );
+            }
+            if let Some(link_node) = graph.resolve_id(&link_id) {
+                graph.add_edge(
+                    doc_node,
+                    link_node,
+                    "binds_to",
+                    FiniteF32::new(0.7),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.5),
+                )?;
+            }
+        }
+
+        for claim in &document.claims {
+            let claim_id = format!("universal::{}::{}", namespace, claim.claim_id);
+            if graph.resolve_id(&claim_id).is_none() {
+                let tags = [
+                    "universal".to_string(),
+                    format!("confidence:{:?}", claim.confidence).to_lowercase(),
+                    "universal:claim".to_string(),
+                    format!("claim:kind:{:?}", claim.kind).to_lowercase(),
+                    format!("claim:modality:{:?}", claim.modality).to_lowercase(),
+                ];
+                let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+                let claim_node = graph.add_node(
+                    &claim_id,
+                    &claim.label.chars().take(80).collect::<String>(),
+                    NodeType::Concept,
+                    &tag_refs,
+                    0.0,
+                    0.25,
+                )?;
+                graph.set_node_provenance(
+                    claim_node,
+                    NodeProvenanceInput {
+                        source_path: Some(&document.source_path),
+                        line_start: claim.provenance.line_start,
+                        line_end: claim.provenance.line_end,
+                        excerpt: claim.provenance.excerpt.as_deref(),
+                        namespace: Some(namespace),
+                        canonical: true,
+                    },
+                );
+            }
+            if let Some(claim_node) = graph.resolve_id(&claim_id) {
+                graph.add_edge(
+                    doc_node,
+                    claim_node,
+                    "declares_claim",
+                    FiniteF32::new(0.8),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.6),
+                )?;
+                for citation in &document.citations {
+                    let excerpt = claim.provenance.excerpt.as_deref().unwrap_or(&claim.label);
+                    if !excerpt.contains(&citation.target) && !excerpt.contains(&citation.label) {
+                        continue;
+                    }
+                    let citation_id = format!(
+                        "universal::{}::citation::{}",
+                        namespace,
+                        slugify(&citation.target)
+                    );
+                    if let Some(citation_node) = graph.resolve_id(&citation_id) {
+                        graph.add_edge(
+                            claim_node,
+                            citation_node,
+                            "supports",
+                            FiniteF32::new(0.5),
+                            EdgeDirection::Forward,
+                            false,
+                            FiniteF32::new(0.4),
+                        )?;
+                    }
+                }
+            }
+        }
+
+        for candidate in &document.code_candidates {
+            let binding_id = format!(
+                "universal::{}::binding::{}",
+                namespace,
+                slugify(&candidate.label)
+            );
+            if binding_nodes.insert(binding_id.clone()) {
+                let tags = [
+                    "universal".to_string(),
+                    "universal:binding".to_string(),
+                    format!("candidate:{:?}", candidate.candidate_kind).to_lowercase(),
+                ];
+                let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+                let binding_node = graph.add_node(
+                    &binding_id,
+                    &candidate.label,
+                    NodeType::Reference,
+                    &tag_refs,
+                    0.0,
+                    0.25,
+                )?;
+                graph.set_node_provenance(
+                    binding_node,
+                    NodeProvenanceInput {
+                        source_path: Some(&document.source_path),
+                        line_start: candidate.provenance.line_start,
+                        line_end: candidate.provenance.line_end,
+                        excerpt: candidate.provenance.excerpt.as_deref(),
+                        namespace: Some(namespace),
+                        canonical: true,
+                    },
+                );
+            }
+            if let Some(binding_node) = graph.resolve_id(&binding_id) {
+                graph.add_edge(
+                    doc_node,
+                    binding_node,
+                    "mentions_symbol",
+                    FiniteF32::new(0.75),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.5),
+                )?;
+            }
+        }
+    }
+
+    if graph.num_nodes() > 0 {
+        graph.finalize()?;
+    }
+    Ok(graph)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_markdown_without_l1ght() {
+        let doc = canonicalize_plain_text(
+            "docs/example.md",
+            SourceKind::Markdown,
+            "test",
+            "# API\n\n`TokenValidator` must validate requests.\n\nSee [Docs](https://example.com).\n\n`TokenValidator`\n",
+        );
+        assert_eq!(doc.detected_type, "markdown");
+        assert!(!doc.sections.is_empty());
+        assert!(matches!(doc.sections[0].kind, DocumentSectionKind::Api));
+        assert!(!doc.links.is_empty());
+        assert!(!doc.entities.is_empty());
+        assert!(!doc.claims.is_empty());
+        assert!(!doc.code_candidates.is_empty());
+        assert!(matches!(doc.claims[0].kind, DocumentClaimKind::Requirement));
+        assert!(matches!(doc.claims[0].modality, ClaimModality::Must));
+    }
+
+    #[test]
+    fn graphify_documents_creates_sections_entities_and_refs() {
+        let doc = canonicalize_plain_text(
+            "docs/example.md",
+            SourceKind::Markdown,
+            "test",
+            "# Overview\n\nHello World.\n\nSee [Docs](https://example.com).\n\n`TokenValidator`\n10.1000/test\n",
+        );
+        let graph = graphify_documents(&[doc], "universal").unwrap();
+        assert!(graph.num_nodes() >= 6);
+        assert!(graph.num_edges() >= 5);
+    }
+
+    #[test]
+    fn canonicalize_extracts_simple_tables() {
+        let doc = canonicalize_plain_text(
+            "docs/table.md",
+            SourceKind::Markdown,
+            "test",
+            "# Overview\n\n| Name | Value |\n| A | B |\n",
+        );
+        assert!(!doc.tables.is_empty());
+        assert_eq!(doc.tables[0].rows.len(), 1);
+    }
+
+    #[test]
+    fn graphify_documents_emits_code_table_and_subsection_edges() {
+        let doc = canonicalize_plain_text(
+            "docs/semantic.md",
+            SourceKind::Markdown,
+            "test",
+            "# API\n\n```rust\nfn validate() {}\n```\n\n## Tables\n\n| Name | Value |\n| A | B |\n",
+        );
+        let graph = graphify_documents(&[doc], "universal").unwrap();
+        let mut contains_code = 0;
+        let mut contains_table = 0;
+        let mut subsection_of = 0;
+        for src in 0..graph.num_nodes() as usize {
+            for edge_idx in graph
+                .csr
+                .out_range(m1nd_core::types::NodeId::new(src as u32))
+            {
+                let rel = graph.strings.resolve(graph.csr.relations[edge_idx]);
+                match rel {
+                    "contains_code" => contains_code += 1,
+                    "contains_table" => contains_table += 1,
+                    "subsection_of" => subsection_of += 1,
+                    _ => {}
+                }
+            }
+        }
+        assert!(contains_code >= 1);
+        assert!(contains_table >= 1);
+        assert!(subsection_of >= 1);
+    }
+
+    #[test]
+    fn claim_support_edges_require_local_citation_evidence() {
+        let doc = canonicalize_plain_text(
+            "docs/evidence.md",
+            SourceKind::Markdown,
+            "test",
+            "# API\n\nTokenValidator must validate requests.\n\n10.1000/alpha\n10.1000/beta\n",
+        );
+        let graph = graphify_documents(&[doc], "universal").unwrap();
+        let mut support_edges = 0;
+        for src in 0..graph.num_nodes() as usize {
+            for edge_idx in graph
+                .csr
+                .out_range(m1nd_core::types::NodeId::new(src as u32))
+            {
+                let rel = graph.strings.resolve(graph.csr.relations[edge_idx]);
+                if rel == "supports" {
+                    support_edges += 1;
+                }
+            }
+        }
+        assert_eq!(support_edges, 0);
+    }
+
+    #[test]
+    fn provider_probe_is_stable() {
+        let providers = UniversalIngestAdapter::provider_availability();
+        let _ = serde_json::to_string(&providers).unwrap();
+    }
+
+    #[test]
+    fn content_hash_tracks_original_source_bytes_for_html_documents() {
+        let temp = std::env::temp_dir().join(format!(
+            "m1nd-universal-hash-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp).unwrap();
+        let file = temp.join("page.html");
+        let raw = "<html><body><h1>Hash Title</h1><p>TokenValidator must validate requests.</p></body></html>";
+        std::fs::write(&file, raw).unwrap();
+
+        let adapter = UniversalIngestAdapter::new(Some("universal".into()));
+        let bundle = adapter.ingest_bundle(&file).unwrap();
+        let document = bundle.documents.first().unwrap();
+
+        assert_eq!(document.content_hash, short_hash_bytes(raw.as_bytes()));
+        assert_ne!(document.content_hash, short_hash(&document.plain_text));
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+}

--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -1,0 +1,1018 @@
+use crate::protocol::auto_ingest::{
+    AutoIngestEventSummary, AutoIngestStartInput, AutoIngestStartOutput, AutoIngestStatusInput,
+    AutoIngestStatusOutput, AutoIngestStopInput, AutoIngestStopOutput, AutoIngestTickInput,
+    AutoIngestTickOutput,
+};
+use crate::session::SessionState;
+use crate::universal_docs;
+use m1nd_core::error::{M1ndError, M1ndResult};
+use m1nd_ingest::document_router::{DocumentFormat, DocumentRouter};
+use m1nd_ingest::merge::{collect_source_claims, prune_source_claims, SourceClaims};
+use m1nd_ingest::{
+    BibTexAdapter, CrossRefAdapter, IngestAdapter, JatsArticleAdapter, L1ghtIngestAdapter,
+    PatentIngestAdapter, RfcAdapter, UniversalIngestAdapter,
+};
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::hash::Hasher;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const RECENT_EVENT_LIMIT: usize = 40;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+enum PendingChangeKind {
+    Upsert,
+    Delete,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AutoIngestFingerprint {
+    pub canonical_path: String,
+    pub size: u64,
+    pub mtime_ms: u64,
+    pub content_hash: String,
+    pub detected_format: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AutoIngestManifestEntry {
+    pub source_path: String,
+    pub format: String,
+    pub namespace: Option<String>,
+    pub fingerprint: AutoIngestFingerprint,
+    pub claims: SourceClaims,
+    pub last_ingested_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct PendingChange {
+    path: String,
+    kind: PendingChangeKind,
+    first_seen_ms: u64,
+    last_seen_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct AutoIngestPersistentState {
+    owner_agent_id: Option<String>,
+    roots: Vec<String>,
+    formats: Vec<String>,
+    debounce_ms: u64,
+    namespace: Option<String>,
+    manifest: HashMap<String, AutoIngestManifestEntry>,
+    events_seen: u64,
+    ingests_applied: u64,
+    removals_applied: u64,
+    skipped_count: u64,
+    error_count: u64,
+    last_tick_ms: Option<u64>,
+    last_error: Option<String>,
+    recent_events: Vec<AutoIngestEventSummary>,
+}
+
+impl Default for AutoIngestPersistentState {
+    fn default() -> Self {
+        Self {
+            owner_agent_id: None,
+            roots: Vec::new(),
+            formats: vec![
+                "universal".into(),
+                "light".into(),
+                "article".into(),
+                "bibtex".into(),
+                "crossref".into(),
+                "rfc".into(),
+                "patent".into(),
+            ],
+            debounce_ms: 200,
+            namespace: None,
+            manifest: HashMap::new(),
+            events_seen: 0,
+            ingests_applied: 0,
+            removals_applied: 0,
+            skipped_count: 0,
+            error_count: 0,
+            last_tick_ms: None,
+            last_error: None,
+            recent_events: Vec::new(),
+        }
+    }
+}
+
+struct AutoIngestWatcherHandle {
+    _watcher: RecommendedWatcher,
+}
+
+fn provider_status_map() -> HashMap<String, bool> {
+    serde_json::to_value(universal_docs::provider_availability())
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .map(|map| {
+            map.into_iter()
+                .filter_map(|(key, value)| value.as_bool().map(|present| (key, present)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub struct AutoIngestState {
+    persistent: AutoIngestPersistentState,
+    running: bool,
+    pending: Arc<parking_lot::Mutex<HashMap<String, PendingChange>>>,
+    watcher: Option<AutoIngestWatcherHandle>,
+}
+
+impl AutoIngestState {
+    fn empty() -> Self {
+        Self {
+            persistent: AutoIngestPersistentState::default(),
+            running: false,
+            pending: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            watcher: None,
+        }
+    }
+
+    pub fn load(runtime_root: &Path) -> Self {
+        let state = fs::read_to_string(Self::state_path(runtime_root))
+            .ok()
+            .and_then(|content| serde_json::from_str::<AutoIngestPersistentState>(&content).ok())
+            .unwrap_or_default();
+
+        Self {
+            persistent: state,
+            running: false,
+            pending: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            watcher: None,
+        }
+    }
+
+    pub fn persist(&self, runtime_root: &Path) -> M1ndResult<()> {
+        save_json_atomic(&Self::state_path(runtime_root), &self.persistent)
+    }
+
+    fn state_path(runtime_root: &Path) -> PathBuf {
+        runtime_root.join("auto_ingest_state.json")
+    }
+
+    fn events_path(runtime_root: &Path) -> PathBuf {
+        runtime_root.join("auto_ingest_events.jsonl")
+    }
+
+    fn normalized_formats(formats: &[String]) -> M1ndResult<Vec<String>> {
+        let supported = HashSet::<&str>::from_iter([
+            "universal",
+            "light",
+            "article",
+            "bibtex",
+            "crossref",
+            "rfc",
+            "patent",
+        ]);
+
+        let normalized = if formats.is_empty() {
+            vec![
+                "universal".into(),
+                "light".into(),
+                "article".into(),
+                "bibtex".into(),
+                "crossref".into(),
+                "rfc".into(),
+                "patent".into(),
+            ]
+        } else {
+            formats
+                .iter()
+                .map(|value| value.trim().to_ascii_lowercase())
+                .collect::<Vec<_>>()
+        };
+
+        for value in &normalized {
+            if !supported.contains(value.as_str()) {
+                return Err(M1ndError::InvalidParams {
+                    tool: "auto_ingest_start".into(),
+                    detail: format!("unsupported auto-ingest format '{}'", value),
+                });
+            }
+        }
+
+        Ok(normalized)
+    }
+
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0)
+    }
+
+    fn append_event(
+        &mut self,
+        runtime_root: &Path,
+        path: String,
+        kind: &str,
+        status: &str,
+        format: Option<String>,
+        detail: Option<String>,
+    ) {
+        let event = AutoIngestEventSummary {
+            path,
+            kind: kind.to_string(),
+            status: status.to_string(),
+            format,
+            detail,
+            timestamp_ms: Self::now_ms(),
+        };
+        self.persistent.events_seen += 1;
+        self.persistent.recent_events.push(event.clone());
+        if self.persistent.recent_events.len() > RECENT_EVENT_LIMIT {
+            let drain = self.persistent.recent_events.len() - RECENT_EVENT_LIMIT;
+            self.persistent.recent_events.drain(0..drain);
+        }
+
+        let line = serde_json::to_string(&event).unwrap_or_default();
+        let path = Self::events_path(runtime_root);
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if !line.is_empty() {
+            let _ = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .and_then(|mut file| {
+                    use std::io::Write;
+                    writeln!(file, "{}", line)
+                });
+        }
+    }
+
+    fn enqueue_change(
+        pending: &Arc<parking_lot::Mutex<HashMap<String, PendingChange>>>,
+        path: String,
+        kind: PendingChangeKind,
+    ) {
+        let now_ms = Self::now_ms();
+        let mut pending = pending.lock();
+        pending
+            .entry(path.clone())
+            .and_modify(|existing| {
+                existing.kind = kind.clone();
+                existing.last_seen_ms = now_ms;
+            })
+            .or_insert(PendingChange {
+                path,
+                kind,
+                first_seen_ms: now_ms,
+                last_seen_ms: now_ms,
+            });
+    }
+
+    fn is_noise_path(path: &Path) -> bool {
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+        name.ends_with('~')
+            || name.ends_with(".swp")
+            || name.ends_with(".tmp")
+            || name == ".DS_Store"
+            || name.starts_with(".#")
+            || name.starts_with("4913")
+    }
+
+    fn canonicalize_path(path: &Path) -> Option<PathBuf> {
+        path.canonicalize().ok()
+    }
+
+    fn detect_allowed_format(path: &Path, allowed_formats: &[String]) -> Option<String> {
+        let (format, _) = DocumentRouter::detect(path);
+        let normalized = match format {
+            DocumentFormat::L1ght => "light",
+            DocumentFormat::JatsArticle => "article",
+            DocumentFormat::BibTeX => "bibtex",
+            DocumentFormat::CrossRef => "crossref",
+            DocumentFormat::Rfc => "rfc",
+            DocumentFormat::Patent => "patent",
+            DocumentFormat::Universal => "universal",
+            DocumentFormat::Code => {
+                return (allowed_formats.iter().any(|value| value == "universal")
+                    && UniversalIngestAdapter::can_handle_path(path))
+                .then(|| "universal".to_string())
+            }
+        };
+
+        allowed_formats
+            .iter()
+            .any(|value| value == normalized)
+            .then(|| normalized.to_string())
+    }
+
+    fn file_fingerprint(path: &Path, format: &str) -> M1ndResult<AutoIngestFingerprint> {
+        let content = fs::read(path).map_err(|error| M1ndError::InvalidParams {
+            tool: "auto_ingest_tick".into(),
+            detail: format!("failed to read {}: {}", path.display(), error),
+        })?;
+        let metadata = fs::metadata(path).map_err(|error| M1ndError::InvalidParams {
+            tool: "auto_ingest_tick".into(),
+            detail: format!("failed to stat {}: {}", path.display(), error),
+        })?;
+        let mtime_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0);
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        hasher.write(&content);
+        let content_hash = format!("{:016x}", hasher.finish());
+
+        Ok(AutoIngestFingerprint {
+            canonical_path: path.to_string_lossy().to_string(),
+            size: metadata.len(),
+            mtime_ms,
+            content_hash,
+            detected_format: format.to_string(),
+        })
+    }
+
+    fn collect_supported_files(root: &Path, out: &mut Vec<PathBuf>) {
+        if !root.exists() {
+            return;
+        }
+        if root.is_file() {
+            out.push(root.to_path_buf());
+            return;
+        }
+
+        let read_dir = match fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(_) => return,
+        };
+
+        for entry in read_dir.filter_map(Result::ok) {
+            let path = entry.path();
+            if Self::is_noise_path(&path) {
+                continue;
+            }
+            if path.is_dir() {
+                Self::collect_supported_files(&path, out);
+            } else if path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+
+    fn ingest_with_format(
+        format: &str,
+        path: &Path,
+        namespace: Option<String>,
+    ) -> M1ndResult<(m1nd_core::graph::Graph, m1nd_ingest::IngestStats)> {
+        match format {
+            "universal" => UniversalIngestAdapter::new(namespace).ingest(path),
+            "light" => L1ghtIngestAdapter::new(namespace).ingest(path),
+            "article" => JatsArticleAdapter::new(namespace).ingest(path),
+            "bibtex" => BibTexAdapter::new(namespace).ingest(path),
+            "crossref" => CrossRefAdapter::new(namespace).ingest(path),
+            "rfc" => RfcAdapter::new(namespace).ingest(path),
+            "patent" => PatentIngestAdapter::new(namespace).ingest(path),
+            other => Err(M1ndError::InvalidParams {
+                tool: "auto_ingest_tick".into(),
+                detail: format!("unsupported format '{}'", other),
+            }),
+        }
+    }
+
+    fn replace_graph(state: &mut SessionState, graph: m1nd_core::graph::Graph) -> M1ndResult<()> {
+        {
+            let mut current = state.graph.write();
+            *current = graph;
+            if !current.finalized && current.num_nodes() > 0 {
+                current.finalize()?;
+            }
+        }
+
+        state.rebuild_engines()?;
+        if let Err(error) = state.persist() {
+            eprintln!("[m1nd] auto-ingest persist failed: {}", error);
+        }
+        Ok(())
+    }
+
+    fn scan_roots_for_bootstrap(&mut self) {
+        let formats = self.persistent.formats.clone();
+        let roots = self.persistent.roots.clone();
+
+        for root in roots {
+            let root = PathBuf::from(root);
+            let mut files = Vec::new();
+            Self::collect_supported_files(&root, &mut files);
+            for path in files {
+                if Self::is_noise_path(&path) {
+                    continue;
+                }
+                let Some(canonical) = Self::canonicalize_path(&path) else {
+                    continue;
+                };
+                if Self::detect_allowed_format(&canonical, &formats).is_some() {
+                    Self::enqueue_change(
+                        &self.pending,
+                        canonical.to_string_lossy().to_string(),
+                        PendingChangeKind::Upsert,
+                    );
+                }
+            }
+        }
+
+        let missing_paths: Vec<String> = self
+            .persistent
+            .manifest
+            .keys()
+            .filter(|path| !Path::new(path).exists())
+            .cloned()
+            .collect();
+        for path in missing_paths {
+            Self::enqueue_change(&self.pending, path, PendingChangeKind::Delete);
+        }
+    }
+
+    fn take_ready_changes(&mut self, force: bool) -> Vec<PendingChange> {
+        let now_ms = Self::now_ms();
+        let debounce_ms = self.persistent.debounce_ms;
+        let mut pending = self.pending.lock();
+        let ready_keys: Vec<String> = pending
+            .iter()
+            .filter_map(|(key, change)| {
+                let is_ready = force || now_ms.saturating_sub(change.last_seen_ms) >= debounce_ms;
+                is_ready.then(|| key.clone())
+            })
+            .collect();
+
+        ready_keys
+            .into_iter()
+            .filter_map(|key| pending.remove(&key))
+            .collect()
+    }
+
+    fn start_watcher(&mut self) -> M1ndResult<()> {
+        let pending = Arc::clone(&self.pending);
+        let mut watcher = RecommendedWatcher::new(
+            move |result: notify::Result<notify::Event>| {
+                let Ok(event) = result else {
+                    return;
+                };
+                for path in event.paths {
+                    if AutoIngestState::is_noise_path(&path) {
+                        continue;
+                    }
+                    let canonical =
+                        AutoIngestState::canonicalize_path(&path).unwrap_or_else(|| path.clone());
+                    let kind = if canonical.exists() {
+                        PendingChangeKind::Upsert
+                    } else {
+                        PendingChangeKind::Delete
+                    };
+                    AutoIngestState::enqueue_change(
+                        &pending,
+                        canonical.to_string_lossy().to_string(),
+                        kind,
+                    );
+                }
+            },
+            Config::default(),
+        )
+        .map_err(|error| M1ndError::InvalidParams {
+            tool: "auto_ingest_start".into(),
+            detail: format!("failed to create notify watcher: {}", error),
+        })?;
+
+        for root in &self.persistent.roots {
+            watcher
+                .watch(Path::new(root), RecursiveMode::Recursive)
+                .map_err(|error| M1ndError::InvalidParams {
+                    tool: "auto_ingest_start".into(),
+                    detail: format!("failed to watch {}: {}", root, error),
+                })?;
+        }
+
+        self.watcher = Some(AutoIngestWatcherHandle { _watcher: watcher });
+        self.running = true;
+        Ok(())
+    }
+
+    pub fn start(
+        &mut self,
+        state: &mut SessionState,
+        input: AutoIngestStartInput,
+    ) -> M1ndResult<AutoIngestStartOutput> {
+        self.stop_internal();
+        self.persistent.owner_agent_id = Some(input.agent_id);
+        self.persistent.roots = input.roots;
+        self.persistent.formats = Self::normalized_formats(&input.formats)?;
+        self.persistent.debounce_ms = input.debounce_ms;
+        self.persistent.namespace = input.namespace;
+        self.persistent.last_error = None;
+
+        for root in &self.persistent.roots {
+            if let Some(pos) = state
+                .ingest_roots
+                .iter()
+                .position(|existing| existing == root)
+            {
+                let root = state.ingest_roots.remove(pos);
+                state.ingest_roots.push(root);
+            } else {
+                state.ingest_roots.push(root.clone());
+            }
+        }
+        if let Some(first_root) = self.persistent.roots.first() {
+            state.workspace_root = Some(first_root.clone());
+        }
+
+        self.start_watcher()?;
+        self.scan_roots_for_bootstrap();
+        let bootstrap = self.tick(state, true)?;
+        self.persist(&state.runtime_root)?;
+
+        Ok(AutoIngestStartOutput {
+            running: self.running,
+            backend: "notify".into(),
+            roots: self.persistent.roots.clone(),
+            formats: self.persistent.formats.clone(),
+            debounce_ms: self.persistent.debounce_ms,
+            provider_status: provider_status_map(),
+            bootstrap,
+        })
+    }
+
+    fn stop_internal(&mut self) {
+        self.watcher = None;
+        self.running = false;
+    }
+
+    pub fn stop(
+        &mut self,
+        state: &mut SessionState,
+        _input: AutoIngestStopInput,
+    ) -> M1ndResult<AutoIngestStopOutput> {
+        self.stop_internal();
+        self.persist(&state.runtime_root)?;
+        Ok(AutoIngestStopOutput {
+            stopped: true,
+            manifest_entries: self.persistent.manifest.len(),
+        })
+    }
+
+    pub fn status(
+        &mut self,
+        state: &mut SessionState,
+        _input: AutoIngestStatusInput,
+    ) -> AutoIngestStatusOutput {
+        let (
+            semantic_document_count,
+            semantic_section_count,
+            semantic_claim_count,
+            semantic_entity_count,
+            semantic_citation_count,
+            drift_document_count,
+        ) = universal_docs::aggregate_semantic_metrics(state);
+        let (provider_route_counts, provider_fallback_counts) =
+            universal_docs::provider_route_metrics(state);
+        AutoIngestStatusOutput {
+            running: self.running,
+            owner_agent_id: self.persistent.owner_agent_id.clone(),
+            backend: "notify".into(),
+            roots: self.persistent.roots.clone(),
+            formats: self.persistent.formats.clone(),
+            debounce_ms: self.persistent.debounce_ms,
+            manifest_entries: self.persistent.manifest.len(),
+            queue_depth: self.pending.lock().len(),
+            events_seen: self.persistent.events_seen,
+            ingests_applied: self.persistent.ingests_applied,
+            removals_applied: self.persistent.removals_applied,
+            skipped_count: self.persistent.skipped_count,
+            error_count: self.persistent.error_count,
+            last_tick_ms: self.persistent.last_tick_ms,
+            last_error: self.persistent.last_error.clone(),
+            provider_status: provider_status_map(),
+            canonical_artifact_count: self
+                .persistent
+                .manifest
+                .values()
+                .filter(|entry| entry.format == "universal")
+                .count(),
+            semantic_document_count,
+            semantic_section_count,
+            semantic_claim_count,
+            semantic_entity_count,
+            semantic_citation_count,
+            drift_document_count,
+            provider_route_counts,
+            provider_fallback_counts,
+            recent_events: self.persistent.recent_events.clone(),
+        }
+    }
+
+    pub fn maybe_tick(&mut self, state: &mut SessionState) -> M1ndResult<()> {
+        if !self.running {
+            return Ok(());
+        }
+        if self.pending.lock().is_empty() {
+            return Ok(());
+        }
+        let _ = self.tick(state, false)?;
+        Ok(())
+    }
+
+    pub fn tick(
+        &mut self,
+        state: &mut SessionState,
+        force: bool,
+    ) -> M1ndResult<AutoIngestTickOutput> {
+        let changes = self.take_ready_changes(force);
+        let mut changed_paths = Vec::new();
+        let mut ingested_paths = Vec::new();
+        let mut removed_paths = Vec::new();
+        let mut skipped_paths = Vec::new();
+        let mut errored_paths = Vec::new();
+        let mut applied_any = false;
+
+        for change in changes {
+            let path = change.path.clone();
+            changed_paths.push(path.clone());
+            let format = Self::detect_allowed_format(Path::new(&path), &self.persistent.formats);
+
+            match change.kind {
+                PendingChangeKind::Delete => {
+                    if self.persistent.manifest.contains_key(&path) {
+                        let claims = self
+                            .persistent
+                            .manifest
+                            .iter()
+                            .map(|(source, claims)| (source.clone(), claims.claims.clone()))
+                            .collect::<HashMap<_, _>>();
+                        let current = state.graph.read();
+                        let pruned = prune_source_claims(&current, &path, &claims)?;
+                        drop(current);
+                        Self::replace_graph(state, pruned)?;
+                        self.persistent.manifest.remove(&path);
+                        state.document_cache.entries.remove(&path);
+                        let _ =
+                            universal_docs::remove_artifacts_for_source(&state.runtime_root, &path);
+                        self.persistent.removals_applied += 1;
+                        removed_paths.push(path.clone());
+                        applied_any = true;
+                        self.append_event(
+                            &state.runtime_root,
+                            path,
+                            "delete",
+                            "removed",
+                            None,
+                            None,
+                        );
+                    } else {
+                        self.persistent.skipped_count += 1;
+                        skipped_paths.push(path.clone());
+                        self.append_event(
+                            &state.runtime_root,
+                            path,
+                            "delete",
+                            "skipped",
+                            None,
+                            Some("no manifest entry".into()),
+                        );
+                    }
+                }
+                PendingChangeKind::Upsert => {
+                    let Some(format) = format else {
+                        if self.persistent.manifest.contains_key(&path) {
+                            let claims = self
+                                .persistent
+                                .manifest
+                                .iter()
+                                .map(|(source, claims)| (source.clone(), claims.claims.clone()))
+                                .collect::<HashMap<_, _>>();
+                            let current = state.graph.read();
+                            let pruned = prune_source_claims(&current, &path, &claims)?;
+                            drop(current);
+                            Self::replace_graph(state, pruned)?;
+                            self.persistent.manifest.remove(&path);
+                            state.document_cache.entries.remove(&path);
+                            let _ = universal_docs::remove_artifacts_for_source(
+                                &state.runtime_root,
+                                &path,
+                            );
+                            self.persistent.removals_applied += 1;
+                            removed_paths.push(path.clone());
+                            applied_any = true;
+                        } else {
+                            self.persistent.skipped_count += 1;
+                            skipped_paths.push(path.clone());
+                        }
+                        self.append_event(
+                            &state.runtime_root,
+                            path,
+                            "upsert",
+                            "ignored",
+                            None,
+                            Some("unsupported or code file".into()),
+                        );
+                        continue;
+                    };
+
+                    let fingerprint = match Self::file_fingerprint(Path::new(&path), &format) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            self.persistent.error_count += 1;
+                            self.persistent.last_error = Some(error.to_string());
+                            errored_paths.push(path.clone());
+                            self.append_event(
+                                &state.runtime_root,
+                                path,
+                                "upsert",
+                                "error",
+                                Some(format),
+                                Some(error.to_string()),
+                            );
+                            continue;
+                        }
+                    };
+
+                    if self.persistent.manifest.get(&path).is_some_and(|entry| {
+                        entry.fingerprint.content_hash == fingerprint.content_hash
+                    }) {
+                        self.persistent.skipped_count += 1;
+                        skipped_paths.push(path.clone());
+                        self.append_event(
+                            &state.runtime_root,
+                            path,
+                            "upsert",
+                            "skipped",
+                            Some(format),
+                            Some("unchanged fingerprint".into()),
+                        );
+                        continue;
+                    }
+
+                    let overlay = if format == "universal" {
+                        let namespace = self
+                            .persistent
+                            .namespace
+                            .clone()
+                            .unwrap_or_else(|| "universal".to_string());
+                        match UniversalIngestAdapter::new(Some(namespace.clone()))
+                            .ingest_bundle(Path::new(&path))
+                        {
+                            Ok(mut bundle) => {
+                                match universal_docs::write_canonical_artifacts_with_source_root(
+                                    &state.runtime_root,
+                                    Some(Path::new(&path)),
+                                    &bundle.documents,
+                                    &namespace,
+                                ) {
+                                    Ok(artifacts) => {
+                                        universal_docs::ensure_cache_root_in_ingest_roots(state);
+                                        universal_docs::rewrite_graph_provenance_to_canonical(
+                                            &mut bundle.graph,
+                                            &artifacts.entries,
+                                            &namespace,
+                                        );
+                                        for entry in artifacts.entries {
+                                            state
+                                                .document_cache
+                                                .entries
+                                                .insert(entry.source_path.clone(), entry);
+                                        }
+                                    }
+                                    Err(error) => {
+                                        self.persistent.error_count += 1;
+                                        self.persistent.last_error = Some(error.to_string());
+                                        errored_paths.push(path.clone());
+                                        self.append_event(
+                                            &state.runtime_root,
+                                            path.clone(),
+                                            "upsert",
+                                            "error",
+                                            Some(format.clone()),
+                                            Some(error.to_string()),
+                                        );
+                                        continue;
+                                    }
+                                }
+                                (bundle.graph, bundle.stats)
+                            }
+                            Err(error) => {
+                                self.persistent.error_count += 1;
+                                self.persistent.last_error = Some(error.to_string());
+                                errored_paths.push(path.clone());
+                                self.append_event(
+                                    &state.runtime_root,
+                                    path.clone(),
+                                    "upsert",
+                                    "error",
+                                    Some(format.clone()),
+                                    Some(error.to_string()),
+                                );
+                                continue;
+                            }
+                        }
+                    } else {
+                        match Self::ingest_with_format(
+                            &format,
+                            Path::new(&path),
+                            self.persistent.namespace.clone(),
+                        ) {
+                            Ok(value) => value,
+                            Err(error) => {
+                                self.persistent.error_count += 1;
+                                self.persistent.last_error = Some(error.to_string());
+                                errored_paths.push(path.clone());
+                                self.append_event(
+                                    &state.runtime_root,
+                                    path,
+                                    "upsert",
+                                    "error",
+                                    Some(format),
+                                    Some(error.to_string()),
+                                );
+                                continue;
+                            }
+                        }
+                    };
+
+                    let claims = collect_source_claims(&overlay.0);
+                    let existing_claims = self
+                        .persistent
+                        .manifest
+                        .iter()
+                        .map(|(source, entry)| (source.clone(), entry.claims.clone()))
+                        .collect::<HashMap<_, _>>();
+                    let current = state.graph.read();
+                    let pruned = prune_source_claims(&current, &path, &existing_claims)?;
+                    drop(current);
+                    let merged = m1nd_ingest::merge::merge_graphs(&pruned, &overlay.0)?;
+                    Self::replace_graph(state, merged)?;
+
+                    self.persistent.manifest.insert(
+                        path.clone(),
+                        AutoIngestManifestEntry {
+                            source_path: path.clone(),
+                            format: format.clone(),
+                            namespace: self.persistent.namespace.clone(),
+                            fingerprint,
+                            claims,
+                            last_ingested_ms: Self::now_ms(),
+                        },
+                    );
+                    self.persistent.ingests_applied += 1;
+                    ingested_paths.push(path.clone());
+                    applied_any = true;
+                    self.append_event(
+                        &state.runtime_root,
+                        path,
+                        "upsert",
+                        "ingested",
+                        Some(format),
+                        None,
+                    );
+                }
+            }
+        }
+
+        if applied_any {
+            universal_docs::refresh_all_document_semantics(state);
+            state.notify_watchers(crate::perspective::state::WatchTrigger::Ingest);
+        }
+
+        self.persistent.last_tick_ms = Some(Self::now_ms());
+        self.persist(&state.runtime_root)?;
+
+        Ok(AutoIngestTickOutput {
+            changed_paths,
+            ingested_paths,
+            removed_paths,
+            skipped_paths,
+            errored_paths,
+            queue_depth: self.pending.lock().len(),
+            last_tick_ms: self.persistent.last_tick_ms,
+            recent_events: self.persistent.recent_events.clone(),
+        })
+    }
+}
+
+pub fn handle_auto_ingest_start(
+    state: &mut SessionState,
+    input: AutoIngestStartInput,
+) -> M1ndResult<serde_json::Value> {
+    let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+    let output = runtime.start(state, input)?;
+    state.auto_ingest = runtime;
+    serde_json::to_value(output).map_err(M1ndError::Serde)
+}
+
+pub fn handle_auto_ingest_stop(
+    state: &mut SessionState,
+    input: AutoIngestStopInput,
+) -> M1ndResult<serde_json::Value> {
+    let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+    let output = runtime.stop(state, input)?;
+    state.auto_ingest = runtime;
+    serde_json::to_value(output).map_err(M1ndError::Serde)
+}
+
+pub fn handle_auto_ingest_status(
+    state: &mut SessionState,
+    input: AutoIngestStatusInput,
+) -> M1ndResult<serde_json::Value> {
+    let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+    let output = runtime.status(state, input);
+    state.auto_ingest = runtime;
+    serde_json::to_value(output).map_err(M1ndError::Serde)
+}
+
+pub fn handle_auto_ingest_tick(
+    state: &mut SessionState,
+    _input: AutoIngestTickInput,
+) -> M1ndResult<serde_json::Value> {
+    let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+    let output = runtime.tick(state, true)?;
+    state.auto_ingest = runtime;
+    serde_json::to_value(output).map_err(M1ndError::Serde)
+}
+
+pub fn maybe_tick_auto_ingest(state: &mut SessionState, tool_name: &str) -> M1ndResult<()> {
+    if matches!(
+        tool_name,
+        "auto_ingest_start" | "auto_ingest_stop" | "auto_ingest_status" | "auto_ingest_tick"
+    ) {
+        return Ok(());
+    }
+    let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+    let result = runtime.maybe_tick(state);
+    state.auto_ingest = runtime;
+    result
+}
+
+fn save_json_atomic<T: Serialize>(path: &Path, value: &T) -> M1ndResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+    let payload = serde_json::to_vec_pretty(value)?;
+    fs::write(&tmp, payload)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noise_paths_are_ignored() {
+        assert!(AutoIngestState::is_noise_path(Path::new(
+            "/tmp/file.md.swp"
+        )));
+        assert!(AutoIngestState::is_noise_path(Path::new("/tmp/.DS_Store")));
+        assert!(!AutoIngestState::is_noise_path(Path::new("/tmp/notes.md")));
+    }
+
+    #[test]
+    fn enqueue_coalesces_last_kind() {
+        let pending = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        AutoIngestState::enqueue_change(&pending, "/tmp/a.md".into(), PendingChangeKind::Upsert);
+        AutoIngestState::enqueue_change(&pending, "/tmp/a.md".into(), PendingChangeKind::Delete);
+        let pending = pending.lock();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending["/tmp/a.md"].kind, PendingChangeKind::Delete);
+    }
+
+    #[test]
+    fn load_and_persist_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AutoIngestState::load(dir.path());
+        state.persistent.owner_agent_id = Some("agent".into());
+        state.persistent.roots = vec!["/tmp".into()];
+        state.persist(dir.path()).unwrap();
+
+        let reloaded = AutoIngestState::load(dir.path());
+        assert_eq!(reloaded.persistent.owner_agent_id.as_deref(), Some("agent"));
+        assert_eq!(reloaded.persistent.roots, vec!["/tmp".to_string()]);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_unchanged_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("note.md");
+        fs::write(&file, "Protocol: L1GHT/1\nNode: stable\n").unwrap();
+
+        let first = AutoIngestState::file_fingerprint(&file, "light").unwrap();
+        let second = AutoIngestState::file_fingerprint(&file, "light").unwrap();
+
+        assert_eq!(first.content_hash, second.content_hash);
+        assert_eq!(first.size, second.size);
+    }
+}

--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -396,9 +396,6 @@ impl AutoIngestState {
         }
 
         state.rebuild_engines()?;
-        if let Err(error) = state.persist() {
-            eprintln!("[m1nd] auto-ingest persist failed: {}", error);
-        }
         Ok(())
     }
 
@@ -490,8 +487,14 @@ impl AutoIngestState {
         })?;
 
         for root in &self.persistent.roots {
+            let root_path = Path::new(root);
+            let mode = if root_path.is_file() {
+                RecursiveMode::NonRecursive
+            } else {
+                RecursiveMode::Recursive
+            };
             watcher
-                .watch(Path::new(root), RecursiveMode::Recursive)
+                .watch(root_path, mode)
                 .map_err(|error| M1ndError::InvalidParams {
                     tool: "auto_ingest_start".into(),
                     detail: format!("failed to watch {}: {}", root, error),

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -2,6 +2,7 @@
 #![recursion_limit = "512"]
 
 pub mod audit_handlers;
+pub mod auto_ingest;
 pub mod cli;
 pub mod daemon_handlers;
 pub mod protocol;
@@ -25,6 +26,7 @@ pub mod report_handlers;
 pub mod result_shaping;
 pub mod scope;
 pub mod search_handlers;
+pub mod universal_docs;
 
 // HTTP server + types (feature-gated behind "serve")
 #[cfg(feature = "serve")]

--- a/m1nd-mcp/src/protocol/auto_ingest.rs
+++ b/m1nd-mcp/src/protocol/auto_ingest.rs
@@ -1,0 +1,252 @@
+use serde::{Deserialize, Serialize};
+
+fn default_auto_ingest_formats() -> Vec<String> {
+    vec![
+        "universal".into(),
+        "light".into(),
+        "article".into(),
+        "bibtex".into(),
+        "crossref".into(),
+        "rfc".into(),
+        "patent".into(),
+    ]
+}
+
+fn default_debounce_ms() -> u64 {
+    200
+}
+
+fn default_top_k_10() -> usize {
+    10
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AutoIngestStartInput {
+    pub agent_id: String,
+    pub roots: Vec<String>,
+    #[serde(default = "default_auto_ingest_formats")]
+    pub formats: Vec<String>,
+    #[serde(default = "default_debounce_ms")]
+    pub debounce_ms: u64,
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AutoIngestStopInput {
+    pub agent_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AutoIngestStatusInput {
+    pub agent_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct AutoIngestTickInput {
+    pub agent_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DocumentResolveInput {
+    pub agent_id: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DocumentProviderHealthInput {
+    pub agent_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DocumentBindingsInput {
+    pub agent_id: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+    #[serde(default = "default_top_k_10")]
+    pub top_k: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DocumentDriftInput {
+    pub agent_id: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AutoIngestEventSummary {
+    pub path: String,
+    pub kind: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub timestamp_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoIngestStartOutput {
+    pub running: bool,
+    pub backend: String,
+    pub roots: Vec<String>,
+    pub formats: Vec<String>,
+    pub debounce_ms: u64,
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub provider_status: std::collections::HashMap<String, bool>,
+    pub bootstrap: AutoIngestTickOutput,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoIngestStopOutput {
+    pub stopped: bool,
+    pub manifest_entries: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoIngestStatusOutput {
+    pub running: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_agent_id: Option<String>,
+    pub backend: String,
+    pub roots: Vec<String>,
+    pub formats: Vec<String>,
+    pub debounce_ms: u64,
+    pub manifest_entries: usize,
+    pub queue_depth: usize,
+    pub events_seen: u64,
+    pub ingests_applied: u64,
+    pub removals_applied: u64,
+    pub skipped_count: u64,
+    pub error_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_tick_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub provider_status: std::collections::HashMap<String, bool>,
+    #[serde(default)]
+    pub canonical_artifact_count: usize,
+    #[serde(default)]
+    pub semantic_document_count: usize,
+    #[serde(default)]
+    pub semantic_section_count: usize,
+    #[serde(default)]
+    pub semantic_claim_count: usize,
+    #[serde(default)]
+    pub semantic_entity_count: usize,
+    #[serde(default)]
+    pub semantic_citation_count: usize,
+    #[serde(default)]
+    pub drift_document_count: usize,
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub provider_route_counts: std::collections::HashMap<String, usize>,
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub provider_fallback_counts: std::collections::HashMap<String, usize>,
+    pub recent_events: Vec<AutoIngestEventSummary>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoIngestTickOutput {
+    pub changed_paths: Vec<String>,
+    pub ingested_paths: Vec<String>,
+    pub removed_paths: Vec<String>,
+    pub skipped_paths: Vec<String>,
+    pub errored_paths: Vec<String>,
+    pub queue_depth: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_tick_ms: Option<u64>,
+    pub recent_events: Vec<AutoIngestEventSummary>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentResolveOutput {
+    pub source_path: String,
+    pub source_key: String,
+    pub original_source_path: String,
+    pub canonical_markdown_path: String,
+    pub canonical_json_path: String,
+    pub claims_path: String,
+    pub metadata_path: String,
+    pub detected_type: String,
+    pub producer: String,
+    pub node_ids: Vec<String>,
+    pub confidence_summary: std::collections::HashMap<String, usize>,
+    pub section_count: usize,
+    pub claim_count: usize,
+    pub entity_count: usize,
+    pub citation_count: usize,
+    pub binding_count: usize,
+    pub binding_preview: Vec<DocumentBindingEntry>,
+    pub drift_summary: DocumentDriftSummary,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentProviderHealthEntry {
+    pub name: String,
+    pub available: bool,
+    pub mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_hint: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentProviderHealthOutput {
+    pub python: String,
+    pub providers: Vec<DocumentProviderHealthEntry>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentBindingEntry {
+    pub target_node_id: String,
+    pub target_label: String,
+    pub relation: String,
+    pub score: f32,
+    pub confidence: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentDriftFinding {
+    pub class: String,
+    pub message: String,
+    pub confidence: String,
+    pub heuristic: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct DocumentDriftSummary {
+    pub total_findings: usize,
+    pub stale_bindings: usize,
+    pub missing_targets: usize,
+    pub ambiguous_targets: usize,
+    pub unbacked_claims: usize,
+    pub code_change_unreflected: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentBindingsOutput {
+    pub source_path: String,
+    pub bindings: Vec<DocumentBindingEntry>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentDriftOutput {
+    pub source_path: String,
+    pub findings: Vec<DocumentDriftFinding>,
+    pub summary: DocumentDriftSummary,
+}

--- a/m1nd-mcp/src/protocol/mod.rs
+++ b/m1nd-mcp/src/protocol/mod.rs
@@ -5,6 +5,7 @@
 // - perspective:  11 perspective tool + 2 management tool types
 // - lock:         5 lock tool types
 
+pub mod auto_ingest;
 pub mod core;
 pub mod layers;
 pub mod lock;
@@ -12,4 +13,5 @@ pub mod perspective;
 pub mod surgical;
 
 // Re-export core types so existing `use crate::protocol::*` continues to work.
+pub use self::auto_ingest::*;
 pub use self::core::*;

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -1,5 +1,6 @@
 // === crates/m1nd-mcp/src/server.rs ===
 
+use crate::auto_ingest;
 use crate::layer_handlers;
 use crate::personality;
 use crate::protocol::layers;
@@ -9,6 +10,7 @@ use crate::search_handlers;
 use crate::session::SessionState;
 use crate::surgical_handlers;
 use crate::tools;
+use crate::universal_docs;
 use m1nd_core::domain::DomainConfig;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
@@ -448,6 +450,111 @@ pub fn tool_schemas() -> serde_json::Value {
                         }
                     },
                     "required": ["path", "agent_id"]
+                }
+            },
+            {
+                "name": "document_resolve",
+                "description": "Resolve a canonical universal-document artifact by source path or node id",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "path": { "type": "string", "description": "Original source path or canonical markdown path" },
+                        "node_id": { "type": "string", "description": "Graph node id emitted from universal ingest" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "document_provider_health",
+                "description": "Report availability and install hints for universal document providers",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "document_bindings",
+                "description": "Resolve deterministic document-to-code bindings for a universal document",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "path": { "type": "string", "description": "Original source path or canonical markdown path" },
+                        "node_id": { "type": "string", "description": "Graph node id emitted from universal ingest" },
+                        "top_k": { "type": "integer", "default": 10, "description": "Maximum bindings to return" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "document_drift",
+                "description": "Analyze stale, missing, or ambiguous document/code bindings for a universal document",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "path": { "type": "string", "description": "Original source path or canonical markdown path" },
+                        "node_id": { "type": "string", "description": "Graph node id emitted from universal ingest" },
+                        "scope": { "type": "string", "description": "Optional drift scope hint" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "auto_ingest_start",
+                "description": "Start local-first document auto-ingest watchers for supported l1ght-family formats",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "roots": { "type": "array", "items": { "type": "string" }, "description": "Filesystem roots to watch recursively" },
+                        "formats": {
+                            "type": "array",
+                            "items": { "type": "string", "enum": ["universal", "light", "article", "bibtex", "crossref", "rfc", "patent"] },
+                            "default": ["universal", "light", "article", "bibtex", "crossref", "rfc", "patent"],
+                            "description": "Supported document formats to auto-ingest"
+                        },
+                        "debounce_ms": { "type": "integer", "default": 200, "description": "Minimum quiet period before a change is eligible for ingestion" },
+                        "namespace": { "type": "string", "description": "Optional namespace for non-code document nodes" }
+                    },
+                    "required": ["agent_id", "roots"]
+                }
+            },
+            {
+                "name": "auto_ingest_stop",
+                "description": "Stop active document auto-ingest watchers and persist manifest state",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "auto_ingest_status",
+                "description": "Report current auto-ingest runtime state, counters, manifest size, and queue depth",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["agent_id"]
+                }
+            },
+            {
+                "name": "auto_ingest_tick",
+                "description": "Drain queued document changes immediately and apply them to the active graph",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["agent_id"]
                 }
             },
             {
@@ -1658,6 +1765,8 @@ pub fn dispatch_tool(
         })
         .to_string();
 
+    auto_ingest::maybe_tick_auto_ingest(state, &normalized)?;
+
     let result = match normalized.as_str() {
         name if name.starts_with("perspective_") => dispatch_perspective_tool(state, name, params),
         name if name.starts_with("lock_") => dispatch_lock_tool(state, name, params),
@@ -1757,6 +1866,46 @@ fn dispatch_core_tool(
             let input: IngestInput =
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
             tools::handle_ingest(state, input)
+        }
+        "document_resolve" => {
+            let input: DocumentResolveInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            universal_docs::resolve_document(state, input)
+        }
+        "document_provider_health" => {
+            let input: DocumentProviderHealthInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            universal_docs::provider_health(input)
+        }
+        "document_bindings" => {
+            let input: DocumentBindingsInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            universal_docs::document_bindings(state, input)
+        }
+        "document_drift" => {
+            let input: DocumentDriftInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            universal_docs::document_drift(state, input)
+        }
+        "auto_ingest_start" => {
+            let input: AutoIngestStartInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            auto_ingest::handle_auto_ingest_start(state, input)
+        }
+        "auto_ingest_stop" => {
+            let input: AutoIngestStopInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            auto_ingest::handle_auto_ingest_stop(state, input)
+        }
+        "auto_ingest_status" => {
+            let input: AutoIngestStatusInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            auto_ingest::handle_auto_ingest_status(state, input)
+        }
+        "auto_ingest_tick" => {
+            let input: AutoIngestTickInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            auto_ingest::handle_auto_ingest_tick(state, input)
         }
         "resonate" => {
             let input: ResonateInput =

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -19,9 +19,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::auto_ingest::AutoIngestState;
 use crate::perspective::state::{
     LockState, PeekSecurityConfig, PerspectiveLimits, PerspectiveState, WatchTrigger, WatcherEvent,
 };
+use crate::universal_docs::{load_document_cache, persist_document_cache, DocumentCacheState};
 
 // ---------------------------------------------------------------------------
 // AgentSession — per-agent session tracking
@@ -352,6 +354,10 @@ pub struct SessionState {
     pub file_inventory: HashMap<String, FileInventoryEntry>,
     /// Per-agent exploration coverage state for visited files/nodes.
     pub coverage_sessions: HashMap<String, CoverageSessionState>,
+    /// Local document auto-ingest runtime.
+    pub auto_ingest: AutoIngestState,
+    /// Universal document artifact/cache index.
+    pub document_cache: DocumentCacheState,
 }
 
 impl SessionState {
@@ -518,6 +524,8 @@ impl SessionState {
             },
             file_inventory: HashMap::new(),
             coverage_sessions: HashMap::new(),
+            auto_ingest: AutoIngestState::load(&runtime_root),
+            document_cache: load_document_cache(&runtime_root),
         })
     }
 
@@ -589,6 +597,12 @@ impl SessionState {
         if let Err(e) = self.persist_daemon_alerts() {
             eprintln!("[m1nd] WARNING: daemon alert persist failed: {}", e);
         }
+        if let Err(e) = self.auto_ingest.persist(&self.runtime_root) {
+            eprintln!("[m1nd] WARNING: auto-ingest persist failed: {}", e);
+        }
+        if let Err(e) = persist_document_cache(&self.runtime_root, &self.document_cache) {
+            eprintln!("[m1nd] WARNING: document cache persist failed: {}", e);
+        }
 
         self.last_persist_time = Some(Instant::now());
         Ok(())
@@ -603,7 +617,13 @@ impl SessionState {
             return;
         };
 
-        let ingest_roots_path = std::path::Path::new(&root).join("ingest_roots.json");
+        let root_path = std::path::Path::new(&root);
+        let persist_root = if root_path.is_dir() {
+            root_path.to_path_buf()
+        } else {
+            self.runtime_root.clone()
+        };
+        let ingest_roots_path = persist_root.join("ingest_roots.json");
         if let Ok(json) = serde_json::to_string_pretty(&self.ingest_roots) {
             if let Err(e) = std::fs::write(&ingest_roots_path, json) {
                 eprintln!("[m1nd] WARNING: ingest roots persist failed: {}", e);

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -3,6 +3,7 @@
 use crate::protocol::*;
 use crate::result_shaping::dedupe_ranked;
 use crate::session::SessionState;
+use crate::universal_docs;
 use m1nd_core::error::M1ndResult;
 use m1nd_core::query::QueryConfig;
 use m1nd_core::temporal::ImpactDirection;
@@ -240,6 +241,9 @@ fn finalize_ingest(
     state.record_file_inventory(inventory_entries);
 
     state.rebuild_engines()?;
+    if !state.document_cache.entries.is_empty() {
+        universal_docs::refresh_all_document_semantics(state);
+    }
 
     // Track ingest roots for L3 git discovery and scope normalization.
     // Replace mode resets the active roots to the new source of truth.
@@ -260,7 +264,16 @@ fn finalize_ingest(
             state.ingest_roots.push(input.path.clone());
         }
     }
-    state.workspace_root = Some(input.path.clone());
+    let input_path = std::path::Path::new(&input.path);
+    state.workspace_root = Some(if input_path.is_dir() {
+        input.path.clone()
+    } else {
+        input_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_string_lossy()
+            .to_string()
+    });
 
     if let Err(e) = state.persist() {
         eprintln!("[m1nd] auto-persist after ingest failed: {}", e);
@@ -1842,6 +1855,46 @@ pub fn handle_ingest(
             let (new_graph, stats) = adapter.ingest(&path)?;
             finalize_ingest(state, &input, "crossref", new_graph, stats)
         }
+        "universal" => {
+            let namespace = input
+                .namespace
+                .clone()
+                .unwrap_or_else(|| "universal".to_string());
+            let adapter = m1nd_ingest::UniversalIngestAdapter::new(Some(namespace.clone()));
+            let bundle = adapter.ingest_bundle(&path)?;
+            let artifacts = universal_docs::write_canonical_artifacts_with_source_root(
+                &state.runtime_root,
+                Some(&path),
+                &bundle.documents,
+                &namespace,
+            )?;
+            universal_docs::ensure_cache_root_in_ingest_roots(state);
+            let mut graph = bundle.graph;
+            universal_docs::rewrite_graph_provenance_to_canonical(
+                &mut graph,
+                &artifacts.entries,
+                &namespace,
+            );
+            for entry in artifacts.entries {
+                state
+                    .document_cache
+                    .entries
+                    .insert(entry.source_path.clone(), entry);
+            }
+            let mut output = finalize_ingest(state, &input, "universal", graph, bundle.stats)?;
+            if let Some(obj) = output.as_object_mut() {
+                obj.insert(
+                    "canonical_artifact_count".into(),
+                    serde_json::json!(state.document_cache.entries.len()),
+                );
+                let providers = universal_docs::provider_availability();
+                obj.insert(
+                    "provider_status".into(),
+                    serde_json::to_value(providers).unwrap_or(serde_json::json!({})),
+                );
+            }
+            Ok(output)
+        }
         "auto" | "document" => {
             // Auto-detect format from file content
             let (format, adapter) =
@@ -1866,7 +1919,7 @@ pub fn handle_ingest(
             }
         }
         other => Ok(serde_json::json!({
-            "error": format!("Unknown adapter: '{}'. Supported: 'code', 'json', 'memory', 'light', 'patent', 'article', 'bibtex', 'rfc', 'crossref', 'auto'", other),
+            "error": format!("Unknown adapter: '{}'. Supported: 'code', 'json', 'memory', 'light', 'patent', 'article', 'bibtex', 'rfc', 'crossref', 'universal', 'auto'", other),
         })),
     }
 }

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -241,7 +241,7 @@ fn finalize_ingest(
     state.record_file_inventory(inventory_entries);
 
     state.rebuild_engines()?;
-    if !state.document_cache.entries.is_empty() {
+    if adapter == "universal" && !state.document_cache.entries.is_empty() {
         universal_docs::refresh_all_document_semantics(state);
     }
 

--- a/m1nd-mcp/src/universal_docs.rs
+++ b/m1nd-mcp/src/universal_docs.rs
@@ -1,0 +1,1500 @@
+use crate::protocol::auto_ingest::{
+    DocumentBindingEntry, DocumentBindingsInput, DocumentBindingsOutput, DocumentDriftFinding,
+    DocumentDriftInput, DocumentDriftOutput, DocumentDriftSummary, DocumentProviderHealthEntry,
+    DocumentProviderHealthInput, DocumentProviderHealthOutput, DocumentResolveInput,
+    DocumentResolveOutput,
+};
+use crate::session::SessionState;
+use m1nd_core::error::{M1ndError, M1ndResult};
+use m1nd_core::graph::{Graph, NodeProvenanceInput};
+use m1nd_core::types::NodeId;
+use m1nd_ingest::canonical::{
+    source_key, CanonicalDocument, ConfidenceLevel, DocumentCodeCandidate, DocumentEntityCandidate,
+};
+use m1nd_ingest::universal_adapter::{ProviderAvailability, UniversalIngestAdapter};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentCacheEntry {
+    pub source_path: String,
+    pub source_key: String,
+    pub source_kind: String,
+    pub detected_type: String,
+    pub producer: String,
+    pub node_ids: Vec<String>,
+    pub original_source_path: String,
+    pub canonical_markdown_path: String,
+    pub canonical_json_path: String,
+    pub claims_path: String,
+    pub metadata_path: String,
+    pub confidence_summary: HashMap<String, usize>,
+    pub section_count: usize,
+    pub entity_count: usize,
+    pub claim_count: usize,
+    pub citation_count: usize,
+    pub updated_at_ms: u64,
+    pub last_binding_count: usize,
+    pub last_drift_findings: usize,
+    #[serde(default)]
+    pub binding_preview: Vec<DocumentBindingEntry>,
+    #[serde(default)]
+    pub drift_summary: DocumentDriftSummary,
+    #[serde(default)]
+    pub last_binding_refresh_generation: u64,
+    #[serde(default)]
+    pub last_drift_refresh_generation: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DocumentCacheState {
+    pub entries: HashMap<String, DocumentCacheEntry>,
+}
+
+pub struct UniversalArtifacts {
+    pub entries: Vec<DocumentCacheEntry>,
+}
+
+pub fn cache_root(runtime_root: &Path) -> PathBuf {
+    runtime_root.join("l1ght-cache").join("sources")
+}
+
+pub fn cache_index_path(runtime_root: &Path) -> PathBuf {
+    runtime_root.join("document_cache_index.json")
+}
+
+pub fn ensure_cache_root_in_ingest_roots(state: &mut SessionState) {
+    let cache_root = cache_root(&state.runtime_root)
+        .to_string_lossy()
+        .to_string();
+    if let Some(pos) = state
+        .ingest_roots
+        .iter()
+        .position(|root| root == &cache_root)
+    {
+        let root = state.ingest_roots.remove(pos);
+        state.ingest_roots.push(root);
+    } else {
+        state.ingest_roots.push(cache_root);
+    }
+}
+
+pub fn load_document_cache(runtime_root: &Path) -> DocumentCacheState {
+    fs::read_to_string(cache_index_path(runtime_root))
+        .ok()
+        .and_then(|content| serde_json::from_str::<DocumentCacheState>(&content).ok())
+        .unwrap_or_default()
+}
+
+pub fn persist_document_cache(runtime_root: &Path, state: &DocumentCacheState) -> M1ndResult<()> {
+    save_json_atomic(&cache_index_path(runtime_root), state)
+}
+
+pub fn provider_availability() -> ProviderAvailability {
+    UniversalIngestAdapter::provider_availability()
+}
+
+pub fn provider_health(_input: DocumentProviderHealthInput) -> M1ndResult<serde_json::Value> {
+    let availability = provider_availability();
+    let python = m1nd_ingest::UniversalIngestAdapter::provider_python_command();
+    let providers = vec![
+        DocumentProviderHealthEntry {
+            name: "magika".into(),
+            available: availability.magika,
+            mode: "type-detection".into(),
+            detail: None,
+            install_hint: (!availability.magika).then_some("Install the Python package `magika` into the provider environment.".into()),
+        },
+        DocumentProviderHealthEntry {
+            name: "trafilatura".into(),
+            available: availability.trafilatura,
+            mode: "html/wiki extraction".into(),
+            detail: None,
+            install_hint: (!availability.trafilatura)
+                .then_some("Install the Python package `trafilatura` into the provider environment.".into()),
+        },
+        DocumentProviderHealthEntry {
+            name: "markitdown".into(),
+            available: availability.markitdown,
+            mode: "office/pdf fallback".into(),
+            detail: None,
+            install_hint: (!availability.markitdown)
+                .then_some("Install `markitdown` (and extras like `markitdown[docx]`) into the provider environment.".into()),
+        },
+        DocumentProviderHealthEntry {
+            name: "docling".into(),
+            available: availability.docling,
+            mode: "broad-spectrum canonicalizer".into(),
+            detail: None,
+            install_hint: (!availability.docling)
+                .then_some("Install the Python package `docling` into the provider environment.".into()),
+        },
+        DocumentProviderHealthEntry {
+            name: "grobid".into(),
+            available: availability.grobid,
+            mode: "scholarly pdf lane".into(),
+            detail: std::env::var("M1ND_GROBID_URL").ok(),
+            install_hint: (!availability.grobid)
+                .then_some("Set `M1ND_GROBID_URL` to a reachable GROBID service.".into()),
+        },
+        DocumentProviderHealthEntry {
+            name: "marker".into(),
+            available: availability.marker,
+            mode: "premium pdf lane".into(),
+            detail: None,
+            install_hint: (!availability.marker).then_some("Install the `marker` CLI and expose it on PATH.".into()),
+        },
+        DocumentProviderHealthEntry {
+            name: "mineru".into(),
+            available: availability.mineru,
+            mode: "ocr/layout premium lane".into(),
+            detail: None,
+            install_hint: (!availability.mineru).then_some("Install the `mineru` CLI and expose it on PATH.".into()),
+        },
+    ];
+
+    serde_json::to_value(DocumentProviderHealthOutput { python, providers })
+        .map_err(M1ndError::Serde)
+}
+
+pub fn write_canonical_artifacts(
+    runtime_root: &Path,
+    documents: &[CanonicalDocument],
+    namespace: &str,
+) -> M1ndResult<UniversalArtifacts> {
+    write_canonical_artifacts_with_source_root(runtime_root, None, documents, namespace)
+}
+
+pub fn write_canonical_artifacts_with_source_root(
+    runtime_root: &Path,
+    source_root: Option<&Path>,
+    documents: &[CanonicalDocument],
+    namespace: &str,
+) -> M1ndResult<UniversalArtifacts> {
+    let mut entries = Vec::new();
+    for document in documents {
+        let key = source_key(&document.source_path);
+        let dir = cache_root(runtime_root).join(&key);
+        fs::create_dir_all(&dir)?;
+
+        let ext = Path::new(&document.source_path)
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or("txt");
+        let source_copy = dir.join(format!("source.{}", ext));
+        let canonical_md = dir.join("canonical.md");
+        let canonical_json = dir.join("canonical.json");
+        let claims_json = dir.join("claims.json");
+        let metadata_json = dir.join("metadata.json");
+        let original_source_bytes = read_original_source_bytes(source_root, &document.source_path);
+        let preserved_original_source = original_source_bytes.is_some();
+        let source_bytes =
+            original_source_bytes.unwrap_or_else(|| document.plain_text.as_bytes().to_vec());
+
+        fs::write(&source_copy, &source_bytes)?;
+        fs::write(&canonical_md, render_markdown(document))?;
+        save_json_atomic(&canonical_json, document)?;
+        save_json_atomic(
+            &claims_json,
+            &serde_json::json!({
+                "entities": document.entities,
+                "claims": document.claims,
+                "citations": document.citations,
+                "links": document.links,
+                "sections": document.sections,
+            }),
+        )?;
+        save_json_atomic(
+            &metadata_json,
+            &serde_json::json!({
+                "doc_id": document.doc_id,
+                "source_path": document.source_path,
+                "source_kind": format!("{:?}", document.source_kind).to_lowercase(),
+                "detected_type": document.detected_type,
+                "producer": document.producer,
+                "content_hash": document.content_hash,
+                "source_size_bytes": source_bytes.len(),
+                "preserved_original_source": preserved_original_source,
+                "namespace": namespace,
+            }),
+        )?;
+
+        entries.push(DocumentCacheEntry {
+            source_path: document.source_path.clone(),
+            source_key: key,
+            source_kind: format!("{:?}", document.source_kind).to_lowercase(),
+            detected_type: document.detected_type.clone(),
+            producer: document.producer.clone(),
+            node_ids: expected_node_ids(document, namespace),
+            original_source_path: source_copy.to_string_lossy().to_string(),
+            canonical_markdown_path: canonical_md.to_string_lossy().to_string(),
+            canonical_json_path: canonical_json.to_string_lossy().to_string(),
+            claims_path: claims_json.to_string_lossy().to_string(),
+            metadata_path: metadata_json.to_string_lossy().to_string(),
+            confidence_summary: confidence_summary(document),
+            section_count: document.sections.len(),
+            entity_count: document.entities.len(),
+            claim_count: document.claims.len(),
+            citation_count: document.citations.len(),
+            updated_at_ms: now_ms(),
+            last_binding_count: 0,
+            last_drift_findings: 0,
+            binding_preview: Vec::new(),
+            drift_summary: DocumentDriftSummary::default(),
+            last_binding_refresh_generation: 0,
+            last_drift_refresh_generation: 0,
+        });
+    }
+
+    Ok(UniversalArtifacts { entries })
+}
+
+pub fn remove_artifacts_for_source(runtime_root: &Path, source_path: &str) -> M1ndResult<()> {
+    let dir = cache_root(runtime_root).join(source_key(source_path));
+    if dir.exists() {
+        fs::remove_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+fn resolve_source_input_path(source_root: &Path, source_path: &str) -> PathBuf {
+    let source = Path::new(source_path);
+    if source.is_absolute() {
+        return source.to_path_buf();
+    }
+    if source_root.is_file() {
+        return source_root
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(source);
+    }
+    source_root.join(source)
+}
+
+fn read_original_source_bytes(source_root: Option<&Path>, source_path: &str) -> Option<Vec<u8>> {
+    let root = source_root?;
+    fs::read(resolve_source_input_path(root, source_path)).ok()
+}
+
+pub fn rewrite_graph_provenance_to_canonical(
+    graph: &mut Graph,
+    entries: &[DocumentCacheEntry],
+    namespace: &str,
+) {
+    let mut by_source = HashMap::new();
+    for entry in entries {
+        by_source.insert(
+            entry.source_path.clone(),
+            entry.canonical_markdown_path.clone(),
+        );
+    }
+
+    for idx in 0..graph.num_nodes() as usize {
+        let node = NodeId::new(idx as u32);
+        let provenance = graph.resolve_node_provenance(node);
+        let Some(source_path) = provenance.source_path.as_ref() else {
+            continue;
+        };
+        let Some(canonical_path) = by_source.get(source_path) else {
+            continue;
+        };
+        graph.set_node_provenance(
+            node,
+            NodeProvenanceInput {
+                source_path: Some(canonical_path),
+                line_start: provenance.line_start,
+                line_end: provenance.line_end,
+                excerpt: provenance.excerpt.as_deref(),
+                namespace: provenance.namespace.as_deref().or(Some(namespace)),
+                canonical: provenance.canonical,
+            },
+        );
+    }
+}
+
+fn should_refresh_document_semantics(entry: &DocumentCacheEntry, graph_generation: u64) -> bool {
+    entry.last_binding_refresh_generation < graph_generation
+        || entry.last_drift_refresh_generation < graph_generation
+        || (entry.last_binding_refresh_generation == 0 && entry.last_drift_refresh_generation == 0)
+}
+
+fn refresh_document_cache_entry(state: &mut SessionState, source_path: &str) -> M1ndResult<()> {
+    let Some(snapshot) = state.document_cache.entries.get(source_path).cloned() else {
+        return Ok(());
+    };
+    if !should_refresh_document_semantics(&snapshot, state.graph_generation) {
+        return Ok(());
+    }
+
+    let bindings = compute_bindings(state, &snapshot, 8)?;
+    let drift = compute_drift(state, &snapshot, &bindings)?;
+    if let Some(entry) = state.document_cache.entries.get_mut(source_path) {
+        entry.last_binding_count = bindings.len();
+        entry.binding_preview = bindings.into_iter().take(8).collect();
+        entry.last_drift_findings = drift.summary.total_findings;
+        entry.drift_summary = drift.summary;
+        entry.last_binding_refresh_generation = state.graph_generation;
+        entry.last_drift_refresh_generation = state.graph_generation;
+    }
+    Ok(())
+}
+
+pub fn refresh_all_document_semantics(state: &mut SessionState) {
+    let stale_sources = state
+        .document_cache
+        .entries
+        .values()
+        .filter(|entry| should_refresh_document_semantics(entry, state.graph_generation))
+        .map(|entry| entry.source_path.clone())
+        .collect::<Vec<_>>();
+    for source_path in stale_sources {
+        let _ = refresh_document_cache_entry(state, &source_path);
+    }
+}
+
+pub fn resolve_document(
+    state: &mut SessionState,
+    input: DocumentResolveInput,
+) -> M1ndResult<serde_json::Value> {
+    let source_path = resolve_entry_source_path(
+        &state.document_cache,
+        "document_resolve",
+        input.path,
+        input.node_id,
+    )?;
+
+    refresh_document_cache_entry(state, &source_path)?;
+    let entry = state
+        .document_cache
+        .entries
+        .get(&source_path)
+        .ok_or_else(|| M1ndError::InvalidParams {
+            tool: "document_resolve".into(),
+            detail: "document cache entry disappeared during refresh".into(),
+        })?;
+
+    serde_json::to_value(DocumentResolveOutput {
+        source_path: entry.source_path.clone(),
+        source_key: entry.source_key.clone(),
+        original_source_path: entry.original_source_path.clone(),
+        canonical_markdown_path: entry.canonical_markdown_path.clone(),
+        canonical_json_path: entry.canonical_json_path.clone(),
+        claims_path: entry.claims_path.clone(),
+        metadata_path: entry.metadata_path.clone(),
+        detected_type: entry.detected_type.clone(),
+        producer: entry.producer.clone(),
+        node_ids: entry.node_ids.clone(),
+        confidence_summary: entry.confidence_summary.clone(),
+        section_count: entry.section_count,
+        claim_count: entry.claim_count,
+        entity_count: entry.entity_count,
+        citation_count: entry.citation_count,
+        binding_count: entry.last_binding_count,
+        binding_preview: entry.binding_preview.iter().take(3).cloned().collect(),
+        drift_summary: entry.drift_summary.clone(),
+    })
+    .map_err(M1ndError::Serde)
+}
+
+pub fn document_bindings(
+    state: &mut SessionState,
+    input: DocumentBindingsInput,
+) -> M1ndResult<serde_json::Value> {
+    let source_path = resolve_entry_source_path(
+        &state.document_cache,
+        "document_bindings",
+        input.path,
+        input.node_id,
+    )?;
+    let entry = cache_entry_clone(&state.document_cache, "document_bindings", &source_path)?;
+    let bindings = compute_bindings(state, &entry, input.top_k)?;
+    if let Some(cache_entry) = state.document_cache.entries.get_mut(&source_path) {
+        cache_entry.last_binding_count = bindings.len();
+        cache_entry.binding_preview = bindings.iter().take(8).cloned().collect();
+        cache_entry.last_binding_refresh_generation = state.graph_generation;
+    }
+    serde_json::to_value(DocumentBindingsOutput {
+        source_path,
+        bindings,
+    })
+    .map_err(M1ndError::Serde)
+}
+
+pub fn document_drift(
+    state: &mut SessionState,
+    input: DocumentDriftInput,
+) -> M1ndResult<serde_json::Value> {
+    let source_path = resolve_entry_source_path(
+        &state.document_cache,
+        "document_drift",
+        input.path,
+        input.node_id,
+    )?;
+    let entry = cache_entry_clone(&state.document_cache, "document_drift", &source_path)?;
+    let bindings = compute_bindings(state, &entry, 16)?;
+    let drift = compute_drift(state, &entry, &bindings)?;
+    if let Some(cache_entry) = state.document_cache.entries.get_mut(&source_path) {
+        cache_entry.last_binding_count = bindings.len();
+        cache_entry.binding_preview = bindings.iter().take(8).cloned().collect();
+        cache_entry.last_drift_findings = drift.summary.total_findings;
+        cache_entry.drift_summary = drift.summary.clone();
+        cache_entry.last_binding_refresh_generation = state.graph_generation;
+        cache_entry.last_drift_refresh_generation = state.graph_generation;
+    }
+    serde_json::to_value(drift).map_err(M1ndError::Serde)
+}
+
+fn resolve_by_path<'a>(
+    cache: &'a DocumentCacheState,
+    path: &str,
+) -> Option<&'a DocumentCacheEntry> {
+    cache.entries.get(path).or_else(|| {
+        let matches = cache
+            .entries
+            .values()
+            .filter(|entry| {
+                entry.source_path.ends_with(path) || entry.canonical_markdown_path == path
+            })
+            .collect::<Vec<_>>();
+        (matches.len() == 1).then(|| matches[0])
+    })
+}
+
+fn resolve_by_node_id<'a>(
+    cache: &'a DocumentCacheState,
+    node_id: &str,
+) -> Option<&'a DocumentCacheEntry> {
+    cache
+        .entries
+        .values()
+        .find(|entry| entry.node_ids.iter().any(|value| value == node_id))
+}
+
+fn resolve_entry_source_path(
+    cache: &DocumentCacheState,
+    tool: &str,
+    path: Option<String>,
+    node_id: Option<String>,
+) -> M1ndResult<String> {
+    if let Some(path) = path {
+        if let Some(entry) = cache.entries.get(&path) {
+            return Ok(entry.source_path.clone());
+        }
+        let matches = cache
+            .entries
+            .values()
+            .filter(|entry| {
+                entry.source_path.ends_with(&path) || entry.canonical_markdown_path == path
+            })
+            .collect::<Vec<_>>();
+        return match matches.len() {
+            1 => Ok(matches[0].source_path.clone()),
+            0 => Err(M1ndError::InvalidParams {
+                tool: tool.into(),
+                detail: format!("no document cache entry found for path '{}'", path),
+            }),
+            _ => Err(M1ndError::InvalidParams {
+                tool: tool.into(),
+                detail: format!(
+                    "ambiguous document path '{}'; provide a more specific path",
+                    path
+                ),
+            }),
+        };
+    }
+    if let Some(node_id) = node_id {
+        return resolve_by_node_id(cache, &node_id)
+            .map(|entry| entry.source_path.clone())
+            .ok_or_else(|| M1ndError::InvalidParams {
+                tool: tool.into(),
+                detail: format!("no document cache entry found for node_id '{}'", node_id),
+            });
+    }
+    Err(M1ndError::InvalidParams {
+        tool: tool.into(),
+        detail: "path or node_id is required".into(),
+    })
+}
+
+fn cache_entry_clone(
+    cache: &DocumentCacheState,
+    tool: &str,
+    source_path: &str,
+) -> M1ndResult<DocumentCacheEntry> {
+    cache
+        .entries
+        .get(source_path)
+        .cloned()
+        .ok_or_else(|| M1ndError::InvalidParams {
+            tool: tool.into(),
+            detail: "document cache entry disappeared".into(),
+        })
+}
+
+fn confidence_summary(document: &CanonicalDocument) -> HashMap<String, usize> {
+    let mut summary = HashMap::new();
+    for confidence in document
+        .entities
+        .iter()
+        .map(|value| &value.confidence)
+        .chain(document.claims.iter().map(|value| &value.confidence))
+        .chain(document.citations.iter().map(|value| &value.confidence))
+        .chain(document.links.iter().map(|value| &value.confidence))
+    {
+        let key = match confidence {
+            ConfidenceLevel::Explicit => "explicit",
+            ConfidenceLevel::Parsed => "parsed",
+            ConfidenceLevel::Inferred => "inferred",
+        };
+        *summary.entry(key.to_string()).or_insert(0) += 1;
+    }
+    summary
+}
+
+pub fn aggregate_semantic_metrics(
+    state: &SessionState,
+) -> (usize, usize, usize, usize, usize, usize) {
+    let document_count = state.document_cache.entries.len();
+    let section_count = state
+        .document_cache
+        .entries
+        .values()
+        .map(|entry| entry.section_count)
+        .sum();
+    let claim_count = state
+        .document_cache
+        .entries
+        .values()
+        .map(|entry| entry.claim_count)
+        .sum();
+    let entity_count = state
+        .document_cache
+        .entries
+        .values()
+        .map(|entry| entry.entity_count)
+        .sum();
+    let citation_count = state
+        .document_cache
+        .entries
+        .values()
+        .map(|entry| entry.citation_count)
+        .sum();
+
+    let drift_document_count = state
+        .document_cache
+        .entries
+        .values()
+        .filter(|entry| entry.drift_summary.total_findings > 0)
+        .count();
+
+    (
+        document_count,
+        section_count,
+        claim_count,
+        entity_count,
+        citation_count,
+        drift_document_count,
+    )
+}
+
+fn is_fallback_route(producer: &str) -> bool {
+    matches!(
+        producer,
+        "universal:internal" | "universal:internal-html" | "universal:markitdown"
+    )
+}
+
+pub fn provider_route_metrics(
+    state: &SessionState,
+) -> (HashMap<String, usize>, HashMap<String, usize>) {
+    let mut route_counts = HashMap::new();
+    let mut fallback_counts = HashMap::new();
+    for entry in state.document_cache.entries.values() {
+        *route_counts.entry(entry.producer.clone()).or_insert(0) += 1;
+        if is_fallback_route(&entry.producer) {
+            *fallback_counts.entry(entry.producer.clone()).or_insert(0) += 1;
+        }
+    }
+    (route_counts, fallback_counts)
+}
+
+fn load_canonical_document(entry: &DocumentCacheEntry) -> M1ndResult<CanonicalDocument> {
+    let content = fs::read_to_string(&entry.canonical_json_path)?;
+    serde_json::from_str(&content).map_err(M1ndError::Serde)
+}
+
+fn collect_binding_candidates(
+    document: &CanonicalDocument,
+) -> Vec<(String, String, ConfidenceLevel)> {
+    let mut out = Vec::new();
+    for candidate in &document.code_candidates {
+        out.push((
+            candidate.label.clone(),
+            format!("candidate:{:?}", candidate.candidate_kind).to_lowercase(),
+            candidate.confidence.clone(),
+        ));
+    }
+    for entity in &document.entities {
+        out.push((
+            entity.label.clone(),
+            format!("entity:{:?}", entity.kind).to_lowercase(),
+            entity.confidence.clone(),
+        ));
+    }
+    out
+}
+
+fn score_binding(
+    candidate: &str,
+    relation_hint: &str,
+    ext_id: &str,
+    label: &str,
+    file_path: Option<&str>,
+) -> Option<(f32, String, String)> {
+    if candidate.is_empty() {
+        return None;
+    }
+    if ext_id == candidate || ext_id.ends_with(candidate) {
+        return Some((
+            1.0,
+            infer_relation(relation_hint, candidate),
+            "exact external id match".into(),
+        ));
+    }
+    if label == candidate {
+        return Some((
+            0.92,
+            infer_relation(relation_hint, candidate),
+            "exact label match".into(),
+        ));
+    }
+    if let Some(path) = file_path {
+        if path.ends_with(candidate) || candidate.ends_with(path) || path.contains(candidate) {
+            return Some((0.88, "mentions_file".into(), "file path match".into()));
+        }
+    }
+    if candidate.starts_with("m1nd.") && (label.contains(candidate) || ext_id.contains(candidate)) {
+        return Some((0.9, "mentions_tool".into(), "tool id match".into()));
+    }
+    if (candidate.contains("::") || candidate.contains('.'))
+        && (label.contains(candidate) || ext_id.contains(candidate))
+    {
+        return Some((
+            0.8,
+            infer_relation(relation_hint, candidate),
+            "symbol-like substring match".into(),
+        ));
+    }
+    None
+}
+
+fn infer_relation(relation_hint: &str, candidate: &str) -> String {
+    if relation_hint.contains("filepath") {
+        "mentions_file".into()
+    } else if relation_hint.contains("tool") || candidate.starts_with("m1nd.") {
+        "mentions_tool".into()
+    } else if relation_hint.contains("test") || candidate.to_ascii_lowercase().contains("test") {
+        "tests".into()
+    } else {
+        "mentions_symbol".into()
+    }
+}
+
+fn compute_bindings(
+    state: &SessionState,
+    entry: &DocumentCacheEntry,
+    top_k: usize,
+) -> M1ndResult<Vec<DocumentBindingEntry>> {
+    let document = load_canonical_document(entry)?;
+    let candidates = collect_binding_candidates(&document);
+    let graph = state.graph.read();
+    let mut bindings = Vec::new();
+    for (interned, &node_id) in &graph.id_to_node {
+        let ext_id = graph.strings.resolve(*interned);
+        if ext_id.starts_with("universal::") {
+            continue;
+        }
+        let idx = node_id.as_usize();
+        let label = graph.strings.resolve(graph.nodes.label[idx]);
+        let provenance = graph.resolve_node_provenance(node_id);
+        let file_path = provenance.source_path.clone();
+        if file_path
+            .as_deref()
+            .is_some_and(|path| path == entry.canonical_markdown_path || path == entry.source_path)
+        {
+            continue;
+        }
+        for (candidate, relation_hint, confidence) in &candidates {
+            if let Some((score, relation, reason)) = score_binding(
+                candidate,
+                relation_hint,
+                ext_id,
+                label,
+                file_path.as_deref(),
+            ) {
+                bindings.push(DocumentBindingEntry {
+                    target_node_id: ext_id.to_string(),
+                    target_label: label.to_string(),
+                    relation,
+                    score,
+                    confidence: format!("{:?}", confidence).to_lowercase(),
+                    reason,
+                    file_path: file_path.clone(),
+                });
+            }
+        }
+    }
+    bindings.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    bindings.dedup_by(|a, b| a.target_node_id == b.target_node_id && a.relation == b.relation);
+    bindings.truncate(top_k);
+    Ok(bindings)
+}
+
+fn compute_drift(
+    state: &SessionState,
+    entry: &DocumentCacheEntry,
+    bindings: &[DocumentBindingEntry],
+) -> M1ndResult<DocumentDriftOutput> {
+    let document = load_canonical_document(entry)?;
+    let mut findings = Vec::new();
+    let mut summary = DocumentDriftSummary::default();
+    let graph = state.graph.read();
+
+    if !document.code_candidates.is_empty() && bindings.is_empty() {
+        summary.unbacked_claims += document.claims.len();
+        findings.push(DocumentDriftFinding {
+            class: "doc_claim_unbacked".into(),
+            message: "document has code-oriented candidates but no resolved bindings".into(),
+            confidence: "parsed".into(),
+            heuristic: "zero_bindings_with_candidates".into(),
+        });
+    }
+
+    for candidate in &document.code_candidates {
+        let exact_matches = bindings
+            .iter()
+            .filter(|binding| {
+                binding.target_label == candidate.label
+                    || binding.target_node_id.ends_with(&candidate.label)
+            })
+            .map(|binding| binding.target_node_id.as_str())
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        if exact_matches == 0 {
+            summary.missing_targets += 1;
+            findings.push(DocumentDriftFinding {
+                class: "binding_missing".into(),
+                message: format!("no binding target resolved for {}", candidate.label),
+                confidence: format!("{:?}", candidate.confidence).to_lowercase(),
+                heuristic: "candidate_unresolved".into(),
+            });
+        } else if exact_matches > 1 {
+            summary.ambiguous_targets += 1;
+            findings.push(DocumentDriftFinding {
+                class: "binding_ambiguous".into(),
+                message: format!("multiple binding targets resolved for {}", candidate.label),
+                confidence: format!("{:?}", candidate.confidence).to_lowercase(),
+                heuristic: "candidate_multiple_matches".into(),
+            });
+        }
+    }
+
+    let mut seen_targets = std::collections::HashSet::new();
+    for binding in bindings {
+        if !seen_targets.insert(binding.target_node_id.clone()) {
+            continue;
+        }
+        if let Some(node_id) = graph.resolve_id(&binding.target_node_id) {
+            let idx = node_id.as_usize();
+            let modified_ms = (graph.nodes.last_modified[idx] * 1000.0) as u64;
+            if modified_ms > entry.updated_at_ms {
+                summary.stale_bindings += 1;
+                summary.code_change_unreflected += 1;
+                findings.push(DocumentDriftFinding {
+                    class: "code_change_unreflected".into(),
+                    message: format!(
+                        "bound target {} changed after document ingest",
+                        binding.target_label
+                    ),
+                    confidence: binding.confidence.clone(),
+                    heuristic: "target_newer_than_document".into(),
+                });
+            }
+        } else {
+            summary.missing_targets += 1;
+            findings.push(DocumentDriftFinding {
+                class: "binding_moved".into(),
+                message: format!(
+                    "binding target {} no longer resolves",
+                    binding.target_node_id
+                ),
+                confidence: binding.confidence.clone(),
+                heuristic: "resolved_binding_missing".into(),
+            });
+        }
+    }
+
+    summary.total_findings = findings.len();
+    Ok(DocumentDriftOutput {
+        source_path: entry.source_path.clone(),
+        findings,
+        summary,
+    })
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn expected_node_ids(document: &CanonicalDocument, namespace: &str) -> Vec<String> {
+    let mut ids = vec![format!(
+        "universal::{}::doc::{}",
+        namespace, document.doc_id
+    )];
+    ids.extend(
+        document
+            .sections
+            .iter()
+            .map(|section| format!("universal::{}::{}", namespace, section.section_id)),
+    );
+    ids
+}
+
+fn render_markdown(document: &CanonicalDocument) -> String {
+    let mut out = String::new();
+    out.push_str("# ");
+    out.push_str(&document.title);
+    out.push_str("\n\n");
+    out.push_str("> Source: ");
+    out.push_str(&document.source_path);
+    out.push_str("\n\n");
+    for section in &document.sections {
+        out.push_str(&"#".repeat(section.level as usize));
+        out.push(' ');
+        out.push_str(&section.heading);
+        out.push_str("\n\n");
+        for block in &section.blocks {
+            out.push_str(&block.text);
+            out.push_str("\n\n");
+        }
+    }
+    if document.sections.is_empty() {
+        out.push_str(&document.plain_text);
+    }
+    out
+}
+
+fn save_json_atomic<T: Serialize>(path: &Path, value: &T) -> M1ndResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+    let payload = serde_json::to_vec_pretty(value)?;
+    fs::write(&tmp, payload)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::McpConfig;
+    use crate::session::SessionState;
+    use m1nd_core::domain::DomainConfig;
+    use m1nd_core::graph::Graph;
+    use m1nd_ingest::canonical::{
+        CanonicalDocument, ClaimModality, ConfidenceLevel, DocumentClaimCandidate,
+        DocumentClaimKind, DocumentCodeCandidate, DocumentEntityCandidate, DocumentEntityKind,
+        DocumentMetadata, DocumentSection, DocumentSectionKind, ProvenanceSpan, SourceKind,
+    };
+
+    #[test]
+    fn writes_and_resolves_document_artifacts() {
+        let temp = tempfile::tempdir().unwrap();
+        let doc = CanonicalDocument {
+            doc_id: "canon::1".into(),
+            source_path: "docs/example.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash".into(),
+            title: "Example".into(),
+            plain_text: "# Example\nHello".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![DocumentSection {
+                section_id: "section::1".into(),
+                heading: "Example".into(),
+                level: 1,
+                kind: DocumentSectionKind::Overview,
+                parent_section_id: None,
+                blocks: vec![],
+                provenance: ProvenanceSpan::default(),
+            }],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![DocumentEntityCandidate {
+                label: "TokenValidator".into(),
+                kind: DocumentEntityKind::Symbol,
+                aliases: vec![],
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            claims: vec![DocumentClaimCandidate {
+                claim_id: "claim::1".into(),
+                label: "TokenValidator must validate requests.".into(),
+                kind: DocumentClaimKind::Requirement,
+                modality: ClaimModality::Must,
+                subject: None,
+                predicate: None,
+                object: None,
+                negated: false,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            code_candidates: vec![DocumentCodeCandidate {
+                label: "TokenValidator".into(),
+                candidate_kind: DocumentEntityKind::Symbol,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        assert_eq!(artifacts.entries.len(), 1);
+        assert!(Path::new(&artifacts.entries[0].canonical_markdown_path).exists());
+        assert!(Path::new(&artifacts.entries[0].canonical_json_path).exists());
+        assert_eq!(artifacts.entries[0].section_count, 1);
+        assert_eq!(artifacts.entries[0].entity_count, 1);
+    }
+
+    #[test]
+    fn preserves_original_source_bytes_when_available() {
+        let temp = tempfile::tempdir().unwrap();
+        let docs_root = temp.path().join("docs");
+        fs::create_dir_all(&docs_root).unwrap();
+        let source = docs_root.join("provider.docx");
+        let bytes = b"PK\x03\x04binary-docx-fixture";
+        fs::write(&source, bytes).unwrap();
+
+        let doc = CanonicalDocument {
+            doc_id: "canon::source".into(),
+            source_path: "provider.docx".into(),
+            source_kind: SourceKind::Docx,
+            detected_type: "docx".into(),
+            producer: "test".into(),
+            content_hash: "raw-hash".into(),
+            title: "Provider".into(),
+            plain_text: "Converted provider text".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![],
+            claims: vec![],
+            code_candidates: vec![],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+
+        let artifacts = write_canonical_artifacts_with_source_root(
+            temp.path(),
+            Some(&docs_root),
+            &[doc],
+            "universal",
+        )
+        .unwrap();
+        let entry = artifacts.entries.first().unwrap();
+        assert_eq!(fs::read(&entry.original_source_path).unwrap(), bytes);
+
+        let metadata: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&entry.metadata_path).unwrap()).unwrap();
+        assert_eq!(
+            metadata["source_size_bytes"].as_u64().unwrap_or_default(),
+            bytes.len() as u64
+        );
+        assert_eq!(metadata["preserved_original_source"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn provider_health_serializes() {
+        let value = provider_health(DocumentProviderHealthInput {
+            agent_id: "tester".into(),
+        })
+        .unwrap();
+        assert!(value.get("providers").and_then(|v| v.as_array()).is_some());
+        assert!(value.get("python").and_then(|v| v.as_str()).is_some());
+    }
+
+    #[test]
+    fn resolve_entry_source_path_rejects_ambiguous_suffix_matches() {
+        let mut cache = DocumentCacheState::default();
+        let entry_a = DocumentCacheEntry {
+            source_path: "docs/spec.md".into(),
+            source_key: "a".into(),
+            source_kind: "markdown".into(),
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            node_ids: vec![],
+            original_source_path: "a".into(),
+            canonical_markdown_path: "cache/a/canonical.md".into(),
+            canonical_json_path: "cache/a/canonical.json".into(),
+            claims_path: "cache/a/claims.json".into(),
+            metadata_path: "cache/a/metadata.json".into(),
+            confidence_summary: HashMap::new(),
+            section_count: 0,
+            entity_count: 0,
+            claim_count: 0,
+            citation_count: 0,
+            updated_at_ms: 0,
+            last_binding_count: 0,
+            last_drift_findings: 0,
+            binding_preview: vec![],
+            drift_summary: DocumentDriftSummary::default(),
+            last_binding_refresh_generation: 0,
+            last_drift_refresh_generation: 0,
+        };
+        let mut entry_b = entry_a.clone();
+        entry_b.source_path = "guides/spec.md".into();
+        entry_b.source_key = "b".into();
+        cache.entries.insert(entry_a.source_path.clone(), entry_a);
+        cache.entries.insert(entry_b.source_path.clone(), entry_b);
+
+        let err =
+            resolve_entry_source_path(&cache, "document_resolve", Some("spec.md".into()), None)
+                .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("ambiguous document path 'spec.md'"));
+    }
+
+    fn build_state(root: &Path) -> SessionState {
+        let config = McpConfig {
+            graph_source: root.join("graph_snapshot.json"),
+            plasticity_state: root.join("plasticity_state.json"),
+            runtime_dir: Some(root.to_path_buf()),
+            ..McpConfig::default()
+        };
+        SessionState::initialize(Graph::new(), &config, DomainConfig::code()).unwrap()
+    }
+
+    #[test]
+    fn bindings_and_drift_work_for_cached_document() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        {
+            let mut graph = state.graph.write();
+            graph
+                .add_node(
+                    "file::src/token_validator.rs",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::File,
+                    &["code"],
+                    10.0,
+                    0.1,
+                )
+                .unwrap();
+            graph.finalize().unwrap();
+        }
+        let doc = CanonicalDocument {
+            doc_id: "canon::1".into(),
+            source_path: "docs/example.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash".into(),
+            title: "Example".into(),
+            plain_text: "# Example\nTokenValidator must validate requests.".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![DocumentEntityCandidate {
+                label: "TokenValidator".into(),
+                kind: DocumentEntityKind::Symbol,
+                aliases: vec![],
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            claims: vec![DocumentClaimCandidate {
+                claim_id: "claim::1".into(),
+                label: "TokenValidator must validate requests.".into(),
+                kind: DocumentClaimKind::Requirement,
+                modality: ClaimModality::Must,
+                subject: None,
+                predicate: None,
+                object: None,
+                negated: false,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            code_candidates: vec![DocumentCodeCandidate {
+                label: "TokenValidator".into(),
+                candidate_kind: DocumentEntityKind::Symbol,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let entry = artifacts.entries.first().unwrap().clone();
+        state
+            .document_cache
+            .entries
+            .insert(entry.source_path.clone(), entry.clone());
+
+        let bindings = compute_bindings(&state, &entry, 5).unwrap();
+        assert!(!bindings.is_empty());
+        let drift = compute_drift(&state, &entry, &bindings).unwrap();
+        assert_eq!(drift.source_path, "docs/example.md");
+    }
+
+    #[test]
+    fn compute_bindings_ignores_universal_self_nodes() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        {
+            let mut graph = state.graph.write();
+            graph
+                .add_node(
+                    "file::src/token_validator.rs",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::File,
+                    &["code"],
+                    10.0,
+                    0.1,
+                )
+                .unwrap();
+            graph
+                .add_node(
+                    "universal::universal::entity::tokenvalidator",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::Concept,
+                    &["universal"],
+                    10.0,
+                    0.1,
+                )
+                .unwrap();
+            graph.finalize().unwrap();
+        }
+        let doc = CanonicalDocument {
+            doc_id: "canon::2".into(),
+            source_path: "docs/spec.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash2".into(),
+            title: "Spec".into(),
+            plain_text: "`TokenValidator`".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![DocumentEntityCandidate {
+                label: "TokenValidator".into(),
+                kind: DocumentEntityKind::Symbol,
+                aliases: vec![],
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            claims: vec![],
+            code_candidates: vec![DocumentCodeCandidate {
+                label: "TokenValidator".into(),
+                candidate_kind: DocumentEntityKind::Symbol,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let entry = artifacts.entries.first().unwrap().clone();
+        state
+            .document_cache
+            .entries
+            .insert(entry.source_path.clone(), entry.clone());
+
+        let bindings = compute_bindings(&state, &entry, 5).unwrap();
+        assert!(bindings
+            .iter()
+            .all(|binding| !binding.target_node_id.starts_with("universal::")));
+        assert!(bindings
+            .iter()
+            .any(|binding| binding.target_node_id == "file::src/token_validator.rs"));
+    }
+
+    #[test]
+    fn drift_reports_missing_binding_when_target_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        let doc = CanonicalDocument {
+            doc_id: "canon::3".into(),
+            source_path: "docs/spec.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash3".into(),
+            title: "Spec".into(),
+            plain_text: "`MissingThing` must exist.".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![],
+            claims: vec![DocumentClaimCandidate {
+                claim_id: "claim::3".into(),
+                label: "MissingThing must exist.".into(),
+                kind: DocumentClaimKind::Requirement,
+                modality: ClaimModality::Must,
+                subject: Some("MissingThing".into()),
+                predicate: Some("must".into()),
+                object: Some("exist".into()),
+                negated: false,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            code_candidates: vec![DocumentCodeCandidate {
+                label: "MissingThing".into(),
+                candidate_kind: DocumentEntityKind::Symbol,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let entry = artifacts.entries.first().unwrap().clone();
+        let bindings = compute_bindings(&state, &entry, 5).unwrap();
+        assert!(bindings.is_empty());
+        let drift = compute_drift(&state, &entry, &bindings).unwrap();
+        assert!(drift.summary.missing_targets >= 1);
+    }
+
+    #[test]
+    fn drift_reports_code_change_unreflected_for_newer_bound_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        {
+            let mut graph = state.graph.write();
+            graph
+                .add_node(
+                    "file::src/token_validator.rs",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::File,
+                    &["code"],
+                    9999999999.0,
+                    0.1,
+                )
+                .unwrap();
+            graph.finalize().unwrap();
+        }
+        let doc = CanonicalDocument {
+            doc_id: "canon::4".into(),
+            source_path: "docs/spec.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash4".into(),
+            title: "Spec".into(),
+            plain_text: "`src/token_validator.rs` should stay aligned.".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![],
+            claims: vec![],
+            code_candidates: vec![DocumentCodeCandidate {
+                label: "src/token_validator.rs".into(),
+                candidate_kind: DocumentEntityKind::FilePath,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let mut entry = artifacts.entries.first().unwrap().clone();
+        entry.updated_at_ms = 1;
+        let bindings = compute_bindings(&state, &entry, 5).unwrap();
+        let drift = compute_drift(&state, &entry, &bindings).unwrap();
+        assert!(drift.summary.code_change_unreflected >= 1);
+    }
+
+    #[test]
+    fn drift_reports_ambiguous_binding_when_multiple_targets_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        {
+            let mut graph = state.graph.write();
+            graph
+                .add_node(
+                    "file::src/token_validator.rs",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::File,
+                    &["code"],
+                    10.0,
+                    0.1,
+                )
+                .unwrap();
+            graph
+                .add_node(
+                    "file::src/token_validator_v2.rs",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::File,
+                    &["code"],
+                    10.0,
+                    0.1,
+                )
+                .unwrap();
+            graph.finalize().unwrap();
+        }
+        let doc = CanonicalDocument {
+            doc_id: "canon::5".into(),
+            source_path: "docs/spec.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash5".into(),
+            title: "Spec".into(),
+            plain_text: "`TokenValidator` must validate requests.".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![],
+            claims: vec![],
+            code_candidates: vec![DocumentCodeCandidate {
+                label: "TokenValidator".into(),
+                candidate_kind: DocumentEntityKind::Symbol,
+                confidence: ConfidenceLevel::Parsed,
+                provenance: ProvenanceSpan::default(),
+            }],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let entry = artifacts.entries.first().unwrap().clone();
+        let bindings = compute_bindings(&state, &entry, 5).unwrap();
+        let drift = compute_drift(&state, &entry, &bindings).unwrap();
+        assert!(drift.summary.ambiguous_targets >= 1);
+    }
+
+    #[test]
+    fn drift_does_not_flag_ambiguous_when_one_target_has_multiple_relations() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        {
+            let mut graph = state.graph.write();
+            graph
+                .add_node(
+                    "file::src/token_validator.rs",
+                    "TokenValidator",
+                    m1nd_core::types::NodeType::File,
+                    &["code"],
+                    10.0,
+                    0.1,
+                )
+                .unwrap();
+            graph.finalize().unwrap();
+        }
+        let doc = CanonicalDocument {
+            doc_id: "canon::one-target".into(),
+            source_path: "docs/spec.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash-one-target".into(),
+            title: "Spec".into(),
+            plain_text: "`TokenValidator` must validate requests.\nSee `src/token_validator.rs`."
+                .into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![],
+            claims: vec![],
+            code_candidates: vec![
+                DocumentCodeCandidate {
+                    label: "TokenValidator".into(),
+                    candidate_kind: DocumentEntityKind::Symbol,
+                    confidence: ConfidenceLevel::Parsed,
+                    provenance: ProvenanceSpan::default(),
+                },
+                DocumentCodeCandidate {
+                    label: "src/token_validator.rs".into(),
+                    candidate_kind: DocumentEntityKind::FilePath,
+                    confidence: ConfidenceLevel::Parsed,
+                    provenance: ProvenanceSpan::default(),
+                },
+            ],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let entry = artifacts.entries.first().unwrap().clone();
+        let bindings = compute_bindings(&state, &entry, 8).unwrap();
+        let drift = compute_drift(&state, &entry, &bindings).unwrap();
+        assert_eq!(drift.summary.ambiguous_targets, 0);
+    }
+
+    #[test]
+    fn drift_reports_binding_moved_for_stale_binding_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut state = build_state(temp.path());
+        let doc = CanonicalDocument {
+            doc_id: "canon::6".into(),
+            source_path: "docs/spec.md".into(),
+            source_kind: SourceKind::Markdown,
+            detected_type: "markdown".into(),
+            producer: "test".into(),
+            content_hash: "hash6".into(),
+            title: "Spec".into(),
+            plain_text: "`TokenValidator` must validate requests.".into(),
+            metadata: DocumentMetadata::default(),
+            sections: vec![],
+            tables: vec![],
+            links: vec![],
+            citations: vec![],
+            entities: vec![],
+            claims: vec![],
+            code_candidates: vec![],
+            confidence: ConfidenceLevel::Parsed,
+            structured_origin: serde_json::json!({}),
+        };
+        let artifacts = write_canonical_artifacts(temp.path(), &[doc], "universal").unwrap();
+        let entry = artifacts.entries.first().unwrap().clone();
+        let bindings = vec![DocumentBindingEntry {
+            target_node_id: "file::src/token_validator.rs".into(),
+            target_label: "TokenValidator".into(),
+            relation: "mentions_symbol".into(),
+            score: 1.0,
+            confidence: "parsed".into(),
+            reason: "stale".into(),
+            file_path: Some("src/token_validator.rs".into()),
+        }];
+        let drift = compute_drift(&state, &entry, &bindings).unwrap();
+        assert!(drift.summary.missing_targets >= 1);
+        assert!(drift
+            .findings
+            .iter()
+            .any(|finding| finding.class == "binding_moved"));
+    }
+}

--- a/m1nd-mcp/tests/test_auto_ingest.rs
+++ b/m1nd-mcp/tests/test_auto_ingest.rs
@@ -68,17 +68,24 @@ fn search_file_paths(state: &mut SessionState, query: &str) -> Vec<String> {
 }
 
 fn wait_for_queue(state: &mut SessionState, expected_min: usize) {
+    let mut last_queue_depth = 0;
     for _ in 0..50 {
         let status = call(state, "auto_ingest_status", json!({ "agent_id": "tester" }));
         let queue_depth = status
             .get("queue_depth")
             .and_then(|value| value.as_u64())
             .unwrap_or(0) as usize;
+        last_queue_depth = queue_depth;
         if queue_depth >= expected_min {
             return;
         }
         thread::sleep(Duration::from_millis(20));
     }
+    panic!(
+        "timed out waiting for auto-ingest queue depth to reach at least {}; last observed queue depth was {} after 50 retries with 20ms sleep",
+        expected_min,
+        last_queue_depth
+    );
 }
 
 fn write(path: &Path, content: &str) {

--- a/m1nd-mcp/tests/test_auto_ingest.rs
+++ b/m1nd-mcp/tests/test_auto_ingest.rs
@@ -1,0 +1,821 @@
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+fn search_count(state: &mut SessionState, query: &str) -> usize {
+    call(
+        state,
+        "search",
+        json!({"agent_id":"tester","query":query,"mode":"literal"}),
+    )
+    .get("results")
+    .and_then(|value| value.as_array())
+    .map(|value| value.len())
+    .unwrap_or(0)
+}
+
+fn search_first_node_id(state: &mut SessionState, query: &str) -> String {
+    call(
+        state,
+        "search",
+        json!({"agent_id":"tester","query":query,"mode":"literal"}),
+    )
+    .get("results")
+    .and_then(|value| value.as_array())
+    .and_then(|value| value.first())
+    .and_then(|value| value.get("node_id"))
+    .and_then(|value| value.as_str())
+    .unwrap_or("")
+    .to_string()
+}
+
+fn search_file_paths(state: &mut SessionState, query: &str) -> Vec<String> {
+    call(
+        state,
+        "search",
+        json!({"agent_id":"tester","query":query,"mode":"literal"}),
+    )
+    .get("results")
+    .and_then(|value| value.as_array())
+    .map(|results| {
+        results
+            .iter()
+            .filter_map(|entry| entry.get("file_path").and_then(|value| value.as_str()))
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+    })
+    .unwrap_or_default()
+}
+
+fn wait_for_queue(state: &mut SessionState, expected_min: usize) {
+    for _ in 0..50 {
+        let status = call(state, "auto_ingest_status", json!({ "agent_id": "tester" }));
+        let queue_depth = status
+            .get("queue_depth")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize;
+        if queue_depth >= expected_min {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn light_doc(entity: &str, doi: &str) -> String {
+    format!(
+        r#"---
+Protocol: L1GHT/1
+Node: {entity}
+State: active
+Color: amber
+Glyph: *
+Completeness: draft
+Proof: working
+Depends on:
+- {doi}
+Next:
+- validate
+---
+## Contract
+[⍂ entity: {entity}]
+[⟁ depends_on: {doi}]
+[𝔻 evidence: ready]
+"#
+    )
+}
+
+fn pubmed_article(title: &str, doi: &str) -> String {
+    format!(
+        r#"<?xml version="1.0"?>
+<PubmedArticleSet>
+<PubmedArticle>
+  <MedlineCitation>
+    <PMID>12345678</PMID>
+    <Article>
+      <ArticleTitle>{title}</ArticleTitle>
+      <Journal><Title>Nature</Title></Journal>
+      <AuthorList>
+        <Author><ForeName>Jane</ForeName><LastName>Doe</LastName></Author>
+      </AuthorList>
+    </Article>
+  </MedlineCitation>
+  <PubmedData>
+    <ReferenceList>
+      <Reference>
+        <ArticleIdList>
+          <ArticleId IdType="doi">{doi}</ArticleId>
+        </ArticleIdList>
+      </Reference>
+    </ReferenceList>
+  </PubmedData>
+</PubmedArticle>
+</PubmedArticleSet>"#
+    )
+}
+
+fn bibtex_entry(title: &str, doi: &str) -> String {
+    format!(
+        r#"@article{{shared2026,
+  author = {{Doe, Jane}},
+  title = {{{title}}},
+  journal = {{Nature}},
+  year = {{2026}},
+  doi = {{{doi}}}
+}}
+"#
+    )
+}
+
+fn crossref_work(title: &str, doi: &str) -> String {
+    json!({
+        "DOI": doi,
+        "title": [title],
+        "type": "journal-article",
+        "publisher": "Nature",
+        "author": [{"given": "Jane", "family": "Doe", "sequence": "first"}],
+        "reference": []
+    })
+    .to_string()
+}
+
+fn plain_markdown(title: &str, body: &str) -> String {
+    format!("# {}\n\n{}\n", title, body)
+}
+
+fn html_doc(title: &str, body: &str) -> String {
+    format!(
+        "<html><body><h1>{}</h1><p>{}</p><p><a href=\"https://example.com/docs\">Docs</a></p></body></html>",
+        title, body
+    )
+}
+
+#[test]
+fn auto_ingest_light_file_lifecycle_end_to_end() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("docs");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("notes.md");
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["light"],"debounce_ms":0}),
+    );
+
+    write(&file, &light_doc("AlphaNode", "10.1000/shared"));
+    wait_for_queue(&mut state, 1);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    assert!(
+        search_count(&mut state, "AlphaNode") > 0,
+        "light entity must be searchable after create"
+    );
+
+    write(&file, &light_doc("OmegaNode", "10.1000/shared"));
+    wait_for_queue(&mut state, 1);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    assert_eq!(
+        search_count(&mut state, "AlphaNode"),
+        0,
+        "old entity should disappear after update"
+    );
+
+    assert!(
+        search_count(&mut state, "OmegaNode") > 0,
+        "new entity must be searchable after update"
+    );
+
+    fs::remove_file(&file).unwrap();
+    wait_for_queue(&mut state, 1);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    assert_eq!(
+        search_count(&mut state, "OmegaNode"),
+        0,
+        "entity should disappear after delete"
+    );
+}
+
+#[test]
+fn auto_ingest_supports_article_bibtex_and_crossref() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("research");
+    fs::create_dir_all(&docs_root).unwrap();
+    let article = docs_root.join("paper.xml");
+    let bib = docs_root.join("refs.bib");
+    let crossref = docs_root.join("work.json");
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["article","bibtex","crossref"],"debounce_ms":0}),
+    );
+
+    write(&article, &pubmed_article("Test Article", "10.1000/shared"));
+    write(&bib, &bibtex_entry("Shared Bibliography", "10.1000/shared"));
+    write(&crossref, &crossref_work("Shared Work", "10.1000/shared"));
+    wait_for_queue(&mut state, 3);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    for needle in ["12345678", "Shared Bibliography", "Shared Work"] {
+        assert!(
+            search_count(&mut state, needle) > 0,
+            "expected searchable result for {}",
+            needle
+        );
+    }
+}
+
+#[test]
+fn auto_ingest_mixed_domain_query_returns_multiple_formats() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("mixed");
+    fs::create_dir_all(&docs_root).unwrap();
+
+    write(
+        &docs_root.join("spec.md"),
+        &light_doc("BridgeStudy", "10.1000/shared"),
+    );
+    write(
+        &docs_root.join("paper.xml"),
+        &pubmed_article("Bridge Article", "10.1000/shared"),
+    );
+    write(
+        &docs_root.join("refs.bib"),
+        &bibtex_entry("Bridge Bibliography", "10.1000/shared"),
+    );
+    write(
+        &docs_root.join("work.json"),
+        &crossref_work("Bridge CrossRef", "10.1000/shared"),
+    );
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"debounce_ms":0}),
+    );
+
+    let file_paths = search_file_paths(&mut state, "10.1000/shared");
+    assert!(file_paths.iter().any(|path| path.ends_with(".md")));
+    assert!(file_paths.iter().any(|path| path.ends_with(".xml")));
+    assert!(
+        file_paths.len() >= 3,
+        "expected mixed-domain retrieval, got {:?}",
+        file_paths
+    );
+}
+
+#[test]
+fn auto_ingest_lock_watch_observes_ingest_mutations() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("locks");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("watch.md");
+    write(&file, &light_doc("WatchedNode", "10.1000/watch"));
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["light"],"debounce_ms":0}),
+    );
+
+    let node_id = search_first_node_id(&mut state, "WatchedNode");
+    assert!(!node_id.is_empty(), "watched node result");
+
+    let created = call(
+        &mut state,
+        "lock_create",
+        json!({"agent_id":"tester","scope":"node","root_nodes":[node_id]}),
+    );
+    let lock_id = created
+        .get("lock_id")
+        .and_then(|value| value.as_str())
+        .expect("lock id")
+        .to_string();
+
+    call(
+        &mut state,
+        "lock_watch",
+        json!({"agent_id":"tester","lock_id":lock_id,"strategy":"on_ingest"}),
+    );
+
+    write(&file, &light_doc("WatchedNodeV2", "10.1000/watch"));
+    wait_for_queue(&mut state, 1);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    let diff = call(
+        &mut state,
+        "lock_diff",
+        json!({"agent_id":"tester","lock_id":lock_id}),
+    );
+    assert!(
+        diff.get("watcher_events_drained")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0)
+            >= 1
+    );
+}
+
+#[test]
+fn auto_ingest_restart_skips_unchanged_files() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("restart");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("restart.md");
+    write(&file, &light_doc("RestartStudy", "10.1000/restart"));
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["light"],"debounce_ms":0}),
+    );
+    call(&mut state, "auto_ingest_stop", json!({"agent_id":"tester"}));
+
+    let mut restarted = build_state(temp.path());
+    let start = call(
+        &mut restarted,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["light"],"debounce_ms":0}),
+    );
+    let skipped = start
+        .get("bootstrap")
+        .and_then(|value| value.get("skipped_paths"))
+        .and_then(|value| value.as_array())
+        .map(|value| value.len())
+        .unwrap_or(0);
+    assert!(skipped >= 1, "restart should skip unchanged file");
+
+    write(&file, &light_doc("RestartStudyV2", "10.1000/restart"));
+    wait_for_queue(&mut restarted, 1);
+    let tick = call(
+        &mut restarted,
+        "auto_ingest_tick",
+        json!({"agent_id":"tester"}),
+    );
+    let ingested = tick
+        .get("ingested_paths")
+        .and_then(|value| value.as_array())
+        .map(|value| value.len())
+        .unwrap_or(0);
+    assert_eq!(ingested, 1, "only the changed file should be reingested");
+}
+
+#[test]
+fn auto_ingest_hot_file_storm_converges_to_last_write() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("storm");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("storm.md");
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["light"],"debounce_ms":0}),
+    );
+
+    for i in 0..50 {
+        write(&file, &light_doc(&format!("Storm{}", i), "10.1000/storm"));
+    }
+    wait_for_queue(&mut state, 1);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    assert!(
+        search_count(&mut state, "Storm49") > 0,
+        "final write should win"
+    );
+}
+
+#[test]
+fn auto_ingest_burst_stress_handles_many_documents() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("burst");
+    fs::create_dir_all(&docs_root).unwrap();
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["light"],"debounce_ms":0}),
+    );
+
+    for round in 0..5 {
+        for index in 0..200 {
+            write(
+                &docs_root.join(format!("doc-{}.md", index)),
+                &light_doc(&format!("Burst{}-{}", round, index), "10.1000/burst"),
+            );
+        }
+        thread::sleep(Duration::from_millis(40));
+    }
+
+    wait_for_queue(&mut state, 1);
+    call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+
+    assert!(
+        search_count(&mut state, "Burst4-199") > 0,
+        "burst stress should leave final graph queryable"
+    );
+}
+
+#[test]
+fn universal_ingest_writes_canonical_artifacts_and_resolves_document() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("universal");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("notes.md");
+    write(
+        &file,
+        &plain_markdown(
+            "Universal Notes",
+            "This document mentions TokenValidator and 10.1000/test.",
+        ),
+    );
+
+    let mut state = build_state(temp.path());
+    let ingest = call(
+        &mut state,
+        "ingest",
+        json!({"agent_id":"tester","path":file.to_string_lossy().to_string(),"adapter":"universal","mode":"merge"}),
+    );
+    assert_eq!(
+        ingest.get("adapter").and_then(|v| v.as_str()),
+        Some("universal")
+    );
+
+    let resolved = call(
+        &mut state,
+        "document_resolve",
+        json!({"agent_id":"tester","path":"notes.md"}),
+    );
+    let canonical_md = resolved
+        .get("canonical_markdown_path")
+        .and_then(|value| value.as_str())
+        .unwrap();
+    let canonical_json = resolved
+        .get("canonical_json_path")
+        .and_then(|value| value.as_str())
+        .unwrap();
+    let claims_json = resolved
+        .get("claims_path")
+        .and_then(|value| value.as_str())
+        .unwrap();
+
+    assert!(Path::new(canonical_md).exists());
+    assert!(Path::new(canonical_json).exists());
+    assert!(Path::new(claims_json).exists());
+    assert!(search_count(&mut state, "TokenValidator") > 0);
+}
+
+#[test]
+fn auto_ingest_universal_handles_markdown_and_html() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("universal-watch");
+    fs::create_dir_all(&docs_root).unwrap();
+    let md = docs_root.join("notes.md");
+    let html = docs_root.join("page.html");
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["universal"],"debounce_ms":0}),
+    );
+
+    write(
+        &md,
+        &plain_markdown("Universal Watch", "TokenValidator appears here."),
+    );
+    write(&html, &html_doc("HTML Watch", "DesignSystem appears here."));
+    wait_for_queue(&mut state, 2);
+    let tick = call(&mut state, "auto_ingest_tick", json!({"agent_id":"tester"}));
+    let ingested = tick
+        .get("ingested_paths")
+        .and_then(|value| value.as_array())
+        .map(|value| value.len())
+        .unwrap_or(0);
+    assert_eq!(ingested, 2);
+
+    assert!(search_count(&mut state, "Universal Watch") > 0);
+    assert!(search_count(&mut state, "HTML Watch") > 0);
+
+    let md_resolved = call(
+        &mut state,
+        "document_resolve",
+        json!({"agent_id":"tester","path":"notes.md"}),
+    );
+    let html_resolved = call(
+        &mut state,
+        "document_resolve",
+        json!({"agent_id":"tester","path":"page.html"}),
+    );
+    assert!(Path::new(md_resolved["canonical_markdown_path"].as_str().unwrap()).exists());
+    assert!(Path::new(html_resolved["canonical_markdown_path"].as_str().unwrap()).exists());
+}
+
+#[test]
+fn universal_document_bindings_and_drift_surface_work() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("semantic");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("spec.md");
+    write(
+        &file,
+        "# API\n\n`TokenValidator` must validate requests.\n\nSee `src/token_validator.rs`.\n",
+    );
+
+    let mut state = build_state(temp.path());
+    {
+        let mut graph = state.graph.write();
+        graph
+            .add_node(
+                "file::src/token_validator.rs",
+                "TokenValidator",
+                m1nd_core::types::NodeType::File,
+                &["code"],
+                1.0,
+                0.1,
+            )
+            .unwrap();
+        graph.finalize().unwrap();
+    }
+    state.rebuild_engines().unwrap();
+
+    call(
+        &mut state,
+        "ingest",
+        json!({"agent_id":"tester","path":file.to_string_lossy().to_string(),"adapter":"universal","mode":"merge"}),
+    );
+
+    let bindings = call(
+        &mut state,
+        "document_bindings",
+        json!({"agent_id":"tester","path":"spec.md","top_k":5}),
+    );
+    let bindings_len = bindings["bindings"]
+        .as_array()
+        .map(|v| v.len())
+        .unwrap_or(0);
+    assert!(bindings_len > 0);
+
+    let drift = call(
+        &mut state,
+        "document_drift",
+        json!({"agent_id":"tester","path":"spec.md"}),
+    );
+    assert!(drift.get("summary").is_some());
+}
+
+#[test]
+fn auto_ingest_status_exposes_semantic_counts() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("status");
+    fs::create_dir_all(&docs_root).unwrap();
+    write(
+        &docs_root.join("notes.md"),
+        "# Overview\n\n`TokenValidator` must validate requests.\n10.1000/test\n",
+    );
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["universal"],"debounce_ms":0}),
+    );
+    let status = call(
+        &mut state,
+        "auto_ingest_status",
+        json!({"agent_id":"tester"}),
+    );
+    assert!(status["semantic_document_count"].as_u64().unwrap_or(0) >= 1);
+    assert!(status["semantic_section_count"].as_u64().unwrap_or(0) >= 1);
+    assert!(status["semantic_entity_count"].as_u64().unwrap_or(0) >= 1);
+    assert!(status["semantic_claim_count"].as_u64().unwrap_or(0) >= 1);
+    assert_eq!(status["drift_document_count"].as_u64().unwrap_or(0), 1);
+    assert_eq!(
+        status["provider_route_counts"]["universal:internal"]
+            .as_u64()
+            .unwrap_or(0),
+        1
+    );
+    assert_eq!(
+        status["provider_fallback_counts"]["universal:internal"]
+            .as_u64()
+            .unwrap_or(0),
+        1
+    );
+}
+
+#[test]
+fn auto_ingest_status_reflects_drift_after_explicit_refresh() {
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("status-drift");
+    fs::create_dir_all(&docs_root).unwrap();
+    let file = docs_root.join("spec.md");
+    write(
+        &file,
+        "# API\n\n`TokenValidator` must validate requests.\n\nSee `src/token_validator.rs`.\n",
+    );
+
+    let mut state = build_state(temp.path());
+    {
+        let mut graph = state.graph.write();
+        graph
+            .add_node(
+                "file::src/token_validator.rs",
+                "TokenValidator",
+                m1nd_core::types::NodeType::File,
+                &["code"],
+                1.0,
+                0.1,
+            )
+            .unwrap();
+        graph.finalize().unwrap();
+    }
+    state.bump_graph_generation();
+
+    call(
+        &mut state,
+        "ingest",
+        json!({"agent_id":"tester","path":file.to_string_lossy().to_string(),"adapter":"universal","mode":"merge"}),
+    );
+
+    let initial = call(
+        &mut state,
+        "auto_ingest_status",
+        json!({"agent_id":"tester"}),
+    );
+    assert_eq!(initial["drift_document_count"].as_u64().unwrap_or(0), 0);
+
+    {
+        let mut graph = state.graph.write();
+        let node = graph.resolve_id("file::src/token_validator.rs").unwrap();
+        graph.nodes.last_modified[node.as_usize()] = 9999999999.0;
+    }
+    state.bump_graph_generation();
+
+    let drift = call(
+        &mut state,
+        "document_drift",
+        json!({"agent_id":"tester","path":"spec.md"}),
+    );
+    assert!(
+        drift["summary"]["code_change_unreflected"]
+            .as_u64()
+            .unwrap_or(0)
+            >= 1
+    );
+
+    let refreshed = call(
+        &mut state,
+        "auto_ingest_status",
+        json!({"agent_id":"tester"}),
+    );
+    assert_eq!(refreshed["drift_document_count"].as_u64().unwrap_or(0), 1);
+    assert!(
+        refreshed["semantic_document_count"].as_u64().unwrap_or(0) >= 1,
+        "semantic counts should remain populated after drift refresh"
+    );
+}
+
+#[test]
+fn provider_gated_docling_docx_flow_skips_without_provider_python() {
+    let Some(provider_python) = std::env::var_os("M1ND_PROVIDER_PYTHON") else {
+        eprintln!("SKIP: M1ND_PROVIDER_PYTHON not configured");
+        return;
+    };
+    let provider_python = PathBuf::from(provider_python);
+    if !provider_python.exists() {
+        eprintln!("SKIP: configured provider python missing");
+        return;
+    }
+    let Ok(docling_probe) = std::process::Command::new(&provider_python)
+        .arg("-c")
+        .arg("import docling")
+        .output()
+    else {
+        eprintln!("SKIP: failed to spawn configured provider python");
+        return;
+    };
+    if !docling_probe.status.success() {
+        eprintln!("SKIP: docling not available in provider env");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("provider");
+    fs::create_dir_all(&docs_root).unwrap();
+    let docx = docs_root.join("provider.docx");
+
+    let Ok(output) = std::process::Command::new(&provider_python)
+        .arg("-c")
+        .arg(format!(
+            "from docx import Document; d=Document(); d.add_heading('Provider Docx', level=1); d.add_paragraph('DoclingKnowledge appears here.'); d.save(r'{}')",
+            docx.display()
+        ))
+        .output()
+    else {
+        eprintln!("SKIP: failed to spawn configured provider python");
+        return;
+    };
+    if !output.status.success() {
+        eprintln!("SKIP: python-docx not available in provider env");
+        return;
+    }
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "auto_ingest_start",
+        json!({"agent_id":"tester","roots":[docs_root.to_string_lossy().to_string()],"formats":["universal"],"debounce_ms":0}),
+    );
+    let resolved = call(
+        &mut state,
+        "document_resolve",
+        json!({"agent_id":"tester","path":"provider.docx"}),
+    );
+    assert_eq!(resolved["producer"].as_str(), Some("universal:docling"));
+    let source_copy = resolved["original_source_path"].as_str().unwrap();
+    assert_eq!(fs::read(source_copy).unwrap(), fs::read(&docx).unwrap());
+}
+
+#[test]
+fn provider_gated_trafilatura_html_flow_skips_without_provider_python() {
+    let Some(provider_python) = std::env::var_os("M1ND_PROVIDER_PYTHON") else {
+        eprintln!("SKIP: M1ND_PROVIDER_PYTHON not configured");
+        return;
+    };
+    let provider_python = PathBuf::from(provider_python);
+    if !provider_python.exists() {
+        eprintln!("SKIP: configured provider python missing");
+        return;
+    }
+    let Ok(trafilatura_probe) = std::process::Command::new(&provider_python)
+        .arg("-c")
+        .arg("import trafilatura")
+        .output()
+    else {
+        eprintln!("SKIP: failed to spawn configured provider python");
+        return;
+    };
+    if !trafilatura_probe.status.success() {
+        eprintln!("SKIP: trafilatura not available in provider env");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let docs_root = temp.path().join("provider-html");
+    fs::create_dir_all(&docs_root).unwrap();
+    let page = docs_root.join("provider.html");
+    write(
+        &page,
+        &html_doc("Provider Html", "SemanticBridge appears here."),
+    );
+
+    let mut state = build_state(temp.path());
+    call(
+        &mut state,
+        "ingest",
+        json!({"agent_id":"tester","path":page.to_string_lossy().to_string(),"adapter":"universal","mode":"merge"}),
+    );
+    let resolved = call(
+        &mut state,
+        "document_resolve",
+        json!({"agent_id":"tester","path":"provider.html"}),
+    );
+    assert_eq!(resolved["producer"].as_str(), Some("universal:trafilatura"));
+    assert!(search_count(&mut state, "SemanticBridge") > 0);
+}


### PR DESCRIPTION
## Summary
- port the universal `l1ght` ingest substrate into upstream `m1nd` instead of keeping it only in the `SISTEMA` integration lane
- add canonical document artifacts, provider health, document resolve/bindings/drift, local auto-ingest, and the latest hardening fixes
- keep native structured adapters ahead of universal fallback and keep `auto_ingest_status` observational

## Why this is upstream-native
The prior work had been proven in the `SISTEMA` integration repo, but the canonical `m1nd` repo had diverged enough that direct patch application failed. This PR ports the stack natively on top of the current upstream runtime/session/server layout.

## Verification
- `cargo check -p m1nd-ingest`
- `cargo check -p m1nd-mcp`
- `cargo test -p m1nd-ingest`
- `cargo test -p m1nd-mcp`
- `cargo test -p m1nd-mcp --test test_auto_ingest -- --nocapture`
- `cargo test -p m1nd-mcp universal_docs::tests:: -- --nocapture`
- `cargo clippy -p m1nd-ingest -p m1nd-mcp -- -D warnings`
- `M1ND_PROVIDER_PYTHON=/tmp/m1nd-universal-venv/bin/python cargo test -p m1nd-mcp provider_gated_ -- --nocapture`

## Notes
- provider-gated tests still skip cleanly when the provider env is absent or unspawnable
- no dedicated automated `GROBID`-only route assertion was added in this port; the scholarly provider lane still relies on gated/manual validation for that path