### PR TITLE
Align the landing with the new product narrative

### DIFF
--- a/m1nd-demo/src/components/FAQSection.tsx
+++ b/m1nd-demo/src/components/FAQSection.tsx
@@ -13,7 +13,7 @@ const FAQS: FAQ[] = [
     q: "How is m1nd different from Copilot, Cursor, or semantic search?",
     a: (
       <>
-        Copilot and Cursor are editors that use LLMs to write code. m1nd is infrastructure that gives those LLMs a structured map of your codebase before they write anything. Semantic search returns documents that are <em>textually similar</em> to your query. m1nd returns nodes that are <em>structurally connected</em> — it understands that <code>check_expiry()</code> calls <code>SessionManager</code> which reads <code>settings.py</code>. Text search doesn't know that. The graph does.
+        Copilot and Cursor are agent hosts and editors. m1nd is the software intelligence layer that those agents call before they search, edit, review, or change a system. Semantic search returns documents that are <em>textually similar</em> to a query. m1nd returns context that is <em>structurally connected</em> across code, docs, and change. It is less about "find me similar text" and more about "show me what this touches, what moves with it, and what should be verified next."
       </>
     ),
   },
@@ -50,7 +50,7 @@ const FAQS: FAQ[] = [
   {
     tag: "m1nd vs l1ght",
     q: "What is the difference between m1nd and l1ght?",
-    a: "m1nd indexes code — it builds a knowledge graph of your functions, classes, modules, and their relationships. l1ght indexes everything else — research papers, articles, documentation, memories, conversations, Jupyter notebooks, PDFs. Both use the same graph substrate, so a single query can traverse code written last week, a research paper you read last month, and a Slack thread from last quarter. Both ship today, both are free, both are part of the same MIT-licensed binary.",
+    a: "m1nd is the operating layer. l1ght is the document and knowledge lane inside that operating layer. m1nd gives agents durable operational context across code, docs, and change. l1ght is how specs, notes, papers, RFCs, memory, and other non-code artifacts become first-class graph surfaces inside the same system.",
   },
   {
     tag: "pricing",
@@ -158,10 +158,10 @@ export function FAQSection() {
             common questions
           </div>
           <h2 className="text-3xl md:text-5xl font-bold font-sans tracking-tight mb-3">
-            Before you ship it to your agent
+            Before you make it the first layer
           </h2>
           <p className="text-muted-foreground font-mono text-sm max-w-lg mx-auto">
-            The questions every developer asks before adding a new tool to their stack.
+            The questions teams ask before putting a new system in front of their agents.
           </p>
         </motion.div>
 

--- a/m1nd-demo/src/components/Footer.tsx
+++ b/m1nd-demo/src/components/Footer.tsx
@@ -15,13 +15,13 @@ export function Footer() {
           <span style={{ color: "#ffb700", opacity: 0.6 }}>𝔻</span>
           <span style={{ color: "#ff00aa", opacity: 0.6 }}>⟁</span>
           <span className="text-primary/30 mx-2">·</span>
-          <span className="text-primary/40">m1nd + l1ght — one graph</span>
+          <span className="text-primary/40">the software intelligence layer for AI agents</span>
         </p>
         <h2 className="text-4xl md:text-6xl font-bold font-sans tracking-tight mb-4">
           Start building with <M1ndInline glow />.
         </h2>
         <p className="text-muted-foreground max-w-md mx-auto mb-10 text-lg">
-          Code, research, and memory — all in one graph. One install. One query.
+          Code, docs, and change in one operable system. Local-first, MCP-native, and ready for agents.
         </p>
 
         <div className="flex flex-col sm:flex-row items-center gap-4 mb-24">
@@ -66,7 +66,7 @@ export function Footer() {
           <p className="font-mono text-xs" style={{ color: "#ffffff30" }}>
             © {new Date().getFullYear()} m1nd ·{" "}
             <span style={{ color: "#00ff8860" }}>MIT License</span>
-            {" "}· v0.6.1
+            {" "}· v0.8.0
           </p>
           <div className="flex items-center gap-6 text-xs font-mono">
             <a href="https://m1nd.world/wiki/" target="_blank" rel="noreferrer" className="text-primary/40 hover:text-primary/70 transition-colors tracking-widest uppercase">

--- a/m1nd-demo/src/components/Hero.tsx
+++ b/m1nd-demo/src/components/Hero.tsx
@@ -97,29 +97,29 @@ export function Hero() {
             <span className="flex h-2 w-2 flex-shrink-0 rounded-full bg-primary animate-pulse" />
             <span className="whitespace-nowrap">Built for agents first. Humans are welcome.</span>
             <span className="hidden sm:block h-3 w-px flex-shrink-0 bg-primary/30" />
-            <span className="hidden sm:block text-primary/60 whitespace-nowrap">m1nd + l1ght</span>
+            <span className="hidden sm:block text-primary/60 whitespace-nowrap">code + docs + change</span>
           </div>
 
           <h1 className="text-4xl sm:text-5xl md:text-7xl font-bold tracking-tight text-foreground mb-6 font-sans leading-[1.05]">
-            Before you change code,
+            Before an agent acts,
             <br />
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-secondary">
-              see what breaks.
+              give it the system.
             </span>
           </h1>
 
           <p className="text-xl md:text-2xl text-muted-foreground mb-10 max-w-2xl mx-auto leading-relaxed">
-            Ask the codebase a question. Get the map, not the maze. m1nd gives coding agents structural intelligence before they disappear into grep/read drift.
+            m1nd is the software intelligence layer for AI agents. It makes code, docs, and change operable as one system before the agent disappears into grep loops, blind edits, and context waste.
           </p>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <a href="https://github.com/maxkle1nz/m1nd" target="_blank" rel="noreferrer" className="w-full sm:w-auto">
               <button className="w-full sm:w-auto px-8 py-4 bg-primary text-primary-foreground font-bold rounded-md hover:bg-primary/90 transition-all shadow-[0_0_20px_rgba(0,245,255,0.3)] hover:shadow-[0_0_30px_rgba(0,245,255,0.5)]">
-                Install m1nd
+                Install the MCP server
               </button>
             </a>
             <Link href="/use-cases" className="w-full sm:w-auto px-8 py-4 border border-primary/30 text-primary hover:bg-primary/10 transition-all rounded-md font-medium">
-              Explore use cases →
+              See where it fits →
             </Link>
           </div>
 
@@ -138,11 +138,11 @@ export function Hero() {
               MIT License
             </span>
             <span style={{ color: "#ffffff18" }}>·</span>
-            <span style={{ color: "#ffffff45" }}>v0.6.1</span>
+            <span style={{ color: "#ffffff45" }}>v0.8.0</span>
             <span style={{ color: "#ffffff18" }}>·</span>
-            <span style={{ color: "#ffffff45" }}>Written in Rust</span>
+            <span style={{ color: "#ffffff45" }}>Local-first</span>
             <span style={{ color: "#ffffff18" }}>·</span>
-            <span style={{ color: "#ffffff45" }}>MCP protocol</span>
+            <span style={{ color: "#ffffff45" }}>MCP-native</span>
             <span style={{ color: "#ffffff18" }}>·</span>
             <a
               href="https://github.com/maxkle1nz/m1nd"
@@ -168,7 +168,7 @@ export function Hero() {
               { val: "1.36µs", label: "activate 1K nodes", color: "#00f5ff" },
               { val: "84%",    label: "token savings",     color: "#00ff88" },
               { val: "543ns",  label: "blast radius query", color: "#00f5ff" },
-              { val: "0",      label: "API calls needed",  color: "#7b61ff" },
+              { val: "93",     label: "MCP tools live",    color: "#7b61ff" },
             ].map(({ val, label, color }) => (
               <div key={label} className="text-center">
                 <div className="text-2xl md:text-3xl font-bold font-mono" style={{ color }}>{val}</div>

--- a/m1nd-demo/src/components/HowItWorksSection.tsx
+++ b/m1nd-demo/src/components/HowItWorksSection.tsx
@@ -5,10 +5,10 @@ const STEPS = [
     n: "01",
     glyph: "⍂",
     glyphColor: "#00ff88",
-    title: "Index",
-    body: "m1nd parses your codebase using AST-level analysis — not text patterns. Every function, class, import, call, and type becomes a typed node. Every relationship becomes a weighted, directed edge. The entire graph lives in RAM.",
+    title: "Ingest",
+    body: "m1nd ingests code, docs, and related structure into one live graph. The agent stops treating the repo like a pile of files and starts from connected system truth.",
     stat: "14 languages",
-    statSub: "Python · TS · Rust · Go · Java + 9 more",
+    statSub: "plus docs and memory lanes",
     statColor: "#00ff88",
     connector: true,
   },
@@ -16,10 +16,10 @@ const STEPS = [
     n: "02",
     glyph: "⍌",
     glyphColor: "#00f5ff",
-    title: "Query",
-    body: "Your agent calls m1nd.seek(). Embeddings score 9,767 nodes in nanoseconds. The top-k become seeds. Spreading activation fires outward across typed edges — up to 4 hops — then a composite score prunes 116 candidates to 4.",
+    title: "Orient",
+    body: "The agent asks by structure and intent. m1nd returns what is connected, risky, and relevant before the model burns tokens reconstructing context from scratch.",
     stat: "543ns",
-    statSub: "blast radius · depth = 3",
+    statSub: "blast radius at depth = 3",
     statColor: "#00f5ff",
     connector: true,
   },
@@ -27,10 +27,10 @@ const STEPS = [
     n: "03",
     glyph: "⍐",
     glyphColor: "#7b61ff",
-    title: "Return",
-    body: "4 precision nodes come back — already decorated with their caller chains, callees, and linked tests. Not a list of files. A surgical subgraph your agent can act on immediately, with 84% fewer tokens than sending raw files.",
+    title: "Act",
+    body: "The result comes back as operable context: connected nodes, blast radius, likely co-changes, and the exact slice the agent should verify before it edits.",
     stat: "84% fewer tokens",
-    statSub: "vs grep / file read",
+    statSub: "vs grep and file wandering",
     statColor: "#7b61ff",
     connector: false,
   },
@@ -59,10 +59,10 @@ export function HowItWorksSection() {
             how it works
           </p>
           <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-            Three stages. 0.18 seconds. Done.
+            Ingest. Orient. Act.
           </h2>
           <p className="mt-3 text-muted-foreground/60 text-sm max-w-lg mx-auto font-mono">
-            From cold query to surgical subgraph — the full pipeline runs locally, in RAM, faster than a network ACK.
+            The point is not just speed. The point is giving the agent operational context before it changes the system.
           </p>
         </motion.div>
 
@@ -176,7 +176,7 @@ export function HowItWorksSection() {
         >
           <div className="h-px flex-1 bg-border/15 max-w-[80px]" />
           <span className="font-mono text-[10px] text-muted-foreground/25 tracking-widest uppercase">
-            0.18s · end-to-end · local · no network
+            local-first · MCP-native · durable operational context
           </span>
           <div className="h-px flex-1 bg-border/15 max-w-[80px]" />
         </motion.div>

--- a/m1nd-demo/src/components/ProblemSection.tsx
+++ b/m1nd-demo/src/components/ProblemSection.tsx
@@ -1,17 +1,17 @@
 import { motion } from "framer-motion";
 
 const problems = [
-  "grep loops that read every file to find one function",
-  "blast radius is a guess until something breaks in production",
-  "context window flooded with irrelevant code",
-  "every session starts from scratch — no memory of what was found",
+  "agents rebuild repo structure from raw files every turn",
+  "blast radius is still a guess when code, docs, and tests are disconnected",
+  "context windows fill up before the agent reaches the real decision point",
+  "investigations reset between sessions, so the same orientation tax gets paid again",
 ];
 
 const solutions = [
-  "one graph query — authority found in subseconds, no files opened",
-  "blast radius computed before the first edit is written",
-  "surgical context — only the nodes that matter, nothing else",
-  "investigation trails persist across every session",
+  "one graph query returns structural truth instead of another round of file hunting",
+  "change impact is surfaced before the first edit lands",
+  "surgical context binds code, docs, and connected call paths into one operable slice",
+  "continuity survives across sessions through trails, memory, audit, and runtime state",
 ];
 
 export function ProblemSection() {
@@ -26,22 +26,16 @@ export function ProblemSection() {
             transition={{ duration: 0.6 }}
           >
             <h2 className="text-3xl md:text-5xl font-bold font-sans tracking-tight mb-6">
-              grep was built for humans.
+              Most agent loops still start blind.
               <br />
-              <span className="text-muted-foreground font-normal">your agent is paying the price.</span>
+              <span className="text-muted-foreground font-normal">m1nd exists to stop that.</span>
             </h2>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              30-year-old tools. file-by-file reads.
+              Search, read, search again, guess, edit, discover impact too late.
               <br />
-              tokens burned for no reason.
+              That loop was tolerable for humans.
               <br />
-              <br />
-              tokens = money.
-              <br />
-              waste = exponential.
-              <br />
-              <br />
-              and it starts on day one.
+              It is expensive for agents.
             </p>
           </motion.div>
         </div>
@@ -56,7 +50,7 @@ export function ProblemSection() {
           >
             <div className="absolute inset-0 bg-gradient-to-br from-destructive/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
             <h3 className="text-lg font-mono font-semibold mb-6 text-destructive/80 tracking-wide uppercase">
-              Terminal-era tools
+              Stateless agent loop
             </h3>
             <ul className="space-y-5 text-muted-foreground">
               {problems.map((p, i) => (
@@ -77,7 +71,7 @@ export function ProblemSection() {
           >
             <div className="absolute inset-0 bg-gradient-to-br from-primary/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
             <h3 className="text-lg font-mono font-semibold mb-6 text-primary/80 tracking-wide uppercase">
-              m1nd — agent-native
+              m1nd as first layer
             </h3>
             <ul className="space-y-5 text-muted-foreground">
               {solutions.map((s, i) => (
@@ -97,7 +91,7 @@ export function ProblemSection() {
           viewport={{ once: true }}
           transition={{ duration: 0.8, delay: 0.4 }}
         >
-          // the same information. a completely different substrate.
+          // the same task. a completely different substrate.
         </motion.p>
       </div>
     </section>

--- a/m1nd-demo/src/pages/Landing.tsx
+++ b/m1nd-demo/src/pages/Landing.tsx
@@ -47,8 +47,8 @@ export default function Landing() {
   return (
     <main className="w-full min-h-screen bg-background">
       <SEO
-        title="m1nd — Graph Intelligence for MCP AI Agents"
-        description="m1nd gives AI agents an in-memory knowledge graph of your codebase, research, and memory. Activate 1,000 nodes in 1.36µs. 84% fewer tokens than grep. Built for MCP, runs in Rust."
+        title="m1nd — The Software Intelligence Layer for AI Agents"
+        description="m1nd gives AI agents durable operational context for code, docs, and change before they search, edit, review, or act. Local-first, MCP-native, and built in Rust."
         canonicalPath="/"
       />
       <NavBar />


### PR DESCRIPTION
## Summary

This PR aligns the landing with the current product thesis from the README and recent positioning work.

Instead of describing m1nd as a narrower graph-intelligence tool for coding agents, the landing now frames it as the software intelligence layer for AI agents and updates the highest-traffic copy surfaces accordingly.

## What changed

- updates landing SEO title and description
- rewrites the hero headline, subhead, CTA labels, and trust strip
- reframes the problem section around stateless agent loops instead of terminal-era tooling only
- simplifies the how-it-works section into ingest / orient / act
- updates the FAQ language around alternatives and the m1nd vs l1ght relationship
- fixes footer positioning language and version drift (`v0.8.0`)

## Verification

- `npm run build` in `m1nd-demo`
- stale-copy sweep with `rg`

## Risks

- this is a copy-alignment pass, not a full landing redesign
- browser-level visual QA across breakpoints was not rerun after the copy changes
