### PR TITLE
runtime: generalize workspace recovery across agent hosts

### DIFF
--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -366,6 +366,61 @@ pub struct SessionState {
     pub document_cache: DocumentCacheState,
 }
 
+const WORKSPACE_ROOT_ENV_CANDIDATES: &[&str] = &[
+    // Host-neutral contract. Any MCP host can set one of these.
+    "M1ND_WORKSPACE_ROOT",
+    "M1ND_PROJECT_ROOT",
+    "M1ND_REPO_ROOT",
+    "WORKSPACE_ROOT",
+    "PROJECT_ROOT",
+    "REPO_ROOT",
+    // Known agent/editor host hints. These are opportunistic aliases; the
+    // host-neutral M1ND_* variables above remain the preferred contract.
+    "CLAUDE_PROJECT_DIR",
+    "CLAUDE_WORKSPACE_ROOT",
+    "ANTHROPIC_WORKSPACE_ROOT",
+    "ANTIGRAVITY_WORKSPACE_ROOT",
+    "ANTIGRAVITY_PROJECT_ROOT",
+    "GEMINI_WORKSPACE_ROOT",
+    "GEMINI_PROJECT_ROOT",
+    "CURSOR_WORKSPACE_ROOT",
+    "CURSOR_PROJECT_ROOT",
+    "WINDSURF_WORKSPACE_ROOT",
+    "WINDSURF_PROJECT_ROOT",
+    "VSCODE_WORKSPACE",
+    "VSCODE_CWD",
+    // Package-manager/shell fallbacks. These are intentionally later because
+    // shells can point at transient directories in some hosted runtimes.
+    "INIT_CWD",
+    "OLDPWD",
+    "PWD",
+];
+
+const MANAGED_RUNTIME_PATH_MARKERS: &[&str] = &[
+    "/.codex/m1nd-runtimes/",
+    "\\.codex\\m1nd-runtimes\\",
+    "/.claude/m1nd-runtimes/",
+    "\\.claude\\m1nd-runtimes\\",
+    "/.antigravity/m1nd-runtimes/",
+    "\\.antigravity\\m1nd-runtimes\\",
+    "/.gemini/m1nd-runtimes/",
+    "\\.gemini\\m1nd-runtimes\\",
+    "/.cursor/m1nd-runtimes/",
+    "\\.cursor\\m1nd-runtimes\\",
+    "/.windsurf/m1nd-runtimes/",
+    "\\.windsurf\\m1nd-runtimes\\",
+    "/.m1nd-runtimes/",
+    "\\.m1nd-runtimes\\",
+    "/m1nd-runtimes/",
+    "\\m1nd-runtimes\\",
+    "/mcp-runtimes/",
+    "\\mcp-runtimes\\",
+    "/agent-runtimes/",
+    "\\agent-runtimes\\",
+    "/sessions/ppid-",
+    "\\sessions\\ppid-",
+];
+
 impl SessionState {
     pub fn binding_fingerprint(&self) -> serde_json::Value {
         let graph = self.graph.read();
@@ -575,15 +630,7 @@ impl SessionState {
             return (graph_parent, "graph_path_parent".into());
         }
 
-        for env_name in [
-            "M1ND_WORKSPACE_ROOT",
-            "CODEX_WORKSPACE_ROOT",
-            "CODEX_WORKSPACE",
-            "WORKSPACE_ROOT",
-            "PROJECT_ROOT",
-            "OLDPWD",
-            "PWD",
-        ] {
+        for env_name in WORKSPACE_ROOT_ENV_CANDIDATES {
             let Ok(value) = std::env::var(env_name) else {
                 continue;
             };
@@ -627,10 +674,9 @@ impl SessionState {
             }
         }
         let text = path.to_string_lossy();
-        text.contains("/.codex/m1nd-runtimes/")
-            || text.contains("\\.codex\\m1nd-runtimes\\")
-            || text.contains("/.m1nd-runtimes/")
-            || text.contains("\\.m1nd-runtimes\\")
+        MANAGED_RUNTIME_PATH_MARKERS
+            .iter()
+            .any(|marker| text.contains(marker))
     }
 
     /// Initialize from a loaded graph. Builds all engines.
@@ -1263,7 +1309,7 @@ fn save_json_atomic<T: Serialize>(path: &Path, value: &T) -> M1ndResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::SessionState;
+    use super::{SessionState, WORKSPACE_ROOT_ENV_CANDIDATES};
     use crate::server::McpConfig;
     use m1nd_core::domain::DomainConfig;
     use m1nd_core::graph::Graph;
@@ -1272,6 +1318,35 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn clear_workspace_hints() -> Self {
+            let saved = WORKSPACE_ROOT_ENV_CANDIDATES
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect::<Vec<_>>();
+            for name in WORKSPACE_ROOT_ENV_CANDIDATES {
+                std::env::remove_var(name);
+            }
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.saved {
+                if let Some(value) = value {
+                    std::env::set_var(name, value);
+                } else {
+                    std::env::remove_var(name);
+                }
+            }
+        }
     }
 
     #[test]
@@ -1300,7 +1375,7 @@ mod tests {
     #[test]
     fn workspace_root_uses_env_hint_for_codex_runtime_graph_path() {
         let _guard = env_lock().lock().expect("env lock");
-        let old_workspace = std::env::var("M1ND_WORKSPACE_ROOT").ok();
+        let _env = EnvGuard::clear_workspace_hints();
 
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("project");
@@ -1333,11 +1408,80 @@ mod tests {
             state.workspace_root_source.as_deref(),
             Some("env:M1ND_WORKSPACE_ROOT")
         );
+    }
 
-        if let Some(value) = old_workspace {
-            std::env::set_var("M1ND_WORKSPACE_ROOT", value);
-        } else {
-            std::env::remove_var("M1ND_WORKSPACE_ROOT");
-        }
+    #[test]
+    fn workspace_root_uses_claude_hint_for_managed_runtime_graph_path() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = EnvGuard::clear_workspace_hints();
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("claude-project");
+        let runtime = temp
+            .path()
+            .join(".claude")
+            .join("m1nd-runtimes")
+            .join("hash")
+            .join("sessions")
+            .join("ppid-1-pid-2");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::create_dir_all(&runtime).expect("runtime dir");
+        std::env::set_var("CLAUDE_PROJECT_DIR", &workspace);
+
+        let config = McpConfig {
+            graph_source: runtime.join("graph_snapshot.json"),
+            plasticity_state: runtime.join("plasticity_state.json"),
+            runtime_dir: Some(runtime),
+            ..McpConfig::default()
+        };
+
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("initialize session");
+
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(workspace.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            state.workspace_root_source.as_deref(),
+            Some("env:CLAUDE_PROJECT_DIR")
+        );
+    }
+
+    #[test]
+    fn workspace_root_uses_antigravity_hint_for_generic_agent_runtime_graph_path() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = EnvGuard::clear_workspace_hints();
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("antigravity-project");
+        let runtime = temp
+            .path()
+            .join("agent-runtimes")
+            .join("hash")
+            .join("sessions")
+            .join("ppid-1-pid-2");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::create_dir_all(&runtime).expect("runtime dir");
+        std::env::set_var("ANTIGRAVITY_WORKSPACE_ROOT", &workspace);
+
+        let config = McpConfig {
+            graph_source: runtime.join("graph_snapshot.json"),
+            plasticity_state: runtime.join("plasticity_state.json"),
+            runtime_dir: Some(runtime),
+            ..McpConfig::default()
+        };
+
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("initialize session");
+
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(workspace.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            state.workspace_root_source.as_deref(),
+            Some("env:ANTIGRAVITY_WORKSPACE_ROOT")
+        );
     }
 }

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -57,11 +57,15 @@ host refresh, graph mutation, or retrieval probe happens automatically.
 If the verdict is `needs_ingest`, or `graph_state.node_count` is `0` while
 `ingest` is available, treat it as a recoverable cold graph, not as a reason to
 abandon m1nd. Call `ingest` on the same MCP binding with the absolute path of
-the intended repo/workspace, never a `~/.codex/m1nd-runtimes/...` session path.
-Then rerun `session_handshake` and one cheap retrieval. Fall back to direct
-files only when ingest is unavailable, ingest fails, or a post-ingest retrieval
-still reports `blocked` and `recovery_playbook`/`doctor` confirms stale binding
-or degraded host surface.
+the intended repo/workspace, never a managed runtime/session path such as
+`~/.codex/m1nd-runtimes/...`, `~/.claude/m1nd-runtimes/...`, an Antigravity
+agent runtime, or a generic `mcp-runtimes`/`agent-runtimes` folder. Host
+integrations should prefer `M1ND_WORKSPACE_ROOT`; m1nd also recognizes common
+workspace hints from Claude Code, Antigravity, Gemini, Cursor, Windsurf, VS
+Code, and shell/package-manager env vars. Then rerun `session_handshake` and
+one cheap retrieval. Fall back to direct files only when ingest is unavailable,
+ingest fails, or a post-ingest retrieval still reports `blocked` and
+`recovery_playbook`/`doctor` confirms stale binding or degraded host surface.
 
 If `trust_selftest` is not exposed but `session_handshake` is, call the cheaper
 sub-check:

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -46,10 +46,15 @@ Only skip the `m1nd` first pass when:
   mini `graph_state.node_count` is `0` while `ingest` is available, treat the
   session as a recoverable cold graph. Do not jump straight to shell fallback.
   Call `ingest` on the same MCP binding with the absolute intended
-  repo/workspace path, never a `~/.codex/m1nd-runtimes/...` session path. Then
-  rerun `session_handshake` and one cheap retrieval. Fall back only if ingest is
-  unavailable, ingest fails, or post-ingest retrieval is still blocked and
-  `recovery_playbook`/`doctor` confirms stale binding or degraded host surface.
+  repo/workspace path, never a managed runtime/session path such as
+  `~/.codex/m1nd-runtimes/...`, `~/.claude/m1nd-runtimes/...`, an Antigravity
+  agent runtime, or a generic `mcp-runtimes`/`agent-runtimes` folder. Host
+  integrations should prefer `M1ND_WORKSPACE_ROOT`; m1nd also recognizes common
+  workspace hints from Claude Code, Antigravity, Gemini, Cursor, Windsurf, VS
+  Code, and shell/package-manager env vars. Then rerun `session_handshake` and
+  one cheap retrieval. Fall back only if ingest is unavailable, ingest fails,
+  or post-ingest retrieval is still blocked and `recovery_playbook`/`doctor`
+  confirms stale binding or degraded host surface.
 - If the host exposes `health` but not `trust_selftest`, `session_handshake`, or
   `recovery_playbook`, read `health.tool_surface_contract` and
   `health.host_binding_alignment`. Treat missing required host-visible tools as


### PR DESCRIPTION
## What changed

- Promotes `M1ND_WORKSPACE_ROOT` as the host-neutral workspace recovery contract.
- Adds fallback recognition for common agent/editor workspace hints, including Claude Code, Antigravity, Gemini, Cursor, Windsurf, VS Code, shell, and package-manager env vars.
- Expands managed runtime path detection beyond Codex to avoid mistaking `m1nd-runtimes`, `mcp-runtimes`, `agent-runtimes`, and host-specific session folders for real workspaces.
- Updates the packaged m1nd skills so agents treat cold graphs as recoverable across hosts, not just in Codex.

## Why it matters

The previous cold-session fix correctly handled Codex, but agent hosts can launch MCP servers from their own temporary runtime roots. This keeps the recovery path portable: identify the intended workspace, call `ingest` on that same binding, rerun `session_handshake`, then retrieve.

## Verification

- `cargo test -p m1nd-mcp`
- `cargo check -p m1nd-mcp`
- `npm test`
- Claude-style recovery probe using `CLAUDE_PROJECT_DIR`
- Antigravity-style recovery probe using `ANTIGRAVITY_WORKSPACE_ROOT`
- SAMBA handshake probe via `/usr/local/bin/m1nd-mcp`
- `git diff --check`

## Known limits

- Host integrations should set `M1ND_WORKSPACE_ROOT` for the strongest portable behavior.
- Host-specific env vars are accepted as compatibility aliases, not as a promise that every host sets them today.
- Existing already-open MCP sessions still need restart/rebind to load the new binary.
