### PR TITLE
Point repository docs links at the canonical wiki surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
   <a href="#configure-your-agent">Configure Your Agent</a> &middot;
   <a href="#results-and-measurements">Results</a> &middot;
   <a href="#tool-surface">Tools</a> &middot;
-  <a href="https://github.com/maxkle1nz/m1nd/wiki">Wiki</a> &middot;
+  <a href="https://m1nd.world/wiki/">Wiki</a> &middot;
   <a href="EXAMPLES.md">Examples</a>
 </p>
 
@@ -587,7 +587,7 @@ The current `tool_schemas()` implementation in [server.rs](https://github.com/ma
 | `savings` | Session/global token, CO2, and cost savings summary | ~0ms |
 </details>
 
-[Full API reference with examples ->](https://github.com/maxkle1nz/m1nd/wiki/API-Reference)
+[Full API reference with examples ->](https://m1nd.world/wiki/api-reference/overview.html)
 
 ## Post-Write Verification
 
@@ -691,7 +691,7 @@ graph LR
 27+ languages/file formats total.
 Today that means 5 native/manual extractors (`Python`, `TypeScript/JavaScript`, `Rust`, `Go`, `Java`) plus 22 tree-sitter-backed languages across Tier 1 + Tier 2.
 Default build already includes Tier 2, which includes both tree-sitter tiers.
-Language count is broad, but depth varies by language. [Language details ->](https://github.com/maxkle1nz/m1nd/wiki/Ingest-Adapters)
+Language count is broad, but depth varies by language. [Language details ->](https://m1nd.world/wiki/architecture/ingest.html)
 
 The current default build also includes an HTTP/UI surface. Keep it bound to localhost unless you intentionally want remote access; there is no built-in authentication layer for arbitrary public exposure.
 


### PR DESCRIPTION
## Summary
- replace the README's legacy GitHub wiki links with canonical `m1nd.world/wiki` links
- point the API reference CTA at the modern wiki's API reference page
- point the language-details CTA at the canonical ingest/docs page

## Root cause
The modern mdBook wiki is already live at `https://m1nd.world/wiki/`, but the repository README still linked readers into the legacy `.github/wiki` mirror on GitHub. That created the fallback path to the incomplete surface.

## Verification
- live `curl` check of `https://m1nd.world/wiki/`
- `git diff --check`
- grep verification of README links

## Notes
- the site source already links to `m1nd.world/wiki/`
- this PR fixes the repo entrypoint so the canonical docs surface is the one readers actually reach