### PR TITLE
Harden m1nd-viz against the remaining direct Vite alert

### DIFF
--- a/m1nd-viz/package.json
+++ b/m1nd-viz/package.json
@@ -12,7 +12,7 @@
     "@motion-canvas/core": "^3.17.2",
     "@motion-canvas/ui": "^3.17.2",
     "@motion-canvas/vite-plugin": "^3.17.2",
-    "vite": "^5.4.21"
+    "vite": "^6.4.2"
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
- bump `m1nd-viz` from `vite ^5.4.21` to `vite ^6.4.2`
- resolve the remaining direct Vite advisory lane that did not have an open Dependabot PR
- document this as a validated manual compatibility override for Motion Canvas

## Verification
- `npm install --legacy-peer-deps`
- `npm run build`
- `npm audit --json`

## Notes
- `@motion-canvas/vite-plugin@3.17.2` still declares `vite: 4.x || 5.x` as a peer range
- local build passed with `vite 6.4.2`
- the Vite advisory in `m1nd-viz` is cleared, but `npm audit` still reports separate transitive highs in `speech-rule-engine` / `@xmldom/xmldom` / `picomatch`
- `package-lock.json` is globally ignored in this repo, so this PR keeps the fix at the manifest level