### PR TITLE
Move the release workflow off deprecated Node 20 action lanes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }} ${{ matrix.artifact_name }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` in the release workflow from `v4` to `v7`
- update `actions/download-artifact` in the release workflow from `v4` to `v8`
- remove the Node 20 deprecation warnings from the release lane without changing release semantics

## Verification
- YAML parse via Ruby `Psych`
- `git diff --check`

## Notes
- this is preventive workflow hardening after the `v0.8.0` release warnings
- no product/runtime behavior changes are intended