### PR TITLE
Add multi-instance runtime registry and command-center backend

### DIFF
--- a/docs/MULTI_INSTANCE_COMMAND_CENTER_2026-04-11.md
+++ b/docs/MULTI_INSTANCE_COMMAND_CENTER_2026-04-11.md
@@ -1,0 +1,726 @@
+# Multi-Instance Command Center for `m1nd`
+
+Date: `2026-04-11`
+
+## Goal
+
+Allow `m1nd` to run across many projects at once without state collisions, while giving the user one clear UI surface to:
+
+- see every running instance
+- understand when there is a conflict
+- open or explore an instance
+- persist state
+- restart an instance
+- stop an instance
+- delete an instance state directory
+
+This should work whether the user has:
+
+- one project and one instance
+- many unrelated projects
+- multiple worktrees from the same repository
+- duplicate launches of the same project
+
+---
+
+## Current state, grounded in code
+
+The current `m1nd` runtime is already close to the right substrate, but it is still organized as one session state per process.
+
+### 1. One `SessionState` per running server process
+
+`m1nd-mcp/src/session.rs`
+
+- `SessionState` is explicitly described as:
+  - "Server session state. Owns the graph and all engine instances."
+  - "Single instance shared across all agent connections."
+- it owns:
+  - `graph`
+  - `orchestrator`
+  - `temporal`
+  - `plasticity`
+  - perspective/lock state
+  - boot memory
+  - daemon state
+  - daemon alerts
+  - auto-ingest state
+  - document cache
+
+This means:
+
+- many agents can share one running `m1nd`
+- but one `m1nd` process still corresponds to one active runtime state
+
+### 2. HTTP handlers share one session through `Arc<Mutex<SessionState>>`
+
+`m1nd-mcp/src/http_server.rs`
+
+- `AppState` contains:
+  - `session: Arc<Mutex<SessionState>>`
+- `spawn_background()` and `run()` both create an `Arc<Mutex<SessionState>>`
+- all `/api/health`, `/api/graph/stats`, `/api/graph/snapshot`, and tool routes operate on that single session
+
+This means:
+
+- each HTTP surface is currently an instance-local UI
+- there is no built-in global registry of other `m1nd` processes
+
+### 3. The runtime already persists a rich state set under `runtime_root`
+
+`m1nd-mcp/src/session.rs`
+
+`SessionState` persists or loads:
+
+- `graph_path`
+- `plasticity_path`
+- `runtime_root`
+- `boot_memory_path`
+- `daemon_state_path`
+- `daemon_alerts_path`
+- auto-ingest state
+- document cache
+- ingest roots
+
+and `persist()` writes them in a defined order.
+
+This is the key enabling fact:
+
+> `m1nd` already has a strong per-runtime state model.
+
+What it lacks is:
+
+- a stable registry above those runtimes
+- ownership / lease rules for shared state dirs
+- a user-facing multi-instance control plane
+
+### 4. Server startup still assumes one config -> one runtime
+
+`m1nd-mcp/src/server.rs`
+
+- `McpServer::new(config)` loads:
+  - `graph_source`
+  - `plasticity_state`
+- then initializes `SessionState`
+- then `into_session_state()` passes that single runtime into HTTP / stdio
+
+So the configuration model is already instance-shaped, but not registry-shaped.
+
+---
+
+## Product decision
+
+`m1nd` should support **many isolated instances** and **one user-visible command center**.
+
+The correct mental model is:
+
+- **Instance**: one running `m1nd` process with one isolated `SessionState`
+- **Workspace**: the project or worktree that instance is serving
+- **State directory**: the persisted graph/plasticity/runtime sidecars owned by that instance
+- **Command Center**: the UI that aggregates and controls all instances
+
+---
+
+## Recommendation
+
+Build this in two layers:
+
+### Layer 1: isolated runtime instances
+
+Every `m1nd` process should have:
+
+- a stable `instance_id`
+- a canonical `workspace_root`
+- a canonical `runtime_root`
+- a conflict-safe ownership lease over that `runtime_root`
+
+### Layer 2: global instance registry + command center
+
+All running instances should self-register into a single global registry.
+
+Any one `m1nd` HTTP UI can then render:
+
+- all known instances
+- their health
+- their conflicts
+- their actions
+
+without requiring one giant monolithic shared `SessionState`.
+
+This is the most robust path because it preserves what already works:
+
+- per-process `SessionState`
+- per-runtime persistence
+- local-first operation
+
+while adding the missing coordination layer.
+
+---
+
+## Instance model
+
+Each instance gets a durable identity record:
+
+```json
+{
+  "instance_id": "inst_01JXYZ...",
+  "workspace_root": "/abs/path/to/project",
+  "git_root": "/abs/path/to/repo",
+  "worktree_root": "/abs/path/to/worktree",
+  "runtime_root": "/abs/path/to/runtime",
+  "graph_source": "/abs/path/to/runtime/graph.json",
+  "plasticity_state": "/abs/path/to/runtime/plasticity.json",
+  "bind": "127.0.0.1",
+  "port": 3737,
+  "pid": 12345,
+  "started_at_ms": 0,
+  "last_heartbeat_ms": 0,
+  "mode": "read_write",
+  "status": "running"
+}
+```
+
+### Identity rules
+
+Use:
+
+- `workspace_root` as the primary logical identity for the project being served
+- `runtime_root` as the primary state identity
+- `instance_id` as the process identity
+
+### Why this matters
+
+Two launches can be:
+
+- the same workspace and same runtime root
+- the same workspace and different runtime roots
+- different worktrees under the same git root
+- different projects entirely
+
+Those cases must not be treated the same.
+
+---
+
+## Conflict model
+
+We should explicitly classify conflicts.
+
+### No conflict
+
+- different `workspace_root`
+- different `runtime_root`
+
+### Soft duplication
+
+- same `workspace_root`
+- different `runtime_root`
+
+Meaning:
+
+- technically safe
+- but likely redundant
+- UI should warn: "duplicate workspace"
+
+### Hard state conflict
+
+- same `runtime_root`
+- two live processes both trying to own it as read-write
+
+Meaning:
+
+- not safe
+- only one process may hold the write lease
+
+### Port conflict
+
+- requested port already occupied
+
+Meaning:
+
+- recoverable
+- allocate a new port and register it
+
+### Stale lock
+
+- lock file exists
+- pid is gone or heartbeat is stale
+
+Meaning:
+
+- UI should offer reclaim / restart / clear stale lock
+
+---
+
+## Runtime ownership rules
+
+Every `runtime_root` should have an ownership lease record, but in Phase 1 that
+lease should live in the **global registry**, not inside the repo/runtime
+directory itself.
+
+Example Phase 1 lease path:
+
+`~/.m1nd/registry/leases/<runtime-root-fingerprint>.json`
+
+Contents:
+
+```json
+{
+  "instance_id": "inst_...",
+  "pid": 12345,
+  "hostname": "machine",
+  "workspace_root": "/abs/project",
+  "runtime_root": "/abs/runtime",
+  "mode": "read_write",
+  "started_at_ms": 0,
+  "last_heartbeat_ms": 0
+}
+```
+
+### Lease behavior
+
+On startup:
+
+1. if no lock exists -> claim it
+2. if a healthy live owner exists:
+   - if same workspace + same runtime root:
+     - default to attach/open existing instance in UI
+   - else:
+     - block write ownership
+3. if stale owner:
+   - reclaim
+
+### Modes
+
+- `read_write`
+- `read_only`
+- `stale`
+
+Read-only should be allowed for diagnostics or duplicate observers, but only one writer may own the state dir.
+
+---
+
+## Default path strategy
+
+The current config already supports custom `graph_source`, `plasticity_state`, and `runtime_root`.
+
+To make many instances safe by default:
+
+### Current problem
+
+If the user points multiple launches at the same generic temp paths, collisions are easy.
+
+### New default
+
+Generate runtime roots under a namespaced home:
+
+```text
+~/.m1nd/instances/<workspace_fingerprint>/
+```
+
+Inside:
+
+```text
+graph.json
+plasticity.json
+boot_memory_state.json
+daemon_state.json
+daemon_alerts.json
+document_cache.json
+ingest_roots.json
+```
+
+### Workspace fingerprint
+
+Use a stable digest of:
+
+- canonical worktree root
+- git root
+- maybe branch/worktree label when present
+
+Important:
+
+Two worktrees from the same git root should default to **different** instance fingerprints if their filesystem roots differ.
+
+That avoids cross-worktree contamination.
+
+---
+
+## Global registry
+
+Add a global registry, for example:
+
+```text
+~/.m1nd/registry/instances/
+  inst_abc.json
+  inst_def.json
+```
+
+Each running instance writes one heartbeat-updated file.
+
+Why directory-per-instance instead of one giant JSON file:
+
+- simpler atomicity
+- easier stale cleanup
+- less lock contention
+- better crash recovery
+
+### Registry entry fields
+
+- identity
+- workspace info
+- runtime paths
+- port / bind
+- pid
+- status
+- heartbeat
+- graph counts
+- active agent sessions
+- conflict flags
+- current alerts count
+
+### Registry refresh cadence
+
+- heartbeat every `2s` or `5s`
+- on state transitions:
+  - startup
+  - shutdown
+  - persist
+  - conflict
+  - restart
+
+---
+
+## Command center UI
+
+The UI should show all instances in one place.
+
+### Core views
+
+### 1. Instance list
+
+Card per instance:
+
+- project name
+- workspace path
+- git branch / worktree
+- status
+- pid
+- port
+- last heartbeat
+- node count / edge count
+- alert count
+- active agent session count
+
+### 2. Conflict panel
+
+Badges:
+
+- `shared runtime root`
+- `duplicate workspace`
+- `stale lock`
+- `port reassigned`
+
+### 3. Instance detail drawer
+
+Show:
+
+- runtime paths
+- graph source
+- plasticity state
+- daemon state
+- ingest roots
+- persistence timestamps
+- active sessions
+
+### 4. Actions row
+
+Per instance:
+
+- `Open`
+- `Explore`
+- `Save state`
+- `Restart`
+- `Stop`
+- `Delete state`
+- `Reveal runtime dir`
+
+---
+
+## UX behavior
+
+### Open
+
+Open the instance-local UI in browser.
+
+### Explore
+
+Jump into graph stats / subgraph / health of that instance.
+
+### Save state
+
+Call the existing persist path explicitly.
+
+This should serialize:
+
+- graph
+- plasticity
+- boot memory
+- daemon state
+- alerts
+- auto-ingest
+- document cache
+
+### Restart
+
+Needs lifecycle management.
+
+Short-term:
+
+- graceful stop + relaunch if started by supervisor
+
+Long-term:
+
+- managed by a dedicated launcher/daemon
+
+### Stop
+
+Graceful process stop and registry removal.
+
+### Delete state
+
+Delete the `runtime_root` only when:
+
+- process is stopped
+- or force confirmed
+
+### Conflict recovery
+
+Buttons:
+
+- `Attach to running instance`
+- `Clone state into new runtime root`
+- `Reclaim stale lock`
+
+---
+
+## API proposal
+
+Extend the existing HTTP surface with:
+
+### Self endpoints
+
+- `/api/instance/self`
+- `/api/instance/save`
+- `/api/instance/stop`
+- `/api/instance/restart`
+
+### Registry endpoints
+
+- `/api/instances`
+- `/api/instances/:id`
+- `/api/instances/:id/conflicts`
+- `/api/instances/:id/delete-state`
+
+### Why split self vs registry
+
+Because one instance should be able to:
+
+- describe itself locally
+- while the command center aggregates many instances globally
+
+---
+
+## Process model recommendation
+
+There are two viable ways to control restart/stop.
+
+### Option A: self-registering instances only
+
+Pros:
+
+- simpler
+- lowest implementation cost
+
+Cons:
+
+- restart/stop of another process is awkward
+- cross-process control becomes platform-sensitive
+
+### Option B: add a lightweight supervisor (`m1ndd`)
+
+Pros:
+
+- clean lifecycle management
+- easier restart/stop/delete-state
+- central place for registry truth
+
+Cons:
+
+- more moving parts
+
+### Recommendation
+
+Phase it:
+
+1. ship self-registering instances + read-only command center
+2. add supervisor-backed control actions after the registry stabilizes
+
+That gets us value quickly without overbuilding the first version.
+
+---
+
+## Suggested implementation plan
+
+### Phase 1: isolate instances safely
+
+Files:
+
+- `m1nd-mcp/src/session.rs`
+- `m1nd-mcp/src/server.rs`
+- `m1nd-mcp/src/config.rs` or equivalent config surface
+- `m1nd-mcp/src/instance_registry.rs` (new)
+
+Deliver:
+
+- instance identity
+- runtime-root ownership lease (stored in the global registry in Phase 1)
+- namespaced default runtime roots
+- registry heartbeat files
+
+### Phase 2: expose command center API
+
+Files:
+
+- `m1nd-mcp/src/http_server.rs`
+- `m1nd-mcp/src/instance_registry.rs`
+
+Deliver:
+
+- list instances
+- inspect instance
+- conflict diagnostics
+- save-state action
+
+### Phase 3: UI
+
+Files:
+
+- existing embedded UI surface in `m1nd-mcp`
+- or dedicated React page in `m1nd-demo` for product simulation first
+
+Deliver:
+
+- instance table/cards
+- conflict panel
+- actions row
+- detail drawer
+
+### Phase 4: lifecycle control
+
+Files:
+
+- supervisor or launcher surface
+
+Deliver:
+
+- restart
+- stop
+- stale lock reclaim
+- safe delete-state
+
+---
+
+## Suggested UI model
+
+### Top summary strip
+
+- running instances
+- conflicted instances
+- stale locks
+- total active sessions
+
+### Main table columns
+
+- name
+- workspace
+- branch
+- status
+- graph
+- sessions
+- alerts
+- last save
+- actions
+
+### Detail drawer sections
+
+- runtime paths
+- state ownership
+- graph/runtime summary
+- persistence health
+- daemon + auto-ingest
+- recent alerts
+
+---
+
+## Critical product rules
+
+### Rule 1
+
+One writable owner per `runtime_root`.
+
+### Rule 2
+
+Multiple instances across different projects must be zero-conflict by default.
+
+### Rule 3
+
+Multiple worktrees of the same repo must isolate by worktree path unless the user explicitly chooses shared state.
+
+### Rule 4
+
+The UI must surface conflict type explicitly, not just "error".
+
+### Rule 5
+
+`Save state`, `Restart`, and `Delete state` must operate on the instance, not on a guessed workspace.
+
+---
+
+## Validation against the current graph
+
+The current plan touches the right core surfaces:
+
+- `m1nd-mcp/src/session.rs`
+- `m1nd-mcp/src/http_server.rs`
+- `m1nd-mcp/src/server.rs`
+- `m1nd-demo/src/App.tsx`
+- `m1nd-demo/src/pages/Landing.tsx`
+
+`m1nd.validate_plan` classified the overall plan as `medium` risk with no structural gaps, while recommending explicit tests for:
+
+- `session`
+- `http_server`
+- `server`
+- landing/app routing
+
+That is consistent with the code shape.
+
+---
+
+## Bottom line
+
+`m1nd` does not need one giant shared runtime to support many open projects.
+
+It needs:
+
+- isolated instance state
+- deterministic runtime-root ownership
+- a global registry
+- a command center UI above those instances
+
+That is the clean path to:
+
+- many open projects
+- no graph/plasticity collisions
+- visible conflicts
+- explicit restart/save/delete controls
+- and a user experience that makes multi-instance operation understandable instead of mysterious

--- a/docs/TRAY_AND_COMMAND_CENTER_GROUNDING_2026-04-11.md
+++ b/docs/TRAY_AND_COMMAND_CENTER_GROUNDING_2026-04-11.md
@@ -1,0 +1,605 @@
+# Tray + Command Center Grounding for `m1nd`
+
+Date: `2026-04-11`
+
+This note answers three questions:
+
+1. What is possible today in the current `m1nd` architecture?
+2. What should the `m1nd` tray + command center product look like?
+3. Can `GitNexus` serve as a donor for UI/UX patterns?
+
+---
+
+## Short answer
+
+### Yes, a tray-based `m1nd` control surface is realistic
+
+But not as a pure web-page feature.
+
+The clean product shape is:
+
+- **many isolated `m1nd` instances**
+- **one global registry**
+- **one command center UI**
+- **one lightweight native tray shell above that**
+
+### Yes, `GitNexus` is a good UI/UX donor
+
+But only at the level of:
+
+- information architecture
+- interaction patterns
+- surface choreography
+
+Not as a direct code donor.
+
+The license in their README is:
+
+- `PolyForm Noncommercial`
+
+That makes direct code borrowing a bad fit for `m1nd`'s current open/commercial story.
+
+So:
+
+- **borrow ideas**
+- **do not lift implementation**
+
+---
+
+## What is possible today
+
+Grounded in the current `m1nd` codebase:
+
+### Already exists
+
+`m1nd-mcp` already has:
+
+- a local HTTP server
+- embedded web UI support
+- a shared runtime state
+- health endpoints
+- graph stats endpoints
+- daemon, alerts, document cache, boot memory, and auto-ingest state persisted on disk
+
+Relevant files:
+
+- `m1nd-mcp/src/http_server.rs`
+- `m1nd-mcp/src/session.rs`
+- `m1nd-mcp/src/server.rs`
+
+### What that means
+
+Today, we can build:
+
+- a **web-based command center**
+- instance listing
+- status and conflict visibility
+- save-state actions
+- open/explore actions
+
+without changing the core graph engine.
+
+### What does not exist yet
+
+Today, the codebase does **not** have:
+
+- a native tray app
+- a global multi-process instance registry
+- runtime-root lease ownership
+- cross-instance lifecycle control
+
+So:
+
+- a command center is feasible now
+- a tray shell is feasible next
+- robust multi-instance control needs one architectural layer first
+
+---
+
+## Current architecture constraints
+
+### 1. Each process owns one `SessionState`
+
+`m1nd-mcp/src/session.rs`
+
+`SessionState` is explicitly documented as:
+
+- one server session state
+- one graph + engine bundle
+- shared across agent connections
+
+That is good for:
+
+- one process serving many agents
+
+That is not yet enough for:
+
+- many processes coordinated safely
+
+### 2. HTTP UI is process-local
+
+`m1nd-mcp/src/http_server.rs`
+
+The HTTP server wraps one session in:
+
+- `Arc<Mutex<SessionState>>`
+
+Meaning:
+
+- each HTTP UI sees one process
+- there is no built-in “all instances everywhere” view yet
+
+### 3. Persistence is already strong
+
+`m1nd-mcp/src/session.rs`
+
+The runtime already persists:
+
+- graph snapshot
+- plasticity state
+- boot memory
+- daemon state
+- daemon alerts
+- auto-ingest
+- document cache
+- ingest roots
+
+This is the good news:
+
+> the instance boundary already exists implicitly through `runtime_root`
+
+We mainly need to formalize it.
+
+---
+
+## The right product model
+
+The right mental model is not:
+
+- one giant shared `m1nd`
+
+It is:
+
+- **many `m1nd` instances**
+- **one command center**
+- **one tray shell**
+
+### Instance
+
+One running process with:
+
+- one graph
+- one `runtime_root`
+- one `workspace_root`
+- one `port`
+- one `pid`
+- one state lease
+
+### Command center
+
+A global UI that aggregates:
+
+- all running instances
+- all conflicts
+- all runtime roots
+- all saves / alerts / statuses
+
+### Tray shell
+
+A native menubar/tray app that exposes:
+
+- quick status
+- quick actions
+- launch / attach / open command center
+
+---
+
+## Tray feasibility
+
+### What is realistic right now
+
+There are three implementation paths.
+
+### Option A: tray shell + current HTTP UI
+
+Build a very small native shell whose job is only:
+
+- sit in tray
+- show instance count / conflicts
+- open command center in browser or native webview
+- send restart / save / stop actions
+
+Pros:
+
+- fastest path
+- keeps current web UI investment
+- easiest to ship
+
+Cons:
+
+- tray is a wrapper, not a full native desktop product
+
+### Option B: tray shell + embedded webview app
+
+Use a desktop shell that embeds the command center directly.
+
+Pros:
+
+- best UX
+- feels like a real app
+- settings, registry, and instances all live together
+
+Cons:
+
+- bigger packaging/runtime surface
+
+### Option C: native-only tray menus first
+
+Use a tray with nested menus and no rich app window at first.
+
+Pros:
+
+- very fast to prototype
+
+Cons:
+
+- not enough surface for “instances, conflicts, settings, explore”
+- will feel cramped almost immediately
+
+### Recommendation
+
+For `m1nd`, the best path is:
+
+1. build the registry
+2. build the command center web UI
+3. add a thin tray shell that opens and controls it
+
+That gives us the tray experience without designing the whole product inside tray menus.
+
+---
+
+## What the tray should show
+
+At minimum:
+
+- `m1nd` running / not running
+- number of active instances
+- number of conflicts
+- number of alerts
+
+Actions:
+
+- `Open Command Center`
+- `Start New Instance`
+- `Open Last Project`
+- `Save All`
+- `Restart Conflicted Instance`
+- `Quit`
+
+Optional rich submenu:
+
+- recent projects
+- currently running instances
+- stale lock warnings
+
+---
+
+## What the command center should show
+
+This is the main product surface.
+
+### Top strip
+
+- running instances
+- conflicted instances
+- stale locks
+- active agent sessions
+- unsaved state count
+
+### Main table / card list
+
+Each instance row:
+
+- project/workspace name
+- path
+- branch/worktree
+- status
+- port
+- pid
+- graph nodes/edges
+- active sessions
+- alerts
+- last save
+
+Actions:
+
+- `Open`
+- `Explore`
+- `Save`
+- `Restart`
+- `Stop`
+- `Delete State`
+
+### Detail drawer
+
+- runtime root
+- graph path
+- plasticity path
+- daemon state
+- ingest roots
+- cache generation
+- last persist time
+- document cache status
+- auto-ingest status
+
+### Conflict view
+
+Badges:
+
+- `duplicate workspace`
+- `shared runtime root`
+- `stale lock`
+- `port reassigned`
+
+And action suggestions:
+
+- `Attach`
+- `Fork Runtime`
+- `Reclaim Lock`
+- `Stop Other Instance`
+
+---
+
+## GitNexus as donor
+
+## What GitNexus gets right
+
+Grounded in their public repo and web app structure:
+
+- `gitnexus-web/src/App.tsx`
+- `gitnexus-web/src/components/Header.tsx`
+- `gitnexus-web/src/components/StatusBar.tsx`
+- `gitnexus-web/src/components/SettingsPanel.tsx`
+
+The strongest reusable ideas are:
+
+### 1. Header as command surface
+
+Their `Header.tsx` includes:
+
+- active project badge
+- repo dropdown
+- refresh / delete / re-analyze actions
+- global search
+
+For `m1nd`, this maps well to:
+
+- active instance badge
+- instance dropdown
+- attach / restart / save / reclaim actions
+- instance search
+
+### 2. Status bar as always-on operational truth
+
+Their `StatusBar.tsx` shows:
+
+- readiness
+- progress
+- graph stats
+
+For `m1nd`, this maps well to:
+
+- registry health
+- running instances
+- active conflicts
+- selected instance stats
+
+### 3. Settings panel as a serious side sheet
+
+Their `SettingsPanel.tsx` is not tiny.
+It is a proper operational control surface.
+
+That is exactly the right pattern for `m1nd` settings:
+
+- default runtime root strategy
+- conflict policy
+- auto-attach behavior
+- save cadence
+- tray preferences
+- startup behavior
+
+### 4. Repo-centric IA
+
+GitNexus is organized around:
+
+- project selection
+- backend connection
+- graph stats
+- right-side detail panels
+
+That overall IA adapts extremely well to:
+
+- instance selection
+- registry connection/health
+- runtime stats
+- right-side detail drawer
+
+## What should NOT be copied from GitNexus
+
+### 1. Their exact visual theme
+
+Their theme is nice, but:
+
+- too purple-centric
+- too “developer graph app”
+- not obviously aligned to `m1nd`’s newer brand direction
+
+We should borrow:
+
+- layout logic
+- panel density
+- hierarchy
+
+But style it in:
+
+- `m1nd` colors
+- `m1nd` typography
+- `m1nd` visual identity
+
+### 2. Their product model
+
+GitNexus is:
+
+- repo explorer + graph agent surface
+
+`m1nd` needs:
+
+- multi-instance operational control plane
+
+That is not the same thing.
+
+### 3. Their licensing assumptions
+
+GitNexus README declares:
+
+- `PolyForm Noncommercial`
+
+So direct code adaptation is a poor legal/product fit.
+
+Conclusion:
+
+> GitNexus is a donor of **interaction patterns**, not of copy-paste implementation.
+
+---
+
+## Best adaptation strategy
+
+### Borrow from GitNexus
+
+- top header layout
+- dropdown-based instance/project switching
+- status bar
+- settings side panel
+- right-side detail panel model
+
+### Keep from `m1nd`
+
+- existing local HTTP architecture
+- `SessionState`
+- `runtime_root` persistence
+- local-first stance
+- command semantics
+
+### Add for `m1nd`
+
+- instance registry
+- runtime ownership leases
+- conflict classifier
+- command center routes
+- tray launcher
+
+---
+
+## Proposed visual IA for `m1nd`
+
+### Header
+
+Left:
+
+- `m1nd` mark
+- active instance picker
+
+Center:
+
+- workspace / branch / port
+
+Right:
+
+- search instances
+- conflicts badge
+- settings
+
+### Main split
+
+Left rail:
+
+- instances list
+
+Center:
+
+- selected instance overview
+
+Right:
+
+- actions and detail panels
+
+### Footer/status bar
+
+- registry status
+- last heartbeat
+- total instances
+- selected graph nodes/edges
+
+This is where GitNexus is a strong donor.
+
+---
+
+## My recommendation
+
+### Product recommendation
+
+Yes:
+
+- build the command center
+- build the tray shell
+- make multi-instance operation a first-class `m1nd` experience
+
+Because if users run many projects at once, this quickly becomes a product-defining layer.
+
+### Technical recommendation
+
+Do it in this order:
+
+1. instance registry
+2. runtime-root ownership
+3. command center API
+4. command center UI
+5. tray shell
+
+### GitNexus recommendation
+
+Use GitNexus as a donor for:
+
+- panel layout
+- instance selector behavior
+- settings drawer behavior
+- status bar behavior
+
+Do not use it as:
+
+- a direct code transplant
+- a direct design system transplant
+
+---
+
+## Bottom line
+
+What is possible today:
+
+- a strong web-based command center is absolutely possible now
+- a tray shell is realistic right after that
+- robust conflict-safe multi-instance operation needs one new layer: a registry + lease model
+
+What I think:
+
+This is worth doing.
+
+It upgrades `m1nd` from:
+
+- powerful engine per project
+
+to:
+
+- something a user can actually run across many projects without fear or confusion
+
+And that is exactly the kind of product move that makes the system feel mature.

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -44,6 +44,14 @@ pub struct Cli {
     #[arg(long)]
     pub plasticity: Option<String>,
 
+    /// Runtime directory override for instance sidecar state
+    #[arg(long)]
+    pub runtime_dir: Option<String>,
+
+    /// Global registry directory override
+    #[arg(long)]
+    pub registry_dir: Option<String>,
+
     /// Domain: code, music, memory, generic
     #[arg(long, default_value = "code")]
     pub domain: String,

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -23,6 +23,7 @@ use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
 
 use crate::http_types::SubgraphQuery;
+use crate::instance_registry::{list_instances, spawn_heartbeat};
 use crate::server::{dispatch_tool, tool_schemas, McpConfig};
 use crate::session::{ApplyBatchProgressSink, SessionState};
 
@@ -287,6 +288,7 @@ pub struct AppState {
     pub event_tx: broadcast::Sender<SseEvent>,
     /// Optional event log path for cross-process SSE (Option B).
     pub event_log_path: Option<std::path::PathBuf>,
+    pub registry_dir: Option<std::path::PathBuf>,
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +317,10 @@ pub fn spawn_background(
 
     // SSE broadcast channel
     let (event_tx, _) = broadcast::channel::<SseEvent>(64);
+    let registry_root = {
+        let guard = session.lock();
+        guard.instance.registry_root()
+    };
 
     // AppState
     let app_state = Arc::new(AppState {
@@ -322,10 +328,21 @@ pub fn spawn_background(
         tool_schemas_cache,
         event_tx,
         event_log_path: None,
+        registry_dir: Some(registry_root),
     });
+    {
+        let session = app_state.session.lock();
+        let _ = session
+            .instance
+            .set_running_endpoint("127.0.0.1".into(), port);
+    }
+    let _heartbeat = {
+        let session = app_state.session.lock();
+        spawn_heartbeat(session.instance.clone())
+    };
 
     // Router (embedded UI, not dev mode)
-    let router = build_router(app_state, false);
+    let router = build_router(app_state.clone(), false);
 
     let addr: std::net::SocketAddr = format!("127.0.0.1:{}", port)
         .parse()
@@ -344,12 +361,17 @@ pub fn spawn_background(
                 });
                 // Serve until process exits (no graceful shutdown needed — stdio owns lifecycle)
                 let _ = axum::serve(listener, router).await;
+                let mut session = app_state.session.lock();
+                let _ = session.persist();
+                let _ = session.instance.release();
             }
             Err(e) => {
                 eprintln!(
                     "[m1nd-mcp] Background HTTP server failed to bind to {}: {} (GUI unavailable)",
                     addr, e
                 );
+                let session = app_state.session.lock();
+                let _ = session.instance.release();
             }
         }
     })
@@ -405,7 +427,16 @@ pub async fn run(
         tool_schemas_cache,
         event_tx: event_tx.clone(),
         event_log_path: event_log_path.clone(),
+        registry_dir: config.registry_dir.clone(),
     });
+    {
+        let session = app_state.session.lock();
+        let _ = session.instance.set_running_endpoint(bind.clone(), port);
+    }
+    let _heartbeat = {
+        let session = app_state.session.lock();
+        spawn_heartbeat(session.instance.clone())
+    };
 
     // 6b. If --watch-events is specified, spawn the event log watcher
     if let Some(ref watch_path) = watch_events {
@@ -553,6 +584,10 @@ pub async fn run(
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,
         Err(e) => {
+            {
+                let session = session.lock();
+                let _ = session.instance.release();
+            }
             eprintln!("[m1nd-mcp] Failed to bind to {}: {}", addr, e);
             std::process::exit(1);
         }
@@ -568,6 +603,7 @@ pub async fn run(
             if let Err(e) = s.persist() {
                 eprintln!("[m1nd-mcp] Failed to persist state on shutdown: {}", e);
             }
+            let _ = s.instance.release();
             eprintln!("[m1nd-mcp] State persisted. Goodbye.");
         })
         .await
@@ -644,6 +680,8 @@ fn tool_error_payload(e: &m1nd_core::error::M1ndError) -> serde_json::Value {
 pub fn build_router(state: Arc<AppState>, dev_mode: bool) -> Router {
     let api = Router::new()
         .route("/api/health", get(handle_health))
+        .route("/api/instance/self", get(handle_instance_self))
+        .route("/api/instances", get(handle_instances))
         .route("/api/tools", get(handle_list_tools))
         .route("/api/tools/{*tool_name}", post(handle_tool_call))
         .route("/api/graph/stats", get(handle_graph_stats))
@@ -689,6 +727,36 @@ async fn handle_health(State(state): State<Arc<AppState>>) -> impl IntoResponse 
     })
     .await
     .expect("spawn_blocking panicked");
+
+    (StatusCode::OK, Json(result))
+}
+
+async fn handle_instance_self(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let state = state.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let session = state.session.lock();
+        session.instance_self_summary()
+    })
+    .await
+    .expect("spawn_blocking panicked");
+
+    (StatusCode::OK, Json(result))
+}
+
+async fn handle_instances(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let state = state.clone();
+    let result =
+        tokio::task::spawn_blocking(
+            move || match list_instances(state.registry_dir.as_deref()) {
+                Ok(instances) => serde_json::json!({ "instances": instances }),
+                Err(error) => serde_json::json!({
+                    "instances": [],
+                    "error": error.to_string(),
+                }),
+            },
+        )
+        .await
+        .expect("spawn_blocking panicked");
 
     (StatusCode::OK, Json(result))
 }

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -1,0 +1,451 @@
+use m1nd_core::error::{M1ndError, M1ndResult};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::task::JoinHandle;
+use tokio::time::{interval, Duration};
+
+const INSTANCE_DIR_NAME: &str = "instances";
+const LEASE_DIR_NAME: &str = "leases";
+const DEFAULT_REGISTRY_SUBDIR: &str = ".m1nd/registry";
+const STALE_AFTER_MS: u64 = 30_000;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InstanceRegistryEntry {
+    pub instance_id: String,
+    pub workspace_root: String,
+    pub runtime_root: String,
+    pub graph_source: String,
+    pub plasticity_state: String,
+    pub pid: u32,
+    pub bind: Option<String>,
+    pub port: Option<u16>,
+    pub started_at_ms: u64,
+    pub last_heartbeat_ms: u64,
+    pub mode: String,
+    pub status: String,
+    #[serde(default)]
+    pub owner_live: Option<bool>,
+    #[serde(default)]
+    pub stale: bool,
+    #[serde(default)]
+    pub conflicts: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct InstanceHandle {
+    inner: Arc<Mutex<InstanceHandleInner>>,
+}
+
+#[derive(Clone, Debug)]
+struct InstanceHandleInner {
+    entry: InstanceRegistryEntry,
+    registry_root: PathBuf,
+    entry_path: PathBuf,
+    lock_path: PathBuf,
+}
+
+impl InstanceHandle {
+    pub fn acquire(
+        workspace_root: &Path,
+        runtime_root: &Path,
+        graph_source: &Path,
+        plasticity_state: &Path,
+        registry_root: Option<&Path>,
+    ) -> M1ndResult<Self> {
+        let workspace_root = canonicalish(workspace_root)?;
+        let runtime_root = canonicalish(runtime_root)?;
+        let graph_source = canonicalish(graph_source)?;
+        let plasticity_state = canonicalish(plasticity_state)?;
+        let registry_root = registry_root
+            .map(canonicalish)
+            .transpose()?
+            .unwrap_or_else(default_registry_root);
+
+        fs::create_dir_all(registry_root.join(INSTANCE_DIR_NAME))?;
+        fs::create_dir_all(registry_root.join(LEASE_DIR_NAME))?;
+
+        let lock_path = registry_root
+            .join(LEASE_DIR_NAME)
+            .join(format!("{}.json", fingerprint_path(&runtime_root)));
+        if lock_path.exists() {
+            let existing: InstanceRegistryEntry = read_json(&lock_path)?;
+            let live = is_pid_live(existing.pid);
+            let stale = is_stale(existing.last_heartbeat_ms);
+            if live && !stale && existing.pid != std::process::id() {
+                return Err(M1ndError::Io(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!(
+                        "runtime_root {} is already owned by instance {} (pid {})",
+                        runtime_root.display(),
+                        existing.instance_id,
+                        existing.pid
+                    ),
+                )));
+            }
+        }
+
+        let now_ms = now_ms();
+        let instance_id = generate_instance_id(&workspace_root, &runtime_root, now_ms);
+        let entry = InstanceRegistryEntry {
+            instance_id: instance_id.clone(),
+            workspace_root: workspace_root.to_string_lossy().to_string(),
+            runtime_root: runtime_root.to_string_lossy().to_string(),
+            graph_source: graph_source.to_string_lossy().to_string(),
+            plasticity_state: plasticity_state.to_string_lossy().to_string(),
+            pid: std::process::id(),
+            bind: None,
+            port: None,
+            started_at_ms: now_ms,
+            last_heartbeat_ms: now_ms,
+            mode: "read_write".into(),
+            status: "starting".into(),
+            owner_live: Some(true),
+            stale: false,
+            conflicts: Vec::new(),
+        };
+
+        let entry_path = registry_root
+            .join(INSTANCE_DIR_NAME)
+            .join(format!("{}.json", instance_id));
+        save_json_atomic(&lock_path, &entry)?;
+        save_json_atomic(&entry_path, &entry)?;
+
+        Ok(Self {
+            inner: Arc::new(Mutex::new(InstanceHandleInner {
+                entry,
+                registry_root,
+                entry_path,
+                lock_path,
+            })),
+        })
+    }
+
+    pub fn set_running_endpoint(&self, bind: String, port: u16) -> M1ndResult<()> {
+        let mut inner = self.inner.lock();
+        inner.entry.bind = Some(bind);
+        inner.entry.port = Some(port);
+        inner.entry.status = "running".into();
+        inner.entry.last_heartbeat_ms = now_ms();
+        persist_handle_inner(&inner)
+    }
+
+    pub fn mark_heartbeat(&self) -> M1ndResult<()> {
+        let mut inner = self.inner.lock();
+        inner.entry.last_heartbeat_ms = now_ms();
+        if inner.entry.status == "starting" {
+            inner.entry.status = "running".into();
+        }
+        persist_handle_inner(&inner)
+    }
+
+    pub fn mark_degraded(&self) -> M1ndResult<()> {
+        let mut inner = self.inner.lock();
+        inner.entry.status = "degraded".into();
+        inner.entry.last_heartbeat_ms = now_ms();
+        persist_handle_inner(&inner)
+    }
+
+    pub fn summary(&self) -> InstanceRegistryEntry {
+        self.inner.lock().entry.clone()
+    }
+
+    pub fn registry_root(&self) -> PathBuf {
+        self.inner.lock().registry_root.clone()
+    }
+
+    pub fn release(&self) -> M1ndResult<()> {
+        let inner = self.inner.lock();
+        let _ = fs::remove_file(&inner.lock_path);
+        let _ = fs::remove_file(&inner.entry_path);
+        Ok(())
+    }
+}
+
+pub fn spawn_heartbeat(instance: InstanceHandle) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = interval(Duration::from_secs(5));
+        loop {
+            ticker.tick().await;
+            let _ = instance.mark_heartbeat();
+        }
+    })
+}
+
+pub fn list_instances(registry_root: Option<&Path>) -> M1ndResult<Vec<InstanceRegistryEntry>> {
+    let registry_root = registry_root
+        .map(canonicalish)
+        .transpose()?
+        .unwrap_or_else(default_registry_root);
+    let instances_dir = registry_root.join(INSTANCE_DIR_NAME);
+    if !instances_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for item in fs::read_dir(instances_dir)? {
+        let item = item?;
+        let path = item.path();
+        if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        match read_json::<InstanceRegistryEntry>(&path) {
+            Ok(mut entry) => {
+                entry.owner_live = Some(is_pid_live(entry.pid));
+                entry.stale =
+                    !entry.owner_live.unwrap_or(false) || is_stale(entry.last_heartbeat_ms);
+                entries.push(entry);
+            }
+            Err(_) => continue,
+        }
+    }
+
+    apply_conflicts(&mut entries);
+    entries.sort_by(|a, b| {
+        b.last_heartbeat_ms
+            .cmp(&a.last_heartbeat_ms)
+            .then_with(|| a.workspace_root.cmp(&b.workspace_root))
+    });
+    Ok(entries)
+}
+
+pub fn default_registry_root() -> PathBuf {
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(DEFAULT_REGISTRY_SUBDIR);
+    }
+    PathBuf::from(".").join(DEFAULT_REGISTRY_SUBDIR)
+}
+
+fn apply_conflicts(entries: &mut [InstanceRegistryEntry]) {
+    let mut by_runtime: HashMap<String, usize> = HashMap::new();
+    let mut by_workspace: HashMap<String, usize> = HashMap::new();
+    for entry in entries.iter() {
+        *by_runtime.entry(entry.runtime_root.clone()).or_insert(0) += 1;
+        *by_workspace
+            .entry(entry.workspace_root.clone())
+            .or_insert(0) += 1;
+    }
+
+    for entry in entries.iter_mut() {
+        if by_runtime.get(&entry.runtime_root).copied().unwrap_or(0) > 1 {
+            entry.conflicts.push("shared_runtime_root".into());
+        }
+        if by_workspace
+            .get(&entry.workspace_root)
+            .copied()
+            .unwrap_or(0)
+            > 1
+        {
+            entry.conflicts.push("duplicate_workspace".into());
+        }
+        if entry.stale {
+            entry.conflicts.push("stale_lock".into());
+            if entry.status == "running" {
+                entry.status = "stale".into();
+            }
+        }
+    }
+}
+
+fn persist_handle_inner(inner: &InstanceHandleInner) -> M1ndResult<()> {
+    save_json_atomic(&inner.entry_path, &inner.entry)?;
+    save_json_atomic(&inner.lock_path, &inner.entry)
+}
+
+fn generate_instance_id(workspace_root: &Path, runtime_root: &Path, now_ms: u64) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    workspace_root.to_string_lossy().hash(&mut hasher);
+    runtime_root.to_string_lossy().hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    now_ms.hash(&mut hasher);
+    format!("inst_{:x}", hasher.finish())
+}
+
+fn fingerprint_path(path: &Path) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path.to_string_lossy().hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}
+
+fn is_stale(last_heartbeat_ms: u64) -> bool {
+    now_ms().saturating_sub(last_heartbeat_ms) > STALE_AFTER_MS
+}
+
+fn is_pid_live(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .output()
+            .map(|output| {
+                output.status.success()
+                    || String::from_utf8_lossy(&output.stderr)
+                        .to_ascii_lowercase()
+                        .contains("operation not permitted")
+            })
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
+}
+
+fn canonicalish(path: &Path) -> std::io::Result<PathBuf> {
+    if path.exists() {
+        return fs::canonicalize(path);
+    }
+    if let Some(parent) = path.parent() {
+        if parent.exists() {
+            let canonical_parent = fs::canonicalize(parent)?;
+            if let Some(name) = path.file_name() {
+                return Ok(canonical_parent.join(name));
+            }
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> M1ndResult<T> {
+    let raw = fs::read_to_string(path)?;
+    serde_json::from_str(&raw).map_err(|error| {
+        M1ndError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid json at {}: {error}", path.display()),
+        ))
+    })
+}
+
+fn save_json_atomic<T: Serialize>(path: &Path, value: &T) -> M1ndResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(value).map_err(|error| {
+        M1ndError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("failed to serialize {}: {error}", path.display()),
+        ))
+    })?;
+    let temp = path.with_extension("tmp");
+    fs::write(&temp, json)?;
+    fs::rename(temp, path)?;
+    Ok(())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn acquires_and_lists_single_instance() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        let runtime = temp.path().join("runtime");
+        let graph = runtime.join("graph.json");
+        let plasticity = runtime.join("plasticity.json");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&runtime).unwrap();
+        let registry = temp.path().join("registry");
+
+        let handle =
+            InstanceHandle::acquire(&workspace, &runtime, &graph, &plasticity, Some(&registry))
+                .unwrap();
+        handle
+            .set_running_endpoint("127.0.0.1".into(), 1337)
+            .unwrap();
+
+        let instances = list_instances(Some(&registry)).unwrap();
+        assert_eq!(instances.len(), 1);
+        assert_eq!(
+            instances[0].workspace_root,
+            canonicalish(&workspace).unwrap().to_string_lossy()
+        );
+        assert_eq!(instances[0].status, "running");
+        assert!(instances[0].owner_live.unwrap_or(false));
+    }
+
+    #[test]
+    fn rejects_live_runtime_root_collision_for_foreign_owner() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        let runtime = temp.path().join("runtime");
+        let graph = runtime.join("graph.json");
+        let plasticity = runtime.join("plasticity.json");
+        let registry = temp.path().join("registry");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&runtime).unwrap();
+
+        let first =
+            InstanceHandle::acquire(&workspace, &runtime, &graph, &plasticity, Some(&registry))
+                .unwrap();
+        let mut foreign = first.summary();
+        foreign.instance_id = "inst_foreign".into();
+        foreign.pid = 1;
+        foreign.last_heartbeat_ms = now_ms();
+        let lock_path = registry.join(LEASE_DIR_NAME).join(format!(
+            "{}.json",
+            fingerprint_path(&canonicalish(&runtime).unwrap())
+        ));
+        save_json_atomic(&lock_path, &foreign).unwrap();
+        let err =
+            InstanceHandle::acquire(&workspace, &runtime, &graph, &plasticity, Some(&registry))
+                .unwrap_err();
+        assert!(err.to_string().contains("already owned"));
+    }
+
+    #[test]
+    fn marks_duplicate_workspaces_as_soft_conflicts() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let registry = temp.path().join("registry");
+
+        let runtime_a = temp.path().join("runtime-a");
+        let runtime_b = temp.path().join("runtime-b");
+        fs::create_dir_all(&runtime_a).unwrap();
+        fs::create_dir_all(&runtime_b).unwrap();
+        let graph_a = runtime_a.join("graph.json");
+        let plasticity_a = runtime_a.join("plasticity.json");
+        let graph_b = runtime_b.join("graph.json");
+        let plasticity_b = runtime_b.join("plasticity.json");
+
+        let _a = InstanceHandle::acquire(
+            &workspace,
+            &runtime_a,
+            &graph_a,
+            &plasticity_a,
+            Some(&registry),
+        )
+        .unwrap();
+        let _b = InstanceHandle::acquire(
+            &workspace,
+            &runtime_b,
+            &graph_b,
+            &plasticity_b,
+            Some(&registry),
+        )
+        .unwrap();
+
+        let instances = list_instances(Some(&registry)).unwrap();
+        assert_eq!(instances.len(), 2);
+        assert!(instances
+            .iter()
+            .all(|entry| entry.conflicts.contains(&"duplicate_workspace".to_string())));
+    }
+}

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -13,6 +13,7 @@ pub mod tools;
 // Perspective MCP — stateful navigation layer (12-PERSPECTIVE-SYNTHESIS)
 pub mod boot_memory_handlers;
 pub mod engine_ops;
+pub mod instance_registry;
 pub mod layer_handlers;
 pub mod lock_handlers;
 pub mod persist_handlers;

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -1,8 +1,8 @@
 // === m1nd-mcp binary entry point ===
 //
 // Modes:
-//   m1nd-mcp                     → JSON-RPC stdio + auto-launch GUI on :1337 (default)
-//   m1nd-mcp --no-gui            → JSON-RPC stdio only (CI, headless)
+//   m1nd-mcp                     → JSON-RPC stdio only (default runtime path)
+//   m1nd-mcp --no-gui            → JSON-RPC stdio only (explicit CI/headless intent)
 //   m1nd-mcp --serve             → HTTP server + embedded UI on :1337
 //   m1nd-mcp --serve --stdio     → Both transports simultaneously (SSE cross-process bridge)
 //   m1nd-mcp --serve --dev       → HTTP with frontend served from disk (Vite HMR)
@@ -15,6 +15,7 @@
 
 use clap::Parser;
 use m1nd_mcp::cli::Cli;
+use m1nd_mcp::instance_registry::spawn_heartbeat;
 use m1nd_mcp::server::{McpConfig, McpServer};
 use std::path::PathBuf;
 
@@ -95,6 +96,12 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
         .unwrap_or_else(|| PathBuf::from("./plasticity_state.json"));
 
     let runtime_dir = std::env::var("M1ND_RUNTIME_DIR").ok().map(PathBuf::from);
+    let runtime_dir = cli.runtime_dir.as_ref().map(PathBuf::from).or(runtime_dir);
+    let registry_dir = cli
+        .registry_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("M1ND_REGISTRY_DIR").ok().map(PathBuf::from));
 
     let xlr_enabled = std::env::var("M1ND_XLR_ENABLED")
         .map(|v| v != "0" && v != "false")
@@ -109,13 +116,14 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
         graph_source,
         plasticity_state,
         runtime_dir,
+        registry_dir,
         xlr_enabled,
         domain,
         ..McpConfig::default()
     }
 }
 
-async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: bool, port: u16) {
+async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: bool, _port: u16) {
     if event_log.is_some() {
         eprintln!(
             "[m1nd-mcp] NOTE: --event-log in stdio-only mode writes events for external consumers."
@@ -127,22 +135,14 @@ async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: 
 
     // Spawn background HTTP GUI server (unless --no-gui or serve feature disabled)
     #[cfg(feature = "serve")]
-    let _gui_handle = if !no_gui {
-        // Create a separate McpServer for the HTTP GUI (same config, independent state)
-        match McpServer::new(config.clone()) {
-            Ok(gui_server) => {
-                let session_state = gui_server.into_session_state();
-                let session = std::sync::Arc::new(parking_lot::Mutex::new(session_state));
-                Some(m1nd_mcp::http_server::spawn_background(session, port))
-            }
-            Err(e) => {
-                eprintln!(
-                    "[m1nd-mcp] GUI server init failed (continuing without GUI): {}",
-                    e
-                );
-                None
-            }
-        }
+    let _gui_handle: Option<tokio::task::JoinHandle<()>> = if !no_gui {
+        eprintln!(
+            "[m1nd-mcp] Auto GUI disabled in stdio mode while multi-instance runtime leases are active."
+        );
+        eprintln!(
+            "[m1nd-mcp] Use `m1nd-mcp --serve --stdio` when you want one shared HTTP + stdio instance."
+        );
+        None
     } else {
         None
     };
@@ -162,6 +162,8 @@ async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: 
         eprintln!("[m1nd-mcp] Failed to start server: {}", e);
         std::process::exit(1);
     }
+
+    let _heartbeat = spawn_heartbeat(server.instance_handle());
 
     // Spawn the serve loop in a blocking task (synchronous stdio I/O)
     let serve_handle = tokio::task::spawn_blocking(move || {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -1,6 +1,7 @@
 // === crates/m1nd-mcp/src/server.rs ===
 
 use crate::auto_ingest;
+use crate::instance_registry::InstanceHandle;
 use crate::layer_handlers;
 use crate::personality;
 use crate::protocol::layers;
@@ -181,6 +182,8 @@ pub struct McpConfig {
     pub plasticity_state: PathBuf,
     #[serde(default)]
     pub runtime_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub registry_dir: Option<PathBuf>,
     pub auto_persist_interval: u32,
     pub learning_rate: f32,
     pub decay_rate: f32,
@@ -199,6 +202,7 @@ impl Default for McpConfig {
             graph_source: PathBuf::from("./graph_snapshot.json"),
             plasticity_state: PathBuf::from("./plasticity_state.json"),
             runtime_dir: None,
+            registry_dir: None,
             auto_persist_interval: 50,
             learning_rate: 0.08,
             decay_rate: 0.005,
@@ -2762,6 +2766,10 @@ impl McpServer {
         self.state
     }
 
+    pub fn instance_handle(&self) -> InstanceHandle {
+        self.state.instance.clone()
+    }
+
     /// Startup sequence (03-MCP Section 1.2):
     /// 1. Load graph snapshot       (done in new())
     /// 2. Load plasticity state     (done in new())
@@ -2967,6 +2975,7 @@ impl McpServer {
     pub fn shutdown(&mut self) -> M1ndResult<()> {
         eprintln!("[m1nd-mcp] Shutting down...");
         let _ = self.state.persist();
+        let _ = self.state.instance.release();
         eprintln!("[m1nd-mcp] State persisted. Goodbye.");
         Ok(())
     }

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::auto_ingest::AutoIngestState;
+use crate::instance_registry::{InstanceHandle, InstanceRegistryEntry};
 use crate::perspective::state::{
     LockState, PeekSecurityConfig, PerspectiveLimits, PerspectiveState, WatchTrigger, WatcherEvent,
 };
@@ -304,6 +305,8 @@ pub struct SessionState {
     pub workspace_root: Option<String>,
     /// Dedicated runtime root for persisted sidecar state.
     pub runtime_root: PathBuf,
+    /// Registry + lease handle for this process instance.
+    pub instance: InstanceHandle,
     /// Optional live sink for apply_batch progress emission.
     pub apply_batch_progress_sink: Option<ApplyBatchProgressSink>,
 
@@ -377,6 +380,17 @@ impl SessionState {
         })
     }
 
+    pub fn instance_self_summary(&self) -> serde_json::Value {
+        let instance: InstanceRegistryEntry = self.instance.summary();
+        serde_json::json!({
+            "instance": instance,
+            "graph_state": self.graph_runtime_summary(),
+            "active_agent_sessions": self.sessions.len(),
+            "queries_processed": self.queries_processed,
+            "last_persist_secs_ago": self.last_persist_time.map(|ts| ts.elapsed().as_secs_f64()),
+        })
+    }
+
     pub fn empty_graph_diagnostic(
         &self,
         tool: &str,
@@ -438,6 +452,18 @@ impl SessionState {
                 .unwrap_or(std::path::Path::new("."))
                 .to_path_buf()
         });
+        let workspace_root = config
+            .graph_source
+            .parent()
+            .unwrap_or(runtime_root.as_path())
+            .to_path_buf();
+        let instance = InstanceHandle::acquire(
+            &workspace_root,
+            &runtime_root,
+            &config.graph_source,
+            &config.plasticity_state,
+            config.registry_dir.as_deref(),
+        )?;
         let ingest_roots = Self::load_ingest_roots(&config.graph_source);
 
         Ok(Self {
@@ -469,11 +495,9 @@ impl SessionState {
             perspective_limits: PerspectiveLimits::default(),
             peek_security: PeekSecurityConfig::default(),
             ingest_roots,
-            workspace_root: config
-                .graph_source
-                .parent()
-                .map(|p| p.to_string_lossy().to_string()),
+            workspace_root: Some(workspace_root.to_string_lossy().to_string()),
             runtime_root: runtime_root.clone(),
+            instance,
             apply_batch_progress_sink: None,
             // Superpowers: Antibody state
             antibodies: {
@@ -543,6 +567,7 @@ impl SessionState {
     /// If graph save fails, skip plasticity to avoid inconsistent state.
     /// If plasticity save fails after graph succeeds, log warning but don't crash.
     pub fn persist(&mut self) -> M1ndResult<()> {
+        let _ = self.instance.mark_heartbeat();
         self.persist_ingest_roots();
         let graph = self.graph.read();
 
@@ -906,6 +931,7 @@ impl SessionState {
     /// Track an agent session. Creates a new session if first contact,
     /// otherwise updates last_seen and increments query_count.
     pub fn track_agent(&mut self, agent_id: &str) {
+        let _ = self.instance.mark_heartbeat();
         let now = Instant::now();
         let session = self
             .sessions


### PR DESCRIPTION
## Summary

This PR adds the first backend slice of the multi-instance command center for `m1nd`.

It keeps the existing one-`SessionState`-per-process model, but makes many project-bound instances safer and visible through:

- instance identity
- global file-backed registry
- runtime-root ownership leases
- periodic heartbeats
- read-only HTTP introspection endpoints

## What changed

- adds `m1nd-mcp/src/instance_registry.rs`
- extends `McpConfig` and CLI with `runtime_dir` / `registry_dir`
- acquires per-runtime leases during `SessionState::initialize`
- persists and heartbeats instance metadata during stdio and HTTP runtime paths
- adds `/api/instance/self` and `/api/instances`
- disables the old stdio auto-GUI double-instantiation path in favor of the safe `--serve --stdio` model
- adds grounding docs for the command center and tray path

## Verification

- `cargo fmt --all`
- `cargo test -p m1nd-mcp --lib --tests`

## Scope notes

This is intentionally Phase 1 only.

In scope:
- registry
- lease ownership
- heartbeat
- self/list introspection

Out of scope:
- tray app
- destructive lifecycle controls
- supervisor daemon
- full command-center UI

## Risks

- `workspace_root` is still inferred from snapshot placement rather than an explicit project root
- `spawn_background()` is now safer, but the richer multi-instance UX still needs the next UI/control-plane pass
