### PR TITLE
npm: publish beta under the m1nd package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ and other MCP-capable hosts.
 Install the beta agent pack:
 
 ```bash
-npm install -g @m1nd/m1nd@beta
+npm install -g m1nd@beta
 m1nd doctor
 m1nd pack-check
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@m1nd/m1nd",
+  "name": "m1nd",
   "version": "0.9.0-beta.0",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",


### PR DESCRIPTION
## What changed

- Switches the npm package name from `@m1nd/m1nd` to `m1nd`.
- Updates beta install docs to use `npm install -g m1nd@beta`.

## Why it matters

The `@m1nd` npm scope is not available to this npm account, while the direct `m1nd` package name is available and gives users the cleanest install path.

## Verification

- `npm test`
- Isolated `npm pack` tarball install in `/tmp`
- Installed tarball `m1nd --help`, `pack-check --json`, `doctor --json`, and `install-skills generic`
- `npm publish --dry-run --access public --tag beta --json`

## Publish command

```bash
npm publish --access public --tag beta --otp <code>
```
