### PR TITLE
runtime: cap MCP responses and isolate stdio sessions

### DIFF
--- a/docs/IDE-INTEGRATIONS.md
+++ b/docs/IDE-INTEGRATIONS.md
@@ -52,6 +52,21 @@ M1ND_GRAPH_SOURCE = "/tmp/m1nd-graph.json"
 M1ND_PLASTICITY_STATE = "/tmp/m1nd-plasticity.json"
 ```
 
+If an editor may open several stdio sessions for the same workspace, use the
+session wrapper so each client process gets its own runtime directory instead
+of competing for one persisted graph lock:
+
+```toml
+[mcp_servers.m1nd]
+command = "/path/to/m1nd/scripts/macos/m1nd-stdio-session.sh"
+
+[mcp_servers.m1nd.env]
+M1ND_MCP_BINARY = "/path/to/m1nd-mcp"
+M1ND_WORKSPACE = "/path/to/project"
+M1ND_RUNTIME_BASE = "/Users/you/.m1nd/runtimes"
+M1ND_RUNTIME_RETENTION_DAYS = "1"
+```
+
 But some editor hosts still pay too much overhead if they cold-start a stdio MCP
 server for every interaction.
 

--- a/m1nd-ingest/src/lib.rs
+++ b/m1nd-ingest/src/lib.rs
@@ -120,6 +120,10 @@ impl Default for IngestConfig {
                 "dist".into(),
                 "build".into(),
                 ".next".into(),
+                ".turbo".into(),
+                ".m1nd-runtime".into(),
+                ".m1nd-runtime-ila".into(),
+                ".m1nd-runtimes".into(),
                 "vendor".into(),
             ],
             skip_files: vec![
@@ -127,6 +131,17 @@ impl Default for IngestConfig {
                 "yarn.lock".into(),
                 "Cargo.lock".into(),
                 "poetry.lock".into(),
+                "plasticity_state.json".into(),
+                "graph_snapshot.json".into(),
+                "ingest_roots.json".into(),
+                "auto_ingest_state.json".into(),
+                "auto_ingest_events.jsonl".into(),
+                "daemon_state.json".into(),
+                "daemon_alerts.json".into(),
+                "boot_memory_state.json".into(),
+                "document_cache_index.json".into(),
+                "tremor_state.json".into(),
+                "trust_state.json".into(),
             ],
             parallelism: std::thread::available_parallelism()
                 .map(|p| p.get().min(16))
@@ -429,6 +444,35 @@ mod tests {
         assert!(!is_valid_external_id("file::   "));
         assert!(is_valid_external_id("cargo::workspace::Cargo.toml"));
         assert!(is_valid_external_id("file::src/main.rs"));
+    }
+
+    #[test]
+    fn default_ingest_config_skips_runtime_state_artifacts() {
+        let config = IngestConfig::default();
+
+        for skipped_dir in [
+            ".m1nd-runtime",
+            ".m1nd-runtime-ila",
+            ".m1nd-runtimes",
+            ".turbo",
+        ] {
+            assert!(
+                config.skip_dirs.iter().any(|entry| entry == skipped_dir),
+                "default skip dirs should include {skipped_dir}"
+            );
+        }
+
+        for skipped_file in [
+            "plasticity_state.json",
+            "graph_snapshot.json",
+            "auto_ingest_state.json",
+            "daemon_state.json",
+        ] {
+            assert!(
+                config.skip_files.iter().any(|entry| entry == skipped_file),
+                "default skip files should include {skipped_file}"
+            );
+        }
     }
 
     #[test]

--- a/m1nd-ingest/src/universal_adapter.rs
+++ b/m1nd-ingest/src/universal_adapter.rs
@@ -378,16 +378,48 @@ if text:
 
 fn collect_candidate_files(root: &Path) -> Vec<PathBuf> {
     if root.is_file() {
-        return vec![root.to_path_buf()];
+        return (!is_universal_noise_path(root))
+            .then(|| root.to_path_buf())
+            .into_iter()
+            .collect();
     }
 
     WalkDir::new(root)
         .follow_links(true)
         .into_iter()
+        .filter_entry(|entry| !is_universal_noise_path(entry.path()))
         .filter_map(Result::ok)
         .filter(|entry| entry.file_type().is_file())
         .map(|entry| entry.into_path())
         .collect()
+}
+
+fn is_universal_noise_path(path: &Path) -> bool {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    name == "node_modules"
+        || name == "target"
+        || name == "dist"
+        || name == "build"
+        || name == ".next"
+        || name == ".turbo"
+        || name.starts_with(".m1nd-runtime")
+        || matches!(
+            name,
+            "plasticity_state.json"
+                | "graph_snapshot.json"
+                | "ingest_roots.json"
+                | "auto_ingest_state.json"
+                | "auto_ingest_events.jsonl"
+                | "daemon_state.json"
+                | "daemon_alerts.json"
+                | "boot_memory_state.json"
+                | "document_cache_index.json"
+                | "tremor_state.json"
+                | "trust_state.json"
+        )
 }
 
 fn slugify(raw: &str) -> String {
@@ -1414,6 +1446,16 @@ mod tests {
         let graph = graphify_documents(&[doc], "universal").unwrap();
         assert!(graph.num_nodes() >= 6);
         assert!(graph.num_edges() >= 5);
+    }
+
+    #[test]
+    fn universal_candidate_filter_skips_runtime_state_artifacts() {
+        assert!(is_universal_noise_path(Path::new("/tmp/node_modules")));
+        assert!(is_universal_noise_path(Path::new("/tmp/.m1nd-runtime-ila")));
+        assert!(is_universal_noise_path(Path::new(
+            "/tmp/plasticity_state.json"
+        )));
+        assert!(!is_universal_noise_path(Path::new("/tmp/docs/notes.md")));
     }
 
     #[test]

--- a/m1nd-mcp/src/audit_handlers.rs
+++ b/m1nd-mcp/src/audit_handlers.rs
@@ -2910,6 +2910,25 @@ pub fn handle_audit(
         return Ok(report);
     }
 
+    let report_summary = json!({
+        "identity": report.get("identity").cloned().unwrap_or(json!({})),
+        "inventory": {
+            "file_count": inventory.len(),
+            "kind_breakdown": inventory_breakdown(&inventory_entries),
+        },
+        "topology": {
+            "nodes": health.node_count,
+            "edges": health.edge_count,
+            "critical_alert_count": report
+                .pointer("/topology/critical_alerts")
+                .and_then(|value| value.as_array())
+                .map_or(0, |value| value.len()),
+        },
+        "health_grades": health_grades,
+        "recommendations": recommendations,
+        "elapsed_ms": report.get("elapsed_ms").cloned().unwrap_or(json!(0.0)),
+    });
+
     let markdown = format!(
         "# m1nd Audit\n\n- Profile: `{}`\n- Nodes: `{}`\n- Edges: `{}`\n- Critical modules: `{}`\n- Orphan nodes: `{}`\n- Scan findings: `{}`\n- Stale confidence: `{:.2}`\n",
         effective_profile,
@@ -2931,7 +2950,7 @@ pub fn handle_audit(
         "report_markdown": report_markdown,
         "truncated": truncated,
         "inline_summary": inline_summary,
-        "report": report,
+        "report_summary": report_summary,
     }))
 }
 
@@ -3086,6 +3105,39 @@ mod tests {
 
         assert_eq!(output["identity"]["profile"], "coordination");
         assert!(output["inventory"]["files"].as_array().is_some());
+    }
+
+    #[test]
+    fn audit_markdown_returns_summary_without_full_json_report() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        std::fs::create_dir_all(root.join("src")).expect("src dir");
+        std::fs::write(root.join("src/lib.rs"), "pub fn hello() {}\n").expect("source");
+        std::fs::write(root.join("README.md"), "# demo\n").expect("readme");
+
+        let mut state = build_empty_state(root);
+        let output = handle_audit(
+            &mut state,
+            layers::AuditInput {
+                agent_id: "test".into(),
+                path: root.to_string_lossy().to_string(),
+                profile: "production".into(),
+                depth: "quick".into(),
+                cross_verify: true,
+                include_git: false,
+                include_config: false,
+                scan_patterns: "default".into(),
+                external_refs: false,
+                report_format: "markdown".into(),
+                max_output_chars: Some(20_000),
+            },
+        )
+        .expect("audit");
+
+        assert_eq!(output["report_format"], "markdown");
+        assert!(output.get("report").is_none());
+        assert!(output["report_summary"]["inventory"]["file_count"].is_u64());
+        assert!(output["report_summary"]["identity"].is_object());
     }
 
     #[test]

--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -279,6 +279,27 @@ impl AutoIngestState {
             || name.ends_with(".swp")
             || name.ends_with(".tmp")
             || name == ".DS_Store"
+            || name == "node_modules"
+            || name == "target"
+            || name == "dist"
+            || name == "build"
+            || name == ".next"
+            || name == ".turbo"
+            || name.starts_with(".m1nd-runtime")
+            || matches!(
+                name,
+                "plasticity_state.json"
+                    | "graph_snapshot.json"
+                    | "ingest_roots.json"
+                    | "auto_ingest_state.json"
+                    | "auto_ingest_events.jsonl"
+                    | "daemon_state.json"
+                    | "daemon_alerts.json"
+                    | "boot_memory_state.json"
+                    | "document_cache_index.json"
+                    | "tremor_state.json"
+                    | "trust_state.json"
+            )
             || name.starts_with(".#")
             || name.starts_with("4913")
     }
@@ -980,6 +1001,15 @@ mod tests {
             "/tmp/file.md.swp"
         )));
         assert!(AutoIngestState::is_noise_path(Path::new("/tmp/.DS_Store")));
+        assert!(AutoIngestState::is_noise_path(Path::new(
+            "/tmp/node_modules"
+        )));
+        assert!(AutoIngestState::is_noise_path(Path::new(
+            "/tmp/.m1nd-runtime-ila"
+        )));
+        assert!(AutoIngestState::is_noise_path(Path::new(
+            "/tmp/plasticity_state.json"
+        )));
         assert!(!AutoIngestState::is_noise_path(Path::new("/tmp/notes.md")));
     }
 

--- a/m1nd-mcp/src/search_handlers.rs
+++ b/m1nd-mcp/src/search_handlers.rs
@@ -20,6 +20,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+const DEFAULT_MAX_SEARCH_FILE_BYTES: u64 = 2_000_000;
+
 type GuidedRuntimeTuple = (
     String,
     Option<String>,
@@ -970,6 +972,9 @@ fn collect_graph_files(
         let ext_id = graph.strings.resolve(*interned);
         if ext_id.starts_with("file::") {
             let path = ext_id.strip_prefix("file::").unwrap_or(ext_id);
+            if should_skip_disk_file(Path::new(path)) {
+                continue;
+            }
             // Only take file-level nodes (no ::fn:: or ::class:: sub-nodes)
             if !path.contains("::") && seen_set.insert(path.to_string()) {
                 // Apply scope filter
@@ -1136,6 +1141,10 @@ fn build_disk_fallback_candidate(
         }
     }
 
+    if should_skip_disk_file(full_path) || is_oversized_search_file(full_path) {
+        return None;
+    }
+
     Some(SearchFileCandidate {
         rel_path,
         full_path: full_path.to_path_buf(),
@@ -1183,9 +1192,45 @@ fn should_skip_disk_dir(path: &Path) -> bool {
             | Some("target")
             | Some("dist")
             | Some("build")
+            | Some(".next")
+            | Some(".turbo")
+            | Some(".m1nd-runtime")
+            | Some(".m1nd-runtime-ila")
+            | Some(".m1nd-runtimes")
             | Some(".vault")
             | Some(".roomanizer")
     )
+}
+
+fn should_skip_disk_file(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some("plasticity_state.json")
+            | Some("graph_snapshot.json")
+            | Some("ingest_roots.json")
+            | Some("auto_ingest_state.json")
+            | Some("auto_ingest_events.jsonl")
+            | Some("daemon_state.json")
+            | Some("daemon_alerts.json")
+            | Some("boot_memory_state.json")
+            | Some("document_cache_index.json")
+            | Some("tremor_state.json")
+            | Some("trust_state.json")
+    )
+}
+
+fn max_search_file_bytes() -> u64 {
+    std::env::var("M1ND_SEARCH_MAX_FILE_BYTES")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MAX_SEARCH_FILE_BYTES)
+        .max(64 * 1024)
+}
+
+fn is_oversized_search_file(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len() > max_search_file_bytes())
+        .unwrap_or(false)
 }
 
 fn rank_search_results(query: &str, mode: SearchRankingMode, results: &mut Vec<SearchResultEntry>) {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -95,6 +95,112 @@ enum TransportMode {
     Line,
 }
 
+const DEFAULT_RESPONSE_LIMIT_CHARS: usize = 96_000;
+const DEFAULT_RESPONSE_HARD_LIMIT_CHARS: usize = 256_000;
+
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+}
+
+fn response_limit_chars() -> usize {
+    let hard = env_usize("M1ND_MCP_RESPONSE_HARD_LIMIT_CHARS")
+        .unwrap_or(DEFAULT_RESPONSE_HARD_LIMIT_CHARS)
+        .max(4_096);
+    env_usize("M1ND_MCP_RESPONSE_LIMIT_CHARS")
+        .unwrap_or(DEFAULT_RESPONSE_LIMIT_CHARS)
+        .clamp(4_096, hard)
+}
+
+fn safe_prefix(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn compact_tool_text_payload(text: &str, limit: usize, original_response_bytes: usize) -> String {
+    let original_chars = text.chars().count();
+    let preview_chars = (limit / 4).clamp(512, 16_384);
+    let preview = safe_prefix(text, preview_chars);
+    serde_json::to_string_pretty(&serde_json::json!({
+        "m1nd_output_truncated": true,
+        "original_chars": original_chars,
+        "original_response_bytes": original_response_bytes,
+        "returned_preview_chars": preview.chars().count(),
+        "hint": "The MCP response exceeded the local transport safety cap. Narrow scope/top_k or set max_output_chars for a smaller structured result.",
+        "preview": preview,
+    }))
+    .unwrap_or_else(|_| "{\"m1nd_output_truncated\":true}".to_string())
+}
+
+fn compact_tool_response(
+    response: &JsonRpcResponse,
+    limit: usize,
+    original_response_bytes: usize,
+) -> Option<JsonRpcResponse> {
+    let mut shaped = response.clone();
+    let result = shaped.result.as_mut()?.as_object_mut()?;
+    let content = result.get_mut("content")?.as_array_mut()?;
+
+    for item in content.iter_mut() {
+        let Some(item_obj) = item.as_object_mut() else {
+            continue;
+        };
+        let Some(text_value) = item_obj.get_mut("text") else {
+            continue;
+        };
+        let Some(text) = text_value.as_str() else {
+            continue;
+        };
+        *text_value = serde_json::Value::String(compact_tool_text_payload(
+            text,
+            limit,
+            original_response_bytes,
+        ));
+        return Some(shaped);
+    }
+
+    None
+}
+
+fn fallback_compacted_response(
+    response: &JsonRpcResponse,
+    original_response_bytes: usize,
+) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: response.jsonrpc.clone(),
+        id: response.id.clone(),
+        result: Some(serde_json::json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string_pretty(&serde_json::json!({
+                    "m1nd_output_truncated": true,
+                    "original_response_bytes": original_response_bytes,
+                    "hint": "The MCP response exceeded the local transport safety cap and had no compactable text payload."
+                })).unwrap_or_else(|_| "{\"m1nd_output_truncated\":true}".to_string())
+            }]
+        })),
+        error: None,
+    }
+}
+
+fn serialize_response_safely(response: &JsonRpcResponse) -> String {
+    let json = serde_json::to_string(response).unwrap_or_default();
+    let limit = response_limit_chars();
+    if json.len() <= limit {
+        return json;
+    }
+
+    let shaped = compact_tool_response(response, limit, json.len())
+        .unwrap_or_else(|| fallback_compacted_response(response, json.len()));
+    let shaped_json = serde_json::to_string(&shaped).unwrap_or_default();
+    if shaped_json.len() <= limit {
+        shaped_json
+    } else {
+        let fallback = fallback_compacted_response(response, json.len());
+        serde_json::to_string(&fallback).unwrap_or_default()
+    }
+}
+
 fn read_request_payload<R: BufRead>(
     reader: &mut R,
 ) -> std::io::Result<Option<(String, TransportMode)>> {
@@ -159,7 +265,7 @@ fn write_response<W: Write>(
     response: &JsonRpcResponse,
     mode: TransportMode,
 ) -> std::io::Result<()> {
-    let json = serde_json::to_string(response).unwrap_or_default();
+    let json = serialize_response_safely(response);
     match mode {
         TransportMode::Framed => {
             write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)?;
@@ -3150,9 +3256,10 @@ impl McpServer {
 #[cfg(test)]
 mod tests {
     use super::{
-        background_tick_if_due, daemon_wait_duration_ms, run_daemon_tick, should_autotick_daemon,
-        tool_schemas, DaemonRuntimeControl, McpServer,
+        background_tick_if_due, compact_tool_response, daemon_wait_duration_ms, run_daemon_tick,
+        should_autotick_daemon, tool_schemas, DaemonRuntimeControl, McpServer,
     };
+    use crate::protocol::JsonRpcResponse;
     use crate::server::McpConfig;
     use crate::session::SessionState;
     use m1nd_core::domain::DomainConfig;
@@ -3224,6 +3331,30 @@ mod tests {
                 "tool_schemas should expose {expected}"
             );
         }
+    }
+
+    #[test]
+    fn oversized_tool_response_is_compacted_before_transport() {
+        let response = JsonRpcResponse {
+            jsonrpc: "2.0".into(),
+            id: serde_json::json!(42),
+            result: Some(serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": "x".repeat(50_000),
+                }]
+            })),
+            error: None,
+        };
+
+        let original = serde_json::to_string(&response).expect("response json");
+        let compacted =
+            compact_tool_response(&response, 12_000, original.len()).expect("compacted response");
+        let encoded = serde_json::to_string(&compacted).expect("compacted json");
+        assert!(encoded.len() < 12_000);
+        assert!(encoded.contains("m1nd_output_truncated"));
+        assert!(encoded.contains("original_response_bytes"));
+        assert!(encoded.contains("returned_preview_chars"));
     }
 
     #[test]

--- a/scripts/macos/m1nd-stdio-session.sh
+++ b/scripts/macos/m1nd-stdio-session.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary="${M1ND_MCP_BINARY:-m1nd-mcp}"
+workspace="${M1ND_WORKSPACE:-${PWD}}"
+runtime_base="${M1ND_RUNTIME_BASE:-${HOME}/.m1nd/runtimes}"
+workspace_id="${M1ND_WORKSPACE_ID:-$(printf '%s' "${workspace}" | shasum -a 256 | awk '{print substr($1, 1, 12)}')}"
+session_id="${M1ND_INSTANCE_ID:-ppid-${PPID:-0}-pid-$$}"
+runtime_dir="${M1ND_RUNTIME_DIR:-${runtime_base}/${workspace_id}/sessions/${session_id}}"
+retention_days="${M1ND_RUNTIME_RETENTION_DAYS:-1}"
+
+mkdir -p "${runtime_dir}"
+
+expired_dir="${runtime_base}/_expired/${workspace_id}-$(date +%Y%m%d-%H%M%S)"
+sessions_dir="${runtime_base}/${workspace_id}/sessions"
+if [ -d "${sessions_dir}" ]; then
+  while IFS= read -r -d '' expired_path; do
+    mkdir -p "${expired_dir}"
+    mv "${expired_path}" "${expired_dir}/"
+  done < <(find "${sessions_dir}" -mindepth 1 -maxdepth 1 -mtime +"${retention_days}" -print0 2>/dev/null)
+fi
+
+cd "${runtime_dir}"
+exec "${binary}" \
+  --stdio \
+  --no-gui \
+  --graph "${runtime_dir}/graph_snapshot.json" \
+  --plasticity "${runtime_dir}/plasticity_state.json" \
+  "$@"


### PR DESCRIPTION
What changed:
- Adds a transport-level cap for oversized MCP text responses.
- Keeps markdown audit responses compact by returning a summary instead of embedding the full report JSON.
- Filters m1nd runtime artifacts from ingest, universal document ingest, auto-ingest, and disk search.
- Adds a session-isolated stdio wrapper for clients that open concurrent workspace sessions.

Why it matters:
Large audit/search payloads can overload MCP clients and chat transcripts. Concurrent stdio clients can also collide when they share one persisted runtime root.

Verification:
- bash -n scripts/macos/m1nd-stdio-session.sh
- cargo test -p m1nd-mcp -p m1nd-ingest
- two wrapper health probes in parallel

Known limits:
Persistent HTTP deployment was not separately smoke-tested with the new response cap.