### PR TITLE
npm: prepare 0.9 beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ For graph-native semantic docs, use `adapter: "light"` instead.
 from Codex, Claude, Gemini, Antigravity, Cursor, Cline, Roo, Continue, OpenCode,
 and other MCP-capable hosts.
 
+Install the beta agent pack:
+
+```bash
+npm install -g @m1nd/m1nd@beta
+m1nd doctor
+m1nd pack-check
+```
+
 From a source checkout:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m1nd/m1nd",
-  "version": "0.8.0",
+  "version": "0.9.0-beta.0",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What changed

- Bumps the npm package to `0.9.0-beta.0`.
- Adds public beta install instructions for `@m1nd/m1nd@beta`.

## Why it matters

This prepares the first npm beta path for the universal agent pack and installer diagnostics, while keeping the native runtime boundary explicit.

## Verification

- `npm test`
- `git diff --check`
- Isolated `npm pack` tarball install in `/tmp`
- Installed tarball `m1nd --help`, `pack-check --json`, `doctor --json`, and `install-skills generic`
- `npm publish --dry-run --access public --tag beta --json`

## Publish command

After npm auth is available:

```bash
npm publish --access public --tag beta
```

## Known limits

- Not published yet from this machine because npm auth is not configured.
- The package does not bundle the native runtime; `m1nd-mcp` remains the runtime boundary.
