### PR TITLE
Sync wiki mirror and localized READMEs with the document runtime

### DIFF
--- a/.github/wiki/API-Reference.md
+++ b/.github/wiki/API-Reference.md
@@ -1,11 +1,12 @@
 # API Reference
 
-All 84 MCP tools, grouped by category. Each tool is callable via JSON-RPC stdio as `m1nd_<tool_name>`.
+This mirror summarizes the live 93-tool MCP surface. The exhaustive canonical reference lives in `docs/wiki/src/api-reference/` and the generated `wiki-build/` site. Each tool is callable via JSON-RPC stdio as `m1nd_<tool_name>`.
 
 All tools require an `agent_id` string parameter (use any stable identifier — your editor session ID, agent name, etc.).
 
 Jump to:
 - [Foundation](#foundation-13-tools)
+- [Document Intelligence](#document-intelligence-8-tools)
 - [Perspective Navigation](#perspective-navigation-12-tools)
 - [Lock System](#lock-system-5-tools)
 - [Superpowers](#superpowers-13-tools)
@@ -14,6 +15,23 @@ Jump to:
 - [Surgical](#surgical-4-tools)
 - [Search & Efficiency](#v050--search--efficiency-5-tools)
 - [Audit & Session Ergonomics](#audit--session-ergonomics-13-tools)
+
+---
+
+## Document Intelligence (8 tools)
+
+These tools expose the local-first document runtime that now sits on top of universal ingest:
+
+- `m1nd_document_resolve` — resolve canonical local artifacts for a universal document
+- `m1nd_document_provider_health` — inspect optional provider availability, detail, and install hints
+- `m1nd_document_bindings` — show likely deterministic document-to-code bindings
+- `m1nd_document_drift` — detect stale, missing, or ambiguous document/code links
+- `m1nd_auto_ingest_start` — start local-first watchers for docs/specs/wiki roots
+- `m1nd_auto_ingest_status` — inspect watcher state, semantic counts, provider routes, and fallbacks
+- `m1nd_auto_ingest_tick` — drain queued document changes immediately
+- `m1nd_auto_ingest_stop` — stop watchers and persist manifest state
+
+Use these after `m1nd_ingest(adapter="universal")` or when a caller needs document/runtime observability rather than only graph nodes.
 
 ---
 

--- a/.github/wiki/Architecture.md
+++ b/.github/wiki/Architecture.md
@@ -1,31 +1,44 @@
 # Architecture
 
-m1nd is a three-crate Rust workspace. Each crate has a strict responsibility boundary — understanding where things live saves you from editing the wrong place.
+m1nd is a Rust workspace with three core crates plus one auxiliary bridge crate. Each surface has a strict responsibility boundary — understanding where things live saves you from editing the wrong place.
 
 ```
 m1nd/
   m1nd-core/     Graph engine, plasticity, spreading activation, hypothesis engine,
                  antibody, flow, epidemic, tremor, trust, layer detection, domain config,
                  graph-diff with pre/post node snapshots
-  m1nd-ingest/   Language extractors (27+ languages), memory adapter, JSON adapter,
-                 git enrichment, cross-file resolver, incremental diff
-  m1nd-mcp/      MCP server, 77 tool handlers, JSON-RPC over stdio
+  m1nd-ingest/   Language extractors, structured adapters, universal documents,
+                 canonical artifacts, git enrichment, cross-file resolver, incremental diff
+  m1nd-mcp/      MCP server, 93 tool handlers, JSON-RPC over stdio
+  m1nd-openclaw/ Auxiliary bridge crate for OpenClaw-facing integration surfaces
 ```
 
 ## Dependency Graph
 
 ```mermaid
 graph TD
-    MCP[m1nd-mcp<br/>MCP server · 77 tools · JSON-RPC stdio]
-    INGEST[m1nd-ingest<br/>File walker · Extractors · Adapters · Diff]
+    MCP[m1nd-mcp<br/>MCP server · 93 tools · JSON-RPC stdio]
+    INGEST[m1nd-ingest<br/>File walker · Extractors · Adapters · Canonical docs]
     CORE[m1nd-core<br/>Graph engine · Plasticity · Activation · GraphDiff]
+    OPENCLAW[m1nd-openclaw<br/>Auxiliary bridge]
 
     MCP --> INGEST
     MCP --> CORE
     INGEST --> CORE
+    OPENCLAW --> MCP
 ```
 
-`m1nd-core` has no dependencies on the other two crates and no filesystem I/O — it is pure computation. `m1nd-ingest` depends on core and handles all I/O. `m1nd-mcp` depends on both, manages server state, and dispatches tool calls.
+`m1nd-core` has no dependencies on the other crates and no filesystem I/O — it is pure computation. `m1nd-ingest` depends on core and handles extraction, routing, canonical artifact production, and incremental ingest. `m1nd-mcp` depends on both, manages server state, and dispatches tool calls. `m1nd-openclaw` is an auxiliary integration bridge rather than a core graph/runtime crate.
+
+## Universal Document Runtime
+
+The biggest architectural change after the original code-only story is the universal document lane:
+
+- `m1nd-ingest` can normalize markdown, HTML/wiki pages, office documents, and PDFs
+- it stores canonical local artifacts such as `source.<ext>`, `canonical.md`, `canonical.json`, `claims.json`, and `metadata.json`
+- `m1nd-mcp` exposes `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health`, and the `auto_ingest_*` runtime around those artifacts
+
+This means the graph is no longer just code plus memory notes. It now supports a practical docs/specs/wiki/paper workflow on the same local substrate.
 
 ---
 

--- a/.github/wiki/FAQ.md
+++ b/.github/wiki/FAQ.md
@@ -170,6 +170,31 @@ you will not notice any CPU impact during normal use.
 
 ---
 
+### Does it work with docs, specs, PDFs, and office files?
+
+Yes. The current runtime is no longer limited to code + memory markdown.
+
+You can ingest:
+
+- markdown notes and project docs
+- L1GHT protocol specs
+- HTML/wiki pages
+- office documents
+- scholarly PDFs
+- structured document feeds such as patent/article/BibTeX/CrossRef/RFC sources
+
+The universal lane normalizes those sources into canonical local artifacts and exposes a second layer of document tools:
+
+- `document_resolve`
+- `document_bindings`
+- `document_drift`
+- `document_provider_health`
+- `auto_ingest_start`, `auto_ingest_status`, `auto_ingest_tick`, `auto_ingest_stop`
+
+So the answer is now “code, docs, specs, and papers on one local graph substrate,” not only “code plus memory adapter.”
+
+---
+
 ### Does it work with my language?
 
 m1nd ships extractors for 27+ languages across four tiers:

--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -40,6 +40,32 @@ m1nd-core = "0.4"
 
 ---
 
+## First Document Workflow
+
+The code graph is still the main entrypoint, but the current runtime also supports a universal document lane:
+
+```jsonc
+{"method":"tools/call","params":{"name":"m1nd_ingest","arguments":{
+  "agent_id":"dev","path":"/your/docs/specs","adapter":"universal","mode":"merge"
+}}}
+```
+
+After that, resolve the canonical artifacts and bindings:
+
+```jsonc
+{"method":"tools/call","params":{"name":"m1nd_document_resolve","arguments":{
+  "agent_id":"dev","path":"docs/specs/auth-refresh.md"
+}}}
+
+{"method":"tools/call","params":{"name":"m1nd_document_bindings","arguments":{
+  "agent_id":"dev","path":"docs/specs/auth-refresh.md"
+}}}
+```
+
+Use `m1nd_document_drift` after a refactor and `m1nd_auto_ingest_start` when a docs/wiki root should stay synchronized while you work.
+
+---
+
 ## First Query in 3 Steps
 
 m1nd runs as a JSON-RPC stdio server. Any MCP client sends tool calls to it.

--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -4,7 +4,7 @@
   <strong>The adaptive code graph. It learns.</strong>
 </p>
 
-Neuro-symbolic connectome engine with Hebbian plasticity, spreading activation, and 78 MCP tools. Built in Rust for AI agents.
+Neuro-symbolic connectome engine with Hebbian plasticity, spreading activation, and 93 MCP tools. Built in Rust for AI agents.
 
 **39 bugs found in one audit session · 89% hypothesis accuracy · 12/12 verification accuracy · Zero LLM tokens**
 
@@ -27,7 +27,7 @@ It is not a search engine. It is not a RAG pipeline. It is not a static analysis
 
 | Metric | Value |
 |--------|-------|
-| Tools | **78 MCP tools** |
+| Tools | **93 MCP tools** |
 | Languages supported | **27+** (5 built-in + tier1 + tier2 via tree-sitter) |
 | Bugs found in one session | **39** (production Python backend, 52K lines) |
 | Bugs invisible to grep | **8 of 28 (28.5%)** — required structural analysis |
@@ -39,6 +39,19 @@ It is not a search engine. It is not a RAG pipeline. It is not a static analysis
 | `lock.diff` speed | **0.08µs** — essentially free change detection |
 | Binary size | ~8MB |
 | Memory for 10K nodes | ~2MB |
+
+---
+
+## Canonical Docs Surface
+
+The colorful `mdBook` wiki generated from `docs/wiki/src/` is the canonical public documentation surface. This GitHub wiki folder is now a compact mirror that tracks the same runtime, tool count, and document-intelligence lane.
+
+If you want the exhaustive API pages, architecture notes, and examples, prefer:
+
+- `docs/wiki/src/`
+- `wiki-build/`
+- `README.md`
+- `EXAMPLES.md`
 
 ---
 
@@ -148,7 +161,7 @@ apply_batch(files=[...], verify=true)             → write multiple files + ver
 ## Quick Links
 
 - [Getting Started](Getting-Started) — installation, first query, Claude Code setup
-- [API Reference](API-Reference) — all 77 tools with schemas, examples, benchmark times
+- [API Reference](API-Reference) — live 93-tool surface, document runtime, schemas, examples
 - [EXAMPLES.md](../EXAMPLES.md) — raw examples from a production codebase
 - [README.md](../README.md) — full project overview
 
@@ -166,18 +179,21 @@ m1nd v0.6.1 is the current release line. Add it from [crates.io](https://crates.
 
 ---
 
-## Architecture — 3 Crates
+## Architecture — Core Crates + Bridge
 
 ```
 m1nd/
   m1nd-core/     Graph engine, plasticity, spreading activation, hypothesis engine
                  antibody, flow, epidemic, tremor, trust, layer detection, domain config
-  m1nd-ingest/   Language extractors (27+ languages), memory adapter, JSON adapter,
-                 git enrichment, cross-file resolver, incremental diff
-  m1nd-mcp/      MCP server, 77 tool handlers, JSON-RPC over stdio
+  m1nd-ingest/   Language extractors, structured adapters, universal documents,
+                 git enrichment, cross-file resolver, canonical artifacts
+  m1nd-mcp/      MCP server, 93 tool handlers, JSON-RPC over stdio
+  m1nd-openclaw/ Auxiliary bridge crate for OpenClaw-facing integration surfaces
 ```
 
-Pure Rust. No runtime dependencies. No LLM calls. No API keys.
+The major new lane is universal document intelligence: canonical local artifacts, provider-aware extraction, document/code bindings, drift detection, and local-first auto-ingest watchers.
+
+Pure Rust. No runtime dependencies on the green path. No mandatory API keys.
 
 ---
 

--- a/.github/wiki/Ingest-Adapters.md
+++ b/.github/wiki/Ingest-Adapters.md
@@ -1,12 +1,19 @@
 # Ingest Adapters
 
-m1nd supports three ingestion adapters plus a federation tool for multi-repo ingestion. The `adapter` parameter in the MCP `m1nd_ingest` call selects the adapter:
+m1nd now supports ten ingest adapters plus federation. The `adapter` parameter in the MCP `m1nd_ingest` call selects the lane:
 
 | Adapter | `adapter` value | Input | Use case |
 |---------|----------------|-------|---------|
 | Code (default) | `"code"` or omit | Source files (27+ languages) | Software codebases |
 | Memory | `"memory"` | `.md`, `.txt`, `.markdown` files | Agent memory, docs, wikis |
 | JSON | `"json"` | A single JSON descriptor file | Any other domain |
+| L1GHT | `"light"` | Typed markdown protocol docs | Structured specs, design docs, KBs |
+| Patent | `"patent"` | USPTO/EPO XML | Patent claims and citations |
+| Article | `"article"` | PubMed/JATS XML | Scholarly article metadata and references |
+| BibTeX | `"bibtex"` / `"bib"` | `.bib` bibliographies | Citation graphs |
+| CrossRef | `"crossref"` / `"doi"` | DOI work JSON | DOI metadata and reference links |
+| RFC | `"rfc"` | IETF RFC XML v3 | Structured RFC sections and references |
+| Universal | `"universal"` | Markdown, HTML/wiki, office docs, PDFs | Canonical local docs/specs/wiki/paper workflows |
 | Federate | — | Two or more repo roots | Multi-repo unified graph |
 
 All adapters produce a `(Graph, IngestStats)` and implement the same trait:
@@ -19,6 +26,20 @@ pub trait IngestAdapter: Send + Sync {
 ```
 
 > **Note:** The MCP tool name uses underscores. Both `m1nd_ingest` and `m1nd.ingest` are accepted (the server normalizes dots to underscores before dispatch). Throughout this wiki, underscore form is canonical.
+
+`adapter="auto"` and `adapter="document"` route through the document router and select the appropriate structured or universal adapter automatically.
+
+## Universal Adapter
+
+The universal lane adds a local-first document substrate on top of ingest:
+
+- original source copy (`source.<ext>`) when reachable
+- `canonical.md`
+- `canonical.json`
+- `claims.json`
+- `metadata.json`
+
+That artifact set is what powers `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health`, and the `auto_ingest_*` runtime in `m1nd-mcp`.
 
 ---
 

--- a/.github/wiki/Roadmap.md
+++ b/.github/wiki/Roadmap.md
@@ -5,26 +5,18 @@ next, and where the project is headed long-term.
 
 ---
 
-## In Flight — Audit Mode & Session Foundations
+## Current Surface — Document Intelligence + Local Runtime
 
-The current audit branch adds a new composed workflow layer on top of the existing graph engine:
+The current public surface has moved beyond the earlier audit-only expansion. The big shipped additions are:
 
-- `scan_all` — grouped structural scans in one call
-- `cross_verify` — graph vs filesystem truth checks
-- `coverage_session` — per-agent visit coverage across files/nodes/tools
-- `external_references` — explicit path references outside current ingest roots
-- `batch_view` — multi-file read surface with delimiters and summaries
-- `audit` — profile-aware one-call audit (`auto`, `quick`, `coordination`, `production`, `security`, `migration`)
+- universal document ingest with canonical local artifacts
+- `document_resolve`, `document_bindings`, `document_drift`, and `document_provider_health`
+- local-first `auto_ingest_start`, `auto_ingest_status`, `auto_ingest_tick`, and `auto_ingest_stop`
+- provider-aware document extraction (`Docling`, `Trafilatura`, `MarkItDown`, `GROBID`) when available
+- `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, and `runtime_overlay` in the public tool surface
+- current docs/tool-matrix alignment in the canonical `mdBook` wiki
 
-This branch also closes surface drift by exposing the already-implemented RETROBUILDER tools:
-
-- `ghost_edges`
-- `taint_trace`
-- `twins`
-- `refactor_plan`
-- `runtime_overlay`
-
-Projected tool count on this branch: **78 MCP tools**.
+Current live count: **93 MCP tools**.
 
 ---
 

--- a/README.de.md
+++ b/README.de.md
@@ -81,11 +81,12 @@ Vor einer Änderung hilft m1nd dem Agenten dabei, Auswirkungsradius, verbundene 
 <a id="what-m1nd-does"></a>
 ## Was m1nd macht
 
-m1nd ist ein lokaler Rust-Workspace mit drei Hauptteilen:
+m1nd ist ein lokaler Rust-Workspace mit drei Kern-Crates plus einer Hilfs-Bridge:
 
 - `m1nd-core`: Graph-Engine, Ranking, Propagation, Heuristiken und Analyseschichten
 - `m1nd-ingest`: Code- und Dokumenten-Ingestion, Extraktoren, Resolver, Merge-Pfade und Graph-Konstruktion
 - `m1nd-mcp`: MCP-Server über stdio, plus eine HTTP/UI-Oberfläche im aktuellen Standard-Build
+- `m1nd-openclaw`: Hilfs-Bridge-Crate für OpenClaw-bezogene Integrationsflächen
 
 Aktuelle Stärken:
 
@@ -103,6 +104,9 @@ Aktueller Umfang:
 - Ingest-Adapter für Code, `memory`, `json` und `light`
 - Cargo-Workspace-Anreicherung für Rust-Repos
 - Heuristikzusammenfassungen auf chirurgischen und Planungs-Pfaden
+- eine universelle Dokumenten-Lane für Markdown, HTML/Wiki-Seiten, Office-Dokumente und PDFs
+- kanonische lokale Artefakte wie `source.<ext>`, `canonical.md`, `canonical.json`, `claims.json` und `metadata.json`
+- dokumentbezogene MCP-Workflows wie `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` und `auto_ingest_*`
 
 Die Sprachabdeckung ist breit, aber die Tiefe variiert weiterhin je nach Sprache. Python und Rust haben eine stärkere Behandlung als viele tree-sitter-gestützte Sprachen.
 
@@ -339,13 +343,14 @@ Das ist wichtig, weil m1nd nicht nur ein Such-Endpunkt ist. Es ist eine opiniona
 <a id="tool-surface"></a>
 ## Tool-Oberfläche
 
-Die aktuelle Implementierung von `tool_schemas()` in [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) stellt **77 MCP-Tools** bereit. Die Zahl kann sich ändern; die Kategorien darunter sind wichtiger.
+Die aktuelle Implementierung von `tool_schemas()` in [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) stellt **93 MCP-Tools** bereit. Die Zahl kann sich ändern; die Kategorien darunter sind wichtiger.
 
 Kanonsiche Tool-Namen im exportierten MCP-Schema verwenden Unterstriche, etwa `trail_save`, `perspective_start` und `apply_batch`. Manche Clients zeigen Namen mit einem Transportpräfix wie `m1nd.apply_batch` an, aber die Live-Registry-Einträge basieren auf Unterstrichen.
 
 | Kategorie | Highlights |
 |----------|------------|
 | Grundlagen | ingest, activate, impact, why, learn, drift, seek, search, glob, view, warmup, federate |
+| Dokumentintelligenz | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
 | Perspektivennavigation | perspective_start, perspective_follow, perspective_peek, perspective_branch, perspective_compare, perspective_inspect, perspective_suggest |
 | Graphanalyse | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, validate_plan, trail_* |
 | Erweiterte Analyse | antibody_*, flow_simulate, epidemic, tremor, trust, layers, layer_inspect |

--- a/README.es.md
+++ b/README.es.md
@@ -86,11 +86,12 @@ Eso significa que puede responder a las preguntas que realmente importan:
 - dónde está el contexto conectado para una edición?
 - qué debo verificar después?
 
-Detrás de escena, el workspace tiene tres partes principales:
+Detrás de escena, el workspace tiene tres crates core más un crate puente auxiliar:
 
 - `m1nd-core`: motor de grafo
 - `m1nd-ingest`: recorrido del repositorio, extracción, resolución de referencias y construcción del grafo
 - `m1nd-mcp`: servidor MCP sobre stdio, además de una superficie HTTP/UI en la build por defecto actual
+- `m1nd-openclaw`: crate puente auxiliar para superficies de integración orientadas a OpenClaw
 
 El proyecto es más fuerte en grounding estructural:
 
@@ -110,6 +111,9 @@ Hoy ya incluye:
 - enriquecimiento de Cargo workspace para repositorios Rust
 - ingesta de documentos para patentes (USPTO/EPO XML), artículos científicos (PubMed/JATS), bibliografías BibTeX, metadatos DOI de CrossRef y RFCs de IETF, con detección automática de formato mediante `DocumentRouter` y resolución de aristas entre dominios
 - señales heurísticas inspeccionables en rutas de recuperación de nivel superior, para que `seek` y `predict` puedan exponer más que una nota bruta
+- un carril universal de documentos para markdown, HTML/wiki, documentos de oficina y PDFs
+- artefactos canónicos locales como `source.<ext>`, `canonical.md`, `canonical.json`, `claims.json` y `metadata.json`
+- workflows MCP documentales como `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` y `auto_ingest_*`
 
 La cobertura de lenguajes es amplia, pero la profundidad semántica varía por lenguaje. Python y Rust reciben actualmente un tratamiento más especializado que muchas de las lenguas apoyadas por tree-sitter.
 
@@ -361,11 +365,12 @@ Esto importa porque m1nd no es solo un endpoint de búsqueda. Es una capa opinat
 
 ## Superficie de Herramientas
 
-La implementación actual de `tool_schemas()` en [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) expone **77 herramientas MCP**. Ese número puede cambiar. Las categorías de abajo importan más, pero el conteo actual está anclado en el registro vivo.
+La implementación actual de `tool_schemas()` en [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) expone **93 herramientas MCP**. Ese número puede cambiar. Las categorías de abajo importan más, pero el conteo actual está anclado en el registro vivo.
 
 | Categoría | Destacados |
 |----------|------------|
 | **Base** | ingest, health, activate, impact, why, learn, drift, seek, scan, warmup, federate |
+| **Inteligencia Documental** | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
 | **Navegación por Perspective** | start, follow, peek, routes, branch, compare, inspect, suggest, affinity |
 | **Sistema de Lock** | fija regiones del subgrafo, monitorea cambios, diff del estado bloqueado |
 | **Análisis de Grafo** | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, trails |
@@ -543,14 +548,15 @@ Reglas del verdict: cualquier capa BROKEN => overall BROKEN. Cualquier capa RISK
 
 ## Arquitectura
 
-Tres crates Rust. Ejecución local. No se requieren API keys para la ruta principal del servidor.
+Tres crates core en Rust más un crate puente auxiliar. Ejecución local. No se requieren API keys para la ruta principal del servidor.
 
 ```text
 m1nd-core/     Graph engine, spreading activation, plasticidad hebbiana, hypothesis engine,
                antibody system, flow simulator, epidemic, tremor, trust, layer detection
-m1nd-ingest/   Language extractors, memory adapter, JSON adapter,
-               git enrichment, cross-file resolver, incremental diff
-m1nd-mcp/      Servidor MCP, JSON-RPC sobre stdio, además de soporte HTTP/UI en la build por defecto actual
+m1nd-ingest/   Language extractors, adapters estructurados y universales,
+               artefactos canónicos locales, git enrichment, cross-file resolver, incremental diff
+m1nd-mcp/      Servidor MCP, JSON-RPC sobre stdio, runtime documental y soporte HTTP/UI
+m1nd-openclaw/ Puente auxiliar para superficies de integración orientadas a OpenClaw
 ```
 
 ```mermaid
@@ -560,6 +566,7 @@ graph LR
         MA[Memory adapter] --> R
         JA[JSON adapter] --> R
         DA[Document adapters<br/>patent, article, BibTeX, CrossRef, RFC] --> DR[DocumentRouter]
+        UA[Universal docs<br/>md, html, office, pdf] --> DR
         DR --> R
         R --> GD[Git enrichment]
         GD --> XD[CrossDomainResolver]
@@ -580,6 +587,9 @@ graph LR
         T --> IO[JSON-RPC stdio]
         T --> HTTP[HTTP API + UI]
     end
+    subgraph Bridge
+        OC[m1nd-openclaw] --> T
+    end
     IO --> C[Claude Code / Cursor / any MCP]
     HTTP --> B[Browser on localhost:1337]
 ```
@@ -588,6 +598,8 @@ graph LR
 Hoy eso significa 5 extractors nativos/manuales (`Python`, `TypeScript/JavaScript`, `Rust`, `Go`, `Java`) más 22 lenguajes basados en tree-sitter en Tier 1 + Tier 2.
 La build por defecto ya incluye Tier 2, lo que incluye ambas tiers tree-sitter.
 La cobertura de lenguajes es amplia, pero la profundidad varía según el lenguaje. [Detalles de lenguajes ->](https://github.com/maxkle1nz/m1nd/wiki/Ingest-Adapters)
+
+Además, el carril universal ahora conecta código y documentos con caché canónica local (`source.<ext>`, `canonical.md`, `canonical.json`, `claims.json`, `metadata.json`) y con las superficies `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` y `auto_ingest_*`.
 
 La build por defecto actual también incluye una superficie HTTP/UI. Mantenla atada a localhost, a menos que quieras acceso remoto a propósito; no hay una capa de autenticación incorporada para exposición pública arbitraria.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -85,11 +85,12 @@ Cela signifie qu’il peut répondre aux vraies questions :
 - où se trouve le contexte connecté pour une édition ?
 - qu’est-ce que je devrais vérifier ensuite ?
 
-Sous le capot, le workspace comporte trois parties principales :
+Sous le capot, le workspace comporte trois crates cœur plus un crate de pont auxiliaire :
 
 - `m1nd-core` : moteur de graphe, propagation, plasticité, heuristiques et couches d’analyse
 - `m1nd-ingest` : ingestion de code et de documents, extracteurs, résolveurs, chemins de merge et construction du graphe
 - `m1nd-mcp` : serveur MCP sur stdio, plus une surface HTTP/UI dans le build par défaut actuel
+- `m1nd-openclaw` : crate de pont auxiliaire pour les surfaces d’intégration côté OpenClaw
 
 Points forts actuels :
 
@@ -109,6 +110,9 @@ Aujourd’hui, il inclut :
 - l’enrichissement Cargo workspace pour les dépôts Rust
 - l’ingestion de documents pour les brevets (USPTO/EPO XML), les articles scientifiques (PubMed/JATS), les bibliographies BibTeX, les métadonnées DOI CrossRef et les RFC IETF
 - des signaux heuristiques inspectables sur les chemins de retrieval de niveau supérieur, afin que `seek` et `predict` exposent plus qu’un simple score
+- une voie documentaire universelle pour le markdown, les pages HTML/wiki, les documents bureautiques et les PDF
+- des artefacts locaux canoniques comme `source.<ext>`, `canonical.md`, `canonical.json`, `claims.json` et `metadata.json`
+- des workflows MCP documentaires comme `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` et `auto_ingest_*`
 
 La couverture linguistique est large, mais la profondeur sémantique varie encore d’un langage à l’autre. Python et Rust ont aujourd’hui un traitement plus spécialisé que beaucoup de langages basés sur tree-sitter.
 
@@ -141,7 +145,7 @@ Le bénéfice pratique est simple :
 
 ## Ce qu’est m1nd
 
-m1nd est un workspace Rust local avec trois parties principales :
+m1nd est un workspace Rust local avec trois crates cœur et un crate de pont auxiliaire :
 
 - `m1nd-core` : moteur de graphe, classement, propagation, heuristiques et couches d’analyse
 - `m1nd-ingest` : ingestion de code et de documents, extracteurs, résolveurs, chemins de fusion et construction du graphe
@@ -463,13 +467,14 @@ Ce n’est pas un remplaçant d’un LSP, d’un compilateur ou de l’observabi
 
 ## Surface des outils
 
-L’implémentation actuelle de `tool_schemas()` dans [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) expose **77 outils MCP**.
+L’implémentation actuelle de `tool_schemas()` dans [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) expose **93 outils MCP**.
 
 Les noms canoniques des outils dans le schéma MCP exporté utilisent des underscores, comme `trail_save`, `perspective_start`, et `apply_batch`. Certains clients peuvent afficher des noms avec un préfixe de transport comme `m1nd.apply_batch`, mais les entrées du registre live sont basées sur des underscores.
 
 | Category | Highlights |
 |----------|------------|
 | Foundation | ingest, activate, impact, why, learn, drift, seek, search, glob, view, warmup, federate |
+| Document Intelligence | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
 | Perspective Navigation | perspective_start, perspective_follow, perspective_peek, perspective_branch, perspective_compare, perspective_inspect, perspective_suggest |
 | Graph Analysis | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, validate_plan, trail_* |
 | Extended Analysis | antibody_*, flow_simulate, epidemic, tremor, trust, layers, layer_inspect |

--- a/README.it.md
+++ b/README.it.md
@@ -85,11 +85,12 @@ Questo significa che può rispondere alle domande che contano davvero:
 - dov'è il contesto connesso per una modifica?
 - cosa dovrei verificare dopo?
 
-Sotto il cofano, il workspace ha tre parti principali:
+Sotto il cofano, il workspace ha tre crate core più un crate ponte ausiliario:
 
 - `m1nd-core`: motore del grafo, propagazione, plasticità, euristiche e livelli di analisi
 - `m1nd-ingest`: ingestione di codice e documenti, extractor, resolver, percorsi di merge e costruzione del grafo
 - `m1nd-mcp`: server MCP su stdio, più una superficie HTTP/UI nella build predefinita attuale
+- `m1nd-openclaw`: crate ponte ausiliario per le superfici di integrazione rivolte a OpenClaw
 
 Punti di forza attuali:
 
@@ -109,6 +110,9 @@ Oggi include:
 - arricchimento Cargo workspace per repository Rust
 - ingestione di documenti per brevetti (USPTO/EPO XML), articoli scientifici (PubMed/JATS), bibliografie BibTeX, metadati DOI CrossRef e RFC IETF
 - segnali euristici ispezionabili sui percorsi di recupero di livello superiore, così `seek` e `predict` possono esporre più di un semplice punteggio
+- una lane documentale universale per markdown, pagine HTML/wiki, documenti office e PDF
+- artefatti locali canonici come `source.<ext>`, `canonical.md`, `canonical.json`, `claims.json` e `metadata.json`
+- workflow MCP documentali come `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` e `auto_ingest_*`
 
 La copertura linguistica è ampia, ma la profondità semantica varia ancora da linguaggio a linguaggio. Python e Rust hanno oggi un trattamento più specializzato rispetto a molti linguaggi basati su tree-sitter.
 
@@ -141,7 +145,7 @@ Il vantaggio pratico è semplice:
 
 ## What m1nd Is
 
-m1nd è un workspace Rust locale con tre parti principali:
+m1nd è un workspace Rust locale con tre crate core e un crate ponte ausiliario:
 
 - `m1nd-core`: motore a grafo, ranking, propagazione, euristiche e livelli di analisi
 - `m1nd-ingest`: ingestione di codice e documenti, extractor, resolver, percorsi di merge e costruzione del grafo
@@ -460,13 +464,14 @@ Non sostituisce un LSP, un compilatore o l'osservabilità di runtime. Fornisce a
 
 ## Tool Surface
 
-L'attuale implementazione di `tool_schemas()` in [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) espone **77 strumenti MCP**.
+L'attuale implementazione di `tool_schemas()` in [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) espone **93 strumenti MCP**.
 
 I nomi canonici degli strumenti nello schema MCP esportato usano underscore, come `trail_save`, `perspective_start` e `apply_batch`. Alcuni client possono mostrare i nomi con un prefisso di trasporto come `m1nd.apply_batch`, ma le voci del registry live sono basate su underscore.
 
 | Category | Highlights |
 |----------|------------|
 | Foundation | ingest, activate, impact, why, learn, drift, seek, search, glob, view, warmup, federate |
+| Document Intelligence | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
 | Perspective Navigation | perspective_start, perspective_follow, perspective_peek, perspective_branch, perspective_compare, perspective_inspect, perspective_suggest |
 | Graph Analysis | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, validate_plan, trail_* |
 | Extended Analysis | antibody_*, flow_simulate, epidemic, tremor, trust, layers, layer_inspect |

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -86,11 +86,12 @@ Isso significa que ele consegue responder às perguntas que realmente importam:
 - onde está o contexto conectado para uma edição?
 - o que devo verificar depois?
 
-Nos bastidores, o workspace tem três partes principais:
+Nos bastidores, o workspace tem três crates core mais um crate ponte auxiliar:
 
 - `m1nd-core`: motor de grafo
 - `m1nd-ingest`: caminhada do repositório, extração, resolução de referências e construção do grafo
 - `m1nd-mcp`: servidor MCP sobre stdio, além de uma superfície HTTP/UI no build padrão atual
+- `m1nd-openclaw`: crate ponte auxiliar para superfícies de integração voltadas ao OpenClaw
 
 O projeto é mais forte em grounding estrutural:
 
@@ -110,6 +111,9 @@ Hoje ele já inclui:
 - enriquecimento de Cargo workspace para repositórios Rust
 - ingestão de documentos para patentes (USPTO/EPO XML), artigos científicos (PubMed/JATS), bibliografias BibTeX, metadados DOI da CrossRef e RFCs da IETF — com detecção automática de formato via `DocumentRouter` e resolução de arestas entre domínios
 - sinais heurísticos inspecionáveis em rotas de recuperação de nível mais alto, para que `seek` e `predict` possam expor mais do que uma nota bruta
+- uma lane documental universal para markdown, HTML/wiki, documentos office e PDFs
+- artefatos canônicos locais como `source.<ext>`, `canonical.md`, `canonical.json`, `claims.json` e `metadata.json`
+- workflows MCP documentais como `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` e `auto_ingest_*`
 
 A abrangência de linguagens é ampla, mas a profundidade semântica varia por linguagem. Python e Rust atualmente recebem tratamento mais especializado do que muitas das linguagens apoiadas por tree-sitter.
 
@@ -361,11 +365,12 @@ Isso importa porque m1nd não é só um endpoint de busca. Ele é uma camada opi
 
 ## Superfície de Ferramentas
 
-A implementação atual de `tool_schemas()` em [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) expõe **77 ferramentas MCP**. Esse número pode mudar. As categorias abaixo importam mais, mas a contagem atual está ancorada no registro vivo.
+A implementação atual de `tool_schemas()` em [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) expõe **93 ferramentas MCP**. Esse número pode mudar. As categorias abaixo importam mais, mas a contagem atual está ancorada no registro vivo.
 
 | Categoria | Destaques |
 |----------|------------|
 | **Base** | ingest, health, activate, impact, why, learn, drift, seek, scan, warmup, federate |
+| **Inteligência Documental** | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
 | **Navegação por Perspective** | start, follow, peek, routes, branch, compare, inspect, suggest, affinity |
 | **Sistema de Lock** | prende regiões do subgrafo, monitora mudanças, diff do estado travado |
 | **Análise de Grafo** | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, trails |
@@ -543,14 +548,15 @@ Regras do verdict: qualquer camada BROKEN => overall BROKEN. Qualquer camada RIS
 
 ## Arquitetura
 
-Três crates Rust. Execução local. Nenhuma API key é necessária para o caminho principal do servidor.
+Três crates core em Rust mais um crate ponte auxiliar. Execução local. Nenhuma API key é necessária para o caminho principal do servidor.
 
 ```text
 m1nd-core/     Graph engine, spreading activation, plasticidade hebbiana, hypothesis engine,
                antibody system, flow simulator, epidemic, tremor, trust, layer detection
-m1nd-ingest/   Language extractors, memory adapter, JSON adapter,
-               git enrichment, cross-file resolver, incremental diff
-m1nd-mcp/      Servidor MCP, JSON-RPC sobre stdio, além de suporte HTTP/UI no build padrão atual
+m1nd-ingest/   Language extractors, adapters estruturados e universais,
+               artefatos canônicos locais, git enrichment, cross-file resolver, incremental diff
+m1nd-mcp/      Servidor MCP, JSON-RPC sobre stdio, runtime documental e suporte HTTP/UI
+m1nd-openclaw/ Ponte auxiliar para superfícies de integração voltadas ao OpenClaw
 ```
 
 ```mermaid
@@ -560,6 +566,7 @@ graph LR
         MA[Memory adapter] --> R
         JA[JSON adapter] --> R
         DA[Document adapters<br/>patent, article, BibTeX, CrossRef, RFC] --> DR[DocumentRouter]
+        UA[Universal docs<br/>md, html, office, pdf] --> DR
         DR --> R
         R --> GD[Git enrichment]
         GD --> XD[CrossDomainResolver]
@@ -580,6 +587,9 @@ graph LR
         T --> IO[JSON-RPC stdio]
         T --> HTTP[HTTP API + UI]
     end
+    subgraph Bridge
+        OC[m1nd-openclaw] --> T
+    end
     IO --> C[Claude Code / Cursor / any MCP]
     HTTP --> B[Browser on localhost:1337]
 ```
@@ -588,6 +598,8 @@ graph LR
 Hoje isso significa 5 extractors nativos/manuais (`Python`, `TypeScript/JavaScript`, `Rust`, `Go`, `Java`) mais 22 linguagens baseadas em tree-sitter nas Tier 1 + Tier 2.
 O build padrão já inclui Tier 2, o que inclui ambas as tiers tree-sitter.
 A contagem de linguagens é ampla, mas a profundidade varia por linguagem. [Detalhes das linguagens ->](https://github.com/maxkle1nz/m1nd/wiki/Ingest-Adapters)
+
+Além disso, a lane universal agora fecha o ciclo entre código e documentos com cache canônico local (`source.<ext>`, `canonical.md`, `canonical.json`, `claims.json`, `metadata.json`) e com as superfícies `document_resolve`, `document_bindings`, `document_drift`, `document_provider_health` e `auto_ingest_*`.
 
 O build padrão atual também inclui uma superfície HTTP/UI. Mantenha-a presa a localhost, a menos que você queira acesso remoto de propósito; não há camada de autenticação embutida para exposição pública arbitrária.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -108,11 +108,12 @@ m1nd 适用于“导航成本本身就是瓶颈”的场景。
 
 ## m1nd 做什么
 
-m1nd 是一个本地 Rust 工作区，包含三个主要部分：
+m1nd 是一个本地 Rust 工作区，包含三个核心 crate 加一个辅助桥接 crate：
 
 - `m1nd-core`：图引擎、传播、排名、启发式和分析层
 - `m1nd-ingest`：代码和文档摄取、提取器、解析器、合并路径和图构建
 - `m1nd-mcp`：通过 stdio 提供的 MCP 服务器，以及当前默认构建中的 HTTP/UI 界面
+- `m1nd-openclaw`：面向 OpenClaw 集成表面的辅助桥接 crate
 
 当前优势：
 
@@ -130,6 +131,9 @@ m1nd 是一个本地 Rust 工作区，包含三个主要部分：
 - 代码、`memory`、`json` 和 `light` 摄取适配器
 - 面向 Rust 仓库的 Cargo workspace 增强
 - 在 surgical 和 planning 路径上的启发式摘要
+- 通用文档 lane，可处理 markdown、HTML/wiki、office 文档和 PDF
+- 本地规范化产物，如 `source.<ext>`、`canonical.md`、`canonical.json`、`claims.json` 和 `metadata.json`
+- 文档侧 MCP 工作流，如 `document_resolve`、`document_bindings`、`document_drift`、`document_provider_health` 和 `auto_ingest_*`
 
 语言覆盖面很广，但深度仍会因语言而异。与许多基于 tree-sitter 的语言相比，Python 和 Rust 的处理更强。
 
@@ -407,13 +411,14 @@ Prefer plain tools for single-file edits, exact string chores, and runtime/build
 
 ## 工具表面
 
-当前 [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) 中的 `tool_schemas()` 实现暴露了 **77 个 MCP 工具**。
+当前 [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) 中的 `tool_schemas()` 实现暴露了 **93 个 MCP 工具**。
 
 导出的 MCP schema 里，规范工具名使用下划线，例如 `trail_save`、`perspective_start` 和 `apply_batch`。某些客户端可能会显示带 transport 前缀的名字，比如 `m1nd.apply_batch`，但 live registry 里的条目是以下划线为准的。
 
 | Category | Highlights |
 |----------|------------|
 | Foundation | ingest, activate, impact, why, learn, drift, seek, search, glob, view, warmup, federate |
+| Document Intelligence | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
 | Perspective Navigation | perspective_start, perspective_follow, perspective_peek, perspective_branch, perspective_compare, perspective_inspect, perspective_suggest |
 | Graph Analysis | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, validate_plan, trail_* |
 | Extended Analysis | antibody_*, flow_simulate, epidemic, tremor, trust, layers, layer_inspect |


### PR DESCRIPTION
## Summary
- sync the `.github/wiki` mirror with the canonical mdBook/docs wave
- update localized READMEs to reflect the 93-tool surface and universal document lane
- align public architecture wording with the current core crates plus auxiliary bridge story

## Verification
- `mdbook build docs/wiki`
- `git diff --check`
- stale-count sweep across `.github/wiki` and localized `README.*`

## Notes
- keeps `docs/wiki/src` + `wiki-build` as the canonical docs surface
- leaves `.omx/` untracked on purpose