### PR TITLE
npm: expose smoke command for install verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The fastest way to see the agent-first loop is to run the local demo transcript:
 
 ```bash
 cargo build -p m1nd-mcp
-python3 scripts/m1nd_agent_demo.py --repo . --transport stdio
+m1nd smoke --repo . --transport stdio
 ```
 
 It starts the MCP server, checks `trust_selftest`, ingests the repo, runs
@@ -233,7 +233,7 @@ retrieval, asks for help, calls `doctor`, and verifies that an empty retrieval
 returns a recovery path. The JSON mode is useful for CI or client onboarding:
 
 ```bash
-python3 scripts/m1nd_agent_demo.py --repo . --transport stdio --json
+m1nd smoke --repo . --transport stdio --json
 ```
 
 See [docs/AGENT-FIRST-DEMO.md](docs/AGENT-FIRST-DEMO.md) for the transcript

--- a/docs/AGENT-FIRST-DEMO.md
+++ b/docs/AGENT-FIRST-DEMO.md
@@ -16,19 +16,19 @@ From the repo root:
 
 ```bash
 cargo build -p m1nd-mcp
-python3 scripts/m1nd_agent_demo.py --repo . --transport stdio
+m1nd smoke --repo . --transport stdio
 ```
 
 For the HTTP tool API:
 
 ```bash
-python3 scripts/m1nd_agent_demo.py --repo . --transport http
+m1nd smoke --repo . --transport http
 ```
 
 For machine-readable output:
 
 ```bash
-python3 scripts/m1nd_agent_demo.py --repo . --transport stdio --json
+m1nd smoke --repo . --transport stdio --json
 ```
 
 ## What It Shows

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -20,6 +20,7 @@ Usage:
   m1nd mcp-config <host> [--binary <path>]
   m1nd doctor [--json]
   m1nd demo [--repo <dir>] [--transport stdio|http] [--json]
+  m1nd smoke [--repo <dir>] [--transport stdio|http] [--json]
   m1nd pack-check [--json]
 
 This npm package installs the universal agent doctrine and host adapters. The
@@ -35,7 +36,7 @@ function parseArgs(args) {
       continue;
     }
     const key = arg.slice(2);
-    if (["json", "yes"].includes(key)) {
+    if (["help", "json", "yes"].includes(key)) {
       parsed[key] = true;
       continue;
     }
@@ -219,7 +220,7 @@ function doctor() {
       default_install_path: defaultRuntimePath(),
       visible_on_path_or_env: Boolean(binary),
       hint: binary
-        ? "m1nd-mcp is visible. Use m1nd demo from a repo checkout for a live MCP smoke."
+        ? "m1nd-mcp is visible. Use m1nd smoke from a repo checkout for a live MCP smoke."
         : "m1nd-mcp is not visible. Build from source or install the native runtime before wiring MCP hosts.",
     },
     codex: {
@@ -291,7 +292,7 @@ async function main(rawArgs) {
   const args = parseArgs(rawArgs);
   const command = args._[0] || "help";
 
-  if (["help", "-h", "--help"].includes(command)) {
+  if (args.help || ["help", "-h", "--help"].includes(command)) {
     console.log(usage());
     return;
   }
@@ -325,7 +326,7 @@ async function main(rawArgs) {
     return;
   }
 
-  if (command === "demo") {
+  if (["demo", "smoke"].includes(command)) {
     runDemo(args);
     return;
   }

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -1,12 +1,16 @@
 "use strict";
 
 const assert = require("assert");
+const path = require("path");
+const { spawnSync } = require("child_process");
 
 const {
   defaultRuntimePath,
   mcpConfig,
   runtimeBinaryName,
 } = require("../lib/cli");
+
+const cli = path.resolve(__dirname, "../bin/m1nd.js");
 
 assert.strictEqual(runtimeBinaryName("win32"), "m1nd-mcp.exe");
 assert.strictEqual(runtimeBinaryName("darwin"), "m1nd-mcp");
@@ -32,5 +36,14 @@ assert.strictEqual(
   "C:\\Users\\you\\.m1nd\\bin\\m1nd-mcp.exe"
 );
 assert.deepStrictEqual(genericWindowsConfig.mcpServers.m1nd.args, ["--stdio", "--no-gui"]);
+
+const help = spawnSync(process.execPath, [cli, "--help"], { encoding: "utf8" });
+assert.strictEqual(help.status, 0, help.stderr);
+assert(help.stdout.includes("m1nd installer"));
+assert(help.stdout.includes("m1nd smoke"));
+
+const packCheck = spawnSync(process.execPath, [cli, "pack-check", "--json"], { encoding: "utf8" });
+assert.strictEqual(packCheck.status, 0, packCheck.stderr);
+assert.strictEqual(JSON.parse(packCheck.stdout).schema, "m1nd-agent-pack-check-v0");
 
 console.log("npm cli tests ok");


### PR DESCRIPTION
## What changed

- Fixes npm CLI parsing so `m1nd --help` works from a fresh install.
- Adds `m1nd smoke` as the public alias for the agent-first demo path.
- Updates README and demo docs to use the install-level smoke command.
- Adds CLI regression coverage for `--help` and `pack-check --json`.

## Why it matters

A fresh npm install should be able to answer two questions immediately: is the agent pack present, and can this checkout prove the MCP trust loop when a native runtime is available. This makes the installer easier to trust without changing the native runtime boundary.

## Verification

- `npm test`
- `git diff --check`
- Local isolated npm pack/install in `/tmp`, including `m1nd --help`, `pack-check`, `doctor`, `install-skills generic`, and `m1nd smoke` over stdio/http with `full_trust`
- Genesis Ubuntu isolated npm pack/install in `/tmp`, isolated Rust toolchain/runtime build, and `m1nd smoke` over stdio/http with `full_trust`

## Known limits

- This does not publish the npm package.
- This does not bundle the native runtime into npm; `m1nd-mcp` remains the runtime boundary.
