### PR TITLE
Rewrite the README around the agent-first product narrative

### DIFF
--- a/.github/m1nd-agent-first-map.svg
+++ b/.github/m1nd-agent-first-map.svg
@@ -1,0 +1,99 @@
+<svg width="1600" height="860" viewBox="0 0 1600 860" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="860" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#070B16"/>
+      <stop offset="1" stop-color="#050510"/>
+    </linearGradient>
+    <linearGradient id="oldGlow" x1="120" y1="180" x2="640" y2="700" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ff4d6d" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#ffb700" stop-opacity="0.18"/>
+    </linearGradient>
+    <linearGradient id="newGlow" x1="920" y1="160" x2="1480" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00f5ff" stop-opacity="0.38"/>
+      <stop offset="0.5" stop-color="#7b61ff" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#00ff88" stop-opacity="0.2"/>
+    </linearGradient>
+    <filter id="blur" x="0" y="0" width="1600" height="860" filterUnits="userSpaceOnUse">
+      <feGaussianBlur stdDeviation="70"/>
+    </filter>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="0" stdDeviation="18" flood-color="#00f5ff" flood-opacity="0.16"/>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="860" fill="url(#bg)"/>
+  <g filter="url(#blur)">
+    <ellipse cx="370" cy="290" rx="260" ry="170" fill="url(#oldGlow)"/>
+    <ellipse cx="1210" cy="290" rx="300" ry="190" fill="url(#newGlow)"/>
+  </g>
+
+  <text x="120" y="96" fill="#E2E8F0" font-size="54" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">
+    Agent Loop: Before vs After m1nd
+  </text>
+  <text x="120" y="136" fill="#94A3B8" font-size="24" font-family="Space Mono, monospace">
+    Left: stateless exploration. Right: durable operational context.
+  </text>
+
+  <rect x="86" y="182" width="610" height="564" rx="30" fill="rgba(15,18,28,0.84)" stroke="rgba(255,77,109,0.24)" stroke-width="2"/>
+  <text x="128" y="240" fill="#FF9AAE" font-size="30" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">
+    Stateless Agent Loop
+  </text>
+  <text x="128" y="276" fill="#FCA5A5" font-size="18" font-family="Space Mono, monospace">
+    grep → open file → grep again → guess → edit blind
+  </text>
+
+  <g font-family="Space Mono, monospace" font-size="22" fill="#F8FAFC">
+    <rect x="128" y="328" width="220" height="74" rx="20" fill="#171C28" stroke="#3D4456"/>
+    <text x="160" y="373">grep symbol</text>
+    <rect x="412" y="328" width="220" height="74" rx="20" fill="#171C28" stroke="#3D4456"/>
+    <text x="446" y="373">open file</text>
+
+    <rect x="128" y="452" width="220" height="74" rx="20" fill="#171C28" stroke="#3D4456"/>
+    <text x="147" y="497">grep callers</text>
+    <rect x="412" y="452" width="220" height="74" rx="20" fill="#171C28" stroke="#3D4456"/>
+    <text x="438" y="497">open more</text>
+
+    <rect x="270" y="580" width="220" height="84" rx="20" fill="#20151C" stroke="#FF4D6D"/>
+    <text x="315" y="623">guess impact</text>
+    <text x="302" y="651" fill="#FDBA74" font-size="18">discover risk too late</text>
+  </g>
+
+  <path d="M350 365H412" stroke="#FF9AAE" stroke-width="3" stroke-dasharray="10 10"/>
+  <path d="M350 489H412" stroke="#FF9AAE" stroke-width="3" stroke-dasharray="10 10"/>
+  <path d="M380 526V580" stroke="#FF9AAE" stroke-width="3" stroke-dasharray="10 10"/>
+
+  <rect x="904" y="182" width="610" height="564" rx="30" fill="rgba(10,14,26,0.84)" stroke="rgba(0,245,255,0.26)" stroke-width="2"/>
+  <text x="946" y="240" fill="#C7FBFF" font-size="30" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">
+    m1nd-Grounded Agent Loop
+  </text>
+  <text x="946" y="276" fill="#A5F3FC" font-size="18" font-family="Space Mono, monospace">
+    ingest once → understand structure → predict impact → act with proof
+  </text>
+
+  <g font-family="Space Mono, monospace" font-size="21" fill="#F8FAFC" filter="url(#soft)">
+    <rect x="946" y="322" width="230" height="76" rx="20" fill="#091521" stroke="#00F5FF"/>
+    <text x="992" y="368">⍂ ingest once</text>
+
+    <rect x="1240" y="322" width="230" height="76" rx="20" fill="#0F1226" stroke="#7B61FF"/>
+    <text x="1268" y="368">⍌ understand</text>
+
+    <rect x="946" y="454" width="230" height="76" rx="20" fill="#0C1624" stroke="#00FF88"/>
+    <text x="973" y="500">𝔻 predict impact</text>
+
+    <rect x="1240" y="454" width="230" height="76" rx="20" fill="#150D22" stroke="#FF00AA"/>
+    <text x="1284" y="500">⟁ pull context</text>
+
+    <rect x="1092" y="588" width="230" height="86" rx="22" fill="#081923" stroke="#00F5FF" stroke-width="2.5"/>
+    <text x="1147" y="628">act with proof</text>
+    <text x="1130" y="656" fill="#86EFAC" font-size="18">less guesswork • less waste</text>
+  </g>
+
+  <path d="M1178 360H1240" stroke="#00F5FF" stroke-width="4"/>
+  <path d="M1060 398V454" stroke="#7B61FF" stroke-width="4"/>
+  <path d="M1354 398V454" stroke="#7B61FF" stroke-width="4"/>
+  <path d="M1208 530V588" stroke="#00FF88" stroke-width="4"/>
+
+  <text x="1165" y="84" fill="#00F5FF" font-size="28" font-family="Space Mono, monospace" font-weight="700">
+    ⍌ ⍐ ⍂ 𝔻 ⟁
+  </text>
+</svg>

--- a/.github/m1nd-operability-surface.svg
+++ b/.github/m1nd-operability-surface.svg
@@ -1,0 +1,89 @@
+<svg width="1600" height="980" viewBox="0 0 1600 980" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1600" y2="980" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#050510"/>
+      <stop offset="1" stop-color="#07121E"/>
+    </linearGradient>
+    <filter id="glow2" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="0" stdDeviation="22" flood-color="#00f5ff" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="980" fill="url(#bg2)"/>
+
+  <text x="110" y="96" fill="#E2E8F0" font-size="54" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">
+    The m1nd Operability Surface
+  </text>
+  <text x="110" y="136" fill="#94A3B8" font-size="24" font-family="Space Mono, monospace">
+    Code, docs, concepts, and change become one layer an agent can operate on.
+  </text>
+
+  <g font-family="Space Mono, monospace" font-size="23" fill="#E2E8F0">
+    <rect x="118" y="220" width="270" height="96" rx="24" fill="#0F1824" stroke="#00F5FF"/>
+    <text x="198" y="272">code</text>
+    <text x="156" y="304" fill="#94A3B8" font-size="18">files · functions · modules</text>
+
+    <rect x="118" y="356" width="270" height="96" rx="24" fill="#111626" stroke="#7B61FF"/>
+    <text x="196" y="408">docs</text>
+    <text x="141" y="440" fill="#94A3B8" font-size="18">L1GHT · universal · RFCs</text>
+
+    <rect x="118" y="492" width="270" height="96" rx="24" fill="#0F1D1D" stroke="#00FF88"/>
+    <text x="170" y="544">concepts</text>
+    <text x="151" y="576" fill="#94A3B8" font-size="18">specs · knowledge · memory</text>
+
+    <rect x="118" y="628" width="270" height="96" rx="24" fill="#1A140A" stroke="#FFB700"/>
+    <text x="186" y="680">change</text>
+    <text x="152" y="712" fill="#94A3B8" font-size="18">impact · drift · verification</text>
+  </g>
+
+  <g filter="url(#glow2)">
+    <rect x="530" y="220" width="540" height="504" rx="36" fill="rgba(8,16,28,0.9)" stroke="rgba(0,245,255,0.24)" stroke-width="2"/>
+    <text x="706" y="288" fill="#E2E8F0" font-size="46" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">
+      m1nd
+    </text>
+    <text x="652" y="334" fill="#00F5FF" font-size="24" font-family="Space Mono, monospace">
+      software intelligence layer
+    </text>
+
+    <text x="610" y="416" fill="#E2E8F0" font-size="24" font-family="Space Mono, monospace">⍂ structural truth</text>
+    <text x="610" y="466" fill="#E2E8F0" font-size="24" font-family="Space Mono, monospace">⍌ connected retrieval</text>
+    <text x="610" y="516" fill="#E2E8F0" font-size="24" font-family="Space Mono, monospace">𝔻 change intelligence</text>
+    <text x="610" y="566" fill="#E2E8F0" font-size="24" font-family="Space Mono, monospace">⟁ surgical execution</text>
+    <text x="610" y="616" fill="#E2E8F0" font-size="24" font-family="Space Mono, monospace">⍐ continuity + runtime</text>
+  </g>
+
+  <g font-family="Space Mono, monospace" font-size="23" fill="#E2E8F0">
+    <rect x="1210" y="220" width="270" height="96" rx="24" fill="#091521" stroke="#00F5FF"/>
+    <text x="1272" y="272">search</text>
+    <text x="1244" y="304" fill="#94A3B8" font-size="18">seek · activate · search</text>
+
+    <rect x="1210" y="356" width="270" height="96" rx="24" fill="#120E24" stroke="#7B61FF"/>
+    <text x="1286" y="408">review</text>
+    <text x="1238" y="440" fill="#94A3B8" font-size="18">why risky · what changed</text>
+
+    <rect x="1210" y="492" width="270" height="96" rx="24" fill="#0B1E18" stroke="#00FF88"/>
+    <text x="1294" y="544">edit</text>
+    <text x="1236" y="576" fill="#94A3B8" font-size="18">context → apply → verify</text>
+
+    <rect x="1210" y="628" width="270" height="96" rx="24" fill="#1A110D" stroke="#FF00AA"/>
+    <text x="1288" y="680">operate</text>
+    <text x="1243" y="712" fill="#94A3B8" font-size="18">audit · daemon · alerts</text>
+  </g>
+
+  <path d="M388 268H530" stroke="#00F5FF" stroke-width="4"/>
+  <path d="M388 404H530" stroke="#7B61FF" stroke-width="4"/>
+  <path d="M388 540H530" stroke="#00FF88" stroke-width="4"/>
+  <path d="M388 676H530" stroke="#FFB700" stroke-width="4"/>
+
+  <path d="M1070 268H1210" stroke="#00F5FF" stroke-width="4"/>
+  <path d="M1070 404H1210" stroke="#7B61FF" stroke-width="4"/>
+  <path d="M1070 540H1210" stroke="#00FF88" stroke-width="4"/>
+  <path d="M1070 676H1210" stroke="#FF00AA" stroke-width="4"/>
+
+  <text x="604" y="828" fill="#A5F3FC" font-size="26" font-family="Space Grotesk, Arial, sans-serif" font-weight="700">
+    m1nd gives AI agents durable operational context before they act.
+  </text>
+  <text x="604" y="866" fill="#94A3B8" font-size="20" font-family="Space Mono, monospace">
+    code • docs • concepts • change → one operable system
+  </text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -7,18 +7,13 @@
 <h3 align="center">Built for agents first. Humans are welcome.</h3>
 
 <p align="center">
-  <strong>Before you change code, see what breaks.</strong><br/>
-  <strong>Ask the codebase a question. Get the map, not the maze.</strong><br/><br/>
-  m1nd gives coding agents structural intelligence before they disappear into grep/read drift. Ingest the codebase once, turn it into a graph, and let the agent ask what actually matters: what breaks if this changes, what else moves with it, and what should be verified next.<br/>
-  <em>Local execution. MCP over stdio. Optional HTTP/UI surface in the current default build.</em>
+  <strong>The software intelligence layer for AI agents.</strong>
 </p>
 
 <p align="center">
-  <strong>Grounded in current code, tests, and shipped tool surfaces.</strong>
-</p>
-
-<p align="center">
-  <img src=".github/m1nd-key-visual.png" alt="m1nd — structural intelligence for coding agents" width="860" />
+  m1nd gives AI agents durable operational context before they search, edit, review, or change code.<br/>
+  It makes code, docs, and change operable as one system.<br/>
+  <em>Local execution. MCP over stdio. Optional HTTP/UI surface in the default build.</em>
 </p>
 
 <p align="center">
@@ -26,20 +21,20 @@
   <a href="https://github.com/maxkle1nz/m1nd/actions"><img src="https://github.com/maxkle1nz/m1nd/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://docs.rs/m1nd-core"><img src="https://img.shields.io/docsrs/m1nd-core" alt="docs.rs" /></a>
+  <a href="https://github.com/maxkle1nz/m1nd/releases"><img src="https://img.shields.io/badge/release-v0.8.0-00f5ff" alt="Release" /></a>
 </p>
 
 <p align="center">
-  <a href="#identity">Identity</a> &middot;
-  <a href="#what-m1nd-does">What m1nd Does</a> &middot;
+  <a href="#why-m1nd">Why m1nd</a> &middot;
+  <a href="#why-first">Why First</a> &middot;
+  <a href="#what-m1nd-operationalizes">What It Operationalizes</a> &middot;
+  <a href="#what-ships-today">What Ships Today</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#configure-your-agent">Configure Your Agent</a> &middot;
-  <a href="#results-and-measurements">Results</a> &middot;
-  <a href="#tool-surface">Tools</a> &middot;
+  <a href="#make-it-the-first-layer">Make It The First Layer</a> &middot;
+  <a href="#proof">Proof</a> &middot;
   <a href="https://m1nd.world/wiki/">Wiki</a> &middot;
   <a href="EXAMPLES.md">Examples</a>
 </p>
-
-<h4 align="center">Works with any MCP client</h4>
 
 <p align="center">
   <a href="https://claude.ai/download"><img src="https://img.shields.io/badge/Claude_Code-f0ebe3?logo=claude&logoColor=d97706" alt="Claude Code" /></a>
@@ -54,692 +49,282 @@
   <a href="https://aws.amazon.com/q/developer"><img src="https://img.shields.io/badge/Amazon_Q-232f3e?logo=amazonaws&logoColor=f90" alt="Amazon Q" /></a>
 </p>
 
----
-
 <p align="center">
-  <img src=".github/demo-cinema.gif" alt="m1nd — 5 real queries, 1.9 seconds, zero tokens, 8 invisible bugs" width="720" />
+  <img src=".github/m1nd-key-visual.png" alt="m1nd — code, docs, and change as one operable system for agents" width="860" />
 </p>
 
-## Identity
+<p align="center">
+  <img src=".github/m1nd-agent-first-map.svg" alt="Traditional agent loop vs m1nd-grounded loop" width="960" />
+</p>
 
-m1nd is structural intelligence for coding agents.
+## Why m1nd
 
-Ingest the codebase once, turn it into a graph, and let the agent ask structural questions directly.
+LLMs are good at local pattern matching and bad at durable operational understanding.
 
-Before an edit, m1nd helps the agent see blast radius, connected context, likely co-changes, and what to verify next — before it disappears into grep and read loops.
+Without a structural layer, an agent usually does this:
 
-> Stop paying the orientation tax every turn.
->
-> `grep` finds what you asked for. `m1nd` finds what you missed.
+1. grep for a symbol
+2. open a file
+3. grep again for callers, callees, or related paths
+4. open more files
+5. rediscover the same system shape every turn
 
-## What m1nd Does
+That costs:
 
-m1nd is for the moment before the agent gets lost.
+- too many file reads
+- too many tokens spent rebuilding context
+- too many blind edits
+- too much drift between code and docs
+- too much lost continuity across sessions
 
-You ingest the repo once, turn it into a graph, and stop making the agent rediscover structure from raw text every turn.
+m1nd exists to compensate for that.
 
-That means it can answer the questions that actually matter:
+It ingests a repository once, turns it into a graph, and gives the agent a durable layer for:
 
-- what is related to this?
-- what breaks if I change it?
-- what else probably needs to move?
-- where is the connected edit context?
-- what should I verify next?
+- structural truth
+- connected context
+- change reasoning
+- document grounding
+- operational continuity
 
-Under the hood, the workspace has three core parts plus one auxiliary bridge crate:
+> `grep` finds what the agent asked for.
+> `m1nd` helps the agent understand what it is about to touch.
 
-- `m1nd-core`: the graph engine
-- `m1nd-ingest`: repo walking, extraction, reference resolution, and graph construction
-- `m1nd-mcp`: the MCP server over stdio, plus an HTTP/UI surface in the current default build
-- `m1nd-openclaw`: auxiliary OpenClaw integration surface
+## Why First
 
-The project is strongest at structural grounding:
+`m1nd` should be the first layer an agent reaches for before it acts on a system.
 
-- ingesting code into a graph instead of navigating only by text search
-- ingesting documents and knowledge artifacts into the same graph as code
-- resolving relationships between files, functions, types, modules, and graph neighborhoods
-- exposing that graph through MCP tools for navigation, impact analysis, tracing, prediction, and editing workflows
-- merging code with markdown or structured memory graphs when needed
-- resolving canonical local document artifacts, document/code bindings, and document drift when docs are part of the investigation
-- retaining heuristic memory over time so feedback can shape future retrieval through `learn`, `trust`, `tremor`, and `antibody` sidecars
-- surfacing why a result was ranked, not just what matched
+### Before search
+Use `m1nd` to find the structure that matters, not only the text that matches.
 
-Today it ships with:
+### Before edit
+Use `m1nd` to see blast radius, co-change risk, and connected edit context.
 
-- native/manual extractors for Python, TypeScript/JavaScript, Rust, Go, and Java
-- 22 additional tree-sitter-backed languages across Tier 1 and Tier 2
-- a generic fallback extractor for unsupported file types
-- reference resolution in the live ingest path
-- Cargo workspace enrichment for Rust repos
-- document ingestion for patents (USPTO/EPO XML), scientific articles (PubMed/JATS), BibTeX bibliographies, CrossRef DOI metadata, and IETF RFCs — with automatic format detection via `DocumentRouter` and cross-domain edge resolution
-- inspectable heuristic signals on higher-level retrieval paths, so `seek` and `predict` can expose more than a raw score
+### Before review
+Use `m1nd` to understand what is risky, what is missing, and what else moved.
 
-Language breadth is broad, but semantic depth varies by language. Python and Rust currently have more specialized handling than many of the tree-sitter-backed languages.
+### Before docs work
+Use `m1nd` to bind specs, notes, and concepts back to implementation.
 
-## Results And Measurements
+### Before operations
+Use `m1nd` to audit drift, monitor watched roots, and surface durable alerts.
 
-These are observed runs from current docs and tests, not benchmark cosplay.
+```mermaid
+flowchart LR
+    subgraph Old["Stateless Agent Loop"]
+        A1["grep"] --> A2["open file"]
+        A2 --> A3["grep again"]
+        A3 --> A4["open more files"]
+        A4 --> A5["guess impact"]
+    end
 
-Treat them as reference points, not hard guarantees for every codebase.
+    subgraph New["m1nd-Grounded Agent Loop"]
+        B1["ingest once"] --> B2["understand structure"]
+        B2 --> B3["predict impact"]
+        B3 --> B4["pull connected context"]
+        B4 --> B5["act with proof"]
+    end
+```
 
-Case-study audit on a Python/FastAPI codebase:
+## What m1nd Operationalizes
 
-| Metric | Result |
-|--------|--------|
-| **Bugs found in one session** | 39 (28 confirmed fixed + 9 high-confidence) |
-| **Invisible to grep** | 8 of 28 (28.5%) -- required structural analysis |
-| **Hypothesis accuracy** | 89% over 10 live claims |
-| **Post-write validation set** | 12/12 scenarios classified correctly in the documented sample |
-| **LLM tokens consumed** | 0 -- pure Rust, local binary |
-| **m1nd queries vs grep ops** | 46 vs ~210 |
-| **Total query latency** | ~3.1 seconds vs ~35 minutes estimated |
+`m1nd` does more than index code. It turns multiple kinds of technical reality into one operable layer for agents:
 
-Criterion micro-benchmarks (recorded in current docs):
+- code
+- docs
+- specs
+- concepts
+- change
+- runtime state
+- multi-repo edges
 
-| Operation | Time |
-|-----------|------|
-| `activate` 1K nodes | **1.36 &micro;s** |
-| `impact` depth=3 | **543 ns** |
-| `flow_simulate` 4 particles | 552 &micro;s |
-| `antibody_scan` 50 patterns | 2.68 ms |
-| `layer_detect` 500 nodes | 862 &micro;s |
-| `resonate` 5 harmonics | 8.17 &micro;s |
+<p align="center">
+  <img src=".github/m1nd-operability-surface.svg" alt="m1nd operational intelligence surface" width="960" />
+</p>
+
+That is why `m1nd` is not just code search, not just review, and not just docs tooling.
+
+It is the layer that makes those surfaces legible and actionable together.
+
+## What Ships Today
+
+The current live MCP surface exposes **93 tools**. What matters more than the count is the shape of the system.
+
+| Layer | What it enables | Representative tools |
+|---|---|---|
+| Structural truth | turn repos into navigable graph truth | `ingest`, `activate`, `seek`, `why`, `search`, `impact` |
+| Document intelligence | bind docs/specs/concepts to implementation | `L1GHT`, `document_resolve`, `document_bindings`, `document_drift`, `auto_ingest_*` |
+| Change intelligence | reason about what breaks, what moves, and what is missing | `predict`, `validate_plan`, `trace`, `missing`, `hypothesize`, `counterfactual` |
+| Surgical execution | move from reasoning to bounded safe mutation | `surgical_context`, `surgical_context_v2`, `apply`, `apply_batch`, `edit_preview`, `edit_commit` |
+| Operational runtime | keep the system live, watched, and continuity-aware | `audit`, `cross_verify`, `coverage_session`, `daemon_*`, `alerts_*`, `persist`, `boot_memory` |
+| Federation | operate beyond a single repo | `federate`, `federate_auto`, `external_references` |
+
+### What that means in practice
+
+- **Code + docs in one graph** through `memory`, `light`, `universal`, `json`, and structured document adapters
+- **Canonical local document artifacts** through `document_resolve`
+- **Doc-to-code grounding** through `document_bindings`
+- **Spec drift detection** through `document_drift`
+- **Watcher/runtime continuity** through `auto_ingest_*`, `daemon_*`, and `alerts_*`
+- **Safe multi-file mutation** through `apply_batch(verify=true)`
 
 ## Quick Start
 
-If you just want the shortest path to value, it is this:
+If you want the shortest path to value:
 
 ```bash
 git clone https://github.com/maxkle1nz/m1nd.git
-cd m1nd && cargo build --release
+cd m1nd
+cargo build --release
 ./target/release/m1nd-mcp
 ```
 
+Then do three things:
+
 ```jsonc
-// 1. Ingest your codebase (910ms for 335 files)
+// 1. Build graph truth
 {"method":"tools/call","params":{"name":"m1nd.ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
-// -> 9,767 nodes, 26,557 edges, PageRank computed
 
-// 2. Ask: "What's related to authentication?"
-{"method":"tools/call","params":{"name":"m1nd.activate","arguments":{"query":"authentication","agent_id":"dev"}}}
-// -> auth fires -> propagates to session, middleware, JWT, user model
-//    ghost edges reveal undocumented connections
+// 2. Ask a structural question
+{"method":"tools/call","params":{"name":"m1nd.activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 
-// 3. Tell the graph what was useful
-{"method":"tools/call","params":{"name":"m1nd.learn","arguments":{"feedback":"correct","node_ids":["file::auth.py","file::middleware.py"],"agent_id":"dev"}}}
-// -> 740 edges strengthened via Hebbian LTP. Next query is smarter.
+// 3. Reinforce what was useful
+{"method":"tools/call","params":{"name":"m1nd.learn","arguments":{"query":"authentication flow","feedback":"correct","node_ids":["file::auth.py"],"agent_id":"dev"}}}
 ```
 
-Add to Claude Code (`~/.claude.json`):
+If docs/specs matter too:
 
-```json
-{
-  "mcpServers": {
-    "m1nd": {
-      "command": "/path/to/m1nd-mcp",
-      "env": {
-        "M1ND_GRAPH_SOURCE": "/tmp/m1nd-graph.json",
-        "M1ND_PLASTICITY_STATE": "/tmp/m1nd-plasticity.json"
-      }
-    }
-  }
-}
+```jsonc
+{"method":"tools/call","params":{"name":"m1nd.ingest","arguments":{
+  "path":"/your/docs","adapter":"universal","mode":"merge","agent_id":"dev"
+}}}
 ```
 
-Works with any MCP client that can connect to an MCP server: Claude Code, Codex, Cursor, Windsurf, Zed, or your own.
+## Make It The First Layer
 
-**For large codebases, see [Deployment & Production Setup](docs/deployment.md) for how to run m1nd as a persistent server with smart namespace ingest and near-zero latency.**
+The highest-leverage adoption move is not “install m1nd.”
 
----
+It is:
 
-### Graph-First Instead Of Text-First
+> **make m1nd mandatory before search, edit, review, or change.**
 
-Most AI coding workflows still spend a lot of time on navigation: grep, glob, file reads, and repeated context loading. m1nd takes a different approach by precomputing a graph and exposing that graph through MCP.
+### Minimal system-prompt rule
 
-That changes the shape of the question. Instead of asking the model to reconstruct repo structure from raw files every time, the agent can ask for:
+```text
+You have m1nd available via MCP.
+Use m1nd before grep, glob, or manual file reads when the task depends on structure, impact, docs, or change.
 
-- related code paths
-- blast radius
-- structural holes
-- graph paths between nodes
-- connected context for an edit
-
-This does not replace an LSP, a compiler, or a full static-analysis/security suite. It gives an agent a structural map of the repo so it can spend less time on navigation and more time on the task itself.
-
----
-
-**It worked?** [Star this repo](https://github.com/maxkle1nz/m1nd) -- it helps others find it.
-**Bug or idea?** [Open an issue](https://github.com/maxkle1nz/m1nd/issues).
-**Want to go deeper?** See [EXAMPLES.md](EXAMPLES.md) for real-world pipelines.
-
----
-
-## Configure Your Agent
-
-m1nd is most useful when the agent stops treating the repo like a pile of files and starts treating it like a graph.
-
-**It is critical to establish a strict rule in your agent's system prompt:** The AI must use m1nd *before* attempting to use traditional tools like `grep`, `ls`, or `cat`.
-
-### What to add to your agent's system prompt
-
-```
-CRITICAL RULE: You have m1nd available via MCP. You MUST use m1nd BEFORE falling back to traditional tools like grep, glob, or file reads.
-- m1nd.search(mode="literal") replaces grep — finds exact strings with graph context
-  Use `auto_ingest=true` when `scope` points to a real path outside current ingest roots. It only auto-ingests when scope resolves to exactly one path.
-- m1nd.activate replaces glob — finds related code by meaning, not filename
-- m1nd.heuristics_surface explains why a node or file ranked as risky or important
-- m1nd.validate_plan attaches `heuristics_surface_ref` to hotspots and gaps so the agent can jump straight into the explanation
-- m1nd.surgical_context_v2 replaces Read — returns source + all connected files in one call, with `heuristic_summary` on the primary file and each connected file for trust/tremor/antibody/blast-radius risk
-- m1nd.impact replaces manual dependency checking — shows blast radius before edits
-- m1nd.apply replaces Edit — writes code and auto-updates the graph
-- m1nd.apply_batch(verify=true) — write multiple files + 5-layer post-write verification
-- m1nd.help() — call when unsure which tool to use
+- use m1nd.search for exact text
+- use m1nd.activate / m1nd.seek for connected structure
+- use m1nd.impact before edits
+- use m1nd.validate_plan before risky changes
+- use m1nd.surgical_context_v2 before multi-file edits
+- use m1nd.document_* when specs/docs matter
+- use m1nd.audit / daemon_* / alerts_* for ongoing repo operations
+- use m1nd.help when unsure
 ```
 
-### Claude Code (CLAUDE.md)
-
-Copy-paste into your project's `CLAUDE.md`:
+### Claude Code snippet
 
 ```markdown
 ## Code Intelligence
-m1nd is your primary code navigation tool. Use it before grep/glob/Read.
-Key tools: search (grep replacement), activate (find related), heuristics_surface (why did this rank?),
-surgical_context_v2 (full context + heuristic_summary), impact (blast radius), apply (edit + re-ingest),
-apply_batch(verify=true) (batch edit + verification),
-help (when confused).
-
-Search note: `auto_ingest=true` can ingest a scope outside current roots before searching, but only when the scope resolves to one path. Ambiguous scopes return an error listing candidates.
+m1nd is the first layer before grep/glob/read loops.
+Use it for structural understanding, docs grounding, blast radius, plan validation, and connected edit context.
 ```
 
-### Cursor (.cursorrules)
+### Cursor snippet
 
-Copy-paste into your `.cursorrules`:
-
-```
-When exploring code, use m1nd MCP tools instead of grep:
-- m1nd.search for finding code
-- m1nd.activate for understanding relationships
-- m1nd.impact before making changes
-
-If `m1nd.search` needs to look outside current ingest roots, prefer an explicit `scope` plus `auto_ingest=true`. If multiple paths match that scope, refine it until only one path resolves.
+```text
+Use m1nd before grep or opening lots of files:
+- search for exact text
+- activate/seek for connected structure
+- impact before edits
+- surgical_context_v2 before multi-file changes
 ```
 
-### Generic MCP client
+## Proof
 
-Any MCP-compatible tool (Windsurf, Zed, Cline, Roo Code, Continue, OpenCode, Amazon Q) works the same way. Add the system prompt instructions above to your agent's configuration, and m1nd tools appear automatically once the MCP server is connected.
+These are grounded in current code, tests, and docs. They are evidence, not slogans.
 
-### Why this matters
+| Metric | Observed result |
+|---|---|
+| Public MCP surface | **93 tools** |
+| Bugs found in one documented audit session | **39** |
+| Findings invisible to grep in that session | **8 of 28** |
+| Hypothesis accuracy in live claims | **89%** |
+| Post-write validation sample | **12/12** classified correctly |
+| `activate` on 1K nodes | **1.36 µs** |
+| `impact` depth=3 | **543 ns** |
+| `antibody_scan` on 50 patterns | **2.68 ms** |
 
-m1nd is useful when an agent needs graph-grounded context instead of repeated grep/glob/file-read loops. In the documented audit session, it reduced grep-heavy exploration and surfaced structural findings that plain text search missed.
+The important product claim is not “fast graph queries” by itself.
 
-Instead of paying to read 20,000 lines of code just to figure out how the provider works, the agent asks the graph.
+It is this:
 
-If your agent is still opening files one by one to reconstruct repo structure, it is not exploring. It is wandering.
+> `m1nd` reduces context waste and blind change by giving the agent operational understanding before action.
 
-Make m1nd the mandatory first step before traditional tool usage.
+## Where It Fits
 
----
+`m1nd` is not trying to replace:
 
-## Where m1nd Fits
+- your LSP
+- your compiler
+- your test runner
+- your static security suite
+- your observability stack
 
-m1nd is at its best once plain text search stops being enough.
+It sits in the gap they do not solve well for agents:
 
-It helps when an agent needs graph-grounded repo context instead of another round of grep, glob, and file reads:
+- before the agent acts
+- while the agent is orienting
+- when code and docs need to be bound
+- when change needs prediction
+- when continuity matters across sessions
 
-- persistent graph state instead of one-off search results
-- impact and neighborhood queries before edits
-- saved investigations across sessions
-- structural checks such as hypothesis testing, counterfactual removal, and layer inspection
-- mixed code + documentation graphs through the `memory`, `json`, and `light` adapters
+## Architecture At A Glance
 
-It is not trying to replace your LSP, Sourcegraph, CodeQL, or compiler. It sits in the middle: faster than reconstructing structure from raw text every turn, lighter than full static analysis.
+The workspace has three core crates plus one auxiliary bridge crate:
 
-## What Makes It Different
+- `m1nd-core` — graph engine and reasoning primitives
+- `m1nd-ingest` — extraction, routing, and graph construction
+- `m1nd-mcp` — MCP server and operational runtime surface
+- `m1nd-openclaw` — auxiliary OpenClaw integration surface
 
-**It holds onto a persistent graph, not a pile of one-off search results.** Confirmed paths can be reinforced through `learn`, and later queries can reuse that structure instead of starting from zero.
+Current crate versions:
 
-**It puts structural claims to the test.** Tools like `hypothesize`, `why`, `impact`, and `counterfactual` operate on graph relationships rather than on text matches alone.
+- `m1nd-core` `0.8.0`
+- `m1nd-ingest` `0.8.0`
+- `m1nd-mcp` `0.8.0`
 
-**It can merge code and documentation into the same graph.** m1nd now provides ten ingest adapters:
+## Learn More
 
-- **`code`** (default) — code extractors across 27+ languages/file formats. Build the full code graph from source files.
-- **`json`** — Custom graph descriptors and structured data imports.
-- **`memory`** — Unstructured `.md`/`.txt` corpus as a lightweight knowledge graph.
-- **`universal`** — Best-effort document canonicalization for markdown, HTML, text, office documents, and PDFs. Produces canonical local artifacts and graph-native document structure even when the source was not authored in `L1GHT`.
-- **`light`** — [L1GHT Protocol](docs/wiki-build/l1ght.html): structured markdown with typed YAML frontmatter and inline semantic markers. Transforms specs, design decisions, and knowledge bases into first-class graph nodes with typed edges.
-- **`patent`** — USPTO Red Book / Yellow Book and EPO DocDB XML. Parses patent claims, descriptions, inventors, applicants, and classification codes into graph nodes with citation edges.
-- **`article`** — PubMed NLM and NISO JATS Z39.96 XML. Extracts article metadata, authors (with ORCID when available), abstracts, and reference lists.
-- **`bibtex`** / **`bib`** — `.bib` bibliography files. Extracts entries with author, venue, year, and DOI, building citation edges between entries.
-- **`crossref`** / **`doi`** — CrossRef API JSON (DOI works endpoint). Ingests structured DOI metadata with author, funder, license, and reference links.
-- **`rfc`** — IETF RFC XML v3. Parses RFC sections, authors, references, and cross-references between RFCs.
+- [Canonical wiki](https://m1nd.world/wiki/)
+- [API reference](https://m1nd.world/wiki/api-reference/overview.html)
+- [Tool matrix](https://m1nd.world/wiki/tool-matrix.html)
+- [Architecture overview](https://m1nd.world/wiki/architecture/overview.html)
+- [Examples](EXAMPLES.md)
+- [Deployment & Production Setup](docs/deployment.md)
+- [Release notes](https://github.com/maxkle1nz/m1nd/releases)
 
-Format detection is automatic: `DocumentRouter` inspects file extensions and content (root XML elements, JSON keys) to route to the correct adapter. Use `adapter="auto"` or `adapter="document"` via MCP.
+## When Not To Use m1nd
 
-`CrossDomainResolver` merges multiple adapter outputs and discovers cross-domain connections automatically — DOI identity edges, ORCID matches, shared authors, keyword bridges, and citation chains.
-
-With `mode: "merge"`, these graphs can be queried together. That means a query can return code, patents, papers, and specs from the same graph.
-
-### Universal Document Intelligence
-
-The universal lane adds a practical bridge between code and everything around the codebase:
-
-- design docs
-- markdown notes
-- HTML/wiki pages
-- office documents
-- scholarly PDFs
-
-When the universal lane ingests a document, `m1nd` keeps a canonical local cache and graph surface for it:
-
-- original source copy
-- `canonical.md`
-- `canonical.json`
-- `claims.json`
-- `metadata.json`
-
-That enables a second layer of MCP workflows on top of raw ingest:
-
-- `document_resolve` — find the local canonical artifacts for a document
-- `document_bindings` — see likely deterministic bindings from document content to code
-- `document_drift` — detect missing, stale, or ambiguous document/code links
-- `document_provider_health` — inspect optional provider availability and install hints
-- `auto_ingest_start` / `auto_ingest_status` / `auto_ingest_tick` — keep document roots watched and incrementally reconciled
-
-Optional providers enrich the universal lane when available:
-
-- `Docling` for broad-spectrum office and structured document canonicalization
-- `Trafilatura` for HTML/wiki/article extraction
-- `MarkItDown` as a lightweight fallback lane
-- `GROBID` for scholarly PDF extraction
-
-These providers are intentionally optional. The default green path does not require them, and provider-gated tests skip cleanly when the provider environment is absent or unreachable.
-
-```
-# Example L1GHT document (any .md file)
----
-Protocol: L1GHT/1.0
-Node:     AuthService
-State:    production
-Depends on:
-- JWTService
-- SessionStore
----
-
-## Token Validation
-
-The [⍂ entity: TokenValidator] runs HMAC-SHA256 checks.
-[⟁ depends_on: RedisSessionStore]
-[RED blocker: Connection pool not yet tuned for peak load]
-```
-
-```python
-# Ingest code + specs into a unified graph
-m1nd.ingest({"path": "./src", "adapter": "code", "mode": "replace"})
-m1nd.ingest({"path": "./docs/specs", "adapter": "light", "mode": "merge"})
-m1nd.activate({"query": "auth token refresh"})  # fires across both domains
-```
-
-
-**It exposes more than basic traversal.**
-- antibody scanning for known bug patterns
-- epidemic-style propagation for neighboring risk
-- tremor/trust signals from change history
-- layer detection for architectural violations
-
-**It verifies writes instead of hoping they worked.** `apply_batch(verify=true)` runs multiple post-write checks and returns a SAFE / RISKY / BROKEN-style verdict. See [Post-Write Verification](#post-write-verification).
-
-**It can persist investigations instead of dropping them between sessions.** `trail.save`, `trail.resume`, and `trail.merge` let agents keep and combine graph-grounded investigation state.
-
-**It has a canonical hot-state layer.** `boot_memory` stores small, durable doctrine/state next to the graph without polluting trails or transcripts.
-
-## Operational Workflow For Agents
-
-m1nd is opinionated about how agents should move through a repo. The server's own embedded `M1ND_INSTRUCTIONS` block defines a preferred choreography:
-
-- **Session start**: `health -> drift -> ingest`
-- **Research**: `ingest -> activate -> why -> missing -> learn`
-- **Code change**: `impact -> predict -> counterfactual -> warmup -> surgical/apply path`
-- **Stateful navigation**: `perspective.*` and `trail.*`
-- **Canonical hot state**: `boot_memory`
-
-This matters because m1nd is not just a search endpoint. It is an opinionated graph operating layer for agents, and it works best when the graph becomes part of the workflow instead of a last resort.
-
-## Tool Surface
-
-The current `tool_schemas()` implementation in [server.rs](https://github.com/maxkle1nz/m1nd/blob/main/m1nd-mcp/src/server.rs) exposes **93 MCP tools**. That number will move. The categories below matter more, but the count itself is now grounded in the live registry.
-
-| Category | Highlights |
-|----------|------------|
-| **Foundation** | ingest, health, activate, impact, why, learn, drift, seek, scan, warmup, federate |
-| **Document Intelligence** | document.resolve, document.bindings, document.drift, document.provider_health, auto_ingest.start/status/tick/stop |
-| **Perspective Navigation** | start, follow, peek, routes, branch, compare, inspect, suggest, affinity |
-| **Lock System** | pin subgraph regions, watch for changes, diff locked state |
-| **Graph Analysis** | hypothesize, counterfactual, missing, resonate, fingerprint, trace, predict, trails |
-| **Extended Analysis** | antibody, flow_simulate, epidemic, tremor, trust, layers, heuristics_surface, validate_plan |
-| **RETROBUILDER** | ghost_edges, taint_trace, twins, refactor_plan, runtime_overlay |
-| **Audit & Session** | scan_all, cross_verify, coverage_session, external_references, federate_auto, audit |
-| **Reporting & State** | report, panoramic, savings, persist, boot_memory |
-| **Surgical** | surgical_context, surgical_context_v2, view, batch_view, apply, edit_preview, edit_commit, apply_batch (+ verify=true) |
-
-<details>
-<summary><strong>Foundation</strong></summary>
-
-| Tool | What It Does | Speed |
-|------|-------------|-------|
-| `ingest` | Parse codebase into semantic graph | 910ms / 335 files |
-| `activate` | Spreading activation with 4D scoring | 1.36&micro;s (bench) |
-| `impact` | Blast radius of a code change | 543ns (bench) |
-| `why` | Shortest path between two nodes | 5-6ms |
-| `learn` | Hebbian feedback -- graph gets smarter | <1ms |
-| `drift` | What changed since last session | 23ms |
-| `health` | Server diagnostics | <1ms |
-| `seek` | Find code by natural language intent | 10-15ms |
-| `scan` | 8 structural patterns (concurrency, auth, errors...) | 3-5ms each |
-| `timeline` | Temporal evolution of a node | ~ms |
-| `diverge` | Structural divergence analysis | varies |
-| `warmup` | Prime graph for an upcoming task | 82-89ms |
-| `federate` | Unify multiple repos into one graph | 1.3s / 2 repos |
-</details>
-
-<details>
-<summary><strong>Document Intelligence</strong></summary>
-
-| Tool | What It Does |
-|------|-------------|
-| `document.resolve` | Resolve canonical artifacts for a universal document |
-| `document.bindings` | Show deterministic document-to-code bindings |
-| `document.drift` | Surface stale, missing, or ambiguous document/code links |
-| `document.provider_health` | Show optional document-provider availability and install hints |
-| `auto_ingest.start` | Start local-first document auto-ingest watchers |
-| `auto_ingest.status` | Inspect document auto-ingest runtime state, counts, and provider routes |
-| `auto_ingest.tick` | Drain queued document changes immediately |
-| `auto_ingest.stop` | Stop watchers and persist manifest state |
-</details>
-
-<details>
-<summary><strong>RETROBUILDER</strong></summary>
-
-| Tool | What It Does |
-|------|-------------|
-| `ghost_edges` | Surface temporal co-change edges between files that move together without explicit static dependencies |
-| `taint_trace` | Propagate taint from entry points through the graph to expose missed trust boundaries |
-| `twins` | Find structurally similar nodes by topology signature |
-| `refactor_plan` | Suggest graph-native extraction/refactor communities |
-| `runtime_overlay` | Paint OpenTelemetry runtime heat, latency, and error signals onto graph nodes |
-</details>
-
-<details>
-<summary><strong>Perspective Navigation</strong></summary>
-
-| Tool | Purpose |
-|------|---------|
-| `perspective.start` | Open a perspective anchored to a node |
-| `perspective.routes` | List available routes from current focus |
-| `perspective.follow` | Move focus to a route target |
-| `perspective.back` | Navigate backward |
-| `perspective.peek` | Read source code at the focused node |
-| `perspective.inspect` | Deep metadata + 5-factor score breakdown |
-| `perspective.suggest` | Navigation recommendation |
-| `perspective.affinity` | Check route relevance to current investigation |
-| `perspective.branch` | Fork an independent perspective copy |
-| `perspective.compare` | Diff two perspectives (shared/unique nodes) |
-| `perspective.list` | All active perspectives + memory usage |
-| `perspective.close` | Release perspective state |
-</details>
-
-<details>
-<summary><strong>Lock System</strong></summary>
-
-| Tool | Purpose | Speed |
-|------|---------|-------|
-| `lock.create` | Snapshot a subgraph region | 24ms |
-| `lock.watch` | Register change strategy | ~0ms |
-| `lock.diff` | Compare current vs baseline | 0.08&micro;s |
-| `lock.rebase` | Advance baseline to current | 22ms |
-| `lock.release` | Free lock state | ~0ms |
-</details>
-
-<details>
-<summary><strong>Graph Analysis</strong></summary>
-
-| Tool | What It Does | Speed |
-|------|-------------|-------|
-| `hypothesize` | Test claims against graph structure (89% accuracy) | 28-58ms |
-| `counterfactual` | Simulate module removal -- full cascade | 3ms |
-| `missing` | Find structural holes | 44-67ms |
-| `resonate` | Standing wave analysis -- find structural hubs | 37-52ms |
-| `fingerprint` | Find structural twins by topology | 1-107ms |
-| `trace` | Map stacktraces to root causes | 3.5-5.8ms |
-| `validate_plan` | Pre-flight risk assessment for changes with heuristic-memory signals and direct `heuristics_surface_ref` pointers | 0.5-10ms |
-| `predict` | Co-change prediction with `heuristics_surface_ref` pointers for ranking justification | <1ms |
-| `trail.save` | Persist investigation state | ~0ms |
-| `trail.resume` | Restore exact investigation context | 0.2ms |
-| `trail.merge` | Combine multi-agent investigations | 1.2ms |
-| `trail.list` | Browse saved investigations | ~0ms |
-| `differential` | Structural diff between graph snapshots | ~ms |
-| `boot_memory` | Canonical hot-state memory for doctrine/config/short durable state | ~0ms |
-</details>
-
-<details>
-<summary><strong>Extended Analysis</strong></summary>
-
-| Tool | What It Does | Speed |
-|------|-------------|-------|
-| `antibody_scan` | Scan graph against stored bug patterns | 2.68ms |
-| `antibody_list` | List stored antibodies with match history | ~0ms |
-| `antibody_create` | Create, disable, enable, or delete an antibody | ~0ms |
-| `flow_simulate` | Concurrent execution flow -- race condition detection | 552&micro;s |
-| `epidemic` | SIR bug propagation prediction | 110&micro;s |
-| `tremor` | Change frequency acceleration detection | 236&micro;s |
-| `trust` | Per-module defect history trust scores | 70&micro;s |
-| `layers` | Auto-detect architectural layers + violations | 862&micro;s |
-| `layer_inspect` | Inspect a specific layer: nodes, edges, health | varies |
-</details>
-
-<details>
-<summary><strong>Audit & Session</strong></summary>
-
-| Tool | What It Does |
-|------|-------------|
-| `scan_all` | Run all structural scan patterns in one call and return grouped findings |
-| `cross_verify` | Compare graph state against filesystem truth: existence, LOC drift, hash mismatches |
-| `coverage_session` | Show which files/nodes the current agent has already visited |
-| `external_references` | Find explicit path references that point outside current ingest roots |
-| `federate_auto` | Turn external paths, manifest/workspace hints, import/package names, shared API-route evidence, or contract artifacts like `.proto` messages/enums, MCP tools, and OpenAPI schema/components into repo candidates and an optional one-shot federation plan |
-| `audit` | One-call profile-aware audit across topology, scans, git state, verification, and recommendations |
-</details>
-
-<details>
-<summary><strong>Surgical</strong></summary>
-
-| Tool | What It Does | Speed |
-|------|-------------|-------|
-| `surgical_context` | Complete context for a code node: source, callers, callees, tests, plus `heuristic_summary` with trust/tremor/antibody/blast radius — in one call | varies |
-| `heuristics_surface` | Explain why a node or file ranked as risky or important using the same heuristic substrate as surgical_context and apply_batch | varies |
-| `surgical_context_v2` | All connected files with source code in ONE call, plus `heuristic_summary` on the primary file and each connected file — complete dependency context without multiple round-trips | 1.3ms |
-| `view` | Fast file reader with line numbers, auto-ingest, and inline truncation controls | varies |
-| `batch_view` | Read multiple files or glob patterns in one call with stable delimiters and summaries | varies |
-| `edit_preview` | **Preview a code change without writing to disk** — returns diff, snapshot, validation. Two-phase safety: see before you write | <1ms |
-| `edit_commit` | **Commit a previewed change** — requires explicit `confirm=true`, TTL 5min, source hash verification. Prevents stale/tampered writes | <1ms + apply |
-| `apply` | Write edited code back to file, atomic write, re-ingest graph, and attach proactive follow-up insights | 3.5ms + insights |
-| `apply_batch` | Write multiple files atomically, single re-ingest pass, returns per-file diffs and proactive follow-up insights | 165ms + insights |
-| `apply_batch(verify=true)` | All of the above + **5-layer post-write verification** (pattern detection, compile check, graph BFS impact, test execution, anti-pattern analysis) with `heuristic_summary` on `verification.high_impact_files`; heuristic hotspots can promote the verdict to `RISKY` | 165ms + verify |
-</details>
-
-<details>
-<summary><strong>Reporting & State</strong></summary>
-
-| Tool | What It Does | Speed |
-|------|-------------|-------|
-| `report` | Session report with recent queries, savings, graph stats, and top heuristic hotspots; markdown summary includes `### Heuristic Hotspots` | ~0ms |
-| `panoramic` | Combined repo/module overview: blast radius, heuristics, and critical alerts in one pass | varies |
-| `savings` | Session/global token, CO2, and cost savings summary | ~0ms |
-| `persist` | Force graph + sidecar state persistence now | varies |
-| `boot_memory` | Set/get/list/delete small canonical hot-state values next to the graph | ~0ms |
-</details>
-
-<details>
-<summary><strong>Reporting</strong></summary>
-
-| Tool | What It Does | Speed |
-|------|-------------|-------|
-| `report` | Session report with recent queries, savings, graph stats, and top heuristic hotspots; markdown summary includes `### Heuristic Hotspots` | ~0ms |
-| `savings` | Session/global token, CO2, and cost savings summary | ~0ms |
-</details>
-
-[Full API reference with examples ->](https://m1nd.world/wiki/api-reference/overview.html)
-
-## Post-Write Verification
-
-`apply_batch` with `verify=true` runs 5 independent verification layers on every file written,
-returning a single `VerificationReport` with a SAFE / RISKY / BROKEN verdict.
-When `verification.high_impact_files` carries heuristic hotspots, the report can be
-promoted to `RISKY` even if the structural blast radius alone would have stayed lower.
-In the documented validation sample, 12/12 scenarios were classified correctly.
-
-```jsonc
-// Write multiple files + verify everything in one call
-{
-  "method": "tools/call",
-  "params": {
-    "name": "m1nd.apply_batch",
-    "arguments": {
-      "agent_id": "my-agent",
-      "verify": true,
-      "edits": [
-        { "file_path": "/project/src/auth.py",    "new_content": "..." },
-        { "file_path": "/project/src/session.py", "new_content": "..." }
-      ]
-    }
-  }
-}
-// -> {
-//      "all_succeeded": true,
-//      "verification": {
-//        "verdict": "RISKY",
-//        "total_affected_nodes": 14,
-//        "blast_radius": [{ "file_path": "auth.py", "reachable_files": 7, "risk": "high" }],
-//        "high_impact_files": [{ "file_path": "auth.py", "risk": "high", "heuristic_summary": { "...": "..." } }],
-//        "antibodies_triggered": ["bare-except-swallow"],
-//        "layer_violations": [],
-//        "compile_check": "ok",
-//        "tests_run": 42, "tests_passed": 42, "tests_failed": 0,
-//        "verify_elapsed_ms": 340.2
-//      }
-//    }
-```
-
-### The 5 Layers
-
-| Layer | What it checks | Verdict contribution |
-|-------|---------------|---------------------|
-| **A — Pattern detection** | Graph diff: compares pre-write vs post-write node sets to detect structural deletions and unexpected topology changes | BROKEN if key nodes vanish |
-| **B — Anti-pattern analysis** | Scans textual diff for `todo!()` removal without replacement, bare `unwrap()` additions, swallowed errors, and stub-filling patterns | RISKY if patterns detected |
-| **C — Graph BFS impact** | 2-hop reachability via CSR edges: counts how many other file-level nodes your changes can reach | RISKY if blast radius > 10 files |
-| **D — Test execution** | Detects project type (Rust/Go/Python) and runs the relevant test suite (`cargo test` / `go test` / `pytest`) scoped to affected modules | BROKEN if any test fails |
-| **E — Compile check** | Runs `cargo check` / `go build` / `python -m py_compile` on the project after writes | BROKEN if compilation fails |
-
-Verdict rules: any BROKEN layer → overall BROKEN. Any RISKY layer or heuristic hotspot
-in `verification.high_impact_files` → overall RISKY. All clear → SAFE.
-All 5 layers run in parallel where possible. Verification adds ~340ms median on a 52K-line codebase.
-
----
-
-## Architecture
-
-Three Rust crates. Local execution. No API keys required for the core server path.
-
-```
-m1nd-core/     Graph engine, spreading activation, Hebbian plasticity, hypothesis engine,
-               antibody system, flow simulator, epidemic, tremor, trust, layer detection
-m1nd-ingest/   Language extractors, memory adapter, JSON adapter,
-               git enrichment, cross-file resolver, incremental diff
-m1nd-mcp/      MCP server, JSON-RPC over stdio, plus HTTP/UI support in the current default build
-```
-
-```mermaid
-graph LR
-    subgraph Ingest
-        A[Code / 27+ languages] --> R[Reference Resolver]
-        MA[Memory adapter] --> R
-        JA[JSON adapter] --> R
-        DA[Document adapters<br/>patent, article, BibTeX, CrossRef, RFC] --> DR[DocumentRouter]
-        DR --> R
-        R --> GD[Git enrichment]
-        GD --> XD[CrossDomainResolver]
-        XD --> G[CSR Graph]
-    end
-    subgraph Core
-        G --> SA[Spreading Activation]
-        G --> HP[Hebbian Plasticity]
-        G --> HY[Hypothesis Engine]
-        G --> SX[Superpowers Extended]
-        SA --> XLR[XLR Noise Cancel]
-    end
-    subgraph MCP
-        XLR --> T[Tool Surface]
-        HP --> T
-        HY --> T
-        SX --> T
-        T --> IO[JSON-RPC stdio]
-        T --> HTTP[HTTP API + UI]
-    end
-    IO --> C[Claude Code / Cursor / any MCP]
-    HTTP --> B[Browser on localhost:1337]
-```
-
-27+ languages/file formats total.
-Today that means 5 native/manual extractors (`Python`, `TypeScript/JavaScript`, `Rust`, `Go`, `Java`) plus 22 tree-sitter-backed languages across Tier 1 + Tier 2.
-Default build already includes Tier 2, which includes both tree-sitter tiers.
-Language count is broad, but depth varies by language. [Language details ->](https://m1nd.world/wiki/architecture/ingest.html)
-
-The current default build also includes an HTTP/UI surface. Keep it bound to localhost unless you intentionally want remote access; there is no built-in authentication layer for arbitrary public exposure.
-
-## When NOT to Use m1nd
-
-- **You need frontier-grade embedding-first retrieval as the primary search engine.** m1nd has semantic and intent-level retrieval (`seek`, hybrid semantic indexes, graph re-ranking), but it is optimized for structural grounding rather than pure embedding-first search.
-- **You have 400K+ files and want that to feel cheap.** The graph is still in-memory. It can work at that scale, but it was optimized for repos where agent orientation speed matters more than extreme graph density.
-- **You need CodeQL-class variable-level dataflow guarantees.** m1nd now has flow- and taint-oriented capabilities, but it should still complement -- not replace -- dedicated SAST/dataflow tools for formal security analysis.
-- **You need argument-by-argument SSA-style propagation.** m1nd tracks files, symbols, calls, neighborhoods, surgical edit context, and graph paths well; it is not a full compiler-grade value-flow engine.
-- **You need keystroke-speed indexing on every save.** Ingest is fast, but m1nd is still session-level intelligence, not editor-keystroke infrastructure. Use your LSP for that.
-
-## Use Cases
-
-**Bug hunt:** Start with `hypothesize` -> `missing` -> `flow_simulate` -> `trace`.
-In the documented audit session, this reduced grep-heavy exploration and surfaced issues plain text search missed. [Case study ->](EXAMPLES.md)
-
-**Pre-deploy gate:** `antibody_scan` -> `validate_plan` -> `epidemic`.
-Scans for known bug shapes, assesses blast radius, predicts infection spread.
-
-**Architecture audit:** `layers` -> `layer_inspect` -> `counterfactual`.
-Auto-detects layers, finds violations, simulates what breaks if you remove a module.
-
-**One-call repo audit:** `audit(profile="coordination" | "production" | "security")`.
-Bundles topology, grouped scans, graph-vs-disk verification, git state, external references, and recommendations into one response.
-
-**Onboarding:** `activate` -> `layers` -> `perspective.start` -> `perspective.follow`.
-New developer asks "how does auth work?" and the graph lights up the path.
-
-**Cross-domain search:** `ingest(adapter="memory", mode="merge")` -> `activate`.
-Code + docs in one graph. One question returns both the spec and the implementation.
-
-**Safe multi-file edit:** `surgical_context_v2` -> `apply_batch(verify=true)`.
-Write N files at once. Get a SAFE/RISKY/BROKEN verdict before CI runs.
+- when exact text search is already enough
+- when you need compiler-grade value-flow guarantees
+- when you only need runtime logs and traces, not structural understanding
+- when the repo is so large that in-memory graph cost dominates the gain
 
 ## Contributing
 
-m1nd is still early and moving fast. Contributions welcome:
-language extractors, graph algorithms, MCP tools, and benchmarks.
+Contributions are welcome across:
+
+- extractors and adapters
+- MCP/runtime tooling
+- benchmarks
+- docs
+- graph algorithms
+
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-MIT -- see [LICENSE](LICENSE).
-
----
-
-<p align="center">
-  Created by <a href="https://github.com/cosmophonix">Max Elias Kleinschmidt</a><br/>
-  <em>AI should amplify, never replace. Human and machine in symbiosis.</em><br/>
-  <em>If you can dream it, you can build it. m1nd shortens the distance.</em>
-</p>
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 </p>
 
 <p align="center">
-  m1nd gives AI agents durable operational context before they search, edit, review, or change code.<br/>
-  It makes code, docs, and change operable as one system.<br/>
+  m1nd gives agents a clear view of what changes will touch before they get lost in grep loops and endless file hunting.<br/>
+  It pulls code, docs, and system details into a single layer AI agents can actually work with.<br/>
   <em>Local execution. MCP over stdio. Optional HTTP/UI surface in the default build.</em>
 </p>
 
@@ -128,7 +128,9 @@ flowchart LR
 
 ## What m1nd Operationalizes
 
-`m1nd` does more than index code. It turns multiple kinds of technical reality into one operable layer for agents:
+`m1nd` goes beyond just indexing code.
+
+It pulls together all sorts of technical pieces into one layer agents can actually work with:
 
 - code
 - docs
@@ -138,17 +140,22 @@ flowchart LR
 - runtime state
 - multi-repo edges
 
-<p align="center">
-  <img src=".github/m1nd-operability-surface.svg" alt="m1nd operational intelligence surface" width="960" />
-</p>
+That is why it is not merely code search, review, or docs tooling.
 
-That is why `m1nd` is not just code search, not just review, and not just docs tooling.
-
-It is the layer that makes those surfaces legible and actionable together.
+It makes those surfaces legible and usable as one.
 
 ## What Ships Today
 
-The current live MCP surface exposes **93 tools**. What matters more than the count is the shape of the system.
+The current live MCP surface exposes **93 tools**, but readers should understand the jobs first:
+
+| Job | What it means | Representative tools |
+|---|---|---|
+| Understand the system | turn repos, docs, and concepts into connected structural truth | `ingest`, `activate`, `seek`, `why`, `search`, `document_resolve` |
+| Predict and verify change | see blast radius, drift, and safe mutation context before and after edits | `impact`, `predict`, `validate_plan`, `surgical_context_v2`, `apply_batch(verify=true)` |
+| Keep context alive over time | monitor, audit, persist, and coordinate beyond one turn or one repo | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `boot_memory`, `federate_auto` |
+
+<details>
+<summary><strong>Expanded layer view</strong></summary>
 
 | Layer | What it enables | Representative tools |
 |---|---|---|
@@ -159,14 +166,7 @@ The current live MCP surface exposes **93 tools**. What matters more than the co
 | Operational runtime | keep the system live, watched, and continuity-aware | `audit`, `cross_verify`, `coverage_session`, `daemon_*`, `alerts_*`, `persist`, `boot_memory` |
 | Federation | operate beyond a single repo | `federate`, `federate_auto`, `external_references` |
 
-### What that means in practice
-
-- **Code + docs in one graph** through `memory`, `light`, `universal`, `json`, and structured document adapters
-- **Canonical local document artifacts** through `document_resolve`
-- **Doc-to-code grounding** through `document_bindings`
-- **Spec drift detection** through `document_drift`
-- **Watcher/runtime continuity** through `auto_ingest_*`, `daemon_*`, and `alerts_*`
-- **Safe multi-file mutation** through `apply_batch(verify=true)`
+</details>
 
 ## Quick Start
 
@@ -202,13 +202,11 @@ If docs/specs matter too:
 
 ## Make It The First Layer
 
-The highest-leverage adoption move is not “install m1nd.”
-
-It is:
+The highest-leverage adoption move is simple:
 
 > **make m1nd mandatory before search, edit, review, or change.**
 
-### Minimal system-prompt rule
+### Minimum rule
 
 ```text
 You have m1nd available via MCP.
@@ -224,44 +222,25 @@ Use m1nd before grep, glob, or manual file reads when the task depends on struct
 - use m1nd.help when unsure
 ```
 
-### Claude Code snippet
-
-```markdown
-## Code Intelligence
-m1nd is the first layer before grep/glob/read loops.
-Use it for structural understanding, docs grounding, blast radius, plan validation, and connected edit context.
-```
-
-### Cursor snippet
-
-```text
-Use m1nd before grep or opening lots of files:
-- search for exact text
-- activate/seek for connected structure
-- impact before edits
-- surgical_context_v2 before multi-file changes
-```
+Detailed client-by-client setup lives in the [canonical wiki](https://m1nd.world/wiki/) and deeper examples live in [EXAMPLES.md](EXAMPLES.md).
 
 ## Proof
 
-These are grounded in current code, tests, and docs. They are evidence, not slogans.
+These are grounded in current code, tests, and docs. They are receipts, not slogans.
 
 | Metric | Observed result |
 |---|---|
-| Public MCP surface | **93 tools** |
-| Bugs found in one documented audit session | **39** |
-| Findings invisible to grep in that session | **8 of 28** |
-| Hypothesis accuracy in live claims | **89%** |
+| Public MCP surface | **93 tools** ([tool matrix](https://m1nd.world/wiki/tool-matrix.html)) |
+| `activate` on 1K nodes | **1.36 µs** ([benchmarks](https://m1nd.world/wiki/benchmarks.html)) |
+| `impact` depth=3 | **543 ns** ([benchmarks](https://m1nd.world/wiki/benchmarks.html)) |
 | Post-write validation sample | **12/12** classified correctly |
-| `activate` on 1K nodes | **1.36 µs** |
-| `impact` depth=3 | **543 ns** |
-| `antibody_scan` on 50 patterns | **2.68 ms** |
 
 The important product claim is not “fast graph queries” by itself.
 
 It is this:
 
-> `m1nd` reduces context waste and blind change by giving the agent operational understanding before action.
+> Fast graph queries are not the real point.
+> `m1nd` cuts context waste and blind changes by giving the agent operational understanding before it acts.
 
 ## Where It Fits
 
@@ -295,6 +274,10 @@ Current crate versions:
 - `m1nd-core` `0.8.0`
 - `m1nd-ingest` `0.8.0`
 - `m1nd-mcp` `0.8.0`
+
+<p align="center">
+  <img src=".github/m1nd-operability-surface.svg" alt="m1nd operational intelligence surface" width="960" />
+</p>
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- rewrite the English README from scratch around the product/category story
- shift from engine-first inventory to agent-first product positioning
- add two futuristic SVG diagrams to explain the product visually

## What changed
- establish the category: `The software intelligence layer for AI agents`
- make the core promise explicit: durable operational context before action
- restructure the README around `why first`, `what it operationalizes`, and `what ships today`
- compress the tool catalog into product-facing layers instead of a long feature dump
- remove the broken/missing GIF reference and replace it with shipped SVG diagrams
- cut the README from `745` lines to `330` lines

## Verification
- `git diff --check`
- line-count comparison (`745 -> 330`)
- grep sanity for new narrative and new SVG references

## Notes
- this rewrites only the English README for now
- translated READMEs were intentionally left out of scope for this pass
- the canonical wiki remains the deep technical reference