### PR TITLE
npm: publish beta under the maxkle1nz scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ and other MCP-capable hosts.
 Install the beta agent pack:
 
 ```bash
-npm install -g m1nd@beta
+npm install -g @maxkle1nz/m1nd@beta
 m1nd doctor
 m1nd pack-check
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "m1nd",
+  "name": "@maxkle1nz/m1nd",
   "version": "0.9.0-beta.0",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,6 +21,6 @@ m1nd install-skills generic --project /path/to/project
 For a published package, the same flow becomes:
 
 ```bash
-npm install -g @m1nd/m1nd
+npm install -g @maxkle1nz/m1nd@beta
 m1nd init --host codex
 ```


### PR DESCRIPTION
## What changed

- Publish the beta package under the account-owned npm scope `@maxkle1nz/m1nd`.
- Update README and packaged skill install instructions to use `npm install -g @maxkle1nz/m1nd@beta`.

## Why

The unscoped `m1nd` package name is blocked by npm's name-similarity policy, and the `@m1nd` npm scope is not available to this account yet. This keeps the 0.9 beta shippable without changing the CLI binary name: users still run `m1nd` after install.

## Verification

- `npm test`
- `npm pack` into an isolated temp directory
- isolated global install from the packed tarball
- installed `m1nd --help`
- installed `m1nd pack-check --json`
- installed `m1nd doctor --json`
- installed `m1nd install-skills generic --project <tmp> --json`
- `npm publish --dry-run --access public --tag beta --json`
- `git diff --check`

## Known limits

This does not claim the branded `@m1nd/m1nd` package name. That can be added later after the npm `@m1nd` scope exists and is controlled by the project.
