### PR TITLE
skills: document transport-closed rebind recovery

### DIFF
--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -36,6 +36,14 @@ Skip the `m1nd` first pass only when:
 
 If `m1nd` does not answer enough, then fall back to shell search, direct file reads, compiler output, tests, logs, and debugger data.
 
+If a tool call fails with `Transport closed`, classify it as a host MCP binding
+failure before m1nd can run. Do not call `doctor`, `recovery_playbook`, or
+`ingest` through that dead binding. Verify the binary with a local smoke, kill
+stale `m1nd-mcp --stdio` processes if you own the host, and restart/rebind the
+agent host or open a fresh thread so the MCP client launches a new transport.
+After rebind, run `trust_selftest` or `session_handshake` before trusting
+retrieval.
+
 For local m1nd repo work, prefer the cheap trust selftest path before a full smoke:
 
 ```bash

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -28,6 +28,13 @@ Only skip the `m1nd` first pass when:
 - Prefer the live MCP surface over stale prose. If tool names, counts, or parameters matter, run the bundled helper from this skill directory: `python3 scripts/probe_m1nd.py tools`.
 - Keep `agent_id` stable within one investigation. Change it only when intentionally starting another role or another concurrent investigation.
 - Ingest first. Re-ingest after code changes, or use incremental ingest for code repos when appropriate.
+- If a m1nd tool call fails with `Transport closed`, treat it as a host MCP
+  transport death, not as a graph, retrieval, or proof-state failure. Recovery
+  tools cannot run through a closed transport. Verify the local binary with the
+  repo smoke harness, kill stale `m1nd-mcp --stdio` processes if you own that
+  host, then restart/rebind the MCP client or open a fresh thread. After the
+  host relaunches the transport, run `trust_selftest` or `session_handshake`
+  before relying on retrieval.
 - If the live MCP surface exposes `trust_selftest`, call it first and route by
   `verdict` before relying on retrieval. `full_trust` means proceed with
   m1nd-first; `needs_ingest` means ingest the intended repo; `orientation_only`


### PR DESCRIPTION
## Summary
- teaches m1nd-first and m1nd-operator that `Transport closed` is a host MCP transport failure before m1nd can run
- directs agents to verify the binary with local smokes, kill stale stdio processes when they own the host, then restart/rebind the MCP client or open a fresh thread
- keeps graph recovery guidance scoped to reachable MCP bindings

## Verification
- git diff --check
- npm test