### PR TITLE
runtime: align native crate versions with the 0.9 beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "0.8.0"
+version = "0.9.0-beta.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "0.8.0"
+version = "0.9.0-beta.0"
 dependencies = [
  "cargo_metadata",
  "m1nd-core",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "0.8.0"
+version = "0.9.0-beta.0"
 dependencies = [
  "axum",
  "clap",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://github.com/maxkle1nz/m1nd/actions"><img src="https://github.com/maxkle1nz/m1nd/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://docs.rs/m1nd-core"><img src="https://img.shields.io/docsrs/m1nd-core" alt="docs.rs" /></a>
-  <a href="https://github.com/maxkle1nz/m1nd/releases"><img src="https://img.shields.io/badge/release-v0.8.0-00f5ff" alt="Release" /></a>
+  <a href="https://github.com/maxkle1nz/m1nd/releases"><img src="https://img.shields.io/badge/release-v0.9.0--beta.0-00f5ff" alt="Release" /></a>
 </p>
 
 <p align="center">
@@ -324,9 +324,9 @@ The workspace is split into three core crates plus one auxiliary bridge crate:
 
 Current crate versions:
 
-- `m1nd-core` `0.8.0`
-- `m1nd-ingest` `0.8.0`
-- `m1nd-mcp` `0.8.0`
+- `m1nd-core` `0.9.0-beta.0`
+- `m1nd-ingest` `0.9.0-beta.0`
+- `m1nd-mcp` `0.9.0-beta.0`
 
 <p align="center">
   <img src=".github/m1nd-architecture-overview-v2.jpeg" alt="m1nd architecture overview" width="960" />

--- a/docs/internal/JIMI_GUARDIAN_CONTEXT_2026-05-05.md
+++ b/docs/internal/JIMI_GUARDIAN_CONTEXT_2026-05-05.md
@@ -10,13 +10,15 @@ It is an internal operating note, not public product copy.
 - First guardian commit on this branch: `27c549b docs(readme): show how m1nd preserves agent continuity`
 - Public README change: added a concise continuity quote and a short agent testimonial.
 - m1nd graph re-ingest on the active checkout succeeded.
+- 2026-05-06 update: the npm/package line is `0.9.0-beta.0`, and the native
+  `m1nd-mcp` crate/bin version string was aligned to `0.9.0-beta.0`.
 
 ## Verified Gates
 
 - `cargo fmt --check`: pass
 - `cargo check -p m1nd-mcp -p m1nd-ingest`: pass
 - `cargo test -p m1nd-mcp help -- --nocapture`: pass
-- Local stdio smoke:
+- Historical local stdio smoke from this 2026-05-05 note:
   - server version: `0.8.0`
   - live tool count from `tools/list`: `92`
   - includes `ingest`, `seek`, and `help`

--- a/docs/wiki/src/api-reference/overview.md
+++ b/docs/wiki/src/api-reference/overview.md
@@ -233,7 +233,7 @@ Response:
   "id": 0,
   "result": {
     "protocolVersion": "2024-11-05",
-    "serverInfo": { "name": "m1nd-mcp", "version": "0.8.0" },
+    "serverInfo": { "name": "m1nd-mcp", "version": "0.9.0-beta.0" },
     "capabilities": { "tools": {} }
   }
 }

--- a/docs/wiki/src/changelog.md
+++ b/docs/wiki/src/changelog.md
@@ -6,7 +6,10 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
-The next release train starts here.
+### Fixed
+
+- Aligned the Rust crate versions and `m1nd-mcp --version` output with the
+  `0.9.0-beta.0` npm/package line.
 
 ---
 

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "0.8.0"
+version = "0.9.0-beta.0"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "0.8.0"
+version = "0.9.0-beta.0"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -41,7 +41,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "0.8.0" }
+m1nd-core = { path = "../m1nd-core", version = "0.9.0-beta.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "0.8.0"
+version = "0.9.0-beta.0"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -11,8 +11,8 @@ default = ["serve"]
 serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:tokio-stream", "dep:futures", "dep:reqwest"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "0.8.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "0.8.0" }
+m1nd-core = { path = "../m1nd-core", version = "0.9.0-beta.0" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "0.9.0-beta.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }


### PR DESCRIPTION
## What changed

- Bumped the native Rust crate line for `m1nd-core`, `m1nd-ingest`, and `m1nd-mcp` to `0.9.0-beta.0`.
- Updated the lockfile and public docs that showed the MCP server version.
- Added a changelog note for the version-alignment fix.
- Updated the internal Jimi context note so agents do not repeat the old `0.8.0` runtime claim as current truth.

## Why

The npm/agent-pack release was already published as `0.9.0-beta.0`, but the native `m1nd-mcp` crate still reported `0.8.0`. That made healthy refreshed runtimes look stale to agents checking `m1nd-mcp --version`.

## Verification

- `cargo check -p m1nd-mcp`
- `cargo build -p m1nd-mcp`
- `cargo test -p m1nd-mcp`
- `cargo test --workspace`
- `npm test`
- `python3 scripts/mcp_agent_smoke.py --repo /Users/kle1nz/m1nd --binary /usr/local/bin/m1nd-mcp --handshake-only --handshake-probe --json`
- `python3 scripts/mcp_agent_smoke.py --repo /Users/kle1nz/samba-builder-research --binary /usr/local/bin/m1nd-mcp --handshake-only --handshake-probe --json`
- `git diff --check`

## Known limits

This does not republish the already-published npm tarball. It aligns the repo, native crates, docs, and installed local runtime binaries for the next source/native build.
