### PR TITLE
npm: carry transport recovery in the universal agent pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 The next release train starts here.
 
+## [0.9.0-beta.1] — 2026-05-07
+
+### Changed
+
+- The universal agent pack and integration docs now teach host-neutral
+  workspace binding with `M1ND_WORKSPACE_ROOT`.
+- The agent recovery doctrine now classifies `Transport closed` as a dead MCP
+  transport that needs host rebind/restart before m1nd recovery tools can run.
+
 ---
 
 ## [0.8.0] — 2026-04-10

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ m1nd mcp-config generic
 m1nd pack-check
 ```
 
+For every host that supports environment variables, prefer setting
+`M1ND_WORKSPACE_ROOT` to the real repository/workspace. It is the portable
+signal used across Codex, Claude Code, Antigravity, Gemini, Cursor, Windsurf,
+VS Code, and generic MCP clients.
+
 See [docs/AGENT-PACKS.md](docs/AGENT-PACKS.md) for the full install map.
 
 Windows is part of the universal target. The installer emits Windows-safe MCP
@@ -250,6 +255,10 @@ shape and how to read it.
 If your local demo sees `trust_selftest` but your editor or agent host does not,
 use the [MCP host refresh guide](docs/MCP-HOST-REFRESH.md) to compare the host
 tool surface against the local runtime.
+
+If a host returns `Transport closed`, treat it as a dead MCP transport, not a
+stale graph. Restart/rebind the host MCP client or open a fresh session, then
+run `trust_selftest` or `session_handshake` before relying on retrieval.
 
 ## Default Agent Workflow
 

--- a/docs/AGENT-PACKS.md
+++ b/docs/AGENT-PACKS.md
@@ -47,6 +47,11 @@ Those commands write into `/path/to/project/.m1nd/agent-pack/`. Point the host
 at the generated rule file or paste it into the host custom-instructions
 surface.
 
+The portable pack includes recovery language for dead MCP transports. If a host
+reports `Transport closed`, treat it as a host binding death, not as stale graph
+state. Relaunch/rebind the MCP client or open a fresh session before calling
+`doctor`, `recovery_playbook`, or `ingest`.
+
 ## MCP Config Snippets
 
 Codex:
@@ -77,6 +82,16 @@ Then point your host at:
 target/release/m1nd-mcp
 ```
 
+When the host supports environment variables, set:
+
+```text
+M1ND_WORKSPACE_ROOT=/path/to/project
+```
+
+That is the host-neutral workspace contract. Host-specific variables from
+Claude Code, Antigravity, Gemini, Cursor, Windsurf, VS Code, and shells are
+recognized as aliases, but `M1ND_WORKSPACE_ROOT` is the preferred signal.
+
 On Windows, the native binary is `m1nd-mcp.exe`. The npm installer looks for it
 on `PATH`, through `M1ND_MCP_BINARY`, or at:
 
@@ -96,6 +111,8 @@ should use plain MCP until a Windows-native fast lane is introduced.
 
 ## Trust Loop For Every Host
 
+0. If the host returns `Transport closed`, restart/rebind the host MCP client
+   first. The transport died before m1nd could run a recovery tool.
 1. Call `trust_selftest`.
 2. If unavailable, call `session_handshake`.
 3. If only `health` is visible, inspect `tool_surface_contract`.

--- a/docs/IDE-INTEGRATIONS.md
+++ b/docs/IDE-INTEGRATIONS.md
@@ -33,7 +33,8 @@ Most hosts are perfectly fine with:
       "command": "/path/to/m1nd-mcp",
       "env": {
         "M1ND_GRAPH_SOURCE": "/tmp/m1nd-graph.json",
-        "M1ND_PLASTICITY_STATE": "/tmp/m1nd-plasticity.json"
+        "M1ND_PLASTICITY_STATE": "/tmp/m1nd-plasticity.json",
+        "M1ND_WORKSPACE_ROOT": "/path/to/your/project"
       }
     }
   }
@@ -63,6 +64,7 @@ args = ["--stdio", "--no-gui"]
 [mcp_servers.m1nd.env]
 M1ND_GRAPH_SOURCE = "/tmp/m1nd-graph.json"
 M1ND_PLASTICITY_STATE = "/tmp/m1nd-plasticity.json"
+M1ND_WORKSPACE_ROOT = "/path/to/your/project"
 ```
 
 But some editor hosts still pay too much overhead if they cold-start a stdio MCP
@@ -107,6 +109,20 @@ Examples:
 - Cursor / Windsurf → project-local MCP config pointing at a native proxy if desired
 
 ## Practical recommendations
+
+### Set the workspace root when possible
+
+Use `M1ND_WORKSPACE_ROOT` as the portable contract for Codex, Claude Code,
+Antigravity, Gemini, Cursor, Windsurf, VS Code, and generic MCP clients. Point
+it at the real repository or workspace, not at a host-managed runtime folder.
+
+Host-specific hints such as `CLAUDE_PROJECT_DIR` or
+`ANTIGRAVITY_WORKSPACE_ROOT` are recognized as compatibility aliases, but
+`M1ND_WORKSPACE_ROOT` is the clearest cross-host signal.
+
+If a tool call fails with `Transport closed`, the MCP pipe died before m1nd
+could run. Restart/rebind the host MCP client or open a fresh session, then
+call `trust_selftest` or `session_handshake` before retrieval.
 
 ### Use plain MCP when:
 

--- a/docs/MCP-HOST-REFRESH.md
+++ b/docs/MCP-HOST-REFRESH.md
@@ -10,6 +10,16 @@ The most common symptom is simple:
 - the host session only sees some of those tools
 - retrieval looks blocked or stale even after ingest
 
+Another common symptom is more abrupt:
+
+- a tool call fails with `Transport closed`
+
+That is not graph staleness. It means the MCP transport died before m1nd could
+execute a tool. Recovery tools such as `doctor`, `recovery_playbook`, and
+`ingest` cannot run through that closed transport. Prove the binary locally,
+restart/rebind the host MCP client or open a fresh session, then call
+`trust_selftest` or `session_handshake` on the newly launched binding.
+
 ## 1. Prove The Local Binary First
 
 From the repo root:
@@ -76,10 +86,15 @@ Recommended order:
 
 1. Rebuild `m1nd-mcp`.
 2. Confirm the MCP config points at the rebuilt binary.
-3. Restart the MCP server process if the host manages it separately.
-4. Reload or restart the client window/session.
-5. Re-run `tools/list`.
-6. Call `trust_selftest`.
+3. Set `M1ND_WORKSPACE_ROOT` to the intended repo/workspace when the host lets
+   you configure environment variables.
+4. Restart the MCP server process if the host manages it separately.
+5. Reload or restart the client window/session.
+6. Re-run `tools/list`.
+7. Call `trust_selftest`.
+
+If the error is `Transport closed`, the old binding is already gone. Skip graph
+recovery calls in that session and relaunch the host binding first.
 
 For hosts that cache tool schemas per conversation or workspace, start a new
 conversation/session after rebuilding the binary. The old conversation may keep

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "0.9.0-beta.0",
+  "version": "0.9.0-beta.1",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
   "repository": {

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -15,6 +15,10 @@ local file action.
 
 ## Startup Trust Loop
 
+0. If a tool call fails with `Transport closed`, stop treating it as graph
+   staleness. The MCP transport died before m1nd could run. Verify the binary
+   with a local smoke, restart/rebind the host MCP client or open a fresh
+   thread, then continue with this loop.
 1. Call `trust_selftest` if the host exposes it.
 2. If unavailable, call `session_handshake`.
 3. If only `health` is exposed, inspect `tool_surface_contract` and
@@ -39,6 +43,10 @@ repair, refresh the host, or mutate the graph.
   document binding/drift tools
 
 ## Recovery Rules
+
+`Transport closed` is a host transport failure, not a m1nd proof-state. Do not
+call `doctor`, `recovery_playbook`, or `ingest` through that dead binding. A
+fresh MCP transport must be launched first.
 
 If `seek`, `search`, or `activate` returns `blocked`, zero candidates, or an
 unexpectedly empty graph after ingest, treat it as possible stale binding or
@@ -73,6 +81,11 @@ and local file truth. It does not replace them.
 
 Keep `agent_id` stable within one investigation. Use trails, perspectives, and
 coverage sessions when work spans agents, branches, or sessions.
+
+For host setup, prefer exporting `M1ND_WORKSPACE_ROOT` to the actual repository
+or project root. Claude Code, Antigravity, Gemini, Cursor, Windsurf, VS Code,
+and generic shells can expose their own workspace hints too, but
+`M1ND_WORKSPACE_ROOT` is the portable contract.
 
 ## L1GHT
 


### PR DESCRIPTION
## Summary
- adds `Transport closed` recovery doctrine to the universal agent pack and install docs
- documents `M1ND_WORKSPACE_ROOT` as the portable workspace contract for Codex, Claude Code, Antigravity, Gemini, Cursor, Windsurf, VS Code, and generic MCP clients
- bumps the npm package to `0.9.0-beta.1` so the updated doctrine can ship through the beta channel

## Verification
- npm test
- node npm/bin/m1nd.js pack-check
- npm pack --dry-run
- git diff --check