### PR TITLE
Read-only attach, agent-first tools, and a shared-graph MCP-over-HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,6 +1766,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1787,12 +1788,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2900,6 +2903,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/m1nd-core/src/query.rs
+++ b/m1nd-core/src/query.rs
@@ -261,6 +261,174 @@ impl QueryOrchestrator {
         })
     }
 
+    /// Execute a query with a **zero-mutation guarantee** on the graph.
+    ///
+    /// Runs the identical steps 1–7 of [`Self::query`] (seeds -> 4-dim
+    /// activation -> XLR -> merge -> PageRank boost -> ghost edges ->
+    /// structural holes) and produces byte-identical
+    /// `activation`/`ghost_edges`/`structural_holes` output for the same
+    /// input, but **deliberately skips the mutating Step 8** (the plasticity
+    /// `update`, see [`Self::query`] which calls
+    /// `self.plasticity.update(graph, ..)` and rewrites edge weights via
+    /// atomic CAS + `edge_plasticity`).
+    ///
+    /// This makes it safe to run against a graph that is **shared by other
+    /// readers**: a second (read-only) m1nd process can call this without
+    /// perturbing the activation buffers or edge weights that concurrent
+    /// readers depend on.
+    ///
+    /// ## Zero-mutation proof (why `&self` + `&Graph` is sufficient)
+    ///
+    /// Every step below borrows the graph **immutably** and accumulates its
+    /// work in *local* scratch buffers — none of them writes back into the
+    /// shared `Graph`. The only `&mut Graph` in the whole pipeline is the
+    /// plasticity update we skip here. Verified signatures:
+    ///   - Step 1 `SeedFinder::find_seeds_semantic(graph: &Graph, ..)`  (seed.rs)
+    ///   - Step 2 D1 `HybridEngine::propagate(&self, graph: &Graph, ..)`,
+    ///     which dispatches to `Wavefront`/`Heap` engines that allocate their
+    ///     own `vec![0.0f32; n]` activation buffers (activation.rs).
+    ///   - Step 2 D2/D3/D4 `activate_semantic`/`activate_temporal`/
+    ///     `activate_causal(graph: &Graph, ..)`  (activation.rs).
+    ///   - Step 3 `AdaptiveXlrEngine::query(&self, graph: &Graph, ..)`  (xlr.rs).
+    ///   - Step 4 `merge_dimensions(results, top_k)` — never touches the graph.
+    ///   - Step 5 reads only `graph.nodes.pagerank` and mutates the *local*
+    ///     `activation` struct (owned here), not the graph.
+    ///   - Step 6/7 `detect_ghost_edges`/`detect_structural_holes(&self,
+    ///     graph: &Graph, ..)` — read-only traversals.
+    ///
+    /// CALLER NOTE: activation scores live **in the returned `QueryResult`**
+    /// (`result.activation.activated`), not stamped onto graph nodes. There is
+    /// no `apply_boosts`/`runtime_overlay` write here — that path takes
+    /// `&mut Graph` and is intentionally never invoked.
+    ///
+    /// The `plasticity` field is set to the same empty/zeroed
+    /// [`PlasticityResult`] used by the empty-seeds early return in
+    /// [`Self::query`].
+    pub fn query_readonly(
+        &self,
+        graph: &Graph,
+        config: &QueryConfig,
+    ) -> M1ndResult<QueryResult> {
+        let start = Instant::now();
+
+        // Zeroed plasticity result — Step 8 is intentionally skipped, so no
+        // edges are strengthened/decayed and no events are recorded. This is
+        // the exact shape used by the empty-seeds early-return in `query()`.
+        let empty_plasticity = PlasticityResult {
+            edges_strengthened: 0,
+            edges_decayed: 0,
+            ltp_events: 0,
+            ltd_events: 0,
+            homeostatic_rescales: 0,
+            priming_nodes: 0,
+        };
+
+        // Step 1: Find seeds (read-only; `&Graph`).
+        let seeds = SeedFinder::find_seeds_semantic(
+            graph,
+            &self.semantic,
+            &config.query,
+            config.top_k * 5,
+        )?;
+
+        if seeds.is_empty() {
+            return Ok(QueryResult {
+                activation: ActivationResult {
+                    activated: Vec::new(),
+                    seeds: Vec::new(),
+                    elapsed_ns: 0,
+                    xlr_fallback_used: false,
+                },
+                ghost_edges: Vec::new(),
+                structural_holes: Vec::new(),
+                plasticity: empty_plasticity,
+                elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+            });
+        }
+
+        // Step 2: Run 4 dimensions (all take `&Graph`, write local buffers).
+        // D1: Structural
+        let d1 = self.engine.propagate(graph, &seeds, &config.propagation)?;
+
+        // D2: Semantic
+        let d2 = activate_semantic(graph, &self.semantic, &config.query, config.top_k)?;
+
+        // D3: Temporal
+        let d3 = activate_temporal(graph, &seeds, &TemporalWeights::default())?;
+
+        // D4: Causal
+        let d4 = activate_causal(graph, &seeds, &config.propagation)?;
+
+        // Step 3: XLR noise cancellation on D1 (read-only; `&Graph`).
+        let mut xlr_fallback = false;
+        let d1_final = if config.xlr_enabled {
+            let xlr_result = self.xlr.query(graph, &seeds, &config.propagation)?;
+            xlr_fallback = xlr_result.fallback_to_hot_only;
+
+            // Merge XLR result with D1
+            if !xlr_result.activations.is_empty() {
+                DimensionResult {
+                    scores: xlr_result.activations,
+                    dimension: Dimension::Structural,
+                    elapsed_ns: d1.elapsed_ns,
+                }
+            } else {
+                d1
+            }
+        } else {
+            d1
+        };
+
+        // Step 4: Merge dimensions (does not touch the graph).
+        let results = [d1_final, d2, d3, d4];
+        let mut activation = merge_dimensions(&results, config.top_k)?;
+        activation.seeds = seeds.clone();
+        activation.xlr_fallback_used = xlr_fallback;
+
+        // Step 5: Add PageRank boost. Reads `graph.nodes.pagerank` only and
+        // mutates the *local* `activation` struct owned by this fn — the graph
+        // is untouched.
+        for node in &mut activation.activated {
+            let idx = node.node.as_usize();
+            if idx < graph.nodes.pagerank.len() {
+                let pr_boost = graph.nodes.pagerank[idx].get() * 0.1;
+                node.activation = FiniteF32::new(node.activation.get() + pr_boost);
+            }
+        }
+        // Re-sort after PageRank boost
+        activation
+            .activated
+            .sort_by_key(|entry| std::cmp::Reverse(entry.activation));
+
+        // Step 6: Ghost edges (read-only traversal; `&Graph`).
+        let ghost_edges = if config.include_ghost_edges {
+            self.detect_ghost_edges(graph, &activation)?
+        } else {
+            Vec::new()
+        };
+
+        // Step 7: Structural holes (read-only traversal; `&Graph`).
+        let structural_holes = if config.include_structural_holes {
+            self.detect_structural_holes(graph, &activation, FiniteF32::new(0.3))?
+        } else {
+            Vec::new()
+        };
+
+        // Step 8: SKIPPED. `query()` calls `self.plasticity.update(graph, ..)`
+        // here, which is the sole `&mut Graph` write in the pipeline. We omit
+        // it entirely to keep the shared graph pristine.
+
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        Ok(QueryResult {
+            activation,
+            ghost_edges,
+            structural_holes,
+            plasticity: empty_plasticity,
+            elapsed_ms,
+        })
+    }
+
     /// Detect ghost edges from multi-dimensional resonance.
     /// Nodes activated in multiple dimensions but not directly connected = ghost edge.
     /// Replaces: engine_v2.py ConnectomeEngine._detect_ghost_edges()

--- a/m1nd-core/src/query.rs
+++ b/m1nd-core/src/query.rs
@@ -304,11 +304,7 @@ impl QueryOrchestrator {
     /// The `plasticity` field is set to the same empty/zeroed
     /// [`PlasticityResult`] used by the empty-seeds early return in
     /// [`Self::query`].
-    pub fn query_readonly(
-        &self,
-        graph: &Graph,
-        config: &QueryConfig,
-    ) -> M1ndResult<QueryResult> {
+    pub fn query_readonly(&self, graph: &Graph, config: &QueryConfig) -> M1ndResult<QueryResult> {
         let start = Instant::now();
 
         // Zeroed plasticity result — Step 8 is intentionally skipped, so no

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -29,7 +29,7 @@ rust-embed = { version = "8", optional = true }
 mime_guess = { version = "2", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"], optional = true }
 futures = { version = "0.3", optional = true }
-reqwest = { version = "0.13", features = ["json"], optional = true }
+reqwest = { version = "0.13", features = ["json", "stream"], optional = true }
 
 [[bin]]
 name = "m1nd-mcp"

--- a/m1nd-mcp/src/attach_client.rs
+++ b/m1nd-mcp/src/attach_client.rs
@@ -1,0 +1,437 @@
+// === m1nd-mcp `--attach` stdio↔HTTP bridge ===
+//
+// Wave 4, Slice 3 — THE deliverable.
+//
+// `m1nd-mcp --attach <base_url>` is a thin bridge: to the host (Claude Code) it
+// is a standard stdio MCP server; to a running `m1nd-mcp --serve` owner it is a
+// standard Streamable-HTTP MCP client. It loads NO graph, builds NO engines, and
+// takes NO lease. Two such clients pointed at one `--serve` owner SHARE that
+// owner's single live graph: agent A's mutation is visible to agent B with no
+// reload — because both ultimately drive the SAME `Arc<Mutex<SessionState>>`
+// inside the owner process (via `POST /mcp`).
+//
+// STDOUT FRAMING FIDELITY is the single biggest risk: if this bridge's stdout
+// deviates even slightly from the MCP stdio wire format the host silently fails
+// to initialize. MITIGATION (load-bearing): we reuse the EXACT framing
+// primitives the embedded stdio server uses — `read_request_payload` /
+// `write_response` / `TransportMode` from `server.rs` — verbatim, and keep ALL
+// diagnostics on stderr. Nothing but JSON-RPC frames ever touches stdout.
+//
+// Feature-gated behind "serve" (it needs the `reqwest` HTTP client, which lives
+// under that feature).
+
+#![cfg(feature = "serve")]
+
+use std::io::{BufReader, Write};
+
+use crate::protocol::{JsonRpcError, JsonRpcResponse};
+use crate::server::{read_request_payload, write_response, TransportMode};
+
+/// Per-spec MCP session header name.
+const MCP_SESSION_HEADER: &str = "mcp-session-id";
+/// Per-spec negotiated protocol version header.
+const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+
+/// Session state the bridge captures at `initialize` and replays on every
+/// subsequent request, so the owner routes all of this client's traffic to the
+/// one shared session.
+#[derive(Clone, Default)]
+struct AttachSession {
+    /// `Mcp-Session-Id` minted by the owner at `initialize`.
+    mcp_session_id: Option<String>,
+    /// `result.protocolVersion` negotiated at `initialize`.
+    protocol_version: Option<String>,
+}
+
+/// Run the `--attach` bridge against `base_url` (e.g. `http://127.0.0.1:1337`).
+///
+/// Loop: read one JSON-RPC frame from stdin (preserving its detected
+/// `TransportMode`), POST it to `<base_url>/mcp`, and relay the response frame to
+/// stdout in the SAME mode. Exits cleanly on stdin EOF.
+pub async fn run_attach_client(base_url: String) {
+    let endpoint = format!("{}/mcp", base_url.trim_end_matches('/'));
+    eprintln!(
+        "[m1nd-mcp][attach] bridging stdio MCP host ↔ {} (no graph / no lease loaded)",
+        endpoint
+    );
+
+    let client = match reqwest::Client::builder().build() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[m1nd-mcp][attach] failed to build HTTP client: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let mut session = AttachSession::default();
+
+    // Single persistent stdin reader on a dedicated blocking thread. ONE
+    // `BufReader` lives for the whole session — a fresh reader per frame would
+    // discard already-buffered bytes (read-ahead) and silently drop the next
+    // request. Frames are pushed to the async loop over a bounded channel; this
+    // mirrors the embedded stdio server's reader-thread pattern in `server.rs`.
+    let (frame_tx, mut frame_rx) =
+        tokio::sync::mpsc::channel::<(String, TransportMode)>(64);
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let mut reader = BufReader::new(stdin.lock());
+        loop {
+            match read_request_payload(&mut reader) {
+                Ok(Some(frame)) => {
+                    if frame_tx.blocking_send(frame).is_err() {
+                        break; // async side gone
+                    }
+                }
+                Ok(None) => break, // EOF
+                Err(e) => {
+                    eprintln!("[m1nd-mcp][attach] stdin read error: {}", e);
+                    break;
+                }
+            }
+        }
+        // Drop `frame_tx` → channel closes → async loop sees `None` → clean exit.
+    });
+
+    loop {
+        // --- Receive one inbound frame from the stdin reader thread. ---
+        let (payload, mode) = match frame_rx.recv().await {
+            Some(frame) => frame,
+            // Channel closed → stdin EOF (or read error already logged) → exit.
+            None => {
+                eprintln!("[m1nd-mcp][attach] stdin EOF; exiting");
+                break;
+            }
+        };
+
+        let trimmed = payload.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // --- Classify: requests (have a non-null `id`) vs notifications. ---
+        let parsed: serde_json::Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(e) => {
+                // Malformed JSON from the host → reply with a parse error so the
+                // host sees a clean frame rather than a dropped message.
+                let err = jsonrpc_error(serde_json::Value::Null, -32700, format!("Parse error: {}", e));
+                emit(&err, mode);
+                continue;
+            }
+        };
+
+        let req_id = parsed.get("id").cloned();
+        let is_request = req_id.as_ref().is_some_and(|v| !v.is_null());
+        let method = parsed.get("method").and_then(|m| m.as_str()).map(str::to_owned);
+        let is_initialize = method.as_deref() == Some("initialize");
+
+        // --- Build the POST with the MCP-mandated headers. ---
+        let mut builder = client
+            .post(&endpoint)
+            .header(reqwest::header::ACCEPT, "application/json, text/event-stream")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(payload.clone());
+
+        // After init, every request/notification carries the captured session id
+        // and negotiated protocol version (so the owner routes to the shared
+        // session and not a fresh one).
+        if let Some(sid) = &session.mcp_session_id {
+            builder = builder.header(MCP_SESSION_HEADER, sid.clone());
+        }
+        if let Some(pv) = &session.protocol_version {
+            builder = builder.header(MCP_PROTOCOL_VERSION_HEADER, pv.clone());
+        }
+
+        let response = match builder.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[m1nd-mcp][attach] HTTP send error: {}", e);
+                // Only a request expects a reply; surface a clean JSON-RPC error
+                // to the host so it never hangs. Notifications get nothing.
+                if is_request {
+                    let id = req_id.clone().unwrap_or(serde_json::Value::Null);
+                    let err = jsonrpc_error(
+                        id,
+                        -32002,
+                        format!("attach bridge: failed to reach m1nd owner at {}: {}", endpoint, e),
+                    );
+                    emit(&err, mode);
+                }
+                continue;
+            }
+        };
+
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+
+        // On `initialize`, capture the minted session id BEFORE consuming the body.
+        if is_initialize {
+            if let Some(sid) = response
+                .headers()
+                .get(MCP_SESSION_HEADER)
+                .and_then(|v| v.to_str().ok())
+            {
+                session.mcp_session_id = Some(sid.to_string());
+                eprintln!("[m1nd-mcp][attach] captured Mcp-Session-Id={}", sid);
+            } else {
+                eprintln!(
+                    "[m1nd-mcp][attach] WARNING: initialize response had no Mcp-Session-Id header"
+                );
+            }
+        }
+
+        // --- Notifications/responses (no id): owner replies 202, nothing to stdout. ---
+        if !is_request {
+            if status != reqwest::StatusCode::ACCEPTED && !status.is_success() {
+                eprintln!(
+                    "[m1nd-mcp][attach] notification POST returned {} (expected 202)",
+                    status
+                );
+            }
+            continue;
+        }
+
+        let id_for_error = req_id.clone().unwrap_or(serde_json::Value::Null);
+        let body = match response.text().await {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("[m1nd-mcp][attach] failed to read response body: {}", e);
+                let err = jsonrpc_error(
+                    id_for_error,
+                    -32003,
+                    format!("attach bridge: failed reading owner response: {}", e),
+                );
+                emit(&err, mode);
+                continue;
+            }
+        };
+
+        // --- Demux by content-type. ---
+        let response_value: Option<serde_json::Value> = if content_type.contains("text/event-stream")
+        {
+            // SSE: extract the JSON-RPC response frame whose `id` matches the
+            // request; relay any interim server→client notifications to stdout.
+            extract_sse_response(&body, req_id.as_ref(), mode)
+        } else {
+            // application/json (slice-1's path): the body IS the JSON-RPC response.
+            match serde_json::from_str::<serde_json::Value>(&body) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    eprintln!(
+                        "[m1nd-mcp][attach] owner returned {} with non-JSON body ({}): {}",
+                        status, e, body
+                    );
+                    None
+                }
+            }
+        };
+
+        match response_value {
+            Some(v) => {
+                // On a successful `initialize` response, capture the negotiated
+                // protocol version for subsequent requests.
+                if is_initialize {
+                    if let Some(pv) = v
+                        .get("result")
+                        .and_then(|r| r.get("protocolVersion"))
+                        .and_then(|p| p.as_str())
+                    {
+                        session.protocol_version = Some(pv.to_string());
+                        eprintln!("[m1nd-mcp][attach] negotiated protocolVersion={}", pv);
+                    }
+                }
+                emit_value(&v, mode);
+            }
+            None => {
+                // We got a request but couldn't surface a usable response frame.
+                // Emit a clean JSON-RPC error so the host never hangs.
+                let err = jsonrpc_error(
+                    id_for_error,
+                    -32004,
+                    format!(
+                        "attach bridge: owner returned {} but no matching JSON-RPC response frame",
+                        status
+                    ),
+                );
+                emit(&err, mode);
+            }
+        }
+    }
+
+    // TODO(slice4): a long-lived `GET /mcp` push relay — subscribe to the owner's
+    // server→client SSE stream and forward `notifications/m1nd/graph_changed`
+    // frames to this host's stdout, so an attached agent learns that ANOTHER
+    // agent mutated the shared graph without polling. The request/response bridge
+    // (the must-have for shared-graph mutation visibility) is complete above;
+    // the push relay is deliberately deferred.
+}
+
+/// Build a JSON-RPC error response frame.
+fn jsonrpc_error(id: serde_json::Value, code: i32, message: String) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0".into(),
+        id,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message,
+            data: None,
+        }),
+    }
+}
+
+/// Write a typed `JsonRpcResponse` to stdout using the embedded server's framing
+/// primitive (verbatim), in the inbound `TransportMode`.
+fn emit(resp: &JsonRpcResponse, mode: TransportMode) {
+    let stdout = std::io::stdout();
+    let mut writer = stdout.lock();
+    if write_response(&mut writer, resp, mode).is_err() {
+        eprintln!("[m1nd-mcp][attach] stdout closed while writing response");
+    }
+}
+
+/// Write an arbitrary JSON value (a full JSON-RPC frame received from the owner)
+/// to stdout in the inbound framing mode. We re-frame using the SAME logic
+/// `write_response` uses (Content-Length vs newline) so stdout is byte-identical
+/// to the embedded server — the value is forwarded as-is, preserving the owner's
+/// exact `result`/`error` shape.
+fn emit_value(value: &serde_json::Value, mode: TransportMode) {
+    let json = serde_json::to_string(value).unwrap_or_default();
+    let stdout = std::io::stdout();
+    let mut writer = stdout.lock();
+    let write_res = match mode {
+        TransportMode::Framed => write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)
+            .and_then(|_| writer.flush()),
+        TransportMode::Line => writeln!(writer, "{}", json).and_then(|_| writer.flush()),
+    };
+    if write_res.is_err() {
+        eprintln!("[m1nd-mcp][attach] stdout closed while writing frame");
+    }
+}
+
+/// Parse a `text/event-stream` body, relaying any interim server→client
+/// notification frames (no `id`) to stdout and returning the response frame whose
+/// `id` matches `want_id` (if found). Falls back to the first response-shaped
+/// frame (has `result` or `error`) when no id matches.
+fn extract_sse_response(
+    body: &str,
+    want_id: Option<&serde_json::Value>,
+    mode: TransportMode,
+) -> Option<serde_json::Value> {
+    let mut matched: Option<serde_json::Value> = None;
+    let mut first_response: Option<serde_json::Value> = None;
+
+    for raw in sse_data_payloads(body) {
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let has_id = value.get("id").is_some_and(|v| !v.is_null());
+        let is_response = value.get("result").is_some() || value.get("error").is_some();
+
+        if is_response && has_id {
+            if let Some(want) = want_id {
+                if value.get("id") == Some(want) && matched.is_none() {
+                    matched = Some(value.clone());
+                    continue;
+                }
+            }
+            if first_response.is_none() {
+                first_response = Some(value);
+            }
+        } else if !has_id {
+            // Interim server→client notification → relay to stdout.
+            emit_value(&value, mode);
+        }
+    }
+
+    matched.or(first_response)
+}
+
+/// Extract the concatenated `data:` payloads from an SSE body, one logical frame
+/// per event (events are separated by a blank line; a frame may span multiple
+/// `data:` lines per the SSE spec).
+fn sse_data_payloads(body: &str) -> Vec<String> {
+    let mut frames = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+
+    for line in body.lines() {
+        if line.is_empty() {
+            if !current.is_empty() {
+                frames.push(current.join("\n"));
+                current.clear();
+            }
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("data:") {
+            // Per spec, a single leading space after the colon is stripped.
+            current.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+        }
+        // `id:`, `event:`, `:`-comments and other fields are ignored here.
+    }
+    if !current.is_empty() {
+        frames.push(current.join("\n"));
+    }
+    frames
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_single_data_frame_is_extracted() {
+        let body = "id: 0\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n";
+        let frames = sse_data_payloads(body);
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn sse_multiline_data_frame_is_joined() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\ndata: \"id\":1,\"result\":{}}\n\n";
+        let frames = sse_data_payloads(body);
+        assert_eq!(frames.len(), 1);
+        // The two data lines join with a newline; the JSON re-parses.
+        let v: serde_json::Value = serde_json::from_str(&frames[0]).expect("rejoined JSON parses");
+        assert_eq!(v["id"], 1);
+    }
+
+    #[test]
+    fn extract_picks_response_with_matching_id() {
+        // A notification frame followed by the real response frame.
+        let body = "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/x\",\"params\":{}}\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"v\":42}}\n\n";
+        let want = serde_json::json!(7);
+        let got = extract_sse_response(body, Some(&want), TransportMode::Line)
+            .expect("matching response found");
+        assert_eq!(got["id"], 7);
+        assert_eq!(got["result"]["v"], 42);
+    }
+
+    #[test]
+    fn extract_falls_back_to_first_response_when_no_id_match() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\"id\":99,\"result\":{\"v\":1}}\n\n";
+        let want = serde_json::json!(1);
+        let got = extract_sse_response(body, Some(&want), TransportMode::Line)
+            .expect("falls back to first response");
+        assert_eq!(got["id"], 99);
+    }
+
+    #[test]
+    fn jsonrpc_error_has_expected_shape() {
+        let err = jsonrpc_error(serde_json::json!(5), -32002, "boom".into());
+        assert_eq!(err.jsonrpc, "2.0");
+        assert_eq!(err.id, serde_json::json!(5));
+        assert!(err.result.is_none());
+        let e = err.error.expect("error present");
+        assert_eq!(e.code, -32002);
+        assert_eq!(e.message, "boom");
+    }
+}

--- a/m1nd-mcp/src/attach_client.rs
+++ b/m1nd-mcp/src/attach_client.rs
@@ -24,13 +24,79 @@
 
 use std::io::{BufReader, Write};
 
+use tokio::sync::mpsc;
+
 use crate::protocol::{JsonRpcError, JsonRpcResponse};
-use crate::server::{read_request_payload, write_response, TransportMode};
+use crate::server::{read_request_payload, TransportMode};
 
 /// Per-spec MCP session header name.
 const MCP_SESSION_HEADER: &str = "mcp-session-id";
 /// Per-spec negotiated protocol version header.
 const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+
+/// One framed JSON-RPC message destined for stdout, carrying the `TransportMode`
+/// it must be framed in. Pushed by BOTH the request/response loop and the push
+/// relay; drained by a SINGLE writer task so frames can never interleave.
+type StdoutFrame = (serde_json::Value, TransportMode);
+
+/// Handle to the single serialized stdout writer. Cloneable: every producer (the
+/// request/response loop, the SSE push relay) holds a clone and pushes whole
+/// frames; the one writer task owns `stdout` and is the only thing that touches
+/// it, guaranteeing byte-level framing fidelity with no cross-frame interleave.
+#[derive(Clone)]
+struct StdoutSink {
+    tx: mpsc::UnboundedSender<StdoutFrame>,
+}
+
+impl StdoutSink {
+    /// Push a typed `JsonRpcResponse` (bridge-generated error/response) to the
+    /// serialized writer in `mode`.
+    fn emit(&self, resp: &JsonRpcResponse, mode: TransportMode) {
+        match serde_json::to_value(resp) {
+            Ok(v) => self.send(v, mode),
+            Err(e) => eprintln!("[m1nd-mcp][attach] failed to serialize response frame: {e}"),
+        }
+    }
+
+    /// Push an arbitrary JSON value (an owner-originated frame, forwarded as-is to
+    /// preserve its exact `result`/`error`/notification shape) to the serialized
+    /// writer in `mode`.
+    fn emit_value(&self, value: serde_json::Value, mode: TransportMode) {
+        self.send(value, mode);
+    }
+
+    /// Non-blocking, callable from sync OR async context (unbounded channel). The
+    /// only failure mode is a closed receiver (writer task gone / stdout dead),
+    /// which we log to stderr — there is nowhere left to deliver the frame.
+    fn send(&self, value: serde_json::Value, mode: TransportMode) {
+        if self.tx.send((value, mode)).is_err() {
+            eprintln!("[m1nd-mcp][attach] stdout writer gone; dropping outbound frame");
+        }
+    }
+}
+
+/// The ONE task that owns `stdout`. It drains `rx` in arrival order and frames
+/// each message with the EXACT logic the embedded stdio server uses
+/// (`Content-Length` for `Framed`, newline for `Line`). Because it is the sole
+/// writer, two producers can never interleave a notification inside a response.
+async fn run_stdout_writer(mut rx: mpsc::UnboundedReceiver<StdoutFrame>) {
+    while let Some((value, mode)) = rx.recv().await {
+        let json = serde_json::to_string(&value).unwrap_or_default();
+        let stdout = std::io::stdout();
+        let mut writer = stdout.lock();
+        let write_res = match mode {
+            TransportMode::Framed => {
+                write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)
+                    .and_then(|_| writer.flush())
+            }
+            TransportMode::Line => writeln!(writer, "{}", json).and_then(|_| writer.flush()),
+        };
+        if write_res.is_err() {
+            eprintln!("[m1nd-mcp][attach] stdout closed while writing frame");
+            break;
+        }
+    }
+}
 
 /// Session state the bridge captures at `initialize` and replays on every
 /// subsequent request, so the owner routes all of this client's traffic to the
@@ -64,6 +130,22 @@ pub async fn run_attach_client(base_url: String) {
     };
 
     let mut session = AttachSession::default();
+
+    // --- SINGLE serialized stdout writer (load-bearing for framing fidelity). ---
+    // There are now TWO producers of stdout frames: the request/response loop
+    // below AND the long-lived push relay (spawned once the session id is known).
+    // Both push WHOLE frames into this unbounded channel; one dedicated writer
+    // task owns `stdout` and emits them in arrival order, so a relay notification
+    // can NEVER land in the middle of a response frame. Nothing else writes stdout.
+    let (stdout_tx, stdout_rx) = mpsc::unbounded_channel::<StdoutFrame>();
+    let sink = StdoutSink { tx: stdout_tx };
+    let writer_handle = tokio::spawn(run_stdout_writer(stdout_rx));
+
+    // The push relay is spawned lazily exactly once, right after the first
+    // `initialize` captures the Mcp-Session-Id (the owner needs it to route the
+    // server→client SSE stream). Guarded so a re-`initialize` never double-spawns.
+    let mut relay_spawned = false;
+    let mut relay_handle: Option<tokio::task::JoinHandle<()>> = None;
 
     // Single persistent stdin reader on a dedicated blocking thread. ONE
     // `BufReader` lives for the whole session — a fresh reader per frame would
@@ -115,7 +197,7 @@ pub async fn run_attach_client(base_url: String) {
                 // Malformed JSON from the host → reply with a parse error so the
                 // host sees a clean frame rather than a dropped message.
                 let err = jsonrpc_error(serde_json::Value::Null, -32700, format!("Parse error: {}", e));
-                emit(&err, mode);
+                sink.emit(&err, mode);
                 continue;
             }
         };
@@ -155,7 +237,7 @@ pub async fn run_attach_client(base_url: String) {
                         -32002,
                         format!("attach bridge: failed to reach m1nd owner at {}: {}", endpoint, e),
                     );
-                    emit(&err, mode);
+                    sink.emit(&err, mode);
                 }
                 continue;
             }
@@ -178,6 +260,23 @@ pub async fn run_attach_client(base_url: String) {
             {
                 session.mcp_session_id = Some(sid.to_string());
                 eprintln!("[m1nd-mcp][attach] captured Mcp-Session-Id={}", sid);
+
+                // Lazily spawn the server→client push relay exactly once: the
+                // owner can only route the `GET /mcp` SSE stream once it knows the
+                // session id, which we just captured. Re-`initialize` won't
+                // double-spawn thanks to `relay_spawned`.
+                if !relay_spawned {
+                    relay_spawned = true;
+                    let relay = run_push_relay(
+                        client.clone(),
+                        endpoint.clone(),
+                        sid.to_string(),
+                        session.protocol_version.clone(),
+                        sink.clone(),
+                        mode,
+                    );
+                    relay_handle = Some(tokio::spawn(relay));
+                }
             } else {
                 eprintln!(
                     "[m1nd-mcp][attach] WARNING: initialize response had no Mcp-Session-Id header"
@@ -206,7 +305,7 @@ pub async fn run_attach_client(base_url: String) {
                     -32003,
                     format!("attach bridge: failed reading owner response: {}", e),
                 );
-                emit(&err, mode);
+                sink.emit(&err, mode);
                 continue;
             }
         };
@@ -216,7 +315,7 @@ pub async fn run_attach_client(base_url: String) {
         {
             // SSE: extract the JSON-RPC response frame whose `id` matches the
             // request; relay any interim server→client notifications to stdout.
-            extract_sse_response(&body, req_id.as_ref(), mode)
+            extract_sse_response(&body, req_id.as_ref(), mode, &sink)
         } else {
             // application/json (slice-1's path): the body IS the JSON-RPC response.
             match serde_json::from_str::<serde_json::Value>(&body) {
@@ -245,7 +344,7 @@ pub async fn run_attach_client(base_url: String) {
                         eprintln!("[m1nd-mcp][attach] negotiated protocolVersion={}", pv);
                     }
                 }
-                emit_value(&v, mode);
+                sink.emit_value(v, mode);
             }
             None => {
                 // We got a request but couldn't surface a usable response frame.
@@ -258,17 +357,168 @@ pub async fn run_attach_client(base_url: String) {
                         status
                     ),
                 );
-                emit(&err, mode);
+                sink.emit(&err, mode);
             }
         }
     }
 
-    // TODO(slice4): a long-lived `GET /mcp` push relay — subscribe to the owner's
-    // server→client SSE stream and forward `notifications/m1nd/graph_changed`
-    // frames to this host's stdout, so an attached agent learns that ANOTHER
-    // agent mutated the shared graph without polling. The request/response bridge
-    // (the must-have for shared-graph mutation visibility) is complete above;
-    // the push relay is deliberately deferred.
+    // The loop exited on stdin EOF (the host closed its end): the bridge is done.
+    // Tear down the long-lived push relay (Wave 4 slice 4) — it would otherwise
+    // keep the process alive on its SSE GET forever — then drain the stdout
+    // writer so any in-flight frames flush before we return.
+    if let Some(handle) = relay_handle {
+        handle.abort();
+        let _ = handle.await; // swallow the JoinError from the abort
+    }
+    // Drop the producing sink so the writer task's channel closes and it exits.
+    drop(sink);
+    let _ = writer_handle.await;
+}
+
+/// Long-lived server→client push relay (Wave 4 slice 4).
+///
+/// Issues `GET {endpoint}` with `Accept: text/event-stream` plus the captured
+/// `mcp-session-id` (and `mcp-protocol-version` if negotiated), then streams the
+/// owner's SSE body and forwards every JSON-RPC NOTIFICATION (a frame with no
+/// `id`, e.g. `notifications/m1nd/graph_changed`) to the host through the SAME
+/// serialized `StdoutSink` the request/response loop uses — so an attached agent
+/// learns that ANOTHER agent mutated the shared graph without polling.
+///
+/// Robustness: parsing is incremental (event boundary = blank line); SSE comment
+/// / keep-alive lines (`:` prefix) are skipped and never JSON-parsed; id-bearing
+/// response frames are ignored here (they belong to the request/response loop, so
+/// the relay can never race a real response). On stream error/EOF the relay logs
+/// to stderr and retries with bounded exponential backoff — it NEVER crashes the
+/// bridge or writes anything but well-formed notification frames to stdout.
+async fn run_push_relay(
+    client: reqwest::Client,
+    endpoint: String,
+    session_id: String,
+    protocol_version: Option<String>,
+    sink: StdoutSink,
+    mode: TransportMode,
+) {
+    use std::time::Duration;
+
+    const MAX_BACKOFF_SECS: u64 = 30;
+    let mut backoff_secs: u64 = 1;
+
+    eprintln!("[m1nd-mcp][attach] push relay: subscribing to {} (SSE)", endpoint);
+
+    loop {
+        let mut builder = client
+            .get(&endpoint)
+            .header(reqwest::header::ACCEPT, "text/event-stream")
+            .header(MCP_SESSION_HEADER, session_id.clone());
+        if let Some(pv) = &protocol_version {
+            builder = builder.header(MCP_PROTOCOL_VERSION_HEADER, pv.clone());
+        }
+
+        match builder.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                // Connected: reset backoff and stream until the body ends/errors.
+                backoff_secs = 1;
+                if let Err(e) = stream_relay_body(resp, &sink, mode).await {
+                    eprintln!("[m1nd-mcp][attach] push relay stream ended: {e}");
+                } else {
+                    eprintln!("[m1nd-mcp][attach] push relay stream closed by owner");
+                }
+            }
+            Ok(resp) => {
+                eprintln!(
+                    "[m1nd-mcp][attach] push relay GET returned {} (not subscribing)",
+                    resp.status()
+                );
+            }
+            Err(e) => {
+                eprintln!("[m1nd-mcp][attach] push relay GET failed: {e}");
+            }
+        }
+
+        // Bounded exponential backoff before reconnecting.
+        eprintln!(
+            "[m1nd-mcp][attach] push relay reconnecting in {}s",
+            backoff_secs
+        );
+        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+        backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
+    }
+}
+
+/// Consume a streaming SSE response chunk-by-chunk, splitting it into events on
+/// blank lines and forwarding each id-less notification frame to the sink. Holds
+/// a rolling buffer so a frame split across TCP chunks is reassembled correctly.
+async fn stream_relay_body(
+    resp: reqwest::Response,
+    sink: &StdoutSink,
+    mode: TransportMode,
+) -> Result<(), String> {
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+
+    use futures::StreamExt;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| e.to_string())?;
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+
+        // Drain every complete event (terminated by a blank line) from the buffer.
+        // SSE event separator is "\n\n"; tolerate "\r\n\r\n" too.
+        loop {
+            let sep = find_event_boundary(&buf);
+            let Some((end, sep_len)) = sep else { break };
+            let event: String = buf.drain(..end + sep_len).collect();
+            relay_one_event(&event, sink, mode);
+        }
+    }
+    Ok(())
+}
+
+/// Find the byte offset + length of the first SSE event boundary (a blank line)
+/// in `buf`, handling both `\n\n` and `\r\n\r\n`.
+fn find_event_boundary(buf: &str) -> Option<(usize, usize)> {
+    if let Some(idx) = buf.find("\r\n\r\n") {
+        return Some((idx, 4));
+    }
+    if let Some(idx) = buf.find("\n\n") {
+        return Some((idx, 2));
+    }
+    None
+}
+
+/// Parse one SSE event block, concatenating its `data:` lines, and forward it to
+/// stdout iff it is a JSON-RPC notification (no/null `id`). Comment/keep-alive
+/// lines (leading `:`) and id-bearing response frames are ignored.
+fn relay_one_event(event: &str, sink: &StdoutSink, mode: TransportMode) {
+    let mut data_lines: Vec<String> = Vec::new();
+    for line in event.lines() {
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        if line.is_empty() || line.starts_with(':') {
+            // Blank line or SSE comment / keep-alive — never JSON-parse.
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.strip_prefix(' ').unwrap_or(rest).to_string());
+        }
+        // `id:`, `event:`, and other fields are not needed for forwarding.
+    }
+    if data_lines.is_empty() {
+        return;
+    }
+    let payload = data_lines.join("\n");
+    let value: serde_json::Value = match serde_json::from_str(&payload) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[m1nd-mcp][attach] push relay: skipping non-JSON SSE data ({e})");
+            return;
+        }
+    };
+    // Forward ONLY id-less notifications, so a relayed frame can never collide
+    // with a real request/response in the loop.
+    let has_id = value.get("id").is_some_and(|v| !v.is_null());
+    if has_id {
+        return;
+    }
+    sink.emit_value(value, mode);
 }
 
 /// Build a JSON-RPC error response frame.
@@ -285,43 +535,16 @@ fn jsonrpc_error(id: serde_json::Value, code: i32, message: String) -> JsonRpcRe
     }
 }
 
-/// Write a typed `JsonRpcResponse` to stdout using the embedded server's framing
-/// primitive (verbatim), in the inbound `TransportMode`.
-fn emit(resp: &JsonRpcResponse, mode: TransportMode) {
-    let stdout = std::io::stdout();
-    let mut writer = stdout.lock();
-    if write_response(&mut writer, resp, mode).is_err() {
-        eprintln!("[m1nd-mcp][attach] stdout closed while writing response");
-    }
-}
-
-/// Write an arbitrary JSON value (a full JSON-RPC frame received from the owner)
-/// to stdout in the inbound framing mode. We re-frame using the SAME logic
-/// `write_response` uses (Content-Length vs newline) so stdout is byte-identical
-/// to the embedded server — the value is forwarded as-is, preserving the owner's
-/// exact `result`/`error` shape.
-fn emit_value(value: &serde_json::Value, mode: TransportMode) {
-    let json = serde_json::to_string(value).unwrap_or_default();
-    let stdout = std::io::stdout();
-    let mut writer = stdout.lock();
-    let write_res = match mode {
-        TransportMode::Framed => write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)
-            .and_then(|_| writer.flush()),
-        TransportMode::Line => writeln!(writer, "{}", json).and_then(|_| writer.flush()),
-    };
-    if write_res.is_err() {
-        eprintln!("[m1nd-mcp][attach] stdout closed while writing frame");
-    }
-}
-
 /// Parse a `text/event-stream` body, relaying any interim server→client
-/// notification frames (no `id`) to stdout and returning the response frame whose
-/// `id` matches `want_id` (if found). Falls back to the first response-shaped
-/// frame (has `result` or `error`) when no id matches.
+/// notification frames (no `id`) to stdout via the serialized `sink` and
+/// returning the response frame whose `id` matches `want_id` (if found). Falls
+/// back to the first response-shaped frame (has `result` or `error`) when no id
+/// matches.
 fn extract_sse_response(
     body: &str,
     want_id: Option<&serde_json::Value>,
     mode: TransportMode,
+    sink: &StdoutSink,
 ) -> Option<serde_json::Value> {
     let mut matched: Option<serde_json::Value> = None;
     let mut first_response: Option<serde_json::Value> = None;
@@ -347,7 +570,7 @@ fn extract_sse_response(
             }
         } else if !has_id {
             // Interim server→client notification → relay to stdout.
-            emit_value(&value, mode);
+            sink.emit_value(value, mode);
         }
     }
 
@@ -385,6 +608,21 @@ fn sse_data_payloads(body: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
+    /// Build a `StdoutSink` plus the receiver end so tests can inspect every
+    /// frame the sink was asked to emit (instead of writing real stdout).
+    fn test_sink() -> (StdoutSink, mpsc::UnboundedReceiver<StdoutFrame>) {
+        let (tx, rx) = mpsc::unbounded_channel::<StdoutFrame>();
+        (StdoutSink { tx }, rx)
+    }
+
+    fn drain(rx: &mut mpsc::UnboundedReceiver<StdoutFrame>) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        while let Ok((v, _)) = rx.try_recv() {
+            out.push(v);
+        }
+        out
+    }
+
     #[test]
     fn sse_single_data_frame_is_extracted() {
         let body = "id: 0\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n";
@@ -409,17 +647,23 @@ mod tests {
         let body = "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/x\",\"params\":{}}\n\n\
                     data: {\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"v\":42}}\n\n";
         let want = serde_json::json!(7);
-        let got = extract_sse_response(body, Some(&want), TransportMode::Line)
+        let (sink, mut rx) = test_sink();
+        let got = extract_sse_response(body, Some(&want), TransportMode::Line, &sink)
             .expect("matching response found");
         assert_eq!(got["id"], 7);
         assert_eq!(got["result"]["v"], 42);
+        // The interim notification was relayed to the sink.
+        let relayed = drain(&mut rx);
+        assert_eq!(relayed.len(), 1);
+        assert_eq!(relayed[0]["method"], "notifications/x");
     }
 
     #[test]
     fn extract_falls_back_to_first_response_when_no_id_match() {
         let body = "data: {\"jsonrpc\":\"2.0\",\"id\":99,\"result\":{\"v\":1}}\n\n";
         let want = serde_json::json!(1);
-        let got = extract_sse_response(body, Some(&want), TransportMode::Line)
+        let (sink, _rx) = test_sink();
+        let got = extract_sse_response(body, Some(&want), TransportMode::Line, &sink)
             .expect("falls back to first response");
         assert_eq!(got["id"], 99);
     }
@@ -433,5 +677,51 @@ mod tests {
         let e = err.error.expect("error present");
         assert_eq!(e.code, -32002);
         assert_eq!(e.message, "boom");
+    }
+
+    #[test]
+    fn relay_forwards_graph_changed_notification() {
+        let (sink, mut rx) = test_sink();
+        let event = "id: 3\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/m1nd/graph_changed\",\"params\":{\"event\":\"memorize\"}}\n";
+        relay_one_event(event, &sink, TransportMode::Line);
+        let out = drain(&mut rx);
+        assert_eq!(out.len(), 1, "the notification should be forwarded");
+        assert_eq!(out[0]["method"], "notifications/m1nd/graph_changed");
+        assert!(out[0].get("id").is_none(), "must stay a notification");
+        assert_eq!(out[0]["params"]["event"], "memorize");
+    }
+
+    #[test]
+    fn relay_skips_keepalive_comment() {
+        let (sink, mut rx) = test_sink();
+        // A bare SSE comment / keep-alive line must never be JSON-parsed/forwarded.
+        relay_one_event(":\n", &sink, TransportMode::Line);
+        assert!(drain(&mut rx).is_empty());
+    }
+
+    #[test]
+    fn relay_skips_id_bearing_response() {
+        let (sink, mut rx) = test_sink();
+        // An id-bearing response belongs to the request/response loop, not the relay.
+        let event = "data: {\"jsonrpc\":\"2.0\",\"id\":12,\"result\":{\"ok\":true}}\n";
+        relay_one_event(event, &sink, TransportMode::Line);
+        assert!(drain(&mut rx).is_empty());
+    }
+
+    #[test]
+    fn relay_joins_multiline_data() {
+        let (sink, mut rx) = test_sink();
+        let event = "data: {\"jsonrpc\":\"2.0\",\ndata: \"method\":\"notifications/x\",\"params\":{}}\n";
+        relay_one_event(event, &sink, TransportMode::Line);
+        let out = drain(&mut rx);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["method"], "notifications/x");
+    }
+
+    #[test]
+    fn event_boundary_handles_lf_and_crlf() {
+        assert_eq!(find_event_boundary("data: a\n\nrest"), Some((7, 2)));
+        assert_eq!(find_event_boundary("data: a\r\n\r\nrest"), Some((7, 4)));
+        assert_eq!(find_event_boundary("data: a\n"), None);
     }
 }

--- a/m1nd-mcp/src/attach_client.rs
+++ b/m1nd-mcp/src/attach_client.rs
@@ -152,8 +152,7 @@ pub async fn run_attach_client(base_url: String) {
     // discard already-buffered bytes (read-ahead) and silently drop the next
     // request. Frames are pushed to the async loop over a bounded channel; this
     // mirrors the embedded stdio server's reader-thread pattern in `server.rs`.
-    let (frame_tx, mut frame_rx) =
-        tokio::sync::mpsc::channel::<(String, TransportMode)>(64);
+    let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<(String, TransportMode)>(64);
     std::thread::spawn(move || {
         let stdin = std::io::stdin();
         let mut reader = BufReader::new(stdin.lock());
@@ -196,7 +195,11 @@ pub async fn run_attach_client(base_url: String) {
             Err(e) => {
                 // Malformed JSON from the host → reply with a parse error so the
                 // host sees a clean frame rather than a dropped message.
-                let err = jsonrpc_error(serde_json::Value::Null, -32700, format!("Parse error: {}", e));
+                let err = jsonrpc_error(
+                    serde_json::Value::Null,
+                    -32700,
+                    format!("Parse error: {}", e),
+                );
                 sink.emit(&err, mode);
                 continue;
             }
@@ -204,13 +207,19 @@ pub async fn run_attach_client(base_url: String) {
 
         let req_id = parsed.get("id").cloned();
         let is_request = req_id.as_ref().is_some_and(|v| !v.is_null());
-        let method = parsed.get("method").and_then(|m| m.as_str()).map(str::to_owned);
+        let method = parsed
+            .get("method")
+            .and_then(|m| m.as_str())
+            .map(str::to_owned);
         let is_initialize = method.as_deref() == Some("initialize");
 
         // --- Build the POST with the MCP-mandated headers. ---
         let mut builder = client
             .post(&endpoint)
-            .header(reqwest::header::ACCEPT, "application/json, text/event-stream")
+            .header(
+                reqwest::header::ACCEPT,
+                "application/json, text/event-stream",
+            )
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .body(payload.clone());
 
@@ -235,7 +244,10 @@ pub async fn run_attach_client(base_url: String) {
                     let err = jsonrpc_error(
                         id,
                         -32002,
-                        format!("attach bridge: failed to reach m1nd owner at {}: {}", endpoint, e),
+                        format!(
+                            "attach bridge: failed to reach m1nd owner at {}: {}",
+                            endpoint, e
+                        ),
                     );
                     sink.emit(&err, mode);
                 }
@@ -311,24 +323,24 @@ pub async fn run_attach_client(base_url: String) {
         };
 
         // --- Demux by content-type. ---
-        let response_value: Option<serde_json::Value> = if content_type.contains("text/event-stream")
-        {
-            // SSE: extract the JSON-RPC response frame whose `id` matches the
-            // request; relay any interim server→client notifications to stdout.
-            extract_sse_response(&body, req_id.as_ref(), mode, &sink)
-        } else {
-            // application/json (slice-1's path): the body IS the JSON-RPC response.
-            match serde_json::from_str::<serde_json::Value>(&body) {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    eprintln!(
-                        "[m1nd-mcp][attach] owner returned {} with non-JSON body ({}): {}",
-                        status, e, body
-                    );
-                    None
+        let response_value: Option<serde_json::Value> =
+            if content_type.contains("text/event-stream") {
+                // SSE: extract the JSON-RPC response frame whose `id` matches the
+                // request; relay any interim server→client notifications to stdout.
+                extract_sse_response(&body, req_id.as_ref(), mode, &sink)
+            } else {
+                // application/json (slice-1's path): the body IS the JSON-RPC response.
+                match serde_json::from_str::<serde_json::Value>(&body) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!(
+                            "[m1nd-mcp][attach] owner returned {} with non-JSON body ({}): {}",
+                            status, e, body
+                        );
+                        None
+                    }
                 }
-            }
-        };
+            };
 
         match response_value {
             Some(v) => {
@@ -403,7 +415,10 @@ async fn run_push_relay(
     const MAX_BACKOFF_SECS: u64 = 30;
     let mut backoff_secs: u64 = 1;
 
-    eprintln!("[m1nd-mcp][attach] push relay: subscribing to {} (SSE)", endpoint);
+    eprintln!(
+        "[m1nd-mcp][attach] push relay: subscribing to {} (SSE)",
+        endpoint
+    );
 
     loop {
         let mut builder = client
@@ -711,7 +726,8 @@ mod tests {
     #[test]
     fn relay_joins_multiline_data() {
         let (sink, mut rx) = test_sink();
-        let event = "data: {\"jsonrpc\":\"2.0\",\ndata: \"method\":\"notifications/x\",\"params\":{}}\n";
+        let event =
+            "data: {\"jsonrpc\":\"2.0\",\ndata: \"method\":\"notifications/x\",\"params\":{}}\n";
         relay_one_event(event, &sink, TransportMode::Line);
         let out = drain(&mut rx);
         assert_eq!(out.len(), 1);

--- a/m1nd-mcp/src/audit_handlers.rs
+++ b/m1nd-mcp/src/audit_handlers.rs
@@ -405,7 +405,15 @@ fn supports_external_reference_scan(kind: AuditFileKind) -> bool {
     )
 }
 
-fn simple_content_hash(path: &Path) -> Option<String> {
+/// Canonical on-disk content hash used across freshness/staleness checks.
+///
+/// Reads the whole file and hashes its bytes with the same algorithm the
+/// ingest path records into `FileInventoryEntry::sha256` (see
+/// `tools::build_file_inventory_entries`), so a recomputed hash can be compared
+/// directly against the stored inventory value. Shared by `cross_verify`'s
+/// evidence-freshness check and the `am_i_stale` self-awareness tool — do NOT
+/// roll a second hashing routine.
+pub(crate) fn simple_content_hash(path: &Path) -> Option<String> {
     let bytes = std::fs::read(path).ok()?;
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     bytes.hash(&mut hasher);

--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -661,6 +661,11 @@ impl AutoIngestState {
     }
 
     pub fn maybe_tick(&mut self, state: &mut SessionState) -> M1ndResult<()> {
+        // Read-only attach must never re-ingest/persist, even if a prior
+        // read-write session left auto-ingest `running` in the loaded state.
+        if state.read_only {
+            return Ok(());
+        }
         if !self.running {
             return Ok(());
         }

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -68,4 +68,10 @@ pub struct Cli {
     /// Use when a separate stdio process writes events to this file.
     #[arg(long)]
     pub watch_events: Option<String>,
+
+    /// Attach read-only: load the snapshot and serve queries, but never write to
+    /// disk and never take an exclusive lease. Mutation tools are disabled.
+    /// Also honored via env `M1ND_READ_ONLY=1`.
+    #[arg(long)]
+    pub read_only: bool,
 }

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -74,4 +74,13 @@ pub struct Cli {
     /// Also honored via env `M1ND_READ_ONLY=1`.
     #[arg(long)]
     pub read_only: bool,
+
+    /// Attach to a running `--serve` owner as a thin stdio↔HTTP MCP bridge.
+    /// Takes the owner's base URL (e.g. `http://127.0.0.1:1337`). The bridge
+    /// loads NO graph, builds NO engines, and takes NO lease: it speaks stdio
+    /// MCP to the host (Claude Code) and forwards every JSON-RPC frame to the
+    /// owner's `POST /mcp` endpoint. Multiple `--attach` clients pointed at one
+    /// owner share that owner's single live graph. Requires the `serve` feature.
+    #[arg(long)]
+    pub attach: Option<String>,
 }

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -76,11 +76,16 @@ pub struct Cli {
     pub read_only: bool,
 
     /// Attach to a running `--serve` owner as a thin stdio↔HTTP MCP bridge.
-    /// Takes the owner's base URL (e.g. `http://127.0.0.1:1337`). The bridge
-    /// loads NO graph, builds NO engines, and takes NO lease: it speaks stdio
-    /// MCP to the host (Claude Code) and forwards every JSON-RPC frame to the
-    /// owner's `POST /mcp` endpoint. Multiple `--attach` clients pointed at one
-    /// owner share that owner's single live graph. Requires the `serve` feature.
+    /// Takes the owner's base URL (e.g. `http://127.0.0.1:1337`), or the literal
+    /// `auto` to auto-discover the live serve ReadWrite owner for this client's
+    /// runtime_root via the instance registry (read-only, NO lease). The env var
+    /// `M1ND_ATTACH_URL`, when set, overrides both and wins. The bridge loads NO
+    /// graph, builds NO engines, and takes NO lease: it speaks stdio MCP to the
+    /// host (Claude Code), forwards every JSON-RPC frame to the owner's
+    /// `POST /mcp`, and relays the owner's server→client SSE push notifications
+    /// (`notifications/m1nd/graph_changed`) back to stdout. Multiple `--attach`
+    /// clients pointed at one owner share that owner's single live graph.
+    /// Requires the `serve` feature.
     #[arg(long)]
     pub attach: Option<String>,
 }

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -716,6 +716,16 @@ pub fn handle_daemon_tick(
     let emitted_alerts_total = emitted_alert_ids.len() + heuristic_alerts_emitted;
     state.daemon_state.last_tick_ms = Some(tick_ms);
     state.daemon_state.tick_count = state.daemon_state.tick_count.saturating_add(1);
+
+    // Periodically garbage-collect dead lease/instance entries so crashed
+    // instances don't leak registry files forever. Cheap (a directory scan +
+    // `kill -0` per entry) and only removes provably-dead entries, so it is
+    // safe to run alongside live instances. Throttled to every Nth tick.
+    const GC_EVERY_N_TICKS: u64 = 50;
+    if state.daemon_state.tick_count % GC_EVERY_N_TICKS == 0 {
+        let registry_root = state.instance.registry_root();
+        let _ = crate::instance_registry::gc_dead_leases(&registry_root);
+    }
     state.daemon_state.last_tick_duration_ms = Some(start.elapsed().as_secs_f64() * 1000.0);
     state.daemon_state.last_tick_changed_files = changed_entries.len();
     state.daemon_state.last_tick_deleted_files = deleted_entries.len();

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -722,7 +722,7 @@ pub fn handle_daemon_tick(
     // `kill -0` per entry) and only removes provably-dead entries, so it is
     // safe to run alongside live instances. Throttled to every Nth tick.
     const GC_EVERY_N_TICKS: u64 = 50;
-    if state.daemon_state.tick_count % GC_EVERY_N_TICKS == 0 {
+    if state.daemon_state.tick_count.is_multiple_of(GC_EVERY_N_TICKS) {
         let registry_root = state.instance.registry_root();
         let _ = crate::instance_registry::gc_dead_leases(&registry_root);
     }

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -722,7 +722,11 @@ pub fn handle_daemon_tick(
     // `kill -0` per entry) and only removes provably-dead entries, so it is
     // safe to run alongside live instances. Throttled to every Nth tick.
     const GC_EVERY_N_TICKS: u64 = 50;
-    if state.daemon_state.tick_count.is_multiple_of(GC_EVERY_N_TICKS) {
+    if state
+        .daemon_state
+        .tick_count
+        .is_multiple_of(GC_EVERY_N_TICKS)
+    {
         let registry_root = state.instance.registry_root();
         let _ = crate::instance_registry::gc_dead_leases(&registry_root);
     }

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -291,6 +291,9 @@ pub struct AppState {
     /// Optional event log path for cross-process SSE (Option B).
     pub event_log_path: Option<std::path::PathBuf>,
     pub registry_dir: Option<std::path::PathBuf>,
+    /// Registry of live Streamable-HTTP MCP wire sessions (Wave 4, Slice 1).
+    /// Distinct from the instance lease and from `SessionState.sessions`.
+    pub mcp_sessions: crate::mcp_http::McpSessionRegistry,
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +334,7 @@ pub fn spawn_background(
         event_tx,
         event_log_path: None,
         registry_dir: Some(registry_root),
+        mcp_sessions: crate::mcp_http::new_mcp_session_registry(),
     });
     {
         let session = app_state.session.lock();
@@ -430,6 +434,7 @@ pub async fn run(
         event_tx: event_tx.clone(),
         event_log_path: event_log_path.clone(),
         registry_dir: config.registry_dir.clone(),
+        mcp_sessions: crate::mcp_http::new_mcp_session_registry(),
     });
     {
         let session = app_state.session.lock();
@@ -700,6 +705,8 @@ pub fn build_router(state: Arc<AppState>, dev_mode: bool) -> Router {
         )
         .route("/api/tools", get(handle_list_tools))
         .route("/api/tools/{*tool_name}", post(handle_tool_call))
+        // Streamable-HTTP MCP transport (Wave 4, Slice 1). GET/DELETE land in Slice 2.
+        .route("/mcp", post(crate::mcp_http::handle_mcp_post))
         .route("/api/graph/stats", get(handle_graph_stats))
         .route("/api/graph/subgraph", get(handle_subgraph))
         .route("/api/graph/snapshot", get(handle_graph_snapshot))

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -705,8 +705,14 @@ pub fn build_router(state: Arc<AppState>, dev_mode: bool) -> Router {
         )
         .route("/api/tools", get(handle_list_tools))
         .route("/api/tools/{*tool_name}", post(handle_tool_call))
-        // Streamable-HTTP MCP transport (Wave 4, Slice 1). GET/DELETE land in Slice 2.
-        .route("/mcp", post(crate::mcp_http::handle_mcp_post))
+        // Streamable-HTTP MCP transport. POST = client→server requests (Slice 1);
+        // GET = server→client SSE push, DELETE = session termination (Slice 2).
+        .route(
+            "/mcp",
+            post(crate::mcp_http::handle_mcp_post)
+                .get(crate::mcp_http::handle_mcp_get)
+                .delete(crate::mcp_http::handle_mcp_delete),
+        )
         .route("/api/graph/stats", get(handle_graph_stats))
         .route("/api/graph/subgraph", get(handle_subgraph))
         .route("/api/graph/snapshot", get(handle_graph_snapshot))

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -849,10 +849,9 @@ async fn handle_instance_save(State(state): State<Arc<AppState>>) -> axum::respo
 }
 
 fn instance_base_url(entry: &InstanceRegistryEntry) -> Option<String> {
-    let port = entry.port?;
-    let bind = entry.bind.as_deref().unwrap_or("127.0.0.1");
-    let host = if bind == "0.0.0.0" { "127.0.0.1" } else { bind };
-    Some(format!("http://{}:{}", host, port))
+    // Single source of truth for the bind/port → base-URL rule (0.0.0.0 → 127.0.0.1),
+    // shared with the `--attach auto` discovery client.
+    crate::instance_registry::entry_base_url(entry)
 }
 
 async fn handle_instance_save_target(

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -63,6 +63,9 @@ impl InstanceMode {
     /// Parse the on-disk `mode` string. Anything that is not exactly
     /// `"read_only"` is treated as `ReadWrite` so legacy/unknown values keep
     /// their historical (exclusive) meaning.
+    // Infallible, default-on-unknown conversion — the std `FromStr` trait would
+    // force a never-used `Err` type, so an inherent method is the right shape.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(value: &str) -> Self {
         match value {
             "read_only" => InstanceMode::ReadOnly,

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -595,6 +595,81 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+/// Build the reachable base URL for a registry entry, applying the same rule the
+/// HTTP server uses for self-advertisement: a wildcard `0.0.0.0` bind is rewritten
+/// to a loopback `127.0.0.1`, any other bind is used verbatim. Returns `None` when
+/// the entry has no published port (a stdio-only owner that never called
+/// `set_running_endpoint`), which makes it un-attachable by construction.
+pub fn entry_base_url(entry: &InstanceRegistryEntry) -> Option<String> {
+    let port = entry.port?;
+    let bind = entry.bind.as_deref().unwrap_or("127.0.0.1");
+    let host = if bind == "0.0.0.0" { "127.0.0.1" } else { bind };
+    Some(format!("http://{}:{}", host, port))
+}
+
+/// Read-only discovery for the `--attach auto` thin client.
+///
+/// Given the caller's `runtime_root` (e.g. the cwd or an explicit `--runtime-dir`),
+/// find the freshest live ReadWrite owner that is actually serving HTTP for that
+/// runtime_root and return its base URL (e.g. `http://127.0.0.1:1337`).
+///
+/// This is PURE read-only registry inspection: it calls `list_instances` (which
+/// only reads `instances/*.json`) and NEVER `acquire`/`acquire_with_mode`, so it
+/// takes no lease and never contends the owner's exclusive PID+heartbeat lock.
+///
+/// Matching mirrors `acquire_with_mode`'s persistence exactly:
+///   * the target `runtime_root` is canonicalized with the same `canonicalish`
+///     semantics the owner used before writing `entry.runtime_root`, so the
+///     string comparison lines up on macOS (`/tmp` → `/private/tmp`, symlinks…);
+///   * only `mode == read_write`, `owner_live == Some(true)`, `stale == false`
+///     entries that ALSO publish `bind`+`port` (the serve gate) survive;
+///   * with multiple survivors the freshest by `last_heartbeat_ms` wins
+///     (`list_instances` already sorts descending, so the first survivor is it).
+///
+/// On no match returns `Err(message)` distinguishing "no instances at all" from
+/// "instances exist but none is a live serve ReadWrite owner for this runtime_root".
+pub fn discover_serve_owner_base_url(
+    runtime_root: &Path,
+    registry_dir: Option<&Path>,
+) -> Result<String, String> {
+    // Canonicalize the target identically to how the owner stored it.
+    let target = canonicalish(runtime_root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| runtime_root.to_string_lossy().into_owned());
+
+    let entries = list_instances(registry_dir)
+        .map_err(|e| format!("failed to read instance registry: {e}"))?;
+
+    if entries.is_empty() {
+        return Err(format!(
+            "no m1nd instances registered (looked for a live serve ReadWrite owner for runtime_root {target})"
+        ));
+    }
+
+    // `list_instances` is already sorted freshest-first by last_heartbeat_ms, so
+    // the FIRST entry that passes every gate is the freshest serve owner.
+    for entry in &entries {
+        if entry.runtime_root != target {
+            continue;
+        }
+        if InstanceMode::from_str(&entry.mode) != InstanceMode::ReadWrite {
+            continue;
+        }
+        if entry.owner_live != Some(true) || entry.stale {
+            continue;
+        }
+        // Serve gate: stdio-only owners publish no bind/port and are unreachable.
+        if let Some(url) = entry_base_url(entry) {
+            return Ok(url);
+        }
+    }
+
+    Err(format!(
+        "no live serve ReadWrite owner for runtime_root {target}. \
+Start one with: m1nd-mcp --serve --no-gui"
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -38,6 +38,50 @@ pub struct InstanceRegistryEntry {
     pub conflicts: Vec<String>,
 }
 
+/// Acquisition mode for an instance.
+///
+/// `ReadWrite` takes the exclusive PID+heartbeat lease (one per `runtime_root`),
+/// exactly as before. `ReadOnly` never takes a lease: it only registers a
+/// discoverable `instances/<id>.json` entry and always succeeds, even while a
+/// live `ReadWrite` owner holds the lease.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstanceMode {
+    ReadWrite,
+    ReadOnly,
+}
+
+impl InstanceMode {
+    /// On-disk string used in the `mode` field. Kept stable for backward
+    /// compatibility with the ~54k existing lease/instance JSON files.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InstanceMode::ReadWrite => "read_write",
+            InstanceMode::ReadOnly => "read_only",
+        }
+    }
+
+    /// Parse the on-disk `mode` string. Anything that is not exactly
+    /// `"read_only"` is treated as `ReadWrite` so legacy/unknown values keep
+    /// their historical (exclusive) meaning.
+    pub fn from_str(value: &str) -> Self {
+        match value {
+            "read_only" => InstanceMode::ReadOnly,
+            _ => InstanceMode::ReadWrite,
+        }
+    }
+}
+
+/// Result of a dead-lease garbage-collection sweep.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct GcReport {
+    /// Number of files removed from the `leases/` directory.
+    pub leases_removed: usize,
+    /// Number of files removed from the `instances/` directory.
+    pub instances_removed: usize,
+    /// Total number of JSON entries inspected across both directories.
+    pub scanned: usize,
+}
+
 #[derive(Clone, Debug)]
 pub struct InstanceHandle {
     inner: Arc<Mutex<InstanceHandleInner>>,
@@ -48,16 +92,49 @@ struct InstanceHandleInner {
     entry: InstanceRegistryEntry,
     registry_root: PathBuf,
     entry_path: PathBuf,
-    lock_path: PathBuf,
+    /// `Some` only for `ReadWrite` handles. `ReadOnly` handles hold no
+    /// exclusive lease, so they have no lease file to refresh or remove.
+    lock_path: Option<PathBuf>,
+    mode: InstanceMode,
 }
 
 impl InstanceHandle {
+    /// Acquire in the default `ReadWrite` mode. Behavior is identical to the
+    /// historical single-argument-set version; existing callers are untouched.
     pub fn acquire(
         workspace_root: &Path,
         runtime_root: &Path,
         graph_source: &Path,
         plasticity_state: &Path,
         registry_root: Option<&Path>,
+    ) -> M1ndResult<Self> {
+        Self::acquire_with_mode(
+            workspace_root,
+            runtime_root,
+            graph_source,
+            plasticity_state,
+            registry_root,
+            InstanceMode::ReadWrite,
+        )
+    }
+
+    /// Acquire with an explicit mode.
+    ///
+    /// `ReadWrite` is the exclusive PID+heartbeat lease (unchanged from before):
+    /// if a live, non-stale, foreign owner holds the lease for this
+    /// `runtime_root`, this returns `AlreadyExists`.
+    ///
+    /// `ReadOnly` always succeeds and never touches the lease file. It only
+    /// writes an `instances/<id>.json` entry (with `mode:"read_only"`) so the
+    /// attacher is discoverable via `list_instances`. Multiple `ReadOnly`
+    /// attachers and one `ReadWrite` owner coexist with zero conflict.
+    pub fn acquire_with_mode(
+        workspace_root: &Path,
+        runtime_root: &Path,
+        graph_source: &Path,
+        plasticity_state: &Path,
+        registry_root: Option<&Path>,
+        mode: InstanceMode,
     ) -> M1ndResult<Self> {
         let workspace_root = canonicalish(workspace_root)?;
         let runtime_root = canonicalish(runtime_root)?;
@@ -71,11 +148,14 @@ impl InstanceHandle {
         fs::create_dir_all(registry_root.join(INSTANCE_DIR_NAME))?;
         fs::create_dir_all(registry_root.join(LEASE_DIR_NAME))?;
 
-        let lock_path = registry_root
+        let lease_file = registry_root
             .join(LEASE_DIR_NAME)
             .join(format!("{}.json", fingerprint_path(&runtime_root)));
-        if lock_path.exists() {
-            let existing: InstanceRegistryEntry = read_json(&lock_path)?;
+
+        // ReadWrite is the only mode that contends for the exclusive lease.
+        // ReadOnly never inspects, steals, or overwrites the lease file.
+        if mode == InstanceMode::ReadWrite && lease_file.exists() {
+            let existing: InstanceRegistryEntry = read_json(&lease_file)?;
             let live = is_pid_live(existing.pid);
             let stale = is_stale(existing.last_heartbeat_ms);
             if live && !stale && existing.pid != std::process::id() {
@@ -104,7 +184,7 @@ impl InstanceHandle {
             port: None,
             started_at_ms: now_ms,
             last_heartbeat_ms: now_ms,
-            mode: "read_write".into(),
+            mode: mode.as_str().into(),
             status: "starting".into(),
             owner_live: Some(true),
             stale: false,
@@ -114,7 +194,15 @@ impl InstanceHandle {
         let entry_path = registry_root
             .join(INSTANCE_DIR_NAME)
             .join(format!("{}.json", instance_id));
-        save_json_atomic(&lock_path, &entry)?;
+
+        // ReadOnly: discovery entry only, no exclusive lease.
+        let lock_path = match mode {
+            InstanceMode::ReadWrite => {
+                save_json_atomic(&lease_file, &entry)?;
+                Some(lease_file)
+            }
+            InstanceMode::ReadOnly => None,
+        };
         save_json_atomic(&entry_path, &entry)?;
 
         Ok(Self {
@@ -123,6 +211,7 @@ impl InstanceHandle {
                 registry_root,
                 entry_path,
                 lock_path,
+                mode,
             })),
         })
     }
@@ -160,9 +249,17 @@ impl InstanceHandle {
         self.inner.lock().registry_root.clone()
     }
 
+    /// The mode this handle was acquired with.
+    pub fn mode(&self) -> InstanceMode {
+        self.inner.lock().mode
+    }
+
     pub fn release(&self) -> M1ndResult<()> {
         let inner = self.inner.lock();
-        let _ = fs::remove_file(&inner.lock_path);
+        // ReadOnly handles hold no lease; only the discovery entry is removed.
+        if let Some(lock_path) = &inner.lock_path {
+            let _ = fs::remove_file(lock_path);
+        }
         let _ = fs::remove_file(&inner.entry_path);
         Ok(())
     }
@@ -275,6 +372,61 @@ pub fn delete_instance_state(
     Ok(entry)
 }
 
+/// Garbage-collect dead lease and instance entries.
+///
+/// Scans both `leases/` and `instances/` under `registry_root` and removes any
+/// JSON entry whose recorded `pid` is provably NOT live (via `is_pid_live`).
+/// Entries owned by a live pid are NEVER removed. Any entry that fails to read
+/// or parse is skipped (never deleted), so corrupt/foreign files are left
+/// untouched. Safe to call while a live instance is running — only
+/// provably-dead entries are removed.
+pub fn gc_dead_leases(registry_root: &Path) -> std::io::Result<GcReport> {
+    let mut report = GcReport::default();
+    gc_dead_in_dir(
+        &registry_root.join(LEASE_DIR_NAME),
+        &mut report.scanned,
+        &mut report.leases_removed,
+    )?;
+    gc_dead_in_dir(
+        &registry_root.join(INSTANCE_DIR_NAME),
+        &mut report.scanned,
+        &mut report.instances_removed,
+    )?;
+    Ok(report)
+}
+
+/// Sweep a single registry directory, removing only entries whose pid is dead.
+fn gc_dead_in_dir(dir: &Path, scanned: &mut usize, removed: &mut usize) -> std::io::Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for item in fs::read_dir(dir)? {
+        // Skip unreadable directory entries rather than aborting the sweep.
+        let item = match item {
+            Ok(item) => item,
+            Err(_) => continue,
+        };
+        let path = item.path();
+        if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        // Conservative: any read/parse error -> skip (do NOT delete).
+        let entry: InstanceRegistryEntry = match read_json(&path) {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        *scanned += 1;
+        // NEVER remove an entry whose owning process is still alive.
+        if is_pid_live(entry.pid) {
+            continue;
+        }
+        if fs::remove_file(&path).is_ok() {
+            *removed += 1;
+        }
+    }
+    Ok(())
+}
+
 pub fn default_registry_root() -> PathBuf {
     if let Some(home) = std::env::var_os("HOME") {
         return PathBuf::from(home).join(DEFAULT_REGISTRY_SUBDIR);
@@ -314,9 +466,22 @@ fn apply_conflicts(entries: &mut [InstanceRegistryEntry]) {
 }
 
 fn persist_handle_inner(inner: &InstanceHandleInner) -> M1ndResult<()> {
+    // Always refresh the discovery entry so heartbeats keep ReadOnly attachers
+    // (and ReadWrite owners) visible/live in list_instances.
     save_json_atomic(&inner.entry_path, &inner.entry)?;
-    save_json_atomic(&inner.lock_path, &inner.entry)
+    // Refresh the exclusive lease only for ReadWrite handles.
+    if let Some(lock_path) = &inner.lock_path {
+        save_json_atomic(lock_path, &inner.entry)?;
+    }
+    Ok(())
 }
+
+/// Monotonic per-process nonce so that two instances acquired in the same
+/// process for the same (workspace, runtime) within a single millisecond clock
+/// tick never collide on `instance_id`. The pid already disambiguates across
+/// processes; this disambiguates within one (e.g. a ReadWrite owner and a
+/// ReadOnly attacher started back-to-back, or test setups).
+static INSTANCE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 fn generate_instance_id(workspace_root: &Path, runtime_root: &Path, now_ms: u64) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -324,6 +489,9 @@ fn generate_instance_id(workspace_root: &Path, runtime_root: &Path, now_ms: u64)
     runtime_root.to_string_lossy().hash(&mut hasher);
     std::process::id().hash(&mut hasher);
     now_ms.hash(&mut hasher);
+    INSTANCE_SEQ
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        .hash(&mut hasher);
     format!("inst_{:x}", hasher.finish())
 }
 
@@ -616,5 +784,164 @@ mod tests {
         assert!(runtime.exists());
         assert!(entry_path.exists());
         assert!(lease_path.exists());
+    }
+
+    #[test]
+    fn instance_mode_roundtrips_on_disk_string() {
+        assert_eq!(InstanceMode::ReadWrite.as_str(), "read_write");
+        assert_eq!(InstanceMode::ReadOnly.as_str(), "read_only");
+        assert_eq!(InstanceMode::from_str("read_write"), InstanceMode::ReadWrite);
+        assert_eq!(InstanceMode::from_str("read_only"), InstanceMode::ReadOnly);
+        // Unknown/legacy values default to ReadWrite.
+        assert_eq!(InstanceMode::from_str("whatever"), InstanceMode::ReadWrite);
+    }
+
+    #[test]
+    fn readonly_attach_coexists_with_live_readwrite_owner() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        let runtime = temp.path().join("runtime");
+        let graph = runtime.join("graph.json");
+        let plasticity = runtime.join("plasticity.json");
+        let registry = temp.path().join("registry");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&runtime).unwrap();
+
+        let owner =
+            InstanceHandle::acquire(&workspace, &runtime, &graph, &plasticity, Some(&registry))
+                .unwrap();
+        assert_eq!(owner.mode(), InstanceMode::ReadWrite);
+
+        // Two ReadOnly attachers succeed even with a live ReadWrite owner.
+        let ro_a = InstanceHandle::acquire_with_mode(
+            &workspace,
+            &runtime,
+            &graph,
+            &plasticity,
+            Some(&registry),
+            InstanceMode::ReadOnly,
+        )
+        .unwrap();
+        let ro_b = InstanceHandle::acquire_with_mode(
+            &workspace,
+            &runtime,
+            &graph,
+            &plasticity,
+            Some(&registry),
+            InstanceMode::ReadOnly,
+        )
+        .unwrap();
+        assert_eq!(ro_a.mode(), InstanceMode::ReadOnly);
+        assert_eq!(ro_b.mode(), InstanceMode::ReadOnly);
+
+        // The single exclusive lease still belongs to the ReadWrite owner.
+        let lease_path = registry.join(LEASE_DIR_NAME).join(format!(
+            "{}.json",
+            fingerprint_path(&canonicalish(&runtime).unwrap())
+        ));
+        let lease: InstanceRegistryEntry = read_json(&lease_path).unwrap();
+        assert_eq!(lease.instance_id, owner.summary().instance_id);
+        assert_eq!(lease.mode, "read_write");
+
+        // All three are discoverable; two carry read_only mode.
+        let instances = list_instances(Some(&registry)).unwrap();
+        assert_eq!(instances.len(), 3);
+        let read_only = instances
+            .iter()
+            .filter(|e| e.mode == "read_only")
+            .count();
+        assert_eq!(read_only, 2);
+
+        // ReadOnly release removes only its own discovery entry, never the lease.
+        ro_a.release().unwrap();
+        assert!(lease_path.exists());
+        let after = list_instances(Some(&registry)).unwrap();
+        assert_eq!(after.len(), 2);
+    }
+
+    #[test]
+    fn readonly_acquire_never_creates_a_lease() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        let runtime = temp.path().join("runtime");
+        let graph = runtime.join("graph.json");
+        let plasticity = runtime.join("plasticity.json");
+        let registry = temp.path().join("registry");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&runtime).unwrap();
+
+        let ro = InstanceHandle::acquire_with_mode(
+            &workspace,
+            &runtime,
+            &graph,
+            &plasticity,
+            Some(&registry),
+            InstanceMode::ReadOnly,
+        )
+        .unwrap();
+        let lease_path = registry.join(LEASE_DIR_NAME).join(format!(
+            "{}.json",
+            fingerprint_path(&canonicalish(&runtime).unwrap())
+        ));
+        assert!(!lease_path.exists());
+        // Heartbeats keep the discovery entry fresh without creating a lease.
+        ro.mark_heartbeat().unwrap();
+        assert!(!lease_path.exists());
+        assert_eq!(list_instances(Some(&registry)).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn gc_removes_dead_entries_and_keeps_live_ones() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        let runtime = temp.path().join("runtime");
+        let graph = runtime.join("graph.json");
+        let plasticity = runtime.join("plasticity.json");
+        let registry = temp.path().join("registry");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(&runtime).unwrap();
+
+        // Live owner (current pid) — must survive GC.
+        let live =
+            InstanceHandle::acquire(&workspace, &runtime, &graph, &plasticity, Some(&registry))
+                .unwrap();
+        let live_entry_path = registry
+            .join(INSTANCE_DIR_NAME)
+            .join(format!("{}.json", live.summary().instance_id));
+        let live_lease_path = registry.join(LEASE_DIR_NAME).join(format!(
+            "{}.json",
+            fingerprint_path(&canonicalish(&runtime).unwrap())
+        ));
+
+        // Plant a dead lease + dead instance entry under a different runtime root.
+        let mut dead = live.summary();
+        dead.instance_id = "inst_dead".into();
+        dead.pid = u32::MAX - 1; // never live
+        dead.runtime_root = "/tmp/dead-runtime".into();
+        let dead_entry_path = registry
+            .join(INSTANCE_DIR_NAME)
+            .join("inst_dead.json");
+        let dead_lease_path = registry
+            .join(LEASE_DIR_NAME)
+            .join("deadfingerprint.json");
+        save_json_atomic(&dead_entry_path, &dead).unwrap();
+        save_json_atomic(&dead_lease_path, &dead).unwrap();
+
+        // A corrupt file must be skipped, not deleted.
+        let corrupt_path = registry.join(LEASE_DIR_NAME).join("corrupt.json");
+        fs::write(&corrupt_path, "{ not valid json").unwrap();
+
+        let report = gc_dead_leases(&registry).unwrap();
+        assert_eq!(report.leases_removed, 1);
+        assert_eq!(report.instances_removed, 1);
+        // scanned counts only successfully-parsed entries.
+        assert_eq!(report.scanned, 4);
+
+        // Dead entries gone; live entries and the corrupt file remain.
+        assert!(!dead_entry_path.exists());
+        assert!(!dead_lease_path.exists());
+        assert!(live_entry_path.exists());
+        assert!(live_lease_path.exists());
+        assert!(corrupt_path.exists());
     }
 }

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -868,7 +868,10 @@ mod tests {
     fn instance_mode_roundtrips_on_disk_string() {
         assert_eq!(InstanceMode::ReadWrite.as_str(), "read_write");
         assert_eq!(InstanceMode::ReadOnly.as_str(), "read_only");
-        assert_eq!(InstanceMode::from_str("read_write"), InstanceMode::ReadWrite);
+        assert_eq!(
+            InstanceMode::from_str("read_write"),
+            InstanceMode::ReadWrite
+        );
         assert_eq!(InstanceMode::from_str("read_only"), InstanceMode::ReadOnly);
         // Unknown/legacy values default to ReadWrite.
         assert_eq!(InstanceMode::from_str("whatever"), InstanceMode::ReadWrite);
@@ -924,10 +927,7 @@ mod tests {
         // All three are discoverable; two carry read_only mode.
         let instances = list_instances(Some(&registry)).unwrap();
         assert_eq!(instances.len(), 3);
-        let read_only = instances
-            .iter()
-            .filter(|e| e.mode == "read_only")
-            .count();
+        let read_only = instances.iter().filter(|e| e.mode == "read_only").count();
         assert_eq!(read_only, 2);
 
         // ReadOnly release removes only its own discovery entry, never the lease.
@@ -996,12 +996,8 @@ mod tests {
         dead.instance_id = "inst_dead".into();
         dead.pid = u32::MAX - 1; // never live
         dead.runtime_root = "/tmp/dead-runtime".into();
-        let dead_entry_path = registry
-            .join(INSTANCE_DIR_NAME)
-            .join("inst_dead.json");
-        let dead_lease_path = registry
-            .join(LEASE_DIR_NAME)
-            .join("deadfingerprint.json");
+        let dead_entry_path = registry.join(INSTANCE_DIR_NAME).join("inst_dead.json");
+        let dead_lease_path = registry.join(LEASE_DIR_NAME).join("deadfingerprint.json");
         save_json_atomic(&dead_entry_path, &dead).unwrap();
         save_json_atomic(&dead_lease_path, &dead).unwrap();
 

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -122,6 +122,7 @@ pub fn handle_seek(
             graph_state,
             recovery,
             agent_runtime_contract,
+            budget: None,
         });
     }
 
@@ -454,6 +455,27 @@ pub fn handle_seek(
         .collect();
     let results = dedupe_ranked(results, input.top_k);
 
+    // Context-budget packing: keep highest-signal hits (already rank-ordered by
+    // dedupe_ranked) that fit the agent's declared token budget. Only engages
+    // when `token_budget` is provided — otherwise output is byte-for-byte the
+    // same as before.
+    let (results, budget) = if let Some(budget_tokens) = input.token_budget {
+        let baseline = results.len();
+        let (kept, dropped) =
+            crate::result_shaping::pack_to_budget(results, budget_tokens, seek_entry_token_estimate);
+        let used: usize = kept.iter().map(seek_entry_token_estimate).sum();
+        let block = crate::result_shaping::budget_block(
+            budget_tokens,
+            used,
+            kept.len(),
+            dropped,
+        );
+        debug_assert_eq!(kept.len() + dropped, baseline);
+        (kept, Some(block))
+    } else {
+        (results, None)
+    };
+
     drop(graph);
 
     state.queries_processed += 1;
@@ -518,7 +540,27 @@ pub fn handle_seek(
         graph_state,
         recovery,
         agent_runtime_contract,
+        budget,
     })
+}
+
+/// Per-result token ESTIMATE for a seek hit, summed over its load-bearing text
+/// fields (label, path, intent summary, excerpt). Uses the chars/4 heuristic —
+/// see `result_shaping::estimate_tokens_from_chars`; this is an approximation,
+/// not exact tokenization.
+fn seek_entry_token_estimate(entry: &layers::SeekResultEntry) -> usize {
+    let mut chars = entry.label.len() + entry.node_type.len() + entry.intent_summary.len();
+    chars += entry.node_id.len();
+    if let Some(path) = entry.file_path.as_deref() {
+        chars += path.len();
+    }
+    if let Some(excerpt) = entry.excerpt.as_deref() {
+        chars += excerpt.len();
+    }
+    for conn in &entry.connections {
+        chars += conn.label.len() + conn.relation.len();
+    }
+    crate::result_shaping::estimate_tokens_from_chars(chars)
 }
 
 fn l2_seek_next_step(
@@ -9530,9 +9572,113 @@ mod tests {
                 node_types: vec![],
                 min_score: 0.0,
                 graph_rerank: true,
+                token_budget: None,
             },
         )
         .expect("seek should succeed")
+    }
+
+    /// Build a state whose graph has many seek-matching file nodes, so that
+    /// `seek` returns a sizeable result set we can pack against a token budget.
+    fn build_state_many_search_nodes(root: &std::path::Path, count: usize) -> SessionState {
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut graph = Graph::new();
+        for i in 0..count {
+            // Every label contains "search" so the seek query matches them all.
+            graph
+                .add_node(
+                    &format!("file::src/search_module_{i}.rs"),
+                    &format!("search_module_{i}"),
+                    NodeType::File,
+                    &[],
+                    0.0,
+                    0.0,
+                )
+                .expect("add search node");
+        }
+        graph.finalize().expect("finalize graph");
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![root.to_string_lossy().to_string()];
+        state.workspace_root = Some(root.to_string_lossy().to_string());
+        state
+    }
+
+    fn run_seek_budgeted(
+        state: &mut SessionState,
+        token_budget: Option<usize>,
+    ) -> crate::protocol::layers::SeekOutput {
+        handle_seek(
+            state,
+            SeekInput {
+                query: "search".into(),
+                agent_id: "test".into(),
+                top_k: 50,
+                scope: None,
+                node_types: vec![],
+                min_score: 0.0,
+                graph_rerank: true,
+                token_budget,
+            },
+        )
+        .expect("seek should succeed")
+    }
+
+    /// Handler test: a small `token_budget` returns fewer results than the
+    /// unbudgeted baseline, keeps the top-ranked hit, and emits a consistent
+    /// `budget` block (kept + dropped == baseline; estimated_used <= requested
+    /// unless the single top item alone overflows).
+    #[test]
+    fn seek_token_budget_packs_and_reports_honestly() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_state_many_search_nodes(temp.path(), 40);
+
+        let baseline = run_seek_budgeted(&mut state, None);
+        assert!(baseline.budget.is_none(), "no budget block when unbudgeted");
+        let baseline_count = baseline.results.len();
+        assert!(
+            baseline_count > 3,
+            "expected a sizeable baseline, got {baseline_count}"
+        );
+        let top_label = baseline.results[0].label.clone();
+
+        let budget_tokens = 30usize;
+        let budgeted = run_seek_budgeted(&mut state, Some(budget_tokens));
+        let budget = budgeted.budget.clone().expect("budget block present");
+
+        // Fewer results, top-ranked hit preserved.
+        assert!(
+            budgeted.results.len() < baseline_count,
+            "budgeted ({}) must be < baseline ({})",
+            budgeted.results.len(),
+            baseline_count
+        );
+        assert!(!budgeted.results.is_empty(), "must keep at least one hit");
+        assert_eq!(budgeted.results[0].label, top_label, "keep the top hit");
+
+        // Budget block accounting is internally consistent.
+        let kept = budget["kept"].as_u64().unwrap() as usize;
+        let dropped = budget["dropped"].as_u64().unwrap() as usize;
+        let used = budget["estimated_used_tokens"].as_u64().unwrap() as usize;
+        assert_eq!(kept, budgeted.results.len());
+        assert_eq!(
+            kept + dropped,
+            baseline_count,
+            "kept + dropped must equal the unbudgeted count"
+        );
+        assert_eq!(budget["requested_tokens"].as_u64().unwrap() as usize, budget_tokens);
+        // Estimate stays within budget unless the single top item alone exceeds it.
+        assert!(
+            used <= budget_tokens || kept == 1,
+            "used {used} should be <= {budget_tokens} unless single-item overflow"
+        );
     }
 
     fn run_validate_plan(
@@ -10220,6 +10366,7 @@ def5678|2026-03-23 09:00:00 +0000|max kle1nz|feat: add benchmark harness
                 node_types: vec![],
                 min_score: 0.0,
                 graph_rerank: true,
+                token_budget: None,
             },
         )
         .expect("seek should return a structured blocked response");
@@ -10305,6 +10452,7 @@ def5678|2026-03-23 09:00:00 +0000|max kle1nz|feat: add benchmark harness
                 node_types: vec![],
                 min_score: 0.0,
                 graph_rerank: true,
+                token_budget: None,
             },
         )
         .expect("seek should succeed");
@@ -10337,6 +10485,7 @@ def5678|2026-03-23 09:00:00 +0000|max kle1nz|feat: add benchmark harness
                 node_types: vec![],
                 min_score: 0.0,
                 graph_rerank: true,
+                token_budget: None,
             },
         )
         .expect("seek should succeed");

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -461,15 +461,13 @@ pub fn handle_seek(
     // same as before.
     let (results, budget) = if let Some(budget_tokens) = input.token_budget {
         let baseline = results.len();
-        let (kept, dropped) =
-            crate::result_shaping::pack_to_budget(results, budget_tokens, seek_entry_token_estimate);
-        let used: usize = kept.iter().map(seek_entry_token_estimate).sum();
-        let block = crate::result_shaping::budget_block(
+        let (kept, dropped) = crate::result_shaping::pack_to_budget(
+            results,
             budget_tokens,
-            used,
-            kept.len(),
-            dropped,
+            seek_entry_token_estimate,
         );
+        let used: usize = kept.iter().map(seek_entry_token_estimate).sum();
+        let block = crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
         debug_assert_eq!(kept.len() + dropped, baseline);
         (kept, Some(block))
     } else {
@@ -9705,7 +9703,10 @@ mod tests {
             baseline_count,
             "kept + dropped must equal the unbudgeted count"
         );
-        assert_eq!(budget["requested_tokens"].as_u64().unwrap() as usize, budget_tokens);
+        assert_eq!(
+            budget["requested_tokens"].as_u64().unwrap() as usize,
+            budget_tokens
+        );
         // Estimate stays within budget unless the single top item alone exceeds it.
         assert!(
             used <= budget_tokens || kept == 1,

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -789,6 +789,24 @@ pub fn handle_scan(
     let total_validated = findings.len();
     drop(graph);
 
+    // Record each confirmed/mitigated finding as a per-agent ephemeral mark so a
+    // later edit/apply of the same node can PROPOSE a ready-to-run antibody
+    // (compounding negative memory). False positives are skipped — they are not
+    // bugs worth seeding an antibody from.
+    for finding in &findings {
+        if finding.status == "false_positive" {
+            continue;
+        }
+        let severity_bucket = scan_severity_bucket(finding.severity);
+        state.note_finding(
+            &input.agent_id,
+            &finding.node_id,
+            &finding.pattern,
+            severity_bucket,
+            &finding.file_path,
+        );
+    }
+
     state.queries_processed += 1;
     if state.should_persist() {
         let _ = state.persist();
@@ -1218,6 +1236,20 @@ fn timeline_paths_match(candidate: &str, normalized_target: &str) -> bool {
         .unwrap_or("");
 
     !target_name.is_empty() && target_name == candidate_name
+}
+
+/// Bucket a scan finding's continuous severity (`[0.0, 1.0]`) into the discrete
+/// severity vocabulary shared with antibodies / ProactiveInsight
+/// ("info" | "warning" | "critical"). Mirrors the antibody severity parse so a
+/// proposed antibody inherits a sane severity from the finding that motivated it.
+pub(crate) fn scan_severity_bucket(severity: f32) -> &'static str {
+    if severity >= 0.7 {
+        "critical"
+    } else if severity >= 0.4 {
+        "warning"
+    } else {
+        "info"
+    }
 }
 
 /// Convert a node external_id (e.g. "file::backend/chat_handler.py") to a

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -40,3 +40,7 @@ pub mod http_types;
 // Streamable-HTTP MCP transport (POST /mcp) — Wave 4, Slice 1.
 #[cfg(feature = "serve")]
 pub mod mcp_http;
+// stdio↔HTTP bridge for `--attach` — Wave 4, Slice 3. Lets multiple stdio MCP
+// hosts share one running `--serve` owner's live graph.
+#[cfg(feature = "serve")]
+pub mod attach_client;

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -37,3 +37,6 @@ pub mod universal_docs;
 pub mod http_server;
 #[cfg(feature = "serve")]
 pub mod http_types;
+// Streamable-HTTP MCP transport (POST /mcp) — Wave 4, Slice 1.
+#[cfg(feature = "serve")]
+pub mod mcp_http;

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -158,7 +158,7 @@ async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: 
     };
 
     #[cfg(not(feature = "serve"))]
-    let _ = (no_gui, port); // suppress unused warnings
+    let _ = (no_gui, _port); // suppress unused warnings
 
     let mut server = match McpServer::new(config) {
         Ok(s) => s,
@@ -203,6 +203,26 @@ async fn main() {
     ensure_bwrap_compat_wrapper();
 
     let cli = Cli::parse();
+
+    // --attach: thin stdio↔HTTP bridge. This path loads NO graph, builds NO
+    // engines, and takes NO lease — it must NEVER reach `McpServer::new`. It is
+    // handled before `load_config_from_cli`/`--serve`/stdio so none of that
+    // owner-side machinery runs.
+    if let Some(base_url) = cli.attach.clone() {
+        #[cfg(feature = "serve")]
+        {
+            m1nd_mcp::attach_client::run_attach_client(base_url).await;
+            return;
+        }
+        #[cfg(not(feature = "serve"))]
+        {
+            let _ = base_url;
+            eprintln!("[m1nd-mcp] --attach requires the 'serve' feature (HTTP client).");
+            eprintln!("  Rebuild with: cargo build --release --features serve");
+            std::process::exit(1);
+        }
+    }
+
     let config = load_config_from_cli(&cli);
 
     let event_log = cli.event_log;

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -57,6 +57,41 @@ exec /usr/bin/bwrap "${args[@]}"
     }
 }
 
+/// Resolve `--attach auto` to a concrete owner base URL by discovering the live
+/// serve ReadWrite owner for this client's runtime_root.
+///
+/// The runtime_root is computed with the SAME rule the owner uses
+/// (`session.rs` runtime-root default): explicit `--runtime-dir` if given, else
+/// the parent directory of `--graph` if given, else the current working dir. The
+/// discovery itself is read-only and takes NO lease.
+#[cfg(feature = "serve")]
+fn resolve_attach_auto(cli: &Cli) -> Result<String, String> {
+    let runtime_root: PathBuf = if let Some(dir) = &cli.runtime_dir {
+        PathBuf::from(dir)
+    } else if let Some(graph) = &cli.graph {
+        PathBuf::from(graph)
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."))
+    } else {
+        std::env::current_dir().map_err(|e| format!("cannot read current dir: {e}"))?
+    };
+
+    let registry_dir = cli.registry_dir.as_ref().map(PathBuf::from);
+
+    eprintln!(
+        "[m1nd-mcp][attach] auto-discovery: runtime_root={}",
+        runtime_root.display()
+    );
+
+    let url = m1nd_mcp::instance_registry::discover_serve_owner_base_url(
+        &runtime_root,
+        registry_dir.as_deref(),
+    )?;
+    eprintln!("[m1nd-mcp][attach] auto-discovery resolved owner: {url}");
+    Ok(url)
+}
+
 fn load_config_from_cli(cli: &Cli) -> McpConfig {
     // Priority: --config file > --graph/--plasticity/--domain flags > env vars > defaults
 
@@ -208,15 +243,40 @@ async fn main() {
     // engines, and takes NO lease — it must NEVER reach `McpServer::new`. It is
     // handled before `load_config_from_cli`/`--serve`/stdio so none of that
     // owner-side machinery runs.
-    if let Some(base_url) = cli.attach.clone() {
+    if let Some(attach_arg) = cli.attach.clone() {
         #[cfg(feature = "serve")]
         {
+            // Resolve the owner base URL. Precedence:
+            //   1. env M1ND_ATTACH_URL  — explicit override, always wins.
+            //   2. `--attach auto`      — discover the live serve ReadWrite owner
+            //                             for this runtime_root via the registry
+            //                             (read-only, NO lease).
+            //   3. `--attach <url>`     — use the literal URL verbatim.
+            let base_url = match std::env::var("M1ND_ATTACH_URL") {
+                Ok(url) if !url.trim().is_empty() => {
+                    eprintln!(
+                        "[m1nd-mcp][attach] using M1ND_ATTACH_URL override: {}",
+                        url.trim()
+                    );
+                    url.trim().to_string()
+                }
+                _ if attach_arg.trim().eq_ignore_ascii_case("auto") => {
+                    match resolve_attach_auto(&cli) {
+                        Ok(url) => url,
+                        Err(msg) => {
+                            eprintln!("[m1nd-mcp][attach] auto-discovery failed: {msg}");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                _ => attach_arg,
+            };
             m1nd_mcp::attach_client::run_attach_client(base_url).await;
             return;
         }
         #[cfg(not(feature = "serve"))]
         {
-            let _ = base_url;
+            let _ = attach_arg;
             eprintln!("[m1nd-mcp] --attach requires the 'serve' feature (HTTP client).");
             eprintln!("  Rebuild with: cargo build --release --features serve");
             std::process::exit(1);

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -60,11 +60,20 @@ exec /usr/bin/bwrap "${args[@]}"
 fn load_config_from_cli(cli: &Cli) -> McpConfig {
     // Priority: --config file > --graph/--plasticity/--domain flags > env vars > defaults
 
+    // Read-only attach: --read-only flag OR M1ND_READ_ONLY=1 (any non-"0"/"false").
+    // Resolved up-front so it can be forced on top of a config file too.
+    let force_read_only = cli.read_only
+        || std::env::var("M1ND_READ_ONLY")
+            .map(|v| v != "0" && v != "false" && !v.is_empty())
+            .unwrap_or(false);
+
     // 1. Try config file
     if let Some(ref path) = cli.config {
         if let Ok(contents) = std::fs::read_to_string(path) {
-            if let Ok(config) = serde_json::from_str::<McpConfig>(&contents) {
+            if let Ok(mut config) = serde_json::from_str::<McpConfig>(&contents) {
                 eprintln!("[m1nd-mcp] Config loaded from {}", path);
+                // --read-only / env always wins over a config file (safety opt-in).
+                config.read_only = config.read_only || force_read_only;
                 return config;
             }
         }
@@ -119,6 +128,7 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
         registry_dir,
         xlr_enabled,
         domain,
+        read_only: force_read_only,
         ..McpConfig::default()
     }
 }

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -307,10 +307,7 @@ async fn run_mcp_method(app: Arc<AppState>, request: JsonRpcRequest) -> JsonRpcR
             result: None,
             error: Some(JsonRpcError {
                 code: -32000,
-                message: format!(
-                    "Tool execution exceeded {}s timeout",
-                    MCP_TOOL_TIMEOUT_SECS
-                ),
+                message: format!("Tool execution exceeded {}s timeout", MCP_TOOL_TIMEOUT_SECS),
                 data: None,
             }),
         },
@@ -528,11 +525,7 @@ fn publish_graph_mutation_event(
 fn validate_session(app: &Arc<AppState>, headers: &HeaderMap) -> Result<String, Response> {
     let session_id = match session_id_from_headers(headers) {
         None => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "Missing Mcp-Session-Id header",
-            )
-                .into_response());
+            return Err((StatusCode::BAD_REQUEST, "Missing Mcp-Session-Id header").into_response());
         }
         Some(sid) => sid,
     };
@@ -601,9 +594,7 @@ pub async fn handle_mcp_get(
     });
 
     Sse::new(stream)
-        .keep_alive(
-            sse::KeepAlive::new().interval(Duration::from_secs(MCP_SSE_KEEPALIVE_SECS)),
-        )
+        .keep_alive(sse::KeepAlive::new().interval(Duration::from_secs(MCP_SSE_KEEPALIVE_SECS)))
         .into_response()
 }
 
@@ -706,7 +697,10 @@ mod tests {
     #[test]
     fn apply_batch_handoff_and_progress_relay() {
         for et in ["apply_batch_handoff", "apply_batch_progress"] {
-            let e = ev(et, serde_json::json!({"tool": "apply_batch", "batch_id": "b1"}));
+            let e = ev(
+                et,
+                serde_json::json!({"tool": "apply_batch", "batch_id": "b1"}),
+            );
             let frame = graph_changed_notification(&e).expect("relays");
             assert_eq!(frame["params"]["event"], "apply_batch");
             assert_eq!(frame["params"]["detail"]["batch_id"], "b1");
@@ -786,8 +780,7 @@ mod tests {
     async fn get_missing_session_is_400() {
         let temp = tempfile::tempdir().expect("tempdir");
         let app = build_app_state(temp.path());
-        let resp =
-            handle_mcp_get(axum::extract::State(app), HeaderMap::new()).await;
+        let resp = handle_mcp_get(axum::extract::State(app), HeaderMap::new()).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
@@ -823,8 +816,7 @@ mod tests {
     async fn delete_missing_session_is_400() {
         let temp = tempfile::tempdir().expect("tempdir");
         let app = build_app_state(temp.path());
-        let resp =
-            handle_mcp_delete(axum::extract::State(app), HeaderMap::new()).await;
+        let resp = handle_mcp_delete(axum::extract::State(app), HeaderMap::new()).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
@@ -844,15 +836,20 @@ mod tests {
         let sid = seed_session(&app);
 
         // DELETE → 200 and session gone from registry.
-        let resp =
-            handle_mcp_delete(axum::extract::State(app.clone()), header_map_with_session(&sid))
-                .await;
+        let resp = handle_mcp_delete(
+            axum::extract::State(app.clone()),
+            header_map_with_session(&sid),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(!app.mcp_sessions.lock().contains_key(&sid));
 
         // A subsequent GET with the now-dead session id → 404.
-        let resp2 =
-            handle_mcp_get(axum::extract::State(app.clone()), header_map_with_session(&sid)).await;
+        let resp2 = handle_mcp_get(
+            axum::extract::State(app.clone()),
+            header_map_with_session(&sid),
+        )
+        .await;
         assert_eq!(resp2.status(), StatusCode::NOT_FOUND);
 
         // And a POST tools/list with that session → 404 (matches the probe's

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -1,0 +1,342 @@
+// === m1nd-mcp Streamable-HTTP MCP transport (axum) ===
+//
+// Wave 4, Slice 1: a compliant `POST /mcp` Streamable-HTTP MCP endpoint that
+// handles `initialize` + `tools/list` + `tools/call`, returning JSON
+// (no SSE / GET / DELETE yet — those land in Slice 2).
+//
+// This transport binds to the SAME shared `Arc<Mutex<SessionState>>` that the
+// HTTP server already owns (via `AppState.session`), so a future `--attach`
+// client sees the live graph. Tool execution runs under the same
+// lock + spawn_blocking + timeout discipline as the REST `handle_tool_call`.
+//
+// Feature-gated behind "serve".
+
+#![cfg(feature = "serve")]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    body::Bytes,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use parking_lot::Mutex;
+
+use crate::http_server::AppState;
+use crate::protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
+use crate::server::handle_mcp_method;
+
+/// Per-spec MCP session header name (case-insensitive on the wire).
+const MCP_SESSION_HEADER: &str = "mcp-session-id";
+
+/// Per-tool execution timeout for the HTTP MCP transport (mirrors the REST
+/// `TOOL_TIMEOUT_SECS` discipline in `http_server`).
+const MCP_TOOL_TIMEOUT_SECS: u64 = 120;
+
+/// An MCP *wire* session (Streamable-HTTP transport session).
+///
+/// This is distinct from:
+///   - the instance lease (`SessionState.instance`), and
+///   - the per-agent sessions tracked inside `SessionState.sessions`.
+///
+/// It exists to satisfy the MCP Streamable-HTTP `Mcp-Session-Id` handshake.
+/// Room to grow (last-event-id for resumable SSE, etc.) lands in later slices.
+#[derive(Clone, Debug)]
+pub struct McpTransportSession {
+    /// Negotiated protocol version echoed back at `initialize`.
+    pub protocol_version: String,
+    /// When the session was created (ms since epoch).
+    pub created_ms: u64,
+    /// Last time we saw a request on this session (ms since epoch).
+    pub last_seen_ms: u64,
+}
+
+/// Registry of live MCP wire sessions, keyed by opaque session id.
+pub type McpSessionRegistry = Arc<Mutex<HashMap<String, McpTransportSession>>>;
+
+/// Build a fresh, empty MCP session registry.
+pub fn new_mcp_session_registry() -> McpSessionRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+/// Current timestamp in milliseconds since epoch.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Monotonic counter so two ids minted in the same millisecond differ.
+static MCP_SESSION_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Generate an opaque, URL-safe, visible-ASCII MCP session id (128-bit hex).
+///
+/// No new crate dependency: we combine two `DefaultHasher` digests seeded with
+/// process id, wall-clock time, and a per-process atomic sequence — the same
+/// idiom already used by `instance_registry::generate_instance_id`. The result
+/// is a 32-char lowercase-hex string, which is valid per the MCP spec
+/// (visible ASCII, no whitespace).
+pub fn generate_mcp_session_id() -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let seq = MCP_SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let t = now_ms();
+
+    let mut hi = DefaultHasher::new();
+    pid.hash(&mut hi);
+    t.hash(&mut hi);
+    seq.hash(&mut hi);
+    "m1nd-mcp-hi".hash(&mut hi);
+
+    let mut lo = DefaultHasher::new();
+    seq.hash(&mut lo);
+    t.hash(&mut lo);
+    pid.hash(&mut lo);
+    "m1nd-mcp-lo".hash(&mut lo);
+
+    format!("{:016x}{:016x}", hi.finish(), lo.finish())
+}
+
+/// A parsed inbound JSON-RPC message. We need to distinguish requests (have an
+/// `id`) from notifications/responses (no `id`) without forcing the strict
+/// `JsonRpcRequest` shape, so we keep the raw value too.
+enum ParsedMessage {
+    /// A request with an `id` and a `method` — expects a JSON-RPC response.
+    Request(JsonRpcRequest),
+    /// A notification or response (no `id`, or no `method`) — gets `202 Accepted`.
+    NotificationOrResponse,
+}
+
+/// Build a JSON-RPC error response as an axum `Response` with the given HTTP
+/// status. `id` is echoed (or `null` when unknown).
+fn jsonrpc_error_response(
+    status: StatusCode,
+    id: serde_json::Value,
+    code: i32,
+    message: impl Into<String>,
+) -> Response {
+    let body = JsonRpcResponse {
+        jsonrpc: "2.0".into(),
+        id,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message: message.into(),
+            data: None,
+        }),
+    };
+    let json = serde_json::to_string(&body).unwrap_or_default();
+    (
+        status,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        json,
+    )
+        .into_response()
+}
+
+/// Serialize a `JsonRpcResponse` into an `application/json` axum response,
+/// optionally attaching the `Mcp-Session-Id` header.
+fn jsonrpc_ok_response(resp: &JsonRpcResponse, session_id: Option<&str>) -> Response {
+    let json = serde_json::to_string(resp).unwrap_or_default();
+    let mut response = (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        json,
+    )
+        .into_response();
+    if let Some(sid) = session_id {
+        if let Ok(value) = axum::http::HeaderValue::from_str(sid) {
+            response.headers_mut().insert("mcp-session-id", value);
+        }
+    }
+    response
+}
+
+/// Run an MCP request against the shared session under the same
+/// lock + spawn_blocking + timeout discipline as the REST `handle_tool_call`.
+///
+/// The `parking_lot::Mutex` lock is acquired *inside* `spawn_blocking`, so it is
+/// never held across an `.await`.
+async fn run_mcp_method(app: Arc<AppState>, request: JsonRpcRequest) -> JsonRpcResponse {
+    let id = request.id.clone();
+    let result = tokio::time::timeout(
+        Duration::from_secs(MCP_TOOL_TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || {
+            let mut session = app.session.lock();
+            handle_mcp_method(&mut session, &request)
+        }),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(_join_err)) => JsonRpcResponse {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code: -32603,
+                message: "Internal error: tool task panicked".into(),
+                data: None,
+            }),
+        },
+        Err(_elapsed) => JsonRpcResponse {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code: -32000,
+                message: format!(
+                    "Tool execution exceeded {}s timeout",
+                    MCP_TOOL_TIMEOUT_SECS
+                ),
+                data: None,
+            }),
+        },
+    }
+}
+
+/// Parse the request body into a JSON-RPC message classification.
+fn parse_message(body: &Bytes) -> Result<ParsedMessage, String> {
+    let value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|e| format!("Invalid JSON: {}", e))?;
+
+    // Batches are not part of the 2025-06-18 single-message flow we implement in
+    // Slice 1; reject explicitly rather than silently mishandling.
+    if value.is_array() {
+        return Err("JSON-RPC batches are not supported".into());
+    }
+
+    let has_id = value.get("id").is_some_and(|v| !v.is_null());
+    let has_method = value.get("method").and_then(|v| v.as_str()).is_some();
+
+    if has_id && has_method {
+        let req: JsonRpcRequest = serde_json::from_value(value)
+            .map_err(|e| format!("Malformed JSON-RPC request: {}", e))?;
+        Ok(ParsedMessage::Request(req))
+    } else {
+        // No id (notification) or no method (response) → 202 Accepted.
+        Ok(ParsedMessage::NotificationOrResponse)
+    }
+}
+
+/// Read the `Mcp-Session-Id` request header, if present.
+fn session_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+/// `POST /mcp` — the Streamable-HTTP MCP request handler.
+///
+/// Slice 1 scope: `initialize` mints a session and returns the result with the
+/// `Mcp-Session-Id` response header; subsequent requests must carry that header.
+/// Returns plain `application/json` (no SSE streaming yet).
+pub async fn handle_mcp_post(
+    axum::extract::State(app): axum::extract::State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let incoming_session = session_id_from_headers(&headers);
+
+    // 1. Parse + classify the message.
+    let parsed = match parse_message(&body) {
+        Ok(p) => p,
+        Err(msg) => {
+            return jsonrpc_error_response(
+                StatusCode::BAD_REQUEST,
+                serde_json::Value::Null,
+                -32700,
+                msg,
+            );
+        }
+    };
+
+    let request = match parsed {
+        // Notifications/responses get 202 Accepted with empty body. If they
+        // carry a known session, bump last_seen.
+        ParsedMessage::NotificationOrResponse => {
+            if let Some(sid) = &incoming_session {
+                let mut reg = app.mcp_sessions.lock();
+                if let Some(s) = reg.get_mut(sid) {
+                    s.last_seen_ms = now_ms();
+                }
+            }
+            return StatusCode::ACCEPTED.into_response();
+        }
+        ParsedMessage::Request(req) => req,
+    };
+
+    // 2. `initialize` — mint a new wire session, run, return with session header.
+    if request.method == "initialize" {
+        let session_id = generate_mcp_session_id();
+        let now = now_ms();
+
+        let response = run_mcp_method(app.clone(), request).await;
+
+        // Record the negotiated protocol version from the result we just built.
+        let protocol_version = response
+            .result
+            .as_ref()
+            .and_then(|r| r.get("protocolVersion"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(crate::server::MCP_PROTOCOL_VERSION)
+            .to_string();
+
+        {
+            let mut reg = app.mcp_sessions.lock();
+            reg.insert(
+                session_id.clone(),
+                McpTransportSession {
+                    protocol_version,
+                    created_ms: now,
+                    last_seen_ms: now,
+                },
+            );
+        }
+
+        return jsonrpc_ok_response(&response, Some(&session_id));
+    }
+
+    // 3. Post-init request — require + validate the session header.
+    let session_id = match incoming_session {
+        None => {
+            return jsonrpc_error_response(
+                StatusCode::BAD_REQUEST,
+                request.id.clone(),
+                -32600,
+                "Missing Mcp-Session-Id header",
+            );
+        }
+        Some(sid) => sid,
+    };
+
+    {
+        let mut reg = app.mcp_sessions.lock();
+        match reg.get_mut(&session_id) {
+            // Unknown session → 404 signals the client to re-initialize (per spec).
+            None => {
+                return jsonrpc_error_response(
+                    StatusCode::NOT_FOUND,
+                    request.id.clone(),
+                    -32001,
+                    "Unknown or expired Mcp-Session-Id; re-initialize",
+                );
+            }
+            Some(s) => {
+                s.last_seen_ms = now_ms();
+            }
+        }
+    }
+
+    // 4. Known session → run the method against the shared graph.
+    let response = run_mcp_method(app, request).await;
+    jsonrpc_ok_response(&response, None)
+}

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -1,8 +1,16 @@
 // === m1nd-mcp Streamable-HTTP MCP transport (axum) ===
 //
 // Wave 4, Slice 1: a compliant `POST /mcp` Streamable-HTTP MCP endpoint that
-// handles `initialize` + `tools/list` + `tools/call`, returning JSON
-// (no SSE / GET / DELETE yet — those land in Slice 2).
+// handles `initialize` + `tools/list` + `tools/call`, returning JSON.
+//
+// Wave 4, Slice 2: the server→client SSE stream (`GET /mcp`, a real
+// `text/event-stream` per the Streamable-HTTP MCP spec) and session
+// termination (`DELETE /mcp`). The GET stream is how an attached agent learns
+// that ANOTHER agent changed the shared graph — the start of real
+// server→agent push. It is deliberately LOW-NOISE: only mutation-class
+// broadcast events (the ones that mean "the shared graph changed") are
+// relayed as `notifications/m1nd/graph_changed`; an agent never sees an echo
+// of its own (or anyone's) read-only tool results.
 //
 // This transport binds to the SAME shared `Arc<Mutex<SessionState>>` that the
 // HTTP server already owns (via `AppState.session`), so a future `--attach`
@@ -21,11 +29,12 @@ use std::time::Duration;
 use axum::{
     body::Bytes,
     http::{HeaderMap, StatusCode},
-    response::{IntoResponse, Response},
+    response::{sse, IntoResponse, Response, Sse},
 };
+use futures::stream::StreamExt;
 use parking_lot::Mutex;
 
-use crate::http_server::AppState;
+use crate::http_server::{AppState, SseEvent};
 use crate::protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 use crate::server::handle_mcp_method;
 
@@ -35,6 +44,112 @@ const MCP_SESSION_HEADER: &str = "mcp-session-id";
 /// Per-tool execution timeout for the HTTP MCP transport (mirrors the REST
 /// `TOOL_TIMEOUT_SECS` discipline in `http_server`).
 const MCP_TOOL_TIMEOUT_SECS: u64 = 120;
+
+/// Namespaced JSON-RPC method for the one notification this stream emits.
+/// Clearly scoped under `m1nd/` so it never collides with a spec method.
+const GRAPH_CHANGED_METHOD: &str = "notifications/m1nd/graph_changed";
+
+/// Keepalive interval for the `GET /mcp` SSE stream so proxies / idle clients
+/// don't drop a quiet connection.
+const MCP_SSE_KEEPALIVE_SECS: u64 = 15;
+
+/// Tools whose successful execution mutates the shared graph / plasticity /
+/// disk state in a way ANOTHER attached agent needs to know about. This mirrors
+/// the `READ_ONLY_DENIED_TOOLS` set in `server.rs` (the canonical "mutation"
+/// boundary) — kept local here so the notification relay's intent is explicit
+/// and the relay stays decoupled from the read-only gate's internals.
+///
+/// LOW-NOISE: a `tool_result` broadcast is relayed ONLY when its `tool` is in
+/// this set. Read/analysis tool results (the overwhelming majority of traffic,
+/// and the echoes of an agent's own reads) are never pushed.
+const GRAPH_MUTATION_TOOLS: &[&str] = &[
+    "ingest",
+    "apply",
+    "apply_batch",
+    "edit_commit",
+    "memorize",
+    "learn",
+    "daemon_start",
+    "auto_ingest_start",
+];
+
+/// Normalize an optional `m1nd.`/`m1nd_` tool prefix, matching the same idiom
+/// `server.rs::read_only_denied` uses, so `apply`, `m1nd_apply` and `m1nd.apply`
+/// all resolve to the same bare name.
+fn bare_tool_name(tool: &str) -> &str {
+    tool.strip_prefix("m1nd.")
+        .or_else(|| tool.strip_prefix("m1nd_"))
+        .unwrap_or(tool)
+}
+
+/// Decide whether a broadcast `SseEvent` represents a shared-graph change worth
+/// pushing to an attached agent, and if so, build the minimal JSON-RPC
+/// notification frame to carry on the SSE `data:` line.
+///
+/// Returns `None` for everything we deliberately suppress (read tool results,
+/// unrelated event types, mutations that did not actually succeed).
+fn graph_changed_notification(event: &SseEvent) -> Option<serde_json::Value> {
+    let relay_event_name: &str = match event.event_type.as_str() {
+        // A finished tool call. Relay only mutation tools, and only when the
+        // call actually succeeded (a failed mutation changed nothing).
+        "tool_result" => {
+            let tool = event.data.get("tool").and_then(|v| v.as_str())?;
+            if !GRAPH_MUTATION_TOOLS.contains(&bare_tool_name(tool)) {
+                return None;
+            }
+            // `success` may be absent on older frames; treat absent as success
+            // (the event only exists because the tool returned), but an explicit
+            // `false` means no mutation landed → suppress.
+            if event.data.get("success").and_then(|v| v.as_bool()) == Some(false) {
+                return None;
+            }
+            tool
+        }
+        // Apply-batch handoff / progress are mutation-only by construction.
+        "apply_batch_handoff" | "apply_batch_progress" => event
+            .data
+            .get("tool")
+            .and_then(|v| v.as_str())
+            .unwrap_or("apply_batch"),
+        // A tool that timed out: relay only if it was a mutation tool (a slow
+        // read timing out is not a graph change another agent must act on).
+        "tool_timeout" => {
+            let tool = event.data.get("tool").and_then(|v| v.as_str())?;
+            if !GRAPH_MUTATION_TOOLS.contains(&bare_tool_name(tool)) {
+                return None;
+            }
+            tool
+        }
+        // Everything else (health pings, read results, UI-only events) is noise.
+        _ => return None,
+    };
+
+    // Minimal, non-echoing detail: enough for the receiving agent to know WHAT
+    // changed and re-orient, without replaying the full result payload.
+    let mut detail = serde_json::Map::new();
+    if let Some(agent_id) = event.data.get("agent_id") {
+        detail.insert("agent_id".into(), agent_id.clone());
+    }
+    if let Some(source) = event.data.get("source") {
+        detail.insert("source".into(), source.clone());
+    }
+    if let Some(batch_id) = event.data.get("batch_id") {
+        detail.insert("batch_id".into(), batch_id.clone());
+    }
+    if let Some(ts) = event.data.get("timestamp_ms") {
+        detail.insert("timestamp_ms".into(), ts.clone());
+    }
+    detail.insert("kind".into(), serde_json::json!(event.event_type));
+
+    Some(serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": GRAPH_CHANGED_METHOD,
+        "params": {
+            "event": relay_event_name,
+            "detail": serde_json::Value::Object(detail),
+        },
+    }))
+}
 
 /// An MCP *wire* session (Streamable-HTTP transport session).
 ///
@@ -339,4 +454,362 @@ pub async fn handle_mcp_post(
     // 4. Known session → run the method against the shared graph.
     let response = run_mcp_method(app, request).await;
     jsonrpc_ok_response(&response, None)
+}
+
+/// Validate the `Mcp-Session-Id` header against the live registry, bumping
+/// `last_seen_ms` on success. Mirrors the slice-1 POST validation, factored out
+/// so `GET` and `DELETE` share one source of truth.
+///
+/// Errors are plain-text axum responses with the correct status:
+///   - missing header → `400 Bad Request`
+///   - unknown / expired id → `404 Not Found` (signals "re-initialize")
+///
+/// The `parking_lot` lock is held only for the brief get-and-touch; it is never
+/// carried across an `.await` (critical for the long-lived SSE stream).
+fn validate_session(app: &Arc<AppState>, headers: &HeaderMap) -> Result<String, Response> {
+    let session_id = match session_id_from_headers(headers) {
+        None => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Missing Mcp-Session-Id header",
+            )
+                .into_response());
+        }
+        Some(sid) => sid,
+    };
+
+    {
+        let mut reg = app.mcp_sessions.lock();
+        match reg.get_mut(&session_id) {
+            None => {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    "Unknown or expired Mcp-Session-Id; re-initialize",
+                )
+                    .into_response());
+            }
+            Some(s) => {
+                s.last_seen_ms = now_ms();
+            }
+        }
+    }
+
+    Ok(session_id)
+}
+
+/// `GET /mcp` — the server→client Streamable-HTTP SSE stream.
+///
+/// Per the MCP spec this is a long-lived `text/event-stream` that the server
+/// uses to push JSON-RPC messages to the client. Here it carries exactly one
+/// kind of message — a `notifications/m1nd/graph_changed` notification — emitted
+/// whenever ANOTHER agent mutates the shared graph. It is intentionally
+/// low-noise (see [`graph_changed_notification`]): read-only tool results are
+/// never relayed.
+///
+/// Each frame gets an incrementing SSE `id:` (cheap; enables future
+/// `Last-Event-ID` resumability — replay itself is NOT implemented in this
+/// slice). A periodic keepalive comment keeps idle connections open.
+pub async fn handle_mcp_get(
+    axum::extract::State(app): axum::extract::State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Response {
+    // Validate before opening the stream (no lock held across `.await`).
+    if let Err(resp) = validate_session(&app, &headers) {
+        return resp;
+    }
+
+    let rx = app.event_tx.subscribe();
+    let mut next_id: u64 = 0;
+    let stream = tokio_stream::wrappers::BroadcastStream::new(rx).filter_map(move |event| {
+        // Synchronous mapping closure → no `.await`, so the session mutex is
+        // never touched here and tool dispatch is never blocked by a slow client.
+        let frame = match event {
+            Ok(e) => graph_changed_notification(&e),
+            // Lagged (slow consumer dropped messages) or closed → skip; the
+            // keepalive and subsequent live events keep the stream useful.
+            Err(_) => None,
+        };
+        let item = frame.and_then(|notification| {
+            let id = next_id;
+            next_id += 1;
+            sse::Event::default()
+                .id(id.to_string())
+                .json_data(notification)
+                .ok()
+                .map(Ok::<_, std::convert::Infallible>)
+        });
+        async move { item }
+    });
+
+    Sse::new(stream)
+        .keep_alive(
+            sse::KeepAlive::new().interval(Duration::from_secs(MCP_SSE_KEEPALIVE_SECS)),
+        )
+        .into_response()
+}
+
+/// `DELETE /mcp` — explicit session termination per the Streamable-HTTP spec.
+///
+/// Validates the `Mcp-Session-Id`; on a known session, removes it from the
+/// registry and returns `200 OK` with an empty body. Missing header → `400`,
+/// unknown id → `404`.
+pub async fn handle_mcp_delete(
+    axum::extract::State(app): axum::extract::State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Response {
+    let session_id = match validate_session(&app, &headers) {
+        Ok(sid) => sid,
+        Err(resp) => return resp,
+    };
+
+    {
+        let mut reg = app.mcp_sessions.lock();
+        reg.remove(&session_id);
+    }
+
+    StatusCode::OK.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::{tool_schemas, McpConfig};
+    use crate::session::SessionState;
+    use m1nd_core::domain::DomainConfig;
+    use m1nd_core::graph::Graph;
+    use tokio::sync::broadcast;
+
+    fn ev(event_type: &str, data: serde_json::Value) -> SseEvent {
+        SseEvent {
+            event_type: event_type.to_string(),
+            data,
+        }
+    }
+
+    // ---- Low-noise relay decision -----------------------------------------
+
+    #[test]
+    fn read_tool_result_is_not_relayed() {
+        // A `seek` (read) result must produce no notification — this is the
+        // whole point: an agent never sees an echo of a read.
+        let e = ev(
+            "tool_result",
+            serde_json::json!({"tool": "seek", "success": true, "agent_id": "a"}),
+        );
+        assert!(graph_changed_notification(&e).is_none());
+    }
+
+    #[test]
+    fn mutation_tool_result_is_relayed_with_namespaced_method() {
+        let e = ev(
+            "tool_result",
+            serde_json::json!({
+                "tool": "memorize",
+                "success": true,
+                "agent_id": "agent-b",
+                "source": "http",
+                "timestamp_ms": 1234,
+            }),
+        );
+        let frame = graph_changed_notification(&e).expect("memorize relays");
+        assert_eq!(frame["jsonrpc"], "2.0");
+        assert_eq!(frame["method"], "notifications/m1nd/graph_changed");
+        assert_eq!(frame["params"]["event"], "memorize");
+        assert_eq!(frame["params"]["detail"]["agent_id"], "agent-b");
+        assert_eq!(frame["params"]["detail"]["kind"], "tool_result");
+    }
+
+    #[test]
+    fn prefixed_mutation_tool_is_relayed() {
+        for tool in ["m1nd.apply", "m1nd_apply", "apply"] {
+            let e = ev(
+                "tool_result",
+                serde_json::json!({"tool": tool, "success": true}),
+            );
+            assert!(
+                graph_changed_notification(&e).is_some(),
+                "{} should relay",
+                tool
+            );
+        }
+    }
+
+    #[test]
+    fn failed_mutation_is_suppressed() {
+        // A mutation that did not succeed changed nothing → no push.
+        let e = ev(
+            "tool_result",
+            serde_json::json!({"tool": "ingest", "success": false}),
+        );
+        assert!(graph_changed_notification(&e).is_none());
+    }
+
+    #[test]
+    fn apply_batch_handoff_and_progress_relay() {
+        for et in ["apply_batch_handoff", "apply_batch_progress"] {
+            let e = ev(et, serde_json::json!({"tool": "apply_batch", "batch_id": "b1"}));
+            let frame = graph_changed_notification(&e).expect("relays");
+            assert_eq!(frame["params"]["event"], "apply_batch");
+            assert_eq!(frame["params"]["detail"]["batch_id"], "b1");
+        }
+    }
+
+    #[test]
+    fn read_tool_timeout_is_not_relayed_but_mutation_timeout_is() {
+        let read = ev("tool_timeout", serde_json::json!({"tool": "seek"}));
+        assert!(graph_changed_notification(&read).is_none());
+
+        let mutation = ev("tool_timeout", serde_json::json!({"tool": "ingest"}));
+        assert!(graph_changed_notification(&mutation).is_some());
+    }
+
+    #[test]
+    fn unrelated_event_types_are_dropped() {
+        for et in ["health", "heartbeat", "ui_refresh", "instance_changed"] {
+            let e = ev(et, serde_json::json!({"foo": "bar"}));
+            assert!(
+                graph_changed_notification(&e).is_none(),
+                "{} must not relay",
+                et
+            );
+        }
+    }
+
+    // ---- Handler behavior (validation / termination) ----------------------
+
+    fn build_app_state(root: &std::path::Path) -> Arc<AppState> {
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let session = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+        let (event_tx, _) = broadcast::channel::<SseEvent>(16);
+        let tool_schemas_cache = tool_schemas()
+            .get("tools")
+            .cloned()
+            .unwrap_or(serde_json::Value::Array(vec![]));
+        Arc::new(AppState {
+            session: Arc::new(Mutex::new(session)),
+            tool_schemas_cache,
+            event_tx,
+            event_log_path: None,
+            registry_dir: None,
+            mcp_sessions: new_mcp_session_registry(),
+        })
+    }
+
+    fn header_map_with_session(sid: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(MCP_SESSION_HEADER, sid.parse().unwrap());
+        h
+    }
+
+    fn seed_session(app: &Arc<AppState>) -> String {
+        let sid = generate_mcp_session_id();
+        let now = now_ms();
+        app.mcp_sessions.lock().insert(
+            sid.clone(),
+            McpTransportSession {
+                protocol_version: "test".into(),
+                created_ms: now,
+                last_seen_ms: now,
+            },
+        );
+        sid
+    }
+
+    #[tokio::test]
+    async fn get_missing_session_is_400() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let app = build_app_state(temp.path());
+        let resp =
+            handle_mcp_get(axum::extract::State(app), HeaderMap::new()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn get_unknown_session_is_404() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let app = build_app_state(temp.path());
+        let headers = header_map_with_session("does-not-exist");
+        let resp = handle_mcp_get(axum::extract::State(app), headers).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_known_session_opens_event_stream() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let app = build_app_state(temp.path());
+        let sid = seed_session(&app);
+        let headers = header_map_with_session(&sid);
+        let resp = handle_mcp_get(axum::extract::State(app), headers).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            ct.starts_with("text/event-stream"),
+            "expected SSE content-type, got {ct}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_missing_session_is_400() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let app = build_app_state(temp.path());
+        let resp =
+            handle_mcp_delete(axum::extract::State(app), HeaderMap::new()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn delete_unknown_session_is_404() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let app = build_app_state(temp.path());
+        let headers = header_map_with_session("nope");
+        let resp = handle_mcp_delete(axum::extract::State(app), headers).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_session_then_revalidation_is_404() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let app = build_app_state(temp.path());
+        let sid = seed_session(&app);
+
+        // DELETE → 200 and session gone from registry.
+        let resp =
+            handle_mcp_delete(axum::extract::State(app.clone()), header_map_with_session(&sid))
+                .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(!app.mcp_sessions.lock().contains_key(&sid));
+
+        // A subsequent GET with the now-dead session id → 404.
+        let resp2 =
+            handle_mcp_get(axum::extract::State(app.clone()), header_map_with_session(&sid)).await;
+        assert_eq!(resp2.status(), StatusCode::NOT_FOUND);
+
+        // And a POST tools/list with that session → 404 (matches the probe's
+        // post-delete acceptance check).
+        let body = axum::body::Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list"
+            }))
+            .unwrap(),
+        );
+        let resp3 = handle_mcp_post(
+            axum::extract::State(app),
+            header_map_with_session(&sid),
+            body,
+        )
+        .await;
+        assert_eq!(resp3.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -466,6 +466,9 @@ pub async fn handle_mcp_post(
 ///
 /// The `parking_lot` lock is held only for the brief get-and-touch; it is never
 /// carried across an `.await` (critical for the long-lived SSE stream).
+// The `Err` is an axum `Response` (the natural rejection type for these handlers);
+// boxing it would only push the allocation onto every caller's happy path.
+#[allow(clippy::result_large_err)]
 fn validate_session(app: &Arc<AppState>, headers: &HeaderMap) -> Result<String, Response> {
     let session_id = match session_id_from_headers(headers) {
         None => {

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -452,8 +452,64 @@ pub async fn handle_mcp_post(
     }
 
     // 4. Known session → run the method against the shared graph.
-    let response = run_mcp_method(app, request).await;
+    //
+    // Capture the tool name + agent_id BEFORE `run_mcp_method` consumes the
+    // request, so that after a successful mutation we can publish a `tool_result`
+    // SseEvent onto the broadcast bus. This is the producer side of the
+    // server→client push relay: `handle_mcp_get` subscribes to the same bus and
+    // forwards `notifications/m1nd/graph_changed` to every attached client. Reads
+    // and failed calls publish nothing (`graph_changed_notification` filters to
+    // GRAPH_MUTATION_TOOLS + success).
+    let mutation_meta = mutation_event_meta(&request);
+    let response = run_mcp_method(app.clone(), request).await;
+    if let Some((tool, agent_id)) = mutation_meta {
+        publish_graph_mutation_event(&app, &tool, agent_id.as_deref(), response.error.is_none());
+    }
     jsonrpc_ok_response(&response, None)
+}
+
+/// Extract `(tool_name, agent_id)` from a `tools/call` request whose tool is a
+/// graph-mutation tool; returns `None` for any other method or a non-mutation
+/// tool, so we never publish noise.
+fn mutation_event_meta(request: &JsonRpcRequest) -> Option<(String, Option<String>)> {
+    if request.method != "tools/call" {
+        return None;
+    }
+    let tool = request.params.get("name").and_then(|v| v.as_str())?;
+    if !GRAPH_MUTATION_TOOLS.contains(&bare_tool_name(tool)) {
+        return None;
+    }
+    let agent_id = request
+        .params
+        .get("arguments")
+        .and_then(|a| a.get("agent_id"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    Some((tool.to_string(), agent_id))
+}
+
+/// Publish a `tool_result` SseEvent for a finished mutation onto the broadcast
+/// bus. The shape mirrors the stdio server's `tool_result` event so the shared
+/// [`graph_changed_notification`] relay logic forwards it identically. A failed
+/// call carries `success:false` and is suppressed downstream.
+fn publish_graph_mutation_event(
+    app: &Arc<AppState>,
+    tool: &str,
+    agent_id: Option<&str>,
+    success: bool,
+) {
+    let sse_event = SseEvent {
+        event_type: "tool_result".to_string(),
+        data: serde_json::json!({
+            "tool": tool,
+            "source": "mcp_http",
+            "agent_id": agent_id,
+            "success": success,
+            "timestamp_ms": now_ms(),
+        }),
+    };
+    // Best-effort: a send error only means there are no subscribers right now.
+    let _ = app.event_tx.send(sse_event);
 }
 
 /// Validate the `Mcp-Session-Id` header against the live registry, bumping

--- a/m1nd-mcp/src/protocol/core.rs
+++ b/m1nd-mcp/src/protocol/core.rs
@@ -52,6 +52,13 @@ pub struct ActivateInput {
     pub include_ghost_edges: bool,
     #[serde(default)]
     pub include_structural_holes: bool,
+    /// Optional approximate context-token budget. When set, the `activated`
+    /// node list is kept in graph-importance rank order until the running token
+    /// ESTIMATE (chars/4) would exceed this budget; lower-ranked nodes are
+    /// dropped and a `budget` block reports what was kept vs dropped. None =
+    /// unbudgeted (return the full top_k set, behavior unchanged).
+    #[serde(default)]
+    pub token_budget: Option<usize>,
 }
 
 /// Input for impact (03-MCP Section 2.2).
@@ -361,6 +368,10 @@ pub struct ActivateOutput {
     pub recovery: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_runtime_contract: Option<serde_json::Value>,
+    /// Present only when `token_budget` was requested: an honest accounting of
+    /// the context-budget packing (requested/used estimate, kept, dropped).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -74,6 +74,13 @@ pub struct SeekInput {
     /// Whether to run graph re-ranking on embedding candidates. Default: true.
     #[serde(default = "default_true")]
     pub graph_rerank: bool,
+    /// Optional approximate context-token budget. When set, results are kept
+    /// in graph-importance rank order until the running token ESTIMATE
+    /// (chars/4) would exceed this budget; lower-ranked hits are dropped and a
+    /// `budget` block reports what was kept vs dropped. None = unbudgeted
+    /// (return the full top_k set, behavior unchanged).
+    #[serde(default)]
+    pub token_budget: Option<usize>,
 }
 
 /// Output for seek.
@@ -100,6 +107,10 @@ pub struct SeekOutput {
     pub recovery: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_runtime_contract: Option<serde_json::Value>,
+    /// Present only when `token_budget` was requested: an honest accounting of
+    /// the context-budget packing (requested/used estimate, kept, dropped).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<serde_json::Value>,
 }
 
 /// Shared heuristic metadata exposed by tools that apply trust/tremor priors.
@@ -1875,6 +1886,12 @@ pub struct SearchInput {
     /// Optional cap for total returned characters across serialized matches.
     #[serde(default)]
     pub max_output_chars: Option<usize>,
+    /// Optional approximate context-token budget. When set, ranked results are
+    /// kept best-first until the running token ESTIMATE (chars/4) would exceed
+    /// this budget; lower-ranked rows are dropped and a `budget` block reports
+    /// what was kept vs dropped. None = unbudgeted (behavior unchanged).
+    #[serde(default)]
+    pub token_budget: Option<usize>,
 }
 
 fn default_search_top_k() -> u32 {
@@ -1927,6 +1944,10 @@ pub struct SearchOutput {
     pub recovery: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_runtime_contract: Option<serde_json::Value>,
+    /// Present only when `token_budget` was requested: an honest accounting of
+    /// the context-budget packing (requested/used estimate, kept, dropped).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<serde_json::Value>,
 }
 
 /// A single search result entry.

--- a/m1nd-mcp/src/protocol/surgical.rs
+++ b/m1nd-mcp/src/protocol/surgical.rs
@@ -277,6 +277,10 @@ pub struct EditCommitOutput {
     pub lines_removed: i32,
     pub reingested: bool,
     pub updated_node_ids: Vec<String>,
+    /// Proactive structural follow-up suggestions attached to this commit,
+    /// forwarded from the underlying apply (includes `proposed_antibody`).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub proactive_insights: Vec<ProactiveInsight>,
     pub elapsed_ms: f64,
 }
 

--- a/m1nd-mcp/src/result_shaping.rs
+++ b/m1nd-mcp/src/result_shaping.rs
@@ -42,6 +42,89 @@ pub fn dedupe_ranked<T: RankedResult>(mut items: Vec<T>, top_k: usize) -> Vec<T>
     out
 }
 
+/// Greedily pack a *pre-ranked* list into a token budget, keeping the
+/// highest-signal items first.
+///
+/// `ranked` MUST already be sorted best-first (e.g. the output of
+/// [`dedupe_ranked`] and any `top_k` truncation) — this function does NOT
+/// re-rank. It walks the list in order, accumulating each item's estimated
+/// token cost (via `est`), and stops as soon as the *next* item would push the
+/// running total past `budget_tokens`. At least one item is always kept so a
+/// tiny budget still returns the single top hit (even if that one item alone
+/// exceeds the budget — the "single-item overflow" case).
+///
+/// Returns `(kept, dropped_count)` where `dropped_count == original_len -
+/// kept.len()`.
+pub fn pack_to_budget<T>(
+    ranked: Vec<T>,
+    budget_tokens: usize,
+    est: impl Fn(&T) -> usize,
+) -> (Vec<T>, usize) {
+    let original_len = ranked.len();
+    let mut kept: Vec<T> = Vec::with_capacity(original_len);
+    let mut used = 0usize;
+
+    for item in ranked {
+        let cost = est(&item);
+        // Always keep the first (top-ranked) item, even if it alone overflows.
+        if kept.is_empty() {
+            kept.push(item);
+            used = used.saturating_add(cost);
+            continue;
+        }
+        if used.saturating_add(cost) > budget_tokens {
+            break;
+        }
+        used = used.saturating_add(cost);
+        kept.push(item);
+    }
+
+    let dropped = original_len - kept.len();
+    (kept, dropped)
+}
+
+/// Rough, deterministic token-count ESTIMATE for a string of serialized result
+/// text. This is the widely-used `chars / 4` heuristic — it is NOT real
+/// tokenization (no BPE/tiktoken), so the true token count for any given model
+/// may differ by a meaningful margin. It exists only to let the budget packer
+/// rank/threshold consistently. We round up so a non-empty string never
+/// estimates as zero tokens.
+pub fn estimate_tokens_from_chars(chars: usize) -> usize {
+    if chars == 0 {
+        0
+    } else {
+        chars.div_ceil(4)
+    }
+}
+
+/// Build the honest `budget` accounting block attached to budgeted retrieval
+/// results. `requested` is the agent's declared token budget, `used` is the
+/// summed per-item ESTIMATE of the kept items, `kept`/`dropped` are the
+/// post-packing counts. The note is phrased for an agent reader.
+pub fn budget_block(
+    requested: usize,
+    used: usize,
+    kept: usize,
+    dropped: usize,
+) -> serde_json::Value {
+    let note = if dropped == 0 {
+        format!(
+            "kept all {kept} hits; estimated ~{used} tokens, within the ~{requested} token budget"
+        )
+    } else {
+        format!(
+            "kept the {kept} highest-signal hits; dropped {dropped} lower-ranked to fit ~{requested} tokens"
+        )
+    };
+    serde_json::json!({
+        "requested_tokens": requested,
+        "estimated_used_tokens": used,
+        "kept": kept,
+        "dropped": dropped,
+        "note": note,
+    })
+}
+
 fn normalize_label(label: &str) -> String {
     label.trim().to_lowercase()
 }
@@ -301,5 +384,83 @@ mod tests {
 
         let shaped = dedupe_ranked(items, 10);
         assert_eq!(shaped[0].label, "impl Extractor for RustExtractor");
+    }
+
+    // --- pack_to_budget / estimate_tokens_from_chars ----------------------
+
+    /// Each test item costs a flat 10 tokens, so budgets map cleanly to counts.
+    fn flat_cost(_item: &usize) -> usize {
+        10
+    }
+
+    #[test]
+    fn pack_to_budget_tiny_budget_keeps_at_least_one() {
+        let ranked = vec![1usize, 2, 3, 4, 5];
+        // Budget smaller than a single item's cost -> still keep the top hit.
+        let (kept, dropped) = pack_to_budget(ranked, 3, flat_cost);
+        assert_eq!(kept, vec![1]);
+        assert_eq!(dropped, 4);
+        assert_eq!(kept.len() + dropped, 5);
+    }
+
+    #[test]
+    fn pack_to_budget_zero_budget_still_keeps_one() {
+        let ranked = vec![1usize, 2, 3];
+        let (kept, dropped) = pack_to_budget(ranked, 0, flat_cost);
+        assert_eq!(kept, vec![1]);
+        assert_eq!(dropped, 2);
+    }
+
+    #[test]
+    fn pack_to_budget_generous_budget_keeps_all() {
+        let ranked = vec![1usize, 2, 3, 4, 5];
+        let (kept, dropped) = pack_to_budget(ranked, 10_000, flat_cost);
+        assert_eq!(kept, vec![1, 2, 3, 4, 5]);
+        assert_eq!(dropped, 0);
+    }
+
+    #[test]
+    fn pack_to_budget_mid_budget_keeps_ranked_prefix() {
+        let ranked = vec![1usize, 2, 3, 4, 5];
+        // 35 fits exactly 3 items (30); the 4th (40) would overflow.
+        let (kept, dropped) = pack_to_budget(ranked, 35, flat_cost);
+        assert_eq!(kept, vec![1, 2, 3], "keeps the top-ranked prefix in order");
+        assert_eq!(dropped, 2);
+        assert_eq!(kept.len() + dropped, 5);
+    }
+
+    #[test]
+    fn pack_to_budget_exact_budget_boundary_inclusive() {
+        let ranked = vec![1usize, 2, 3, 4];
+        // 20 == exactly two items; boundary is inclusive (<= budget).
+        let (kept, dropped) = pack_to_budget(ranked, 20, flat_cost);
+        assert_eq!(kept, vec![1, 2]);
+        assert_eq!(dropped, 2);
+    }
+
+    #[test]
+    fn pack_to_budget_empty_input() {
+        let ranked: Vec<usize> = vec![];
+        let (kept, dropped) = pack_to_budget(ranked, 100, flat_cost);
+        assert!(kept.is_empty());
+        assert_eq!(dropped, 0);
+    }
+
+    #[test]
+    fn estimate_tokens_monotonic_and_chars_over_four() {
+        assert_eq!(estimate_tokens_from_chars(0), 0);
+        // chars/4 rounded up: 1..=4 -> 1 token.
+        assert_eq!(estimate_tokens_from_chars(1), 1);
+        assert_eq!(estimate_tokens_from_chars(4), 1);
+        assert_eq!(estimate_tokens_from_chars(5), 2);
+        assert_eq!(estimate_tokens_from_chars(8), 2);
+        assert_eq!(estimate_tokens_from_chars(400), 100);
+        // Monotonic non-decreasing as char count grows.
+        let mut prev = 0;
+        for chars in [0usize, 1, 4, 5, 9, 16, 40, 41, 100, 1000] {
+            let est = estimate_tokens_from_chars(chars);
+            assert!(est >= prev, "estimate must be monotonic in char count");
+            prev = est;
+        }
     }
 }

--- a/m1nd-mcp/src/search_handlers.rs
+++ b/m1nd-mcp/src/search_handlers.rs
@@ -564,12 +564,8 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
                     search_entry_token_estimate,
                 );
                 let used: usize = kept.iter().map(search_entry_token_estimate).sum();
-                let block = crate::result_shaping::budget_block(
-                    budget_tokens,
-                    used,
-                    kept.len(),
-                    dropped,
-                );
+                let block =
+                    crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
                 (kept, Some(block))
             } else {
                 (results, None)
@@ -679,8 +675,7 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
             search_entry_token_estimate,
         );
         let used: usize = kept.iter().map(search_entry_token_estimate).sum();
-        let block =
-            crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
+        let block = crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
         (kept, Some(block))
     } else {
         (final_results, None)
@@ -774,7 +769,11 @@ fn search_entry_token_estimate(entry: &crate::protocol::layers::SearchResultEntr
         + entry.node_type.len()
         + entry.file_path.len()
         + entry.matched_line.len();
-    for line in entry.context_before.iter().chain(entry.context_after.iter()) {
+    for line in entry
+        .context_before
+        .iter()
+        .chain(entry.context_after.iter())
+    {
         chars += line.len();
     }
     crate::result_shaping::estimate_tokens_from_chars(chars)

--- a/m1nd-mcp/src/search_handlers.rs
+++ b/m1nd-mcp/src/search_handlers.rs
@@ -516,6 +516,9 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
                 node_types: vec![],
                 min_score: 0.0,
                 graph_rerank: true,
+                // Search does its own budget packing on the converted rows below;
+                // the delegated seek runs unbudgeted.
+                token_budget: None,
             };
             let seek_result = crate::layer_handlers::handle_seek(state, seek_input)?;
             let seek_candidates = seek_result.total_candidates_scanned;
@@ -552,6 +555,25 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
             let elapsed = start.elapsed().as_secs_f64() * 1000.0;
             let (results, truncated, inline_summary) =
                 truncate_search_results(results, input.max_output_chars);
+            // Context-budget packing for semantic-mode rows (count_only is never
+            // set on this path). Only engages when `token_budget` is provided.
+            let (results, budget) = if let Some(budget_tokens) = input.token_budget {
+                let (kept, dropped) = crate::result_shaping::pack_to_budget(
+                    results,
+                    budget_tokens,
+                    search_entry_token_estimate,
+                );
+                let used: usize = kept.iter().map(search_entry_token_estimate).sum();
+                let block = crate::result_shaping::budget_block(
+                    budget_tokens,
+                    used,
+                    kept.len(),
+                    dropped,
+                );
+                (kept, Some(block))
+            } else {
+                (results, None)
+            };
             state.note_coverage(
                 &input.agent_id,
                 "search",
@@ -617,6 +639,7 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
                 graph_state,
                 recovery,
                 agent_runtime_contract,
+                budget,
             });
         }
     }
@@ -644,6 +667,24 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
     drop(graph);
     let (final_results, truncated, inline_summary) =
         truncate_search_results(final_results, input.max_output_chars);
+    // Context-budget packing: keep the ranked prefix that fits the agent's
+    // declared token budget. Skips count_only (no rows to pack). Only engages
+    // when `token_budget` is provided — otherwise output is unchanged.
+    let (final_results, budget) = if let (Some(budget_tokens), false) =
+        (input.token_budget, input.count_only)
+    {
+        let (kept, dropped) = crate::result_shaping::pack_to_budget(
+            final_results,
+            budget_tokens,
+            search_entry_token_estimate,
+        );
+        let used: usize = kept.iter().map(search_entry_token_estimate).sum();
+        let block =
+            crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
+        (kept, Some(block))
+    } else {
+        (final_results, None)
+    };
     state.note_coverage(
         &input.agent_id,
         "search",
@@ -721,7 +762,22 @@ pub fn handle_search(state: &mut SessionState, input: SearchInput) -> M1ndResult
         graph_state,
         recovery,
         agent_runtime_contract,
+        budget,
     })
+}
+
+/// Per-row token ESTIMATE for a search result, summed over its load-bearing
+/// text fields (label, path, matched line, surrounding context). Uses the
+/// chars/4 heuristic — an approximation, not exact tokenization.
+fn search_entry_token_estimate(entry: &crate::protocol::layers::SearchResultEntry) -> usize {
+    let mut chars = entry.label.len()
+        + entry.node_type.len()
+        + entry.file_path.len()
+        + entry.matched_line.len();
+    for line in entry.context_before.iter().chain(entry.context_after.iter()) {
+        chars += line.len();
+    }
+    crate::result_shaping::estimate_tokens_from_chars(chars)
 }
 
 fn maybe_auto_ingest_search_scope(
@@ -1806,6 +1862,7 @@ mod tests {
                 auto_ingest: false,
                 filename_pattern: Some("*.rs".into()),
                 max_output_chars: None,
+                token_budget: None,
             };
 
             let output = handle_search(state, input).expect("search output");
@@ -1901,6 +1958,7 @@ mod tests {
             auto_ingest: false,
             filename_pattern: Some("*.rs".into()),
             max_output_chars: None,
+            token_budget: None,
         };
 
         let output = handle_search(&mut state, input).expect("search output");
@@ -1942,6 +2000,7 @@ mod tests {
                 auto_ingest: false,
                 filename_pattern: Some("*.js".into()),
                 max_output_chars: None,
+                token_budget: None,
             },
         )
         .expect("search output");
@@ -2003,6 +2062,7 @@ mod tests {
                 auto_ingest: false,
                 filename_pattern: None,
                 max_output_chars: None,
+                token_budget: None,
             },
         )
         .expect("search output");
@@ -2039,6 +2099,7 @@ mod tests {
                 auto_ingest: false,
                 filename_pattern: None,
                 max_output_chars: None,
+                token_budget: None,
             },
         )
         .expect("search output");
@@ -2137,6 +2198,7 @@ mod tests {
             auto_ingest: true,
             filename_pattern: Some("*.rs".into()),
             max_output_chars: None,
+            token_budget: None,
         };
 
         let output = handle_search(&mut state, input).expect("search output");
@@ -2183,6 +2245,7 @@ mod tests {
             auto_ingest: true,
             filename_pattern: Some("*.rs".into()),
             max_output_chars: None,
+            token_budget: None,
         };
 
         let output = handle_search(&mut state, input).expect("search output");
@@ -2237,6 +2300,7 @@ mod tests {
             auto_ingest: true,
             filename_pattern: Some("*.rs".into()),
             max_output_chars: None,
+            token_budget: None,
         };
 
         let err = handle_search(&mut state, input).unwrap_err();
@@ -2269,6 +2333,7 @@ mod tests {
             auto_ingest: false,
             filename_pattern: Some("*.rs".into()),
             max_output_chars: None,
+            token_budget: None,
         };
 
         let err = handle_search(&mut state, input).unwrap_err().to_string();
@@ -2298,6 +2363,7 @@ mod tests {
             auto_ingest: false,
             filename_pattern: Some("[".into()),
             max_output_chars: None,
+            token_budget: None,
         };
 
         let err = handle_search(&mut state, input).unwrap_err().to_string();
@@ -2327,6 +2393,7 @@ mod tests {
             auto_ingest: false,
             filename_pattern: None,
             max_output_chars: None,
+            token_budget: None,
         };
 
         let err = handle_search(&mut state, input).unwrap_err().to_string();

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -221,6 +221,11 @@ pub struct McpConfig {
     /// Controls temporal decay half-lives and relation types.
     #[serde(default)]
     pub domain: Option<String>,
+    /// Attach read-only: the session loads the snapshot and serves queries but
+    /// never persists to disk and never holds an exclusive lease. Mutation tools
+    /// are disabled. Set via `--read-only` CLI flag or `M1ND_READ_ONLY=1`.
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 impl Default for McpConfig {
@@ -237,6 +242,7 @@ impl Default for McpConfig {
             max_concurrent_reads: 32,
             write_queue_size: 64,
             domain: None,
+            read_only: false,
         }
     }
 }
@@ -327,6 +333,20 @@ pub fn active_tool_tier() -> &'static str {
     {
         "full" => "full",
         _ => "essential",
+    }
+}
+
+/// Whether the additive `_m1nd` response envelope is attached to tool results.
+///
+/// Gated by `M1ND_RESPONSE_ENVELOPE`, default ON. Only an explicit `"0"` or
+/// `"false"` (case-insensitive) disables it; any other value (or unset) is ON.
+pub fn response_envelope_enabled() -> bool {
+    match std::env::var("M1ND_RESPONSE_ENVELOPE") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            v != "0" && v != "false"
+        }
+        Err(_) => true,
     }
 }
 
@@ -2114,6 +2134,196 @@ fn all_tool_schemas_inner() -> serde_json::Value {
 }
 
 // ---------------------------------------------------------------------------
+// Read-only attach: mutating-tool deny-list
+// ---------------------------------------------------------------------------
+
+/// Tools that mutate graph/plasticity/disk state and must be refused when the
+/// session is attached read-only. Read-only/analysis tools are NOT listed here
+/// and continue to work normally. `persist` is handled specially (see
+/// [`read_only_denied`]) because its `status` action is read-only.
+const READ_ONLY_DENIED_TOOLS: &[&str] = &[
+    "ingest",
+    "apply",
+    "apply_batch",
+    "edit_commit",
+    "memorize",
+    "learn",
+    "daemon_start",
+    "auto_ingest_start",
+];
+
+/// Returns true if `tool_name` must be refused in read-only attach mode.
+///
+/// Normalizes the optional `m1nd.`/`m1nd_` prefix first so `apply`, `m1nd_apply`
+/// and `m1nd.apply` are all caught. `persist` is allowed only for its read-only
+/// `action == "status"`; every other persist action (`save`/`checkpoint`/`load`)
+/// writes graph/disk state and is denied. `edit_preview` is intentionally
+/// allowed: it stages an in-memory preview and never writes to disk; only
+/// `edit_commit` performs the write.
+fn read_only_denied(tool_name: &str, params: &serde_json::Value) -> bool {
+    let bare = tool_name
+        .strip_prefix("m1nd.")
+        .or_else(|| tool_name.strip_prefix("m1nd_"))
+        .unwrap_or(tool_name);
+    if READ_ONLY_DENIED_TOOLS.contains(&bare) {
+        return true;
+    }
+    if bare == "persist" {
+        let action = params
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("status");
+        return !action.eq_ignore_ascii_case("status");
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3: memory at point-of-relevance (`_m1nd.memory_nearby`)
+// ---------------------------------------------------------------------------
+
+/// Tools whose results carry rankable node ids worth checking for nearby memory.
+fn tool_has_memory_anchors(tool: &str) -> bool {
+    let bare = tool
+        .strip_prefix("m1nd.")
+        .or_else(|| tool.strip_prefix("m1nd_"))
+        .unwrap_or(tool);
+    matches!(
+        bare,
+        "activate" | "seek" | "search" | "surgical_context" | "surgical_context_v2"
+    )
+}
+
+/// Parse a confidence value out of a memory marker label, if present.
+/// Markers authored via `memorize` embed `[𝔻 confidence: 0.9]` in the label text.
+fn parse_marker_confidence(label: &str) -> Option<f64> {
+    let pos = label.find("confidence:")? + "confidence:".len();
+    let tail = &label[pos..];
+    let num: String = tail
+        .trim_start()
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    num.parse::<f64>().ok()
+}
+
+/// Build `_m1nd.memory_nearby`: for the top result node ids of a query/seek/
+/// activate/surgical result, surface any memorized claim that anchors to them
+/// via a `grounded_in` edge (marker → code), so the agent sees prior
+/// conclusions WITHOUT issuing another query.
+///
+/// Best-effort and capped at 3. `evidence_fresh` is a cheap signal: true when
+/// the cited code file still exists on disk (re-hashing on every query would be
+/// too costly here; `audit(checks=["evidence_freshness"])` remains the
+/// authoritative hash-level check). Returns `None` when the tool has no anchors
+/// or nothing is found.
+fn memory_nearby_for_result(
+    state: &SessionState,
+    tool: &str,
+    result: &serde_json::Value,
+) -> Option<Vec<serde_json::Value>> {
+    if !tool_has_memory_anchors(tool) {
+        return None;
+    }
+
+    // Collect up to a few top result node ids (labels / external ids).
+    let results = result.get("results").and_then(|v| v.as_array())?;
+    let top_ids: Vec<String> = results
+        .iter()
+        .take(3)
+        .filter_map(|r| {
+            r.get("node_id")
+                .or_else(|| r.get("label"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect();
+    if top_ids.is_empty() {
+        return None;
+    }
+
+    let graph = state.graph.read();
+    let grounded_in = graph.strings.lookup("grounded_in")?;
+    let evidenced_by_tag = graph.strings.lookup("light:evidenced_by");
+
+    // Map each requested top id → its node index (skip ids not in the graph).
+    let mut target_idx: std::collections::HashMap<usize, String> = std::collections::HashMap::new();
+    for id in &top_ids {
+        if let Some(nid) = graph.resolve_id(id) {
+            target_idx.insert(nid.as_usize(), id.clone());
+        }
+    }
+    if target_idx.is_empty() {
+        return None;
+    }
+
+    // Walk markers: every node with an outgoing `grounded_in` edge whose target
+    // is one of our top result nodes is a memory anchor for that result.
+    let node_count = graph.nodes.count as usize;
+    let mut out: Vec<serde_json::Value> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    'outer: for src_idx in 0..node_count {
+        // Only consider memory/light markers when the tag is present in the graph.
+        if let Some(tag) = evidenced_by_tag {
+            let is_marker = graph
+                .nodes
+                .tags
+                .get(src_idx)
+                .is_some_and(|tags| tags.contains(&tag));
+            if !is_marker {
+                continue;
+            }
+        }
+        let src_nid = m1nd_core::types::NodeId::new(src_idx as u32);
+        for edge_i in graph.csr.out_range(src_nid) {
+            if graph.csr.relations[edge_i] != grounded_in {
+                continue;
+            }
+            let tgt_idx = graph.csr.targets[edge_i].as_usize();
+            let Some(anchor_id) = target_idx.get(&tgt_idx) else {
+                continue;
+            };
+            let claim = graph.strings.resolve(graph.nodes.label[src_idx]).to_string();
+            if !seen.insert(claim.clone()) {
+                continue;
+            }
+            let confidence = parse_marker_confidence(&claim);
+            // Cheap freshness: does the cited code file still exist on disk?
+            let tgt_ext = graph
+                .id_to_node
+                .iter()
+                .find(|(_, &nid)| nid.as_usize() == tgt_idx)
+                .map(|(interned, _)| graph.strings.resolve(*interned).to_string());
+            let evidence_fresh = tgt_ext
+                .as_deref()
+                .and_then(|ext| state.file_inventory.get(ext))
+                .map(|inv| std::path::Path::new(&inv.file_path).exists())
+                .unwrap_or(true);
+
+            let mut entry = serde_json::json!({
+                "claim": claim,
+                "anchored_to": anchor_id,
+                "evidence_fresh": evidence_fresh,
+            });
+            if let Some(c) = confidence {
+                entry["confidence"] = serde_json::json!(c);
+            }
+            out.push(entry);
+            if out.len() >= 3 {
+                break 'outer;
+            }
+        }
+    }
+
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Free dispatch functions — used by both JSON-RPC stdio and HTTP API.
 // Zero duplication: McpServer::dispatch_tool() delegates to these.
 // ---------------------------------------------------------------------------
@@ -2129,6 +2339,18 @@ pub fn dispatch_tool(
 ) -> M1ndResult<serde_json::Value> {
     let normalized = tool_name.to_string();
     let start = std::time::Instant::now();
+
+    // Read-only attach gate: refuse mutating tools BEFORE any dispatch or
+    // side-effecting tick so the writer's on-disk state can never be touched.
+    if state.read_only && read_only_denied(&normalized, params) {
+        return Err(M1ndError::InvalidParams {
+            tool: normalized.clone(),
+            detail: format!(
+                "m1nd is attached read-only (--read-only); mutation tool '{}' is disabled. Detach or run a read-write instance to modify state.",
+                normalized
+            ),
+        });
+    }
 
     // Extract agent_id for tracking
     let agent_id = params
@@ -2186,7 +2408,8 @@ pub fn dispatch_tool(
     });
 
     // Post-dispatch: track savings + log query + add _m1nd metadata
-    if let Ok(ref value) = result {
+    let mut result = result;
+    if let Ok(ref mut value) = result {
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         let result_count = value
             .get("results")
@@ -2223,6 +2446,40 @@ pub fn dispatch_tool(
             result_count,
             &query_preview,
         );
+
+        // Additive `_m1nd` response envelope (Tier 2). Gated behind
+        // M1ND_RESPONSE_ENVELOPE (default ON; set to "0"/"false" to disable).
+        // ADDITIVE ONLY: attaches a `_m1nd` object to JSON-object results;
+        // never removes or renames existing fields. Non-object results (rare)
+        // are left untouched.
+        if response_envelope_enabled() && value.is_object() {
+            let session_saved = state.savings_tracker.tokens_saved;
+            let global_saved = state.global_savings.total_tokens_saved + session_saved;
+            // Builders read the result; snapshot it once to avoid a borrow
+            // conflict with the mutable insert below.
+            let snapshot = value.clone();
+            let mut meta =
+                personality::build_m1nd_meta(&normalized, &snapshot, session_saved, global_saved);
+            // Promote the headline fields the contract calls for so agents get
+            // them without reaching into nested `savings`.
+            let summary = personality::personality_line(&normalized, &snapshot);
+            if !summary.is_empty() {
+                meta["summary"] = serde_json::Value::String(summary);
+            }
+            meta["tokens_saved"] = serde_json::json!(session_saved);
+            meta["read_only"] = serde_json::json!(state.read_only);
+
+            // Tier 3: memory at point-of-relevance (additive, capped, best-effort).
+            if let Some(nearby) = memory_nearby_for_result(state, &normalized, &snapshot) {
+                if !nearby.is_empty() {
+                    meta["memory_nearby"] = serde_json::Value::Array(nearby);
+                }
+            }
+
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert("_m1nd".to_string(), meta);
+            }
+        }
     }
 
     result
@@ -3635,6 +3892,135 @@ mod tests {
         };
         let server = McpServer::new(config).expect("server");
         (temp, server)
+    }
+
+    fn build_state_read_only() -> (tempfile::TempDir, SessionState) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            read_only: true,
+            ..McpConfig::default()
+        };
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+        (temp, state)
+    }
+
+    #[test]
+    fn read_only_deny_list_is_precise() {
+        use super::read_only_denied;
+        let empty = serde_json::json!({});
+        // Mutating tools are denied (bare and prefixed).
+        for t in [
+            "ingest",
+            "apply",
+            "apply_batch",
+            "edit_commit",
+            "memorize",
+            "learn",
+            "daemon_start",
+            "auto_ingest_start",
+            "m1nd_apply",
+            "m1nd.ingest",
+        ] {
+            assert!(read_only_denied(t, &empty), "{t} should be denied");
+        }
+        // Read-only / analysis tools are allowed.
+        for t in [
+            "seek",
+            "search",
+            "activate",
+            "why",
+            "impact",
+            "audit",
+            "surgical_context_v2",
+            "session_handshake",
+            "trust_selftest",
+            "doctor",
+            "health",
+            "view",
+            "scan",
+            "trace",
+            "edit_preview",
+        ] {
+            assert!(!read_only_denied(t, &empty), "{t} should be allowed");
+        }
+        // persist: status is allowed; save/checkpoint/load are denied.
+        assert!(!read_only_denied(
+            "persist",
+            &serde_json::json!({"action": "status"})
+        ));
+        assert!(read_only_denied(
+            "persist",
+            &serde_json::json!({"action": "save"})
+        ));
+        assert!(read_only_denied(
+            "persist",
+            &serde_json::json!({"action": "load"})
+        ));
+        // persist with no action defaults to status (allowed).
+        assert!(!read_only_denied("persist", &empty));
+    }
+
+    #[test]
+    fn read_only_dispatch_refuses_mutation_but_allows_query() {
+        let (_temp, mut state) = build_state_read_only();
+        assert!(state.read_only);
+
+        // A mutation tool is refused with the contract error message.
+        let err = super::dispatch_tool(
+            &mut state,
+            "ingest",
+            &serde_json::json!({"agent_id": "t", "path": "/tmp/x"}),
+        )
+        .expect_err("ingest must be refused in read-only");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("attached read-only") && msg.contains("ingest"),
+            "unexpected error: {msg}"
+        );
+
+        // A read-only tool still works (health needs no graph).
+        let ok = super::dispatch_tool(&mut state, "health", &serde_json::json!({"agent_id": "t"}));
+        assert!(ok.is_ok(), "health should work read-only: {ok:?}");
+    }
+
+    #[test]
+    fn read_only_persist_is_a_noop() {
+        let (_temp, mut state) = build_state_read_only();
+        // persist() must early-return Ok without creating the graph file.
+        state.persist().expect("read-only persist returns Ok");
+        assert!(
+            !state.graph_path.exists(),
+            "read-only persist must not write the graph snapshot"
+        );
+        // should_persist is always false even after many queries.
+        state.queries_processed = state.auto_persist_interval as u64;
+        assert!(!state.should_persist());
+    }
+
+    #[test]
+    fn response_envelope_attaches_additively() {
+        let (_temp, mut state) = build_state();
+        // seek on an empty graph returns a results-shaped object; the envelope
+        // must be attached without removing existing fields.
+        let out = super::dispatch_tool(
+            &mut state,
+            "seek",
+            &serde_json::json!({"agent_id": "t", "query": "anything"}),
+        )
+        .expect("seek ok");
+        let obj = out.as_object().expect("object result");
+        assert!(obj.contains_key("_m1nd"), "_m1nd envelope must be present");
+        let meta = &obj["_m1nd"];
+        assert!(meta.get("suggest_next").is_some(), "suggest_next present");
+        assert!(meta.get("tokens_saved").is_some(), "tokens_saved present");
+        // Additive: the original results field is still there.
+        assert!(obj.contains_key("results"), "results field preserved");
     }
 
     #[test]

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -3563,6 +3563,151 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+/// MCP protocol version this server implements/prefers.
+pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Older MCP protocol versions we remain compatible with. If a client offers one
+/// of these we echo it back (per the MCP spec's version-negotiation handshake);
+/// otherwise we reply with our preferred [`MCP_PROTOCOL_VERSION`].
+const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26", "2024-11-05"];
+
+/// Negotiate the protocol version: honor the client's requested version when we
+/// support it, otherwise fall back to our preferred version.
+fn negotiate_protocol_version(requested: Option<&str>) -> &'static str {
+    if let Some(req) = requested {
+        if let Some(v) = MCP_SUPPORTED_PROTOCOL_VERSIONS
+            .iter()
+            .copied()
+            .find(|v| *v == req)
+        {
+            return v;
+        }
+    }
+    MCP_PROTOCOL_VERSION
+}
+
+/// Transport-agnostic MCP method dispatch.
+///
+/// Handles the JSON-RPC MCP protocol methods (`initialize`,
+/// `notifications/initialized`, `tools/list`, `tools/call`, method-not-found)
+/// against a borrowed [`SessionState`]. Used by both the stdio transport
+/// (via [`McpServer::dispatch`]) and the Streamable-HTTP transport
+/// (`mcp_http::handle_mcp_post`), so both bind to the same shared graph.
+///
+/// Note: the stdio-only live FS watcher refresh for `daemon_start`/`daemon_stop`
+/// is NOT performed here — the caller (`McpServer::dispatch`) handles that after
+/// this returns, since it requires `&mut McpServer`, not just `&mut SessionState`.
+pub fn handle_mcp_method(state: &mut SessionState, request: &JsonRpcRequest) -> JsonRpcResponse {
+    let method = request.method.as_str();
+
+    match method {
+        "initialize" => {
+            let requested = request
+                .params
+                .get("protocolVersion")
+                .and_then(|v| v.as_str());
+            let protocol_version = negotiate_protocol_version(requested);
+            JsonRpcResponse {
+                jsonrpc: "2.0".into(),
+                id: request.id.clone(),
+                result: Some(serde_json::json!({
+                    "protocolVersion": protocol_version,
+                    "serverInfo": {
+                        "name": "m1nd-mcp",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                    "capabilities": {
+                        "tools": {},
+                    },
+                    "instructions": M1ND_INSTRUCTIONS,
+                })),
+                error: None,
+            }
+        }
+        "notifications/initialized" => {
+            // No response needed for notifications, but we return one since caller expects it
+            JsonRpcResponse {
+                jsonrpc: "2.0".into(),
+                id: request.id.clone(),
+                result: Some(serde_json::Value::Null),
+                error: None,
+            }
+        }
+        "tools/list" => JsonRpcResponse {
+            jsonrpc: "2.0".into(),
+            id: request.id.clone(),
+            result: Some(tool_schemas()),
+            error: None,
+        },
+        "tools/call" => {
+            // Extract tool name and arguments from params
+            let tool_name = request
+                .params
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let arguments = request
+                .params
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+
+            // Track agent session from arguments
+            if let Some(agent_id) = arguments.get("agent_id").and_then(|v| v.as_str()) {
+                state.track_agent(agent_id);
+                if state.daemon_state.active
+                    && should_autotick_daemon(tool_name)
+                    && state.daemon_state.last_tick_ms.is_some_and(|last| {
+                        now_ms().saturating_sub(last) >= state.daemon_state.poll_interval_ms
+                    })
+                {
+                    run_daemon_tick(state, "traffic");
+                }
+            }
+
+            // MCP spec: tool execution errors -> isError content, not JSON-RPC errors
+            match dispatch_tool(state, tool_name, &arguments) {
+                Ok(result) => JsonRpcResponse {
+                    jsonrpc: "2.0".into(),
+                    id: request.id.clone(),
+                    result: Some(serde_json::json!({
+                        "content": [{
+                            "type": "text",
+                            "text": serde_json::to_string_pretty(&result).unwrap_or_default(),
+                        }]
+                    })),
+                    error: None,
+                },
+                Err(e) => JsonRpcResponse {
+                    jsonrpc: "2.0".into(),
+                    id: request.id.clone(),
+                    result: Some(serde_json::json!({
+                        "content": [{
+                            "type": "text",
+                            "text": format!("Error: {}", e),
+                        }],
+                        "isError": true
+                    })),
+                    error: None,
+                },
+            }
+        }
+        _ => {
+            // Method not found — JSON-RPC protocol error
+            JsonRpcResponse {
+                jsonrpc: "2.0".into(),
+                id: request.id.clone(),
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32601,
+                    message: format!("Method not found: {}", method),
+                    data: None,
+                }),
+            }
+        }
+    }
+}
+
 fn should_autotick_daemon(tool_name: &str) -> bool {
     !matches!(
         tool_name,
@@ -4257,115 +4402,38 @@ impl McpServer {
     }
 
     /// Dispatch a single JSON-RPC request to the appropriate tool handler.
+    ///
+    /// Thin wrapper over the transport-agnostic [`handle_mcp_method`] free fn.
+    /// The only stdio-specific concern kept here is refreshing the live FS
+    /// watcher after a successful `daemon_start`/`daemon_stop`, which requires
+    /// `&mut self` (the watcher lives on `McpServer`, not `SessionState`).
     fn dispatch(&mut self, request: &JsonRpcRequest) -> M1ndResult<JsonRpcResponse> {
-        let method = request.method.as_str();
+        let response = handle_mcp_method(&mut self.state, request);
 
-        // Handle MCP protocol methods
-        match method {
-            "initialize" => Ok(JsonRpcResponse {
-                jsonrpc: "2.0".into(),
-                id: request.id.clone(),
-                result: Some(serde_json::json!({
-                    "protocolVersion": "2024-11-05",
-                    "serverInfo": {
-                        "name": "m1nd-mcp",
-                        "version": env!("CARGO_PKG_VERSION"),
-                    },
-                    "capabilities": {
-                        "tools": {},
-                    },
-                    "instructions": M1ND_INSTRUCTIONS,
-                })),
-                error: None,
-            }),
-            "notifications/initialized" => {
-                // No response needed for notifications, but we return one since caller expects it
-                Ok(JsonRpcResponse {
-                    jsonrpc: "2.0".into(),
-                    id: request.id.clone(),
-                    result: Some(serde_json::Value::Null),
-                    error: None,
-                })
-            }
-            "tools/list" => Ok(JsonRpcResponse {
-                jsonrpc: "2.0".into(),
-                id: request.id.clone(),
-                result: Some(tool_schemas()),
-                error: None,
-            }),
-            "tools/call" => {
-                // Extract tool name and arguments from params
-                let tool_name = request
-                    .params
-                    .get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let arguments = request
-                    .params
-                    .get("arguments")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-
-                // Track agent session from arguments
-                if let Some(agent_id) = arguments.get("agent_id").and_then(|v| v.as_str()) {
-                    self.state.track_agent(agent_id);
-                    if self.state.daemon_state.active
-                        && should_autotick_daemon(tool_name)
-                        && self.state.daemon_state.last_tick_ms.is_some_and(|last| {
-                            now_ms().saturating_sub(last)
-                                >= self.state.daemon_state.poll_interval_ms
-                        })
-                    {
-                        run_daemon_tick(&mut self.state, "traffic");
-                    }
+        // stdio-only: if this was a successful daemon_start/daemon_stop tool call,
+        // rebind the live FS watcher to match the new daemon state.
+        if request.method == "tools/call" {
+            let tool_name = request
+                .params
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if matches!(tool_name, "daemon_start" | "daemon_stop") {
+                // The MCP wrapper reports tool execution errors via isError content,
+                // not JSON-RPC errors, so only refresh when the call did not error.
+                let is_error = response
+                    .result
+                    .as_ref()
+                    .and_then(|r| r.get("isError"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if !is_error {
+                    self.refresh_daemon_watcher();
                 }
-
-                // MCP spec: tool execution errors -> isError content, not JSON-RPC errors
-                match self.dispatch_tool_call(tool_name, &arguments) {
-                    Ok(result) => {
-                        if matches!(tool_name, "daemon_start" | "daemon_stop") {
-                            self.refresh_daemon_watcher();
-                        }
-                        Ok(JsonRpcResponse {
-                            jsonrpc: "2.0".into(),
-                            id: request.id.clone(),
-                            result: Some(serde_json::json!({
-                                "content": [{
-                                    "type": "text",
-                                    "text": serde_json::to_string_pretty(&result).unwrap_or_default(),
-                                }]
-                            })),
-                            error: None,
-                        })
-                    }
-                    Err(e) => Ok(JsonRpcResponse {
-                        jsonrpc: "2.0".into(),
-                        id: request.id.clone(),
-                        result: Some(serde_json::json!({
-                            "content": [{
-                                "type": "text",
-                                "text": format!("Error: {}", e),
-                            }],
-                            "isError": true
-                        })),
-                        error: None,
-                    }),
-                }
-            }
-            _ => {
-                // Method not found — JSON-RPC protocol error
-                Ok(JsonRpcResponse {
-                    jsonrpc: "2.0".into(),
-                    id: request.id.clone(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32601,
-                        message: format!("Method not found: {}", method),
-                        data: None,
-                    }),
-                })
             }
         }
+
+        Ok(response)
     }
 
     /// Dispatch a tool call by name. Delegates to the free dispatch_tool() function.

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -294,6 +294,7 @@ pub const ESSENTIAL_TOOLS: &[&str] = &[
     "trust_selftest",
     "session_handshake",
     "orient",
+    "am_i_stale",
     "recovery_playbook",
     "health",
     "doctor",
@@ -408,6 +409,27 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "scope": { "type": "string", "description": "Optional scope hint to bound orientation" }
                     },
                     "required": ["agent_id", "task"]
+                }
+            },
+            {
+                "name": "am_i_stale",
+                "description": "Self-awareness check a long-running agent should reach for OFTEN: which files in your working set changed on disk SINCE m1nd ingested them, so you know to re-read before acting. You can't see the filesystem change under you (the user edits, another agent edits, a build runs); this gives you that perception. Pass `files` and/or `nodes` to check specific targets, or pass NEITHER and m1nd checks every file you've touched this session. Returns stale (changed|missing), fresh, and unknown (never-ingested) paths. Read-only safe.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "files": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Optional explicit file paths to check. If omitted (and no `nodes`), defaults to the files you've visited this session."
+                        },
+                        "nodes": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Optional node ids to check; each is resolved to its backing file path."
+                        }
+                    },
+                    "required": ["agent_id"]
                 }
             },
             {
@@ -2543,6 +2565,235 @@ fn handle_orient(
     }))
 }
 
+/// Resolve a node id to its absolute on-disk file path for `am_i_stale`.
+///
+/// Two paths, both grounded in already-recorded state — no new traversal logic:
+///   1. The node id is itself a `file::…` inventory key → return its recorded
+///      `file_path` directly.
+///   2. Otherwise look the node up in the graph and use its provenance
+///      `source_path` (the file the node was ingested from).
+///
+/// Returns `None` when the node is unknown / has no file provenance.
+fn resolve_node_file_path(state: &SessionState, node_id: &str) -> Option<String> {
+    // Fast path: the node id is already a file inventory key.
+    if let Some(entry) = state.file_inventory.get(node_id) {
+        return Some(entry.file_path.clone());
+    }
+    // Otherwise resolve via the graph's provenance source_path.
+    let graph = state.graph.read();
+    let interned = graph.strings.lookup(node_id)?;
+    let nid = *graph.id_to_node.get(&interned)?;
+    let prov = graph.resolve_node_provenance(nid);
+    prov.source_path
+}
+
+/// `am_i_stale` — tell a long-running agent which files in its working set have
+/// changed on disk SINCE m1nd ingested them, so it knows to re-read before
+/// acting. The perception an agent structurally lacks.
+///
+/// AGGREGATION handler: it composes existing primitives and reimplements
+/// nothing.
+///   * `state.file_inventory` is the "what m1nd last saw" baseline — each entry
+///     records the absolute `file_path` and the `sha256` captured at ingest.
+///   * `audit_handlers::simple_content_hash` recomputes the current on-disk hash
+///     with the SAME algorithm the ingest path used, so a recomputed hash is
+///     directly comparable to the stored one (shared fn — no second hasher).
+///   * `state.coverage_sessions[agent_id].visited_files` is the DEFAULT working
+///     set when the caller passes neither `files` nor `nodes`: "you don't even
+///     have to tell me what you're holding; I'll check what you've touched".
+///
+/// READ-ONLY SAFE: only reads disk + inventory. Not in `read_only_denied`.
+fn handle_am_i_stale(
+    state: &mut SessionState,
+    params: &serde_json::Value,
+) -> M1ndResult<serde_json::Value> {
+    let agent_id = params
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| M1ndError::InvalidParams {
+            tool: "am_i_stale".into(),
+            detail: "am_i_stale requires an `agent_id` string".into(),
+        })?
+        .to_string();
+
+    let explicit_files: Vec<String> = params
+        .get("files")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let explicit_nodes: Vec<String> = params
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Decide the working set + its provenance. Each target is (path, node_id?).
+    // `note` is a caller-facing explanation when a target couldn't be turned
+    // into a checkable path (e.g. an unresolvable node id).
+    let mut targets: Vec<(String, Option<String>)> = Vec::new();
+    let mut notes: Vec<String> = Vec::new();
+    let source: &str;
+
+    if !explicit_files.is_empty() {
+        source = "explicit_files";
+        for path in explicit_files {
+            targets.push((path, None));
+        }
+    } else if !explicit_nodes.is_empty() {
+        source = "explicit_nodes";
+        for node_id in explicit_nodes {
+            match resolve_node_file_path(state, &node_id) {
+                Some(path) => targets.push((path, Some(node_id))),
+                None => notes.push(format!(
+                    "node `{}` could not be resolved to a file path (unknown or not file-backed)",
+                    node_id
+                )),
+            }
+        }
+    } else if let Some(session) = state.coverage_sessions.get(&agent_id) {
+        source = "coverage_session";
+        for path in &session.visited_files {
+            targets.push((path.clone(), None));
+        }
+    } else {
+        source = "empty";
+    }
+
+    // Build a quick lookup from absolute file_path → inventory entry. The
+    // inventory is keyed by external_id, but visited_files / explicit files are
+    // disk paths, so index by file_path (mirrors audit_handlers usage). We also
+    // index by the canonicalized form so a caller passing a non-canonical path
+    // (e.g. /var/… on macOS where the inventory recorded /private/var/…) still
+    // matches the same baseline.
+    let mut inventory_by_path: std::collections::HashMap<String, &crate::session::FileInventoryEntry> =
+        std::collections::HashMap::with_capacity(state.file_inventory.len() * 2);
+    for entry in state.file_inventory.values() {
+        inventory_by_path.insert(entry.file_path.clone(), entry);
+        if let Ok(canon) = std::fs::canonicalize(&entry.file_path) {
+            inventory_by_path.insert(canon.to_string_lossy().to_string(), entry);
+        }
+    }
+
+    let mut stale: Vec<serde_json::Value> = Vec::new();
+    let mut fresh: Vec<String> = Vec::new();
+    let mut unknown: Vec<String> = Vec::new();
+
+    for (path, node_id) in &targets {
+        let entry = inventory_by_path.get(path.as_str()).copied().or_else(|| {
+            std::fs::canonicalize(path)
+                .ok()
+                .and_then(|c| inventory_by_path.get(c.to_string_lossy().as_ref()).copied())
+        });
+        let Some(entry) = entry else {
+            // Never ingested → m1nd has no baseline for this path.
+            unknown.push(path.clone());
+            continue;
+        };
+        let disk_path = std::path::Path::new(path.as_str());
+        if !disk_path.exists() {
+            let mut item = serde_json::json!({ "path": path, "reason": "missing" });
+            if let Some(nid) = node_id {
+                item["node_id"] = serde_json::Value::String(nid.clone());
+            }
+            stale.push(item);
+            continue;
+        }
+        let current_hash = crate::audit_handlers::simple_content_hash(disk_path);
+        match (&entry.sha256, current_hash) {
+            (Some(known), Some(now)) if known != &now => {
+                let mut item = serde_json::json!({ "path": path, "reason": "changed" });
+                if let Some(nid) = node_id {
+                    item["node_id"] = serde_json::Value::String(nid.clone());
+                }
+                stale.push(item);
+            }
+            (Some(_), Some(_)) => {
+                // Hash matches — fresh.
+                fresh.push(path.clone());
+            }
+            _ => {
+                // No recorded hash, or the file couldn't be re-read: we can't
+                // make a confident staleness judgement, so report as unknown
+                // rather than silently calling it fresh.
+                unknown.push(path.clone());
+            }
+        }
+    }
+
+    let checked = stale.len() + fresh.len() + unknown.len();
+
+    let summary = if source == "empty" {
+        notes.push(
+            "no `files`/`nodes` given and agent has no coverage session — nothing to check".into(),
+        );
+        format!(
+            "0 files checked: agent `{}` has no coverage session and you passed no files or nodes.",
+            agent_id
+        )
+    } else if checked == 0 {
+        format!(
+            "0 files checked ({}): nothing in your working set was tracked in m1nd's file inventory.",
+            source
+        )
+    } else if stale.is_empty() {
+        format!(
+            "All {} file(s) checked ({}) are fresh — nothing changed on disk since ingest.",
+            checked, source
+        )
+    } else {
+        let stale_paths: Vec<&str> = stale
+            .iter()
+            .filter_map(|s| s.get("path").and_then(|p| p.as_str()))
+            .collect();
+        let preview: Vec<&str> = stale_paths.iter().take(3).copied().collect();
+        let suffix = if stale_paths.len() > preview.len() {
+            format!("{}, +{} more", preview.join(", "), stale_paths.len() - preview.len())
+        } else {
+            preview.join(", ")
+        };
+        let touched = if source == "coverage_session" {
+            "you've touched"
+        } else {
+            "you're checking"
+        };
+        format!(
+            "{} of {} files {} changed since ingest — re-read {} before editing.",
+            stale.len(),
+            checked,
+            touched,
+            suffix
+        )
+    };
+
+    let mut out = serde_json::json!({
+        "checked": checked,
+        "stale": stale,
+        "fresh": fresh,
+        "unknown": unknown,
+        "source": source,
+        "summary": summary,
+    });
+    if !notes.is_empty() {
+        out["notes"] = serde_json::Value::Array(
+            notes.into_iter().map(serde_json::Value::String).collect(),
+        );
+    }
+    Ok(out)
+}
+
 /// Build the `coverage` block for `orient` from `state.coverage_sessions`.
 ///
 /// Returns `{visited, total, unvisited_high_value:[paths]}` when the agent has a
@@ -2762,6 +3013,7 @@ fn dispatch_core_tool(
 ) -> M1ndResult<serde_json::Value> {
     match tool_name {
         "orient" => handle_orient(state, params),
+        "am_i_stale" => handle_am_i_stale(state, params),
         "activate" => {
             let input: ActivateInput =
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
@@ -6102,5 +6354,308 @@ mod tests {
             !out["focus_nodes"].as_array().unwrap().is_empty(),
             "orient must surface focus nodes on the real graph"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // am_i_stale — agent-first on-disk staleness perception
+    // -----------------------------------------------------------------------
+
+    /// Ingest a temp repo with a single file and return (temp, state, abs_path).
+    /// After ingest, `state.file_inventory` holds the recorded sha256 baseline.
+    fn ingest_single_file(contents: &str) -> (tempfile::TempDir, SessionState, std::path::PathBuf) {
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo src");
+        let file = repo.join("src/target.py");
+        std::fs::write(&file, contents).expect("write target file");
+
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: repo.to_string_lossy().to_string(),
+                agent_id: "stale-agent".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+            },
+        )
+        .expect("ingest single file");
+
+        // The ingest pipeline canonicalizes paths (on macOS /var → /private/var),
+        // so resolve the test's path the same way to address the file the tool
+        // will actually see. Mirrors what a caller passing a real on-disk path
+        // gets, and what `am_i_stale`'s own canonicalization-aware match handles.
+        let file = std::fs::canonicalize(&file).unwrap_or(file);
+
+        // Inventory must record the file with a hash baseline.
+        assert!(
+            state
+                .file_inventory
+                .values()
+                .any(|e| e.file_path == file.to_string_lossy() && e.sha256.is_some()),
+            "ingest must record the target file with a sha256 baseline"
+        );
+        (temp, state, file)
+    }
+
+    #[test]
+    fn am_i_stale_detects_changed_file() {
+        let (_temp, mut state, file) =
+            ingest_single_file("def target():\n    return 'original'\n");
+
+        // Rewrite the file on disk with different content (the change m1nd can't see).
+        std::fs::write(&file, "def target():\n    return 'MUTATED'\n").expect("rewrite file");
+
+        let out = super::handle_am_i_stale(
+            &mut state,
+            &serde_json::json!({
+                "agent_id": "stale-agent",
+                "files": [file.to_string_lossy()],
+            }),
+        )
+        .expect("am_i_stale must succeed");
+
+        assert_eq!(out["source"], "explicit_files");
+        assert_eq!(out["checked"], serde_json::json!(1));
+        let stale = out["stale"].as_array().expect("stale array");
+        assert_eq!(stale.len(), 1, "the rewritten file must be flagged stale");
+        assert_eq!(stale[0]["path"], file.to_string_lossy().as_ref());
+        assert_eq!(stale[0]["reason"], "changed");
+        assert!(
+            out["fresh"].as_array().unwrap().is_empty(),
+            "no file should be fresh after the rewrite"
+        );
+    }
+
+    #[test]
+    fn am_i_stale_detects_missing_file() {
+        let (_temp, mut state, file) =
+            ingest_single_file("def target():\n    return 'original'\n");
+
+        // Delete the file on disk after ingest.
+        std::fs::remove_file(&file).expect("delete file");
+
+        let out = super::handle_am_i_stale(
+            &mut state,
+            &serde_json::json!({
+                "agent_id": "stale-agent",
+                "files": [file.to_string_lossy()],
+            }),
+        )
+        .expect("am_i_stale must succeed");
+
+        let stale = out["stale"].as_array().expect("stale array");
+        assert_eq!(stale.len(), 1, "the deleted file must be flagged stale");
+        assert_eq!(stale[0]["reason"], "missing");
+    }
+
+    #[test]
+    fn am_i_stale_reports_fresh() {
+        let (_temp, mut state, file) =
+            ingest_single_file("def target():\n    return 'untouched'\n");
+
+        // Do NOT touch the file — it must come back fresh.
+        let out = super::handle_am_i_stale(
+            &mut state,
+            &serde_json::json!({
+                "agent_id": "stale-agent",
+                "files": [file.to_string_lossy()],
+            }),
+        )
+        .expect("am_i_stale must succeed");
+
+        assert_eq!(out["checked"], serde_json::json!(1));
+        assert!(
+            out["stale"].as_array().unwrap().is_empty(),
+            "an untouched file must not be stale"
+        );
+        let fresh = out["fresh"].as_array().expect("fresh array");
+        assert_eq!(fresh.len(), 1, "the untouched file must be fresh");
+        assert_eq!(fresh[0], file.to_string_lossy().as_ref());
+    }
+
+    #[test]
+    fn am_i_stale_defaults_to_coverage_session() {
+        let (_temp, mut state, file) =
+            ingest_single_file("def target():\n    return 'original'\n");
+
+        // Record a coverage session for the agent that has visited the file,
+        // then mutate the file so the default working set should flag it.
+        state.note_coverage(
+            "stale-agent",
+            "view",
+            [file.to_string_lossy().to_string()],
+            std::iter::empty::<String>(),
+        );
+        std::fs::write(&file, "def target():\n    return 'changed-under-agent'\n")
+            .expect("rewrite file");
+
+        // No `files`/`nodes` → must default to the coverage session's visited files.
+        let out = super::handle_am_i_stale(
+            &mut state,
+            &serde_json::json!({ "agent_id": "stale-agent" }),
+        )
+        .expect("am_i_stale must succeed");
+
+        assert_eq!(
+            out["source"], "coverage_session",
+            "with no explicit targets it must default to the coverage session"
+        );
+        assert_eq!(out["checked"], serde_json::json!(1));
+        let stale = out["stale"].as_array().expect("stale array");
+        assert_eq!(stale.len(), 1, "the touched-then-changed file must be stale");
+        assert_eq!(stale[0]["reason"], "changed");
+    }
+
+    #[test]
+    fn am_i_stale_empty_when_no_targets_and_no_session() {
+        let (_temp, mut state, _file) =
+            ingest_single_file("def target():\n    return 'x'\n");
+
+        // A different agent with no coverage session and no explicit targets.
+        let out = super::handle_am_i_stale(
+            &mut state,
+            &serde_json::json!({ "agent_id": "ghost-agent" }),
+        )
+        .expect("am_i_stale must succeed");
+
+        assert_eq!(out["source"], "empty");
+        assert_eq!(out["checked"], serde_json::json!(0));
+        assert!(out["notes"].is_array(), "empty result must carry a note");
+    }
+
+    #[test]
+    fn am_i_stale_is_not_read_only_denied() {
+        use super::read_only_denied;
+        assert!(
+            !read_only_denied("am_i_stale", &serde_json::json!({})),
+            "am_i_stale only reads disk + inventory — it must be allowed in read-only attach"
+        );
+        // The prefix-normalized forms must also be allowed.
+        assert!(!read_only_denied("m1nd_am_i_stale", &serde_json::json!({})));
+        assert!(!read_only_denied("m1nd.am_i_stale", &serde_json::json!({})));
+    }
+
+    /// REAL PROBE: ingest a SMALL real directory (`m1nd-core/src`), record the
+    /// inventory, mutate ONE real file's content on disk, call `am_i_stale`, and
+    /// print the stale/fresh classification so we can SEE it catch the real
+    /// change. Restores the file afterward so the working tree stays clean.
+    ///
+    /// Run with: `cargo test -p m1nd-mcp am_i_stale_real_probe -- --nocapture`
+    #[test]
+    fn am_i_stale_real_probe() {
+        // Locate m1nd-core/src relative to the crate dir (repo-root/m1nd-core/src).
+        let real_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|p| p.join("m1nd-core").join("src"))
+            .filter(|p| p.is_dir());
+        let Some(real_dir) = real_dir else {
+            eprintln!("[am_i_stale_real_probe] m1nd-core/src not found — skipping");
+            return;
+        };
+
+        let (_temp, mut state) = build_state();
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: real_dir.to_string_lossy().to_string(),
+                agent_id: "real-probe".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+            },
+        )
+        .expect("ingest real m1nd-core/src");
+
+        let inv_count = state.file_inventory.len();
+        eprintln!(
+            "\n=== am_i_stale REAL PROBE: ingested {} files from {} ===",
+            inv_count,
+            real_dir.display()
+        );
+        assert!(inv_count >= 3, "expected several real files in m1nd-core/src");
+
+        // Pick three real ingested files: one to mutate, two left untouched.
+        let mut paths: Vec<String> = state
+            .file_inventory
+            .values()
+            .map(|e| e.file_path.clone())
+            .collect();
+        paths.sort();
+        let victim = paths[0].clone();
+        let untouched_a = paths.get(1).cloned().expect("a second real file");
+        let untouched_b = paths.get(2).cloned().expect("a third real file");
+
+        // Snapshot the victim's real bytes, mutate, and ALWAYS restore.
+        let original_bytes = std::fs::read(&victim).expect("read victim file");
+        let mut mutated = original_bytes.clone();
+        mutated.extend_from_slice(b"\n// am_i_stale real probe touch\n");
+        std::fs::write(&victim, &mutated).expect("mutate victim file");
+
+        // Run the probe inside a closure so we can restore on any path.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let out = super::handle_am_i_stale(
+                &mut state,
+                &serde_json::json!({
+                    "agent_id": "real-probe",
+                    "files": [victim.clone(), untouched_a.clone(), untouched_b.clone()],
+                }),
+            )
+            .expect("am_i_stale on real files");
+
+            eprintln!("source : {}", out["source"]);
+            eprintln!("checked: {}", out["checked"]);
+            eprintln!("summary: {}", out["summary"].as_str().unwrap_or(""));
+            eprintln!("STALE:");
+            for s in out["stale"].as_array().map(|a| a.as_slice()).unwrap_or(&[]) {
+                eprintln!(
+                    "  - {} [{}]",
+                    s["path"].as_str().unwrap_or(""),
+                    s["reason"].as_str().unwrap_or("")
+                );
+            }
+            eprintln!("FRESH:");
+            for f in out["fresh"].as_array().map(|a| a.as_slice()).unwrap_or(&[]) {
+                eprintln!("  - {}", f.as_str().unwrap_or(""));
+            }
+            eprintln!("=== end real probe ===\n");
+
+            // The mutated file MUST be flagged changed; the others MUST be fresh.
+            let stale_paths: Vec<String> = out["stale"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|s| s.get("path").and_then(|p| p.as_str()).map(String::from))
+                .collect();
+            assert!(
+                stale_paths.contains(&victim),
+                "the mutated real file must be flagged stale"
+            );
+            let fresh_paths: Vec<String> = out["fresh"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|f| f.as_str().map(String::from))
+                .collect();
+            assert!(
+                fresh_paths.contains(&untouched_a) && fresh_paths.contains(&untouched_b),
+                "the untouched real files must be fresh, not flagged"
+            );
+        }));
+
+        // ALWAYS restore the real file so the working tree is clean.
+        std::fs::write(&victim, &original_bytes).expect("restore victim file");
+        let restored = std::fs::read(&victim).expect("re-read restored file");
+        assert_eq!(restored, original_bytes, "victim file must be restored byte-for-byte");
+
+        if let Err(panic) = result {
+            std::panic::resume_unwind(panic);
+        }
     }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -293,6 +293,7 @@ struct DaemonRuntimeControl {
 pub const ESSENTIAL_TOOLS: &[&str] = &[
     "trust_selftest",
     "session_handshake",
+    "orient",
     "recovery_playbook",
     "health",
     "doctor",
@@ -395,6 +396,20 @@ pub fn tool_schemas_for_tier(tier: &str) -> serde_json::Value {
 fn all_tool_schemas_inner() -> serde_json::Value {
     serde_json::json!({
         "tools": [
+            {
+                "name": "orient",
+                "description": "Boot into a task in one call. Give your free-form task and get your STARTING CONTEXT pre-packed: the focus nodes the task activates (ranked), prior memorized conclusions nearby, the global PageRank attention backbone, coverage so far, and the concrete first calls to make. Call this FIRST when you receive a task instead of doing exploratory reads. Read-only safe.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "task": { "type": "string", "description": "Free-form description of the task you are about to start. The graph spread-activates on this text to find your starting context." },
+                        "top_k": { "type": "integer", "default": 8, "description": "How many focus nodes to return (ranked by activation from the task)" },
+                        "scope": { "type": "string", "description": "Optional scope hint to bound orientation" }
+                    },
+                    "required": ["agent_id", "task"]
+                }
+            },
             {
                 "name": "activate",
                 "description": "Spreading activation query across the connectome",
@@ -2324,6 +2339,260 @@ fn memory_nearby_for_result(
 }
 
 // ---------------------------------------------------------------------------
+// `orient` — boot into a task in one call (agent-first cold-start aggregation)
+// ---------------------------------------------------------------------------
+
+/// Top-N nodes by PageRank as the global "attention backbone".
+///
+/// Shared helper factored from the `graph_intelligence` block in
+/// `handle_session_handshake` (tools.rs). Returns `{node_id, label, pagerank}`
+/// objects, descending by score, skipping zero scores. Empty when PageRank has
+/// not been computed yet.
+fn top_pagerank_anchors(graph: &m1nd_core::graph::Graph, n: usize) -> Vec<serde_json::Value> {
+    if !graph.pagerank_computed || graph.nodes.pagerank.is_empty() {
+        return vec![];
+    }
+    // NodeId → external id reverse map (only for the few nodes we return).
+    let mut nid_to_ext: std::collections::HashMap<usize, String> =
+        std::collections::HashMap::with_capacity(graph.id_to_node.len());
+    for (interned, &nid) in &graph.id_to_node {
+        nid_to_ext.insert(nid.as_usize(), graph.strings.resolve(*interned).to_string());
+    }
+    let count = graph.nodes.count as usize;
+    let mut ranked: Vec<(f32, usize)> = (0..count)
+        .filter_map(|i| {
+            let pr = graph.nodes.pagerank[i].get();
+            if pr > 0.0 {
+                Some((pr, i))
+            } else {
+                None
+            }
+        })
+        .collect();
+    ranked.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.truncate(n);
+    ranked
+        .into_iter()
+        .map(|(pr, idx)| {
+            let ext_id = nid_to_ext.get(&idx).cloned().unwrap_or_default();
+            let label = graph
+                .strings
+                .try_resolve(graph.nodes.label[idx])
+                .unwrap_or("")
+                .to_string();
+            serde_json::json!({ "node_id": ext_id, "label": label, "pagerank": pr })
+        })
+        .collect()
+}
+
+/// `orient` — pre-pack an agent's STARTING CONTEXT from a free-form task string.
+///
+/// AGGREGATION handler: it composes existing primitives rather than
+/// reimplementing them.
+///   * spread-activation on the task text via `handle_activate` (which uses
+///     `SessionState::run_query`, so this works in `--read-only` attach too) →
+///     `focus_nodes`.
+///   * `memory_nearby_for_result` over the focus nodes → prior conclusions.
+///   * `top_pagerank_anchors` → global attention backbone.
+///   * coverage state from `state.coverage_sessions` → visited/total +
+///     high-PageRank unvisited files (or null when the agent has no session).
+///   * the top focus node → concrete `suggested_first_calls` (surgical_context,
+///     then why) so the agent's very next move is grounded.
+///
+/// READ-ONLY SAFE: only queries. Not in `read_only_denied`.
+fn handle_orient(
+    state: &mut SessionState,
+    params: &serde_json::Value,
+) -> M1ndResult<serde_json::Value> {
+    let agent_id = params
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| M1ndError::InvalidParams {
+            tool: "orient".into(),
+            detail: "orient requires an `agent_id` string".into(),
+        })?
+        .to_string();
+    let task = params
+        .get("task")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| M1ndError::InvalidParams {
+            tool: "orient".into(),
+            detail: "orient requires a `task` string describing what the agent is about to do"
+                .into(),
+        })?
+        .to_string();
+    if task.trim().is_empty() {
+        return Err(M1ndError::InvalidParams {
+            tool: "orient".into(),
+            detail: "orient `task` must be non-empty".into(),
+        });
+    }
+    let top_k = params
+        .get("top_k")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize)
+        .unwrap_or(8)
+        .clamp(1, 50);
+
+    // 1. Spread-activate on the task text. handle_activate routes through
+    //    run_query, which picks query_readonly in read-only mode — so orient is
+    //    safe in --read-only attach. Reuse it wholesale; no reimplementation.
+    let activate_input = ActivateInput {
+        query: task.clone(),
+        agent_id: agent_id.clone(),
+        top_k,
+        dimensions: vec![
+            "structural".into(),
+            "semantic".into(),
+            "temporal".into(),
+            "causal".into(),
+        ],
+        xlr: true,
+        include_ghost_edges: false,
+        include_structural_holes: false,
+    };
+    let activate_out = tools::handle_activate(state, activate_input)?;
+
+    // focus_nodes: compact projection of the activated nodes, ranked by activation.
+    let focus_nodes: Vec<serde_json::Value> = activate_out
+        .activated
+        .iter()
+        .take(top_k)
+        .map(|a| {
+            let path = a
+                .provenance
+                .as_ref()
+                .and_then(|p| p.source_path.clone());
+            serde_json::json!({
+                "node_id": a.node_id,
+                "label": a.label,
+                "path": path,
+                "pagerank": a.pagerank,
+                "activation": a.activation,
+                "kind": a.node_type,
+            })
+        })
+        .collect();
+    let top_focus_id = activate_out
+        .activated
+        .first()
+        .map(|a| a.node_id.clone());
+
+    // 2. memory_nearby: reuse memory_nearby_for_result over the focus nodes.
+    //    It expects a `results` array of `{node_id|label}` — shape one from the
+    //    focus nodes (capped at ~5 prior conclusions).
+    let memory_nearby = {
+        let pseudo_result = serde_json::json!({
+            "results": activate_out
+                .activated
+                .iter()
+                .take(5)
+                .map(|a| serde_json::json!({ "node_id": a.node_id }))
+                .collect::<Vec<_>>(),
+        });
+        memory_nearby_for_result(state, "activate", &pseudo_result).unwrap_or_default()
+    };
+
+    // 3. anchors: global PageRank attention backbone (cap 5).
+    let anchors = {
+        let graph = state.graph.read();
+        top_pagerank_anchors(&graph, 5)
+    };
+
+    // 4. coverage: surface visited/total + a few high-PageRank unvisited files
+    //    when the agent has a coverage session; otherwise null.
+    let coverage = build_orient_coverage(state, &agent_id);
+
+    // 5. suggested_first_calls: lead with surgical_context on the top focus node
+    //    (grounded edit prep), then reuse suggest_next for textual guidance.
+    let mut suggested_first_calls: Vec<serde_json::Value> = Vec::new();
+    if let Some(ref node_id) = top_focus_id {
+        suggested_first_calls.push(serde_json::json!({
+            "tool": "surgical_context",
+            "arguments": { "agent_id": agent_id, "node_id": node_id },
+        }));
+    }
+    suggested_first_calls.push(serde_json::json!({
+        "tool": "why",
+        "arguments": { "agent_id": agent_id, "query": task },
+    }));
+
+    let summary = if let Some(first) = focus_nodes.first() {
+        let label = first
+            .get("label")
+            .and_then(|v| v.as_str())
+            .unwrap_or("the top focus node");
+        format!(
+            "Load {} first ({} focus node(s) activated for this task); then ground it with surgical_context.",
+            label,
+            focus_nodes.len()
+        )
+    } else {
+        "No focus nodes activated for this task — try ingesting the relevant area or refining the task description.".to_string()
+    };
+
+    Ok(serde_json::json!({
+        "task": task,
+        "focus_nodes": focus_nodes,
+        "memory_nearby": memory_nearby,
+        "anchors": anchors,
+        "coverage": coverage,
+        "suggested_first_calls": suggested_first_calls,
+        "proof_state": "triaging",
+        "summary": summary,
+    }))
+}
+
+/// Build the `coverage` block for `orient` from `state.coverage_sessions`.
+///
+/// Returns `{visited, total, unvisited_high_value:[paths]}` when the agent has a
+/// coverage session, otherwise `null`. `unvisited_high_value` lists up to 5 file
+/// paths with the highest PageRank that the agent has not yet visited.
+fn build_orient_coverage(state: &SessionState, agent_id: &str) -> serde_json::Value {
+    let Some(session) = state.coverage_sessions.get(agent_id) else {
+        return serde_json::Value::Null;
+    };
+    let graph = state.graph.read();
+    let total = graph.nodes.count as usize;
+    let visited = session.visited_nodes.len();
+
+    // High-PageRank file nodes the agent has not visited yet.
+    let mut unvisited: Vec<(f32, String)> = Vec::new();
+    if graph.pagerank_computed && !graph.nodes.pagerank.is_empty() {
+        for (interned, &nid) in &graph.id_to_node {
+            let ext = graph.strings.resolve(*interned).to_string();
+            if session.visited_nodes.contains(&ext) || session.visited_files.contains(&ext) {
+                continue;
+            }
+            // Prefer file-level nodes for the "what to read next" hint.
+            if !ext.starts_with("file::") {
+                continue;
+            }
+            let idx = nid.as_usize();
+            let pr = graph
+                .nodes
+                .pagerank
+                .get(idx)
+                .map(|p| p.get())
+                .unwrap_or(0.0);
+            if pr > 0.0 {
+                let path = ext.strip_prefix("file::").unwrap_or(&ext).to_string();
+                unvisited.push((pr, path));
+            }
+        }
+        unvisited.sort_unstable_by(|a, b| {
+            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        unvisited.truncate(5);
+    }
+    serde_json::json!({
+        "visited": visited,
+        "total": total,
+        "unvisited_high_value": unvisited.into_iter().map(|(_, p)| p).collect::<Vec<_>>(),
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Free dispatch functions — used by both JSON-RPC stdio and HTTP API.
 // Zero duplication: McpServer::dispatch_tool() delegates to these.
 // ---------------------------------------------------------------------------
@@ -2492,6 +2761,7 @@ fn dispatch_core_tool(
     params: &serde_json::Value,
 ) -> M1ndResult<serde_json::Value> {
     match tool_name {
+        "orient" => handle_orient(state, params),
         "activate" => {
             let input: ActivateInput =
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
@@ -5554,5 +5824,283 @@ mod tests {
                 label
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // orient — agent-first cold-start aggregation tool
+    // -----------------------------------------------------------------------
+
+    /// Build a SessionState backed by a small populated, finalized graph so
+    /// PageRank is computed and spread-activation has nodes to land on.
+    fn build_state_populated(read_only: bool) -> (tempfile::TempDir, SessionState) {
+        use m1nd_core::types::{EdgeDirection, FiniteF32, NodeType};
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            read_only,
+            ..McpConfig::default()
+        };
+
+        let mut graph = Graph::new();
+        // A tiny "lease" cluster so a task about leases activates something.
+        let lease = graph
+            .add_node(
+                "file::src/lease.rs",
+                "lease enforcement",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add lease node");
+        let registry = graph
+            .add_node(
+                "file::src/registry.rs",
+                "instance registry lease",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add registry node");
+        let other = graph
+            .add_node(
+                "file::src/unrelated.rs",
+                "unrelated helper",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add other node");
+        graph
+            .add_edge(
+                lease,
+                registry,
+                "imports",
+                FiniteF32::new(1.0),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.9),
+            )
+            .expect("edge lease->registry");
+        graph
+            .add_edge(
+                registry,
+                other,
+                "imports",
+                FiniteF32::new(1.0),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.3),
+            )
+            .expect("edge registry->other");
+        graph.finalize().expect("finalize graph");
+
+        let state = SessionState::initialize(graph, &config, DomainConfig::code())
+            .expect("init populated session");
+        (temp, state)
+    }
+
+    #[test]
+    fn orient_returns_focus_nodes_on_populated_graph() {
+        let (_temp, mut state) = build_state_populated(false);
+        let out = super::dispatch_tool(
+            &mut state,
+            "orient",
+            &serde_json::json!({
+                "agent_id": "orienter",
+                "task": "lease enforcement in the instance registry",
+            }),
+        )
+        .expect("orient should succeed on a populated graph");
+
+        // Contract shape.
+        assert_eq!(
+            out["task"], "lease enforcement in the instance registry",
+            "task must be echoed"
+        );
+        assert_eq!(out["proof_state"], "triaging");
+        assert!(out["summary"].is_string(), "summary must be a string");
+
+        let focus = out["focus_nodes"].as_array().expect("focus_nodes array");
+        assert!(
+            !focus.is_empty(),
+            "focus_nodes must be non-empty on a populated graph"
+        );
+        // Each focus node carries the contract fields.
+        for f in focus {
+            assert!(f["node_id"].is_string(), "focus node needs node_id");
+            assert!(f["label"].is_string(), "focus node needs label");
+            assert!(f.get("pagerank").is_some(), "focus node needs pagerank");
+            assert!(f.get("activation").is_some(), "focus node needs activation");
+            assert!(f.get("kind").is_some(), "focus node needs kind");
+            assert!(f.get("path").is_some(), "focus node needs path key");
+        }
+
+        // anchors are the global PageRank backbone (non-empty on a finalized graph).
+        let anchors = out["anchors"].as_array().expect("anchors array");
+        assert!(
+            !anchors.is_empty(),
+            "anchors must be non-empty once PageRank is computed"
+        );
+        for a in anchors {
+            assert!(a["node_id"].is_string());
+            assert!(a["pagerank"].is_number());
+        }
+
+        // The activation inside orient records a coverage session for this agent,
+        // so coverage is populated with visited/total and a high-value shortlist.
+        let cov = &out["coverage"];
+        assert!(cov.is_object(), "coverage must be populated after activation");
+        assert!(cov["visited"].is_number(), "coverage.visited present");
+        assert_eq!(cov["total"], serde_json::json!(3), "graph has 3 nodes");
+        assert!(
+            cov["unvisited_high_value"].is_array(),
+            "coverage.unvisited_high_value is an array"
+        );
+
+        // suggested_first_calls leads with surgical_context on the top focus node.
+        let calls = out["suggested_first_calls"]
+            .as_array()
+            .expect("suggested_first_calls array");
+        assert!(!calls.is_empty(), "must suggest at least one first call");
+        assert_eq!(calls[0]["tool"], "surgical_context");
+        assert!(calls[0]["arguments"]["node_id"].is_string());
+
+        // The _m1nd envelope is attached by dispatch (additive).
+        assert!(
+            out.as_object().unwrap().contains_key("_m1nd"),
+            "_m1nd envelope must wrap orient too"
+        );
+    }
+
+    #[test]
+    fn orient_works_in_read_only_mode() {
+        let (_temp, mut state) = build_state_populated(true);
+        assert!(state.read_only, "state must be read-only");
+
+        // orient must NOT be caught by the mutation deny-list.
+        use super::read_only_denied;
+        assert!(
+            !read_only_denied("orient", &serde_json::json!({})),
+            "orient must be allowed in read-only mode"
+        );
+
+        // It dispatches successfully through the read-only path (query_readonly).
+        let out = super::dispatch_tool(
+            &mut state,
+            "orient",
+            &serde_json::json!({
+                "agent_id": "ro-agent",
+                "task": "lease enforcement",
+            }),
+        )
+        .expect("orient must succeed in read-only attach");
+        assert_eq!(out["task"], "lease enforcement");
+        assert!(out["focus_nodes"].is_array());
+        // read_only flag is surfaced via the envelope.
+        assert_eq!(out["_m1nd"]["read_only"], serde_json::json!(true));
+
+        // A read-only attach must never write the graph snapshot.
+        assert!(
+            !state.graph_path.exists(),
+            "orient must not persist anything in read-only mode"
+        );
+    }
+
+    /// REAL PROBE: load the repo's actual graph_snapshot.json (~5540 nodes) and
+    /// run `orient` on a real task, printing the focus nodes + summary.
+    ///
+    /// Run with: `cargo test -p m1nd-mcp orient_real_snapshot_probe -- --nocapture`
+    /// Skips gracefully (printing a note) if the snapshot is not present.
+    #[test]
+    fn orient_real_snapshot_probe() {
+        // Locate the repo-root snapshot relative to the crate dir.
+        let snapshot = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|p| p.join("graph_snapshot.json"))
+            .filter(|p| p.exists());
+        let Some(snapshot_path) = snapshot else {
+            eprintln!("[orient_real_snapshot_probe] graph_snapshot.json not found — skipping");
+            return;
+        };
+
+        let graph = m1nd_core::snapshot::load_graph(&snapshot_path)
+            .expect("load real graph_snapshot.json");
+        eprintln!(
+            "[orient_real_snapshot_probe] loaded {} nodes from {}",
+            graph.nodes.count,
+            snapshot_path.display()
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            read_only: true, // attach-style: prove orient works without mutating
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(graph, &config, DomainConfig::code())
+            .expect("init session from real snapshot");
+
+        let out = super::dispatch_tool(
+            &mut state,
+            "orient",
+            &serde_json::json!({
+                "agent_id": "probe",
+                "task": "read-only attach lease enforcement",
+                "top_k": 8,
+            }),
+        )
+        .expect("orient on real snapshot");
+
+        eprintln!("\n=== orient(task=\"read-only attach lease enforcement\") on REAL graph ===");
+        eprintln!("summary: {}", out["summary"].as_str().unwrap_or(""));
+        eprintln!("focus_nodes:");
+        for (i, f) in out["focus_nodes"]
+            .as_array()
+            .map(|a| a.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .enumerate()
+        {
+            eprintln!(
+                "  {:>2}. {:<55} act={:.4} pr={:.6} kind={} path={}",
+                i + 1,
+                f["label"].as_str().unwrap_or(""),
+                f["activation"].as_f64().unwrap_or(0.0),
+                f["pagerank"].as_f64().unwrap_or(0.0),
+                f["kind"].as_str().unwrap_or(""),
+                f["path"].as_str().unwrap_or("·"),
+            );
+        }
+        eprintln!("anchors (global PageRank backbone):");
+        for a in out["anchors"].as_array().map(|a| a.as_slice()).unwrap_or(&[]) {
+            eprintln!(
+                "  - {:<55} pr={:.6}",
+                a["label"].as_str().unwrap_or(""),
+                a["pagerank"].as_f64().unwrap_or(0.0)
+            );
+        }
+        eprintln!(
+            "memory_nearby: {} | coverage: {}",
+            out["memory_nearby"].as_array().map(|a| a.len()).unwrap_or(0),
+            out["coverage"]
+        );
+        eprintln!("=== end probe ===\n");
+
+        // Real data must produce a non-empty starting context.
+        assert!(
+            !out["focus_nodes"].as_array().unwrap().is_empty(),
+            "orient must surface focus nodes on the real graph"
+        );
     }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -2257,10 +2257,7 @@ fn proof_gated_write_tool(tool_name: &str) -> Option<&'static str> {
         .strip_prefix("m1nd.")
         .or_else(|| tool_name.strip_prefix("m1nd_"))
         .unwrap_or(tool_name);
-    PROOF_GATED_WRITE_TOOLS
-        .iter()
-        .copied()
-        .find(|&t| t == bare)
+    PROOF_GATED_WRITE_TOOLS.iter().copied().find(|&t| t == bare)
 }
 
 /// Collect the raw target file path(s) a write call will touch, exactly as the
@@ -2408,7 +2405,10 @@ fn memory_nearby_for_result(
             let Some(anchor_id) = target_idx.get(&tgt_idx) else {
                 continue;
             };
-            let claim = graph.strings.resolve(graph.nodes.label[src_idx]).to_string();
+            let claim = graph
+                .strings
+                .resolve(graph.nodes.label[src_idx])
+                .to_string();
             if !seen.insert(claim.clone()) {
                 continue;
             }
@@ -2569,10 +2569,7 @@ fn handle_orient(
         .iter()
         .take(top_k)
         .map(|a| {
-            let path = a
-                .provenance
-                .as_ref()
-                .and_then(|p| p.source_path.clone());
+            let path = a.provenance.as_ref().and_then(|p| p.source_path.clone());
             serde_json::json!({
                 "node_id": a.node_id,
                 "label": a.label,
@@ -2583,10 +2580,7 @@ fn handle_orient(
             })
         })
         .collect();
-    let top_focus_id = activate_out
-        .activated
-        .first()
-        .map(|a| a.node_id.clone());
+    let top_focus_id = activate_out.activated.first().map(|a| a.node_id.clone());
 
     // 2. memory_nearby: reuse memory_nearby_for_result over the focus nodes.
     //    It expects a `results` array of `{node_id|label}` — shape one from the
@@ -2766,8 +2760,10 @@ fn handle_am_i_stale(
     // index by the canonicalized form so a caller passing a non-canonical path
     // (e.g. /var/… on macOS where the inventory recorded /private/var/…) still
     // matches the same baseline.
-    let mut inventory_by_path: std::collections::HashMap<String, &crate::session::FileInventoryEntry> =
-        std::collections::HashMap::with_capacity(state.file_inventory.len() * 2);
+    let mut inventory_by_path: std::collections::HashMap<
+        String,
+        &crate::session::FileInventoryEntry,
+    > = std::collections::HashMap::with_capacity(state.file_inventory.len() * 2);
     for entry in state.file_inventory.values() {
         inventory_by_path.insert(entry.file_path.clone(), entry);
         if let Ok(canon) = std::fs::canonicalize(&entry.file_path) {
@@ -2848,7 +2844,11 @@ fn handle_am_i_stale(
             .collect();
         let preview: Vec<&str> = stale_paths.iter().take(3).copied().collect();
         let suffix = if stale_paths.len() > preview.len() {
-            format!("{}, +{} more", preview.join(", "), stale_paths.len() - preview.len())
+            format!(
+                "{}, +{} more",
+                preview.join(", "),
+                stale_paths.len() - preview.len()
+            )
         } else {
             preview.join(", ")
         };
@@ -2875,9 +2875,8 @@ fn handle_am_i_stale(
         "summary": summary,
     });
     if !notes.is_empty() {
-        out["notes"] = serde_json::Value::Array(
-            notes.into_iter().map(serde_json::Value::String).collect(),
-        );
+        out["notes"] =
+            serde_json::Value::Array(notes.into_iter().map(serde_json::Value::String).collect());
     }
     Ok(out)
 }
@@ -2919,9 +2918,8 @@ fn build_orient_coverage(state: &SessionState, agent_id: &str) -> serde_json::Va
                 unvisited.push((pr, path));
             }
         }
-        unvisited.sort_unstable_by(|a, b| {
-            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
-        });
+        unvisited
+            .sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
         unvisited.truncate(5);
     }
     serde_json::json!({
@@ -6402,7 +6400,10 @@ mod tests {
         // The activation inside orient records a coverage session for this agent,
         // so coverage is populated with visited/total and a high-value shortlist.
         let cov = &out["coverage"];
-        assert!(cov.is_object(), "coverage must be populated after activation");
+        assert!(
+            cov.is_object(),
+            "coverage must be populated after activation"
+        );
         assert!(cov["visited"].is_number(), "coverage.visited present");
         assert_eq!(cov["total"], serde_json::json!(3), "graph has 3 nodes");
         assert!(
@@ -6476,8 +6477,8 @@ mod tests {
             return;
         };
 
-        let graph = m1nd_core::snapshot::load_graph(&snapshot_path)
-            .expect("load real graph_snapshot.json");
+        let graph =
+            m1nd_core::snapshot::load_graph(&snapshot_path).expect("load real graph_snapshot.json");
         eprintln!(
             "[orient_real_snapshot_probe] loaded {} nodes from {}",
             graph.nodes.count,
@@ -6529,7 +6530,11 @@ mod tests {
             );
         }
         eprintln!("anchors (global PageRank backbone):");
-        for a in out["anchors"].as_array().map(|a| a.as_slice()).unwrap_or(&[]) {
+        for a in out["anchors"]
+            .as_array()
+            .map(|a| a.as_slice())
+            .unwrap_or(&[])
+        {
             eprintln!(
                 "  - {:<55} pr={:.6}",
                 a["label"].as_str().unwrap_or(""),
@@ -6538,7 +6543,10 @@ mod tests {
         }
         eprintln!(
             "memory_nearby: {} | coverage: {}",
-            out["memory_nearby"].as_array().map(|a| a.len()).unwrap_or(0),
+            out["memory_nearby"]
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or(0),
             out["coverage"]
         );
         eprintln!("=== end probe ===\n");
@@ -6571,8 +6579,8 @@ mod tests {
             return;
         };
 
-        let graph = m1nd_core::snapshot::load_graph(&snapshot_path)
-            .expect("load real graph_snapshot.json");
+        let graph =
+            m1nd_core::snapshot::load_graph(&snapshot_path).expect("load real graph_snapshot.json");
         let node_count = graph.nodes.count;
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -6724,8 +6732,7 @@ mod tests {
 
     #[test]
     fn am_i_stale_detects_changed_file() {
-        let (_temp, mut state, file) =
-            ingest_single_file("def target():\n    return 'original'\n");
+        let (_temp, mut state, file) = ingest_single_file("def target():\n    return 'original'\n");
 
         // Rewrite the file on disk with different content (the change m1nd can't see).
         std::fs::write(&file, "def target():\n    return 'MUTATED'\n").expect("rewrite file");
@@ -6753,8 +6760,7 @@ mod tests {
 
     #[test]
     fn am_i_stale_detects_missing_file() {
-        let (_temp, mut state, file) =
-            ingest_single_file("def target():\n    return 'original'\n");
+        let (_temp, mut state, file) = ingest_single_file("def target():\n    return 'original'\n");
 
         // Delete the file on disk after ingest.
         std::fs::remove_file(&file).expect("delete file");
@@ -6800,8 +6806,7 @@ mod tests {
 
     #[test]
     fn am_i_stale_defaults_to_coverage_session() {
-        let (_temp, mut state, file) =
-            ingest_single_file("def target():\n    return 'original'\n");
+        let (_temp, mut state, file) = ingest_single_file("def target():\n    return 'original'\n");
 
         // Record a coverage session for the agent that has visited the file,
         // then mutate the file so the default working set should flag it.
@@ -6827,14 +6832,17 @@ mod tests {
         );
         assert_eq!(out["checked"], serde_json::json!(1));
         let stale = out["stale"].as_array().expect("stale array");
-        assert_eq!(stale.len(), 1, "the touched-then-changed file must be stale");
+        assert_eq!(
+            stale.len(),
+            1,
+            "the touched-then-changed file must be stale"
+        );
         assert_eq!(stale[0]["reason"], "changed");
     }
 
     #[test]
     fn am_i_stale_empty_when_no_targets_and_no_session() {
-        let (_temp, mut state, _file) =
-            ingest_single_file("def target():\n    return 'x'\n");
+        let (_temp, mut state, _file) = ingest_single_file("def target():\n    return 'x'\n");
 
         // A different agent with no coverage session and no explicit targets.
         let out = super::handle_am_i_stale(
@@ -6900,7 +6908,10 @@ mod tests {
             inv_count,
             real_dir.display()
         );
-        assert!(inv_count >= 3, "expected several real files in m1nd-core/src");
+        assert!(
+            inv_count >= 3,
+            "expected several real files in m1nd-core/src"
+        );
 
         // Pick three real ingested files: one to mutate, two left untouched.
         let mut paths: Vec<String> = state
@@ -6973,7 +6984,10 @@ mod tests {
         // ALWAYS restore the real file so the working tree is clean.
         std::fs::write(&victim, &original_bytes).expect("restore victim file");
         let restored = std::fs::read(&victim).expect("re-read restored file");
-        assert_eq!(restored, original_bytes, "victim file must be restored byte-for-byte");
+        assert_eq!(
+            restored, original_bytes,
+            "victim file must be restored byte-for-byte"
+        );
 
         if let Err(panic) = result {
             std::panic::resume_unwind(panic);

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -449,7 +449,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         },
                         "xlr": { "type": "boolean", "default": true, "description": "Enable XLR noise cancellation" },
                         "include_ghost_edges": { "type": "boolean", "default": true, "description": "Include ghost edge detection" },
-                        "include_structural_holes": { "type": "boolean", "default": false, "description": "Include structural hole detection" }
+                        "include_structural_holes": { "type": "boolean", "default": false, "description": "Include structural hole detection" },
+                        "token_budget": { "type": "integer", "minimum": 1, "description": "Optional approx context-token budget. m1nd keeps the highest-activation nodes that fit, drops the rest, and returns a 'budget' block (estimate = chars/4, not exact tokenization)" }
                     },
                     "required": ["query", "agent_id"]
                 }
@@ -1007,7 +1008,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "scope": { "type": "string", "description": "File path prefix to limit search scope" },
                         "node_types": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Filter by node type: function, class, struct, module, file" },
                         "min_score": { "type": "number", "default": 0.1, "description": "Minimum combined score threshold" },
-                        "graph_rerank": { "type": "boolean", "default": true, "description": "Whether to run graph re-ranking on embedding candidates" }
+                        "graph_rerank": { "type": "boolean", "default": true, "description": "Whether to run graph re-ranking on embedding candidates" },
+                        "token_budget": { "type": "integer", "minimum": 1, "description": "Optional approx context-token budget. m1nd keeps the highest graph-importance hits that fit, drops the rest, and returns a 'budget' block (estimate = chars/4, not exact tokenization)" }
                     },
                     "required": ["query", "agent_id"]
                 }
@@ -1654,7 +1656,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "multiline": { "type": "boolean", "default": false, "description": "Enable multiline regex: dot matches newline (rg -U). Only for regex mode." },
                         "auto_ingest": { "type": "boolean", "default": false, "description": "Auto-ingest exactly one resolved scope path outside current ingest roots before searching; ambiguous scopes return an error that lists candidate paths in detail" },
                         "filename_pattern": { "type": "string", "description": "Glob pattern to filter filenames (e.g. '*.rs', 'test_*.py')" },
-                        "max_output_chars": { "type": "integer", "description": "Optional cap for total returned characters across serialized matches" }
+                        "max_output_chars": { "type": "integer", "description": "Optional cap for total returned characters across serialized matches" },
+                        "token_budget": { "type": "integer", "minimum": 1, "description": "Optional approx context-token budget. m1nd keeps the highest-ranked rows that fit, drops the rest, and returns a 'budget' block (estimate = chars/4, not exact tokenization; ignored when count_only)" }
                     },
                     "required": ["agent_id", "query"]
                 }
@@ -2472,6 +2475,7 @@ fn handle_orient(
         xlr: true,
         include_ghost_edges: false,
         include_structural_holes: false,
+        token_budget: None,
     };
     let activate_out = tools::handle_activate(state, activate_input)?;
 
@@ -5772,6 +5776,7 @@ mod tests {
                 multiline: false,
                 auto_ingest: false,
                 max_output_chars: None,
+                token_budget: None,
             },
         )
         .expect("search after background tick");
@@ -6354,6 +6359,133 @@ mod tests {
             !out["focus_nodes"].as_array().unwrap().is_empty(),
             "orient must surface focus nodes on the real graph"
         );
+    }
+
+    /// REAL PROBE: load the repo's actual graph_snapshot.json (~5540 nodes) and
+    /// run `seek` for a broad query twice — once unbudgeted, once with a tight
+    /// `token_budget` — printing both result counts, the `budget` block, and the
+    /// kept labels so the context-budget packing can be SEEN keeping the
+    /// top-signal hits and dropping the rest on real data.
+    ///
+    /// Run with: `cargo test -p m1nd-mcp seek_token_budget_real_snapshot_probe -- --nocapture`
+    /// Skips gracefully (printing a note) if the snapshot is not present.
+    #[test]
+    fn seek_token_budget_real_snapshot_probe() {
+        let snapshot = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|p| p.join("graph_snapshot.json"))
+            .filter(|p| p.exists());
+        let Some(snapshot_path) = snapshot else {
+            eprintln!(
+                "[seek_token_budget_real_snapshot_probe] graph_snapshot.json not found — skipping"
+            );
+            return;
+        };
+
+        let graph = m1nd_core::snapshot::load_graph(&snapshot_path)
+            .expect("load real graph_snapshot.json");
+        let node_count = graph.nodes.count;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            read_only: true,
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(graph, &config, DomainConfig::code())
+            .expect("init session from real snapshot");
+
+        let query = "read only";
+        let top_k = 40;
+
+        // Baseline: no token_budget.
+        let base = super::dispatch_tool(
+            &mut state,
+            "seek",
+            &serde_json::json!({
+                "agent_id": "probe",
+                "query": query,
+                "top_k": top_k,
+            }),
+        )
+        .expect("baseline seek on real snapshot");
+        let base_results = base["results"].as_array().cloned().unwrap_or_default();
+
+        // Budgeted: tight ~300-token budget.
+        let budget_tokens = 300u64;
+        let budgeted = super::dispatch_tool(
+            &mut state,
+            "seek",
+            &serde_json::json!({
+                "agent_id": "probe",
+                "query": query,
+                "top_k": top_k,
+                "token_budget": budget_tokens,
+            }),
+        )
+        .expect("budgeted seek on real snapshot");
+        let budgeted_results = budgeted["results"].as_array().cloned().unwrap_or_default();
+
+        eprintln!(
+            "\n=== seek(query=\"{}\") on REAL graph ({} nodes) ===",
+            query, node_count
+        );
+        eprintln!("BASELINE (no token_budget): {} results", base_results.len());
+        eprintln!(
+            "  top labels: {:?}",
+            base_results
+                .iter()
+                .take(8)
+                .map(|r| r["label"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+        eprintln!(
+            "BUDGETED (token_budget={}): {} results",
+            budget_tokens,
+            budgeted_results.len()
+        );
+        eprintln!("  budget block: {}", budgeted["budget"]);
+        eprintln!("  kept labels (score / path):");
+        for (i, r) in budgeted_results.iter().enumerate() {
+            eprintln!(
+                "    {:>2}. {:<48} score={:.4} path={}",
+                i + 1,
+                r["label"].as_str().unwrap_or("?"),
+                r["score"].as_f64().unwrap_or(0.0),
+                r["file_path"].as_str().unwrap_or("·"),
+            );
+        }
+        eprintln!("=== end probe ===\n");
+
+        // Baseline absent of a budget block; budgeted carries one.
+        assert!(base.get("budget").is_none() || base["budget"].is_null());
+        assert!(budgeted["budget"].is_object());
+
+        // Packing must keep fewer than the (larger) baseline and keep the
+        // top-ranked prefix.
+        assert!(
+            budgeted_results.len() <= base_results.len(),
+            "budgeted seek must not return more than baseline"
+        );
+        if !base_results.is_empty() {
+            assert!(!budgeted_results.is_empty(), "must keep at least one hit");
+            assert_eq!(
+                budgeted_results[0]["label"], base_results[0]["label"],
+                "budgeted set must keep the same top-ranked hit"
+            );
+        }
+
+        // budget accounting must be internally consistent.
+        let b = &budgeted["budget"];
+        let kept = b["kept"].as_u64().unwrap();
+        let dropped = b["dropped"].as_u64().unwrap();
+        assert_eq!(kept as usize, budgeted_results.len());
+        assert_eq!(kept + dropped, base_results.len() as u64);
+        assert_eq!(b["requested_tokens"].as_u64().unwrap(), budget_tokens);
     }
 
     // -----------------------------------------------------------------------

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -364,6 +364,19 @@ pub fn response_envelope_enabled() -> bool {
     }
 }
 
+/// Whether the M1ND_PROOF_GATE write guard is active.
+///
+/// Opt-in safety flag (default OFF), mirroring the `M1ND_READ_ONLY` parsing:
+/// any value other than `"0"`/`"false"`/empty turns it ON; unset is OFF. When
+/// ON, code-writing tools (`apply`/`apply_batch`/`edit_commit`) are refused at
+/// dispatch unless the agent has already driven each target to
+/// `proof_state == "ready_to_edit"` (via `surgical_context_v2`) this session.
+pub fn proof_gate_enabled() -> bool {
+    std::env::var("M1ND_PROOF_GATE")
+        .map(|v| v != "0" && v != "false" && !v.is_empty())
+        .unwrap_or(false)
+}
+
 /// Returns ALL registered MCP tool schemas regardless of tier.
 /// Use this when you always need the full 102-tool registry (e.g., health
 /// contract counts, internal tests that verify advanced tool registration).
@@ -2230,6 +2243,65 @@ fn read_only_denied(tool_name: &str, params: &serde_json::Value) -> bool {
     false
 }
 
+/// Real code-writing tools the M1ND_PROOF_GATE guards. These are exactly the
+/// tools that perform an on-disk write of agent-supplied content. `edit_preview`
+/// is deliberately excluded: it only stages an in-memory preview and never
+/// writes — same stance as the read-only gate.
+const PROOF_GATED_WRITE_TOOLS: &[&str] = &["apply", "apply_batch", "edit_commit"];
+
+/// Returns the normalized (prefix-stripped) tool name if `tool_name` is a
+/// proof-gated code-writing tool, else `None`. Mirrors the prefix handling in
+/// [`read_only_denied`].
+fn proof_gated_write_tool(tool_name: &str) -> Option<&'static str> {
+    let bare = tool_name
+        .strip_prefix("m1nd.")
+        .or_else(|| tool_name.strip_prefix("m1nd_"))
+        .unwrap_or(tool_name);
+    PROOF_GATED_WRITE_TOOLS
+        .iter()
+        .copied()
+        .find(|&t| t == bare)
+}
+
+/// Collect the raw target file path(s) a write call will touch, exactly as the
+/// agent supplied them (pre-normalization). For `apply`/`edit_preview` this is
+/// `params["file_path"]`; for `apply_batch` it is every `params["edits"][*]
+/// ["file_path"]`; for `edit_commit` there is no path in params, so it is
+/// recovered from the staged preview (`state.edit_previews[preview_id]
+/// .file_path`). Returns the gathered raw targets (may be empty if params are
+/// malformed — the gate treats an empty/unresolvable target set as unproven).
+fn proof_gate_targets(
+    bare_tool: &str,
+    params: &serde_json::Value,
+    state: &SessionState,
+) -> Vec<String> {
+    match bare_tool {
+        "apply" => params
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .map(|s| vec![s.to_string()])
+            .unwrap_or_default(),
+        "apply_batch" => params
+            .get("edits")
+            .and_then(|v| v.as_array())
+            .map(|edits| {
+                edits
+                    .iter()
+                    .filter_map(|e| e.get("file_path").and_then(|v| v.as_str()))
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        "edit_commit" => params
+            .get("preview_id")
+            .and_then(|v| v.as_str())
+            .and_then(|pid| state.edit_previews.get(pid))
+            .map(|preview| vec![preview.file_path.clone()])
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tier 3: memory at point-of-relevance (`_m1nd.memory_nearby`)
 // ---------------------------------------------------------------------------
@@ -2894,6 +2966,43 @@ pub fn dispatch_tool(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown")
         .to_string();
+
+    // M1ND_PROOF_GATE: when ON, refuse a real code-writing tool BEFORE any write
+    // unless every target it will touch was driven to proof_state ==
+    // "ready_to_edit" this session (via surgical_context_v2). edit_preview is
+    // allowed (it only stages). All targets are normalized through the same
+    // scope normalizer the recorder used, so proved==edited keys compare equal.
+    if proof_gate_enabled() {
+        if let Some(bare_tool) = proof_gated_write_tool(&normalized) {
+            let targets = proof_gate_targets(bare_tool, params, state);
+            let unproven: Vec<String> = if targets.is_empty() {
+                // Malformed/unresolvable target set: refuse rather than allow an
+                // unverifiable write through. Surface the tool itself.
+                vec![format!("<unresolved target for {bare_tool}>")]
+            } else {
+                targets
+                    .iter()
+                    .filter(|t| !state.is_proof_ready(&agent_id, t))
+                    .cloned()
+                    .collect()
+            };
+            if !unproven.is_empty() {
+                let unproven_list = unproven.join(", ");
+                let first = unproven.first().cloned().unwrap_or_default();
+                return Err(M1ndError::InvalidParams {
+                    tool: normalized.clone(),
+                    detail: format!(
+                        "M1ND_PROOF_GATE is on: {count} target(s) not proven ready_to_edit for agent_id='{agent}': {unproven_list}. \
+Run surgical_context_v2 (agent_id='{agent}', path='{first}') for each unproven target to gather context and reach proof_state==ready_to_edit, then retry '{tool}'.",
+                        count = unproven.len(),
+                        agent = agent_id,
+                        tool = normalized,
+                    ),
+                });
+            }
+        }
+    }
+
     let query_preview = params
         .get("query")
         .and_then(|v| v.as_str())

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -115,13 +115,21 @@ next session, and self-flags as stale via `cross_verify(check:[\"evidence_freshn
 that code changes. This is how findings compound across sessions instead of being lost.
 ";
 
+/// Stdio MCP framing mode auto-detected on the inbound stream. The matching
+/// outbound write MUST use the same mode so the host's framing assumptions hold.
+/// Exposed `pub` so the `--attach` stdio↔HTTP bridge reuses the exact same
+/// framing primitives instead of hand-rolling a divergent encoder.
 #[derive(Clone, Copy, Debug)]
-enum TransportMode {
+pub enum TransportMode {
     Framed,
     Line,
 }
 
-fn read_request_payload<R: BufRead>(
+/// Read one JSON-RPC payload from `reader`, auto-detecting Content-Length framing
+/// vs newline framing, and report which mode was seen so the response can be
+/// written back in the same framing. `Ok(None)` signals EOF. Reused verbatim by
+/// the `--attach` bridge — see `attach_client.rs`.
+pub fn read_request_payload<R: BufRead>(
     reader: &mut R,
 ) -> std::io::Result<Option<(String, TransportMode)>> {
     loop {
@@ -180,7 +188,11 @@ fn read_request_payload<R: BufRead>(
     }
 }
 
-fn write_response<W: Write>(
+/// Write a `JsonRpcResponse` to `writer` in the given framing mode (the one
+/// detected by [`read_request_payload`] for the matching request). Reused
+/// verbatim by the `--attach` bridge so its stdout framing is byte-identical to
+/// the embedded stdio server's.
+pub fn write_response<W: Write>(
     writer: &mut W,
     response: &JsonRpcResponse,
     mode: TransportMode,

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -379,6 +379,14 @@ pub struct SessionState {
     /// `session_handshake` (and thus `trust_selftest`). `None` = the auto-load
     /// did not run (no agent-memory dir yet); never hidden.
     pub agent_memory_boot: Option<serde_json::Value>,
+
+    /// Read-only attach mode. When true: `persist()` and every granular
+    /// persist helper are no-ops, `should_persist()` is always false, queries
+    /// take the immutable read path (`query_readonly`), and mutating tools are
+    /// gated off in `dispatch_tool`. The instance holds no exclusive lease.
+    pub read_only: bool,
+    /// One-shot guard so the "skipping persist" line is logged only once.
+    pub read_only_persist_logged: std::cell::Cell<bool>,
 }
 
 const WORKSPACE_ROOT_ENV_CANDIDATES: &[&str] = &[
@@ -1149,13 +1157,24 @@ impl SessionState {
         std::fs::create_dir_all(&runtime_root)?;
         let (workspace_root, workspace_root_source) =
             Self::infer_workspace_root(config, &runtime_root);
-        let instance = InstanceHandle::acquire(
+        let instance_mode = if config.read_only {
+            crate::instance_registry::InstanceMode::ReadOnly
+        } else {
+            crate::instance_registry::InstanceMode::ReadWrite
+        };
+        let instance = InstanceHandle::acquire_with_mode(
             &workspace_root,
             &runtime_root,
             &config.graph_source,
             &config.plasticity_state,
             config.registry_dir.as_deref(),
+            instance_mode,
         )?;
+        if config.read_only {
+            eprintln!(
+                "[m1nd] read-only attach: holding no lease; persistence disabled; mutation tools gated."
+            );
+        }
         let ingest_roots = Self::load_ingest_roots(&config.graph_source);
 
         Ok(Self {
@@ -1244,15 +1263,49 @@ impl SessionState {
             auto_ingest: AutoIngestState::load(&runtime_root),
             document_cache: load_document_cache(&runtime_root),
             agent_memory_boot: None,
+            read_only: config.read_only,
+            read_only_persist_logged: std::cell::Cell::new(false),
         })
     }
 
     /// Check if auto-persist should trigger. Returns true every N queries.
+    ///
+    /// Always false in read-only attach mode so the every-N-queries auto-persist
+    /// never fires and the read-only process never writes to disk.
     pub fn should_persist(&self) -> bool {
-        self.queries_processed > 0
+        !self.read_only
+            && self.queries_processed > 0
             && self
                 .queries_processed
                 .is_multiple_of(self.auto_persist_interval as u64)
+    }
+
+    /// Log the read-only persist skip exactly once per session.
+    fn log_read_only_persist_skip(&self) {
+        if !self.read_only_persist_logged.replace(true) {
+            eprintln!("[m1nd] read-only attach: skipping persist");
+        }
+    }
+
+    /// Run an orchestrator query, picking the lock + method by attach mode.
+    ///
+    /// In read-only mode this takes an immutable `graph.read()` borrow and calls
+    /// [`QueryOrchestrator::query_readonly`], which skips plasticity Step 8 and
+    /// never mutates the graph. In read-write mode it takes `graph.write()` and
+    /// calls the normal `query`, preserving the historical mutate-on-query
+    /// (plasticity) behavior. Centralizing this keeps every call site honest
+    /// about the read-only contract.
+    pub fn run_query(
+        &mut self,
+        config: &m1nd_core::query::QueryConfig,
+    ) -> M1ndResult<m1nd_core::query::QueryResult> {
+        if self.read_only {
+            let graph = self.graph.read();
+            self.orchestrator.query_readonly(&graph, config)
+        } else {
+            let mut graph = self.graph.write();
+            self.orchestrator.query(&mut graph, config)
+        }
     }
 
     /// Persist all state to disk.
@@ -1261,6 +1314,13 @@ impl SessionState {
     /// If graph save fails, skip plasticity to avoid inconsistent state.
     /// If plasticity save fails after graph succeeds, log warning but don't crash.
     pub fn persist(&mut self) -> M1ndResult<()> {
+        // HARD SAFETY: a read-only attach must never write to disk. This is the
+        // single choke point every persist call site funnels through, so this
+        // early return protects the writer's on-disk state from corruption.
+        if self.read_only {
+            self.log_read_only_persist_skip();
+            return Ok(());
+        }
         let _ = self.instance.mark_heartbeat();
         self.persist_ingest_roots();
         let graph = self.graph.read();
@@ -1357,6 +1417,10 @@ impl SessionState {
     }
 
     pub fn persist_boot_memory(&self) -> M1ndResult<()> {
+        if self.read_only {
+            self.log_read_only_persist_skip();
+            return Ok(());
+        }
         let state = BootMemoryState {
             entries: self.boot_memory.clone(),
         };
@@ -1372,6 +1436,10 @@ impl SessionState {
     }
 
     pub fn persist_daemon_state(&self) -> M1ndResult<()> {
+        if self.read_only {
+            self.log_read_only_persist_skip();
+            return Ok(());
+        }
         save_json_atomic(&self.daemon_state_path, &self.daemon_state)
     }
 
@@ -1383,6 +1451,10 @@ impl SessionState {
     }
 
     pub fn persist_daemon_alerts(&self) -> M1ndResult<()> {
+        if self.read_only {
+            self.log_read_only_persist_skip();
+            return Ok(());
+        }
         save_json_atomic(&self.daemon_alerts_path, &self.daemon_alerts)
     }
 
@@ -1672,6 +1744,10 @@ impl SessionState {
 
     /// Persist global savings state to disk.
     pub fn persist_savings(&self) {
+        if self.read_only {
+            self.log_read_only_persist_skip();
+            return;
+        }
         if let Ok(json) = serde_json::to_string_pretty(&self.global_savings) {
             let _ = std::fs::write(&self.savings_path, json);
         }

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -187,6 +187,25 @@ pub struct ProofReadyMark {
     pub evidence: Option<String>,
 }
 
+/// A per-agent mark that an agent's scan/audit flagged a finding against a
+/// concrete node during this session. Ephemeral session intent — NOT persisted;
+/// it lives only on `SessionState.flagged_findings` and dies with the process.
+/// Recorded when a scan/audit finding is assembled, consumed at edit/apply time
+/// to emit a `proposed_antibody` ProactiveInsight (compounding negative memory).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct FindingMark {
+    /// When the finding was flagged, in unix-epoch milliseconds.
+    pub flagged_at_ms: u64,
+    /// Cache generation captured at flag time (for staleness inspection).
+    pub generation: u64,
+    /// Detector/pattern kind that produced the finding, e.g. "auth_boundary".
+    pub kind: String,
+    /// Severity bucket: "info" | "warning" | "critical".
+    pub severity: String,
+    /// File path of the flagged node, for display/template hints (may be empty).
+    pub file_path: String,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DaemonRuntimeState {
     pub active: bool,
@@ -390,6 +409,13 @@ pub struct SessionState {
     /// has driven a target to `proof_state == "ready_to_edit"`; checked at edit
     /// time by the M1ND_PROOF_GATE write gate against the normalized edit target.
     pub proof_ready: HashMap<(String, String), ProofReadyMark>,
+    /// Per-agent flagged findings keyed by (agent_id, node_id) where node_id is
+    /// the node's external id. Ephemeral session intent — NOT persisted. Recorded
+    /// when a scan/audit finding is assembled for an agent; consumed at edit/apply
+    /// time to emit a `proposed_antibody` ProactiveInsight so the next agent's
+    /// audit catches the same structural bug elsewhere (compounding negative
+    /// memory). Dies with the process.
+    pub flagged_findings: HashMap<(String, String), FindingMark>,
     /// Local document auto-ingest runtime.
     pub auto_ingest: AutoIngestState,
     /// Universal document artifact/cache index.
@@ -407,6 +433,11 @@ pub struct SessionState {
     /// One-shot guard so the "skipping persist" line is logged only once.
     pub read_only_persist_logged: std::cell::Cell<bool>,
 }
+
+/// Upper bound on the ephemeral per-agent `flagged_findings` map. Keeps the
+/// compounding-negative-memory store from growing without bound across a long
+/// session; on overflow the oldest mark is evicted (see [`SessionState::note_finding`]).
+const MAX_FLAGGED_FINDINGS: usize = 4096;
 
 const WORKSPACE_ROOT_ENV_CANDIDATES: &[&str] = &[
     // Host-neutral contract. Any MCP host can set one of these.
@@ -1280,6 +1311,7 @@ impl SessionState {
             file_inventory: HashMap::new(),
             coverage_sessions: HashMap::new(),
             proof_ready: HashMap::new(),
+            flagged_findings: HashMap::new(),
             auto_ingest: AutoIngestState::load(&runtime_root),
             document_cache: load_document_cache(&runtime_root),
             agent_memory_boot: None,
@@ -1873,6 +1905,68 @@ impl SessionState {
         let target =
             crate::scope::normalize_scope_path(Some(raw_target), &self.ingest_roots)?;
         self.proof_ready.get(&(agent_id.to_string(), target))
+    }
+
+    /// Record that `agent_id`'s scan/audit flagged a finding against `node_id`
+    /// (an opaque external id) this session. Mirrors [`Self::note_proof_ready`]
+    /// but keys on the raw `node_id` directly (NO path normalization) so the
+    /// recorder (scan/audit) and the reader (edit/apply) agree on the external-id
+    /// form. Ephemeral — never persisted. The map is capped at
+    /// [`MAX_FLAGGED_FINDINGS`] entries; the oldest entry is evicted on overflow
+    /// so a long-running session cannot grow it without bound.
+    pub fn note_finding(
+        &mut self,
+        agent_id: &str,
+        node_id: &str,
+        kind: &str,
+        severity: &str,
+        file_path: &str,
+    ) {
+        if node_id.is_empty() {
+            return;
+        }
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let key = (agent_id.to_string(), node_id.to_string());
+        if !self.flagged_findings.contains_key(&key)
+            && self.flagged_findings.len() >= MAX_FLAGGED_FINDINGS
+        {
+            // Evict the oldest mark to keep the ephemeral map bounded.
+            if let Some(oldest) = self
+                .flagged_findings
+                .iter()
+                .min_by_key(|(_, mark)| mark.flagged_at_ms)
+                .map(|(k, _)| k.clone())
+            {
+                self.flagged_findings.remove(&oldest);
+            }
+        }
+        self.flagged_findings.insert(
+            key,
+            FindingMark {
+                flagged_at_ms: now_ms,
+                generation: self.cache_generation,
+                kind: kind.to_string(),
+                severity: severity.to_string(),
+                file_path: file_path.to_string(),
+            },
+        );
+    }
+
+    /// Borrow the flagged-finding mark for `(agent_id, node_id)` for inspection.
+    pub fn get_finding(&self, agent_id: &str, node_id: &str) -> Option<&FindingMark> {
+        self.flagged_findings
+            .get(&(agent_id.to_string(), node_id.to_string()))
+    }
+
+    /// Consume (remove and return) the flagged-finding mark for `(agent_id,
+    /// node_id)`. Used at edit/apply time so a single fix emits the
+    /// `proposed_antibody` once and does not re-propose on subsequent writes.
+    pub fn take_finding(&mut self, agent_id: &str, node_id: &str) -> Option<FindingMark> {
+        self.flagged_findings
+            .remove(&(agent_id.to_string(), node_id.to_string()))
     }
 }
 

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -1902,8 +1902,7 @@ impl SessionState {
     /// Borrow the proof-ready mark for inspection (staleness/evidence), mirroring
     /// [`Self::get_perspective`].
     pub fn get_proof_ready(&self, agent_id: &str, raw_target: &str) -> Option<&ProofReadyMark> {
-        let target =
-            crate::scope::normalize_scope_path(Some(raw_target), &self.ingest_roots)?;
+        let target = crate::scope::normalize_scope_path(Some(raw_target), &self.ingest_roots)?;
         self.proof_ready.get(&(agent_id.to_string(), target))
     }
 

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -173,6 +173,20 @@ pub struct CoverageSessionState {
     pub tools_used: HashMap<String, u64>,
 }
 
+/// A per-agent mark that a concrete edit target reached `proof_state ==
+/// "ready_to_edit"` during this session (M1ND_PROOF_GATE). Ephemeral session
+/// intent — NOT persisted; it lives only on `SessionState.proof_ready` and dies
+/// with the process. Recorded by the surgical prover, consumed by the write gate.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ProofReadyMark {
+    /// When the target was proved ready, in unix-epoch milliseconds.
+    pub proved_at_ms: u64,
+    /// Cache generation captured at proof time (for staleness inspection).
+    pub generation: u64,
+    /// Tool/evidence that established readiness (e.g. "surgical_context_v2").
+    pub evidence: Option<String>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DaemonRuntimeState {
     pub active: bool,
@@ -371,6 +385,11 @@ pub struct SessionState {
     pub file_inventory: HashMap<String, FileInventoryEntry>,
     /// Per-agent exploration coverage state for visited files/nodes.
     pub coverage_sessions: HashMap<String, CoverageSessionState>,
+    /// Per-agent "proof ready" marks keyed by (agent_id, normalized repo-relative
+    /// target). Ephemeral session intent — NOT persisted. Records that an agent
+    /// has driven a target to `proof_state == "ready_to_edit"`; checked at edit
+    /// time by the M1ND_PROOF_GATE write gate against the normalized edit target.
+    pub proof_ready: HashMap<(String, String), ProofReadyMark>,
     /// Local document auto-ingest runtime.
     pub auto_ingest: AutoIngestState,
     /// Universal document artifact/cache index.
@@ -1260,6 +1279,7 @@ impl SessionState {
             },
             file_inventory: HashMap::new(),
             coverage_sessions: HashMap::new(),
+            proof_ready: HashMap::new(),
             auto_ingest: AutoIngestState::load(&runtime_root),
             document_cache: load_document_cache(&runtime_root),
             agent_memory_boot: None,
@@ -1807,6 +1827,52 @@ impl SessionState {
                 entry.visited_nodes.insert(node);
             }
         }
+    }
+
+    /// Record that `agent_id` drove `raw_target` to `proof_state ==
+    /// "ready_to_edit"` (M1ND_PROOF_GATE). `raw_target` may be absolute,
+    /// repo-relative, or `file::`-prefixed; it is normalized through
+    /// [`crate::scope::normalize_scope_path`] so the recorded key compares equal
+    /// to the key the write gate derives from the about-to-edit path. A target
+    /// that normalizes to `None` (empty/repo-root) is skipped so a malformed
+    /// target never silently grants edit permission. `evidence` names the prover.
+    pub fn note_proof_ready(&mut self, agent_id: &str, raw_target: &str, evidence: &str) {
+        let Some(target) = crate::scope::normalize_scope_path(Some(raw_target), &self.ingest_roots)
+        else {
+            return;
+        };
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        self.proof_ready.insert(
+            (agent_id.to_string(), target),
+            ProofReadyMark {
+                proved_at_ms: now_ms,
+                generation: self.cache_generation,
+                evidence: Some(evidence.to_string()),
+            },
+        );
+    }
+
+    /// Whether `agent_id` has a proof-ready mark for `raw_target` (normalized via
+    /// the same [`crate::scope::normalize_scope_path`] used when recording). A
+    /// target that normalizes to `None` is treated as not-proved.
+    pub fn is_proof_ready(&self, agent_id: &str, raw_target: &str) -> bool {
+        let Some(target) = crate::scope::normalize_scope_path(Some(raw_target), &self.ingest_roots)
+        else {
+            return false;
+        };
+        self.proof_ready
+            .contains_key(&(agent_id.to_string(), target))
+    }
+
+    /// Borrow the proof-ready mark for inspection (staleness/evidence), mirroring
+    /// [`Self::get_perspective`].
+    pub fn get_proof_ready(&self, agent_id: &str, raw_target: &str) -> Option<&ProofReadyMark> {
+        let target =
+            crate::scope::normalize_scope_path(Some(raw_target), &self.ingest_roots)?;
+        self.proof_ready.get(&(agent_id.to_string(), target))
     }
 }
 

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -2657,6 +2657,14 @@ pub fn handle_surgical_context_v2(
         visited_nodes,
     );
 
+    // M1ND_PROOF_GATE: when this prover clears the primary target to edit, record
+    // (agent_id, normalized target) so the write gate can later let a real edit
+    // of that exact file through. Only the primary `file_path` is proved here —
+    // connected files are context, not cleared edit targets.
+    if proof_state == "ready_to_edit" {
+        state.note_proof_ready(&input.agent_id, &primary.file_path, "surgical_context_v2");
+    }
+
     Ok(surgical::SurgicalContextV2Output {
         file_path: primary.file_path,
         file_contents: primary_file_contents,
@@ -5782,5 +5790,205 @@ mod tests {
         assert!(coverage
             .visited_files
             .contains(&secondary.to_string_lossy().to_string()));
+    }
+
+    // -------------------------------------------------------------------------
+    // M1ND_PROOF_GATE — live end-to-end probe through real dispatch.
+    // -------------------------------------------------------------------------
+
+    /// Process-global lock: M1ND_PROOF_GATE is read live from the environment, so
+    /// these tests must not run concurrently with each other. Recovers from
+    /// poison so one failing probe does not cascade-fail the others.
+    fn proof_gate_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+        let m = LOCK.get_or_init(|| Mutex::new(()));
+        m.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Build a state whose graph contains ONE unrelated node, while the probe
+    /// targets a separate on-disk file that is NOT in the graph. An ungraphed
+    /// target resolves to an empty `node_id`, so `surgical_context_v2` produces
+    /// no heuristic summary and no connected files and therefore reaches
+    /// `proof_state == "ready_to_edit"` for that file.
+    fn build_isolated_state(root: &std::path::Path) -> SessionState {
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut graph = Graph::new();
+        // A single unrelated node just so the graph finalizes; the probe target
+        // is deliberately NOT this node.
+        let other = root.join("src/other.rs");
+        std::fs::create_dir_all(other.parent().unwrap()).expect("mk other parent");
+        std::fs::write(&other, "pub fn other() {}\n").expect("write other");
+        let other_str = other.to_string_lossy().to_string();
+        let node = graph
+            .add_node(
+                &format!("file::{other_str}"),
+                "other.rs",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add node");
+        graph.set_node_provenance(
+            node,
+            NodeProvenanceInput {
+                source_path: Some(&other_str),
+                line_start: Some(1),
+                line_end: Some(1),
+                excerpt: None,
+                namespace: None,
+                canonical: true,
+            },
+        );
+        graph.finalize().expect("finalize graph");
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![root.to_string_lossy().to_string()];
+        state.workspace_root = Some(root.to_string_lossy().to_string());
+        state
+    }
+
+    #[test]
+    fn proof_gate_blocks_then_allows_apply_through_real_dispatch() {
+        let _guard = proof_gate_env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let target = root.join("src/isolated.rs");
+        std::fs::create_dir_all(target.parent().unwrap()).expect("mk parent");
+        std::fs::write(&target, "pub fn a() {}\n").expect("write target");
+        let target_str = target.to_string_lossy().to_string();
+
+        let mut state = build_isolated_state(root);
+        let agent = "probe-agent";
+
+        std::env::set_var("M1ND_PROOF_GATE", "1");
+
+        // (1) GATE ON, UNPROVEN apply -> refused with the proof-gate message.
+        let apply_params = serde_json::json!({
+            "agent_id": agent,
+            "file_path": target_str,
+            "new_content": "pub fn a() {}\npub fn b() {}\n",
+        });
+        let err = crate::server::dispatch_tool(&mut state, "apply", &apply_params)
+            .expect_err("unproven apply must be refused");
+        let msg = format!("{err}");
+        println!("[probe] unproven apply refusal: {msg}");
+        assert!(
+            msg.contains("M1ND_PROOF_GATE is on")
+                && msg.contains("not proven ready_to_edit")
+                && msg.contains("surgical_context_v2"),
+            "refusal message must be actionable, got: {msg}"
+        );
+        assert!(
+            !state.is_proof_ready(agent, &target_str),
+            "target must NOT be proved yet"
+        );
+
+        // (2) Drive surgical_context_v2 through dispatch -> reaches ready_to_edit
+        //     and RECORDS the proof for this agent+target.
+        let sctx_params = serde_json::json!({ "agent_id": agent, "file_path": target_str });
+        let sctx_out = crate::server::dispatch_tool(&mut state, "surgical_context_v2", &sctx_params)
+            .expect("surgical_context_v2 dispatch");
+        let proof_state = sctx_out
+            .get("result")
+            .and_then(|r| r.get("proof_state"))
+            .or_else(|| sctx_out.get("proof_state"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("<none>");
+        println!("[probe] surgical_context_v2 proof_state = {proof_state}");
+        assert_eq!(
+            proof_state, "ready_to_edit",
+            "isolated low-risk file must reach ready_to_edit"
+        );
+        assert!(
+            state.is_proof_ready(agent, &target_str),
+            "proof must be recorded after ready_to_edit"
+        );
+
+        // (3) GATE ON, NOW-PROVEN apply -> passes the gate (write succeeds).
+        let apply_out = crate::server::dispatch_tool(&mut state, "apply", &apply_params)
+            .expect("proven apply must pass the gate");
+        println!(
+            "[probe] proven apply passed gate, ok={}",
+            apply_out.get("result").is_some() || apply_out.is_object()
+        );
+
+        // (4) Cross-agent isolation: a DIFFERENT agent is still gated.
+        let other_params = serde_json::json!({
+            "agent_id": "other-agent",
+            "file_path": target_str,
+            "new_content": "pub fn a() {}\n",
+        });
+        let other_err = crate::server::dispatch_tool(&mut state, "apply", &other_params)
+            .expect_err("different agent must still be gated");
+        println!("[probe] cross-agent refusal: {other_err}");
+        assert!(format!("{other_err}").contains("M1ND_PROOF_GATE is on"));
+
+        std::env::remove_var("M1ND_PROOF_GATE");
+    }
+
+    #[test]
+    fn proof_gate_off_allows_unproven_apply() {
+        let _guard = proof_gate_env_lock();
+        std::env::remove_var("M1ND_PROOF_GATE");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let target = root.join("src/isolated.rs");
+        std::fs::create_dir_all(target.parent().unwrap()).expect("mk parent");
+        std::fs::write(&target, "pub fn a() {}\n").expect("write target");
+        let target_str = target.to_string_lossy().to_string();
+        let mut state = build_isolated_state(root);
+
+        let apply_params = serde_json::json!({
+            "agent_id": "no-proof-agent",
+            "file_path": target_str,
+            "new_content": "pub fn a() {}\npub fn c() {}\n",
+        });
+        // Gate OFF: unproven apply must NOT be refused by the proof gate.
+        let out = crate::server::dispatch_tool(&mut state, "apply", &apply_params);
+        println!("[probe] gate OFF unproven apply result is_ok={}", out.is_ok());
+        assert!(
+            out.is_ok(),
+            "with gate OFF an unproven apply must pass: {out:?}"
+        );
+    }
+
+    #[test]
+    fn proof_gate_never_blocks_edit_preview() {
+        let _guard = proof_gate_env_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let target = root.join("src/isolated.rs");
+        std::fs::create_dir_all(target.parent().unwrap()).expect("mk parent");
+        std::fs::write(&target, "pub fn a() {}\n").expect("write target");
+        let target_str = target.to_string_lossy().to_string();
+        let mut state = build_isolated_state(root);
+
+        std::env::set_var("M1ND_PROOF_GATE", "1");
+        let preview_params = serde_json::json!({
+            "agent_id": "preview-agent",
+            "file_path": target_str,
+            "new_content": "pub fn a() {}\npub fn d() {}\n",
+        });
+        // edit_preview only stages; the gate must never block it even when ON.
+        let out = crate::server::dispatch_tool(&mut state, "edit_preview", &preview_params);
+        println!(
+            "[probe] gate ON edit_preview result is_ok={} (must be Ok / not gate-refused)",
+            out.is_ok()
+        );
+        if let Err(e) = &out {
+            assert!(
+                !format!("{e}").contains("M1ND_PROOF_GATE"),
+                "edit_preview must never hit the proof gate, got: {e}"
+            );
+        }
+        std::env::remove_var("M1ND_PROOF_GATE");
     }
 }

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -4246,8 +4246,7 @@ pub fn handle_apply_batch(
             .collect();
         let mut proposed = Vec::new();
         for file_path in &written_files {
-            let mut per_file =
-                propose_antibodies_for_write(state, &input.agent_id, file_path, &[]);
+            let mut per_file = propose_antibodies_for_write(state, &input.agent_id, file_path, &[]);
             proposed.append(&mut per_file);
         }
         if !proposed.is_empty() {
@@ -6191,8 +6190,9 @@ mod tests {
         // (2) Drive surgical_context_v2 through dispatch -> reaches ready_to_edit
         //     and RECORDS the proof for this agent+target.
         let sctx_params = serde_json::json!({ "agent_id": agent, "file_path": target_str });
-        let sctx_out = crate::server::dispatch_tool(&mut state, "surgical_context_v2", &sctx_params)
-            .expect("surgical_context_v2 dispatch");
+        let sctx_out =
+            crate::server::dispatch_tool(&mut state, "surgical_context_v2", &sctx_params)
+                .expect("surgical_context_v2 dispatch");
         let proof_state = sctx_out
             .get("result")
             .and_then(|r| r.get("proof_state"))
@@ -6250,7 +6250,10 @@ mod tests {
         });
         // Gate OFF: unproven apply must NOT be refused by the proof gate.
         let out = crate::server::dispatch_tool(&mut state, "apply", &apply_params);
-        println!("[probe] gate OFF unproven apply result is_ok={}", out.is_ok());
+        println!(
+            "[probe] gate OFF unproven apply result is_ok={}",
+            out.is_ok()
+        );
         assert!(
             out.is_ok(),
             "with gate OFF an unproven apply must pass: {out:?}"
@@ -6314,8 +6317,24 @@ mod tests {
         std::fs::write(target, "pub fn handle_login() {}\n").expect("write target");
         std::fs::create_dir_all(other.parent().unwrap()).expect("mk other parent");
         std::fs::write(other, "pub fn unrelated() {}\n").expect("write other");
-        let target_str = target.to_string_lossy().to_string();
-        let other_str = other.to_string_lossy().to_string();
+        // Resolve the node paths through the SAME functions apply uses
+        // (resolve_file_path + validate_path_safety, which canonicalizes:
+        // resolves symlinks, 8.3 short→long names, and the \\?\ prefix on
+        // Windows). This guarantees each node's source_path matches apply's
+        // `validated_path` on every platform, so find_nodes_for_file links the
+        // written file to its flagged node regardless of OS path form.
+        let root_str = root.to_string_lossy().to_string();
+        let ingest_roots = vec![root_str.clone()];
+        let resolve_like_apply = |p: &std::path::Path| -> String {
+            validate_path_safety(
+                &resolve_file_path(&p.to_string_lossy(), &ingest_roots),
+                &ingest_roots,
+            )
+            .map(|v| v.to_string_lossy().to_string())
+            .unwrap_or_else(|_| p.to_string_lossy().to_string())
+        };
+        let target_str = resolve_like_apply(target);
+        let other_str = resolve_like_apply(other);
 
         let mut graph = Graph::new();
         // A symbol (Function) node for the target: type + discriminating label
@@ -6360,8 +6379,8 @@ mod tests {
         graph.finalize().expect("finalize graph");
         let mut state =
             SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
-        state.ingest_roots = vec![root.to_string_lossy().to_string()];
-        state.workspace_root = Some(root.to_string_lossy().to_string());
+        state.ingest_roots = ingest_roots;
+        state.workspace_root = Some(root_str);
         (state, func_ext)
     }
 
@@ -6431,7 +6450,10 @@ mod tests {
         );
         // Schema sanity: required fields present and well-formed.
         assert_eq!(args.get("agent_id").and_then(|v| v.as_str()), Some(agent));
-        assert!(args.get("pattern").is_some(), "pattern is required for create");
+        assert!(
+            args.get("pattern").is_some(),
+            "pattern is required for create"
+        );
         let nodes = args
             .pointer("/pattern/nodes")
             .and_then(|v| v.as_array())

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -335,6 +335,231 @@ pub(crate) fn daemon_proactive_insights_for_file(
     )
 }
 
+/// Map a `m1nd_core` NodeType to the antibody `node_type` string vocabulary
+/// (the set understood by `ab_str_to_node_type`). Returns `None` for
+/// `Custom(_)`, which the antibody matcher treats as unrecognized/lenient — in
+/// that case we omit `node_type` and lean on `label_contains` instead so we
+/// never emit a constraint that is silently dropped.
+fn antibody_node_type_str(nt: &NodeType) -> Option<&'static str> {
+    match nt {
+        NodeType::File => Some("file"),
+        NodeType::Directory => Some("directory"),
+        NodeType::Function => Some("function"),
+        NodeType::Class => Some("class"),
+        NodeType::Struct => Some("struct"),
+        NodeType::Enum => Some("enum"),
+        NodeType::Type => Some("type"),
+        NodeType::Module => Some("module"),
+        NodeType::Reference => Some("reference"),
+        NodeType::Concept => Some("concept"),
+        NodeType::Material => Some("material"),
+        NodeType::Process => Some("process"),
+        NodeType::Product => Some("product"),
+        NodeType::Supplier => Some("supplier"),
+        NodeType::Regulatory => Some("regulatory"),
+        NodeType::System => Some("system"),
+        NodeType::Cost => Some("cost"),
+        NodeType::Custom(_) => None,
+    }
+}
+
+/// Pick a discriminating `label_contains` fragment from a node label. For symbol
+/// labels (function/struct/... names) we want a token that generalizes across
+/// the codebase, not the whole verbose id. Strips any `file::`/`::`-segmented
+/// id down to its last segment, then takes a meaningful identifier token. Returns
+/// `None` when nothing usable remains (e.g. an empty or path-only label).
+fn antibody_label_fragment(label: &str) -> Option<String> {
+    let last = label.rsplit("::").next().unwrap_or(label).trim();
+    // Drop a leading "file::"-style path tail or empty values.
+    let last = last.trim_start_matches("file::").trim();
+    if last.is_empty() || last.contains('/') {
+        return None;
+    }
+    // Prefer a single identifier-ish token (split on common separators) that is
+    // long enough to be discriminating but short enough to generalize.
+    let token = last
+        .split(['(', ' ', '<', '['])
+        .next()
+        .unwrap_or(last)
+        .trim();
+    if token.len() < 3 {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+/// Build a `proposed_antibody` ProactiveInsight from a flagged finding the agent
+/// just fixed by editing `node_id`. Consumes the finding (so each fix proposes
+/// once) and derives a MINIMAL VIABLE antibody template from the edited node's
+/// live structural signature (seed node = node_type + a discriminating label
+/// fragment). The insight carries a ready-to-run `antibody_create` call: the
+/// complete `arguments` object is embedded as a compact JSON string in
+/// `evidence[0]` so the agent can send it as-is. This is a PROPOSAL only — it
+/// never writes to the antibody store.
+///
+/// Honest degradation: if no usable structural signature can be derived from the
+/// node (e.g. a file-level finding whose only label is a path), the proposal
+/// still emits a syntactically valid `antibody_create` call seeded with whatever
+/// is known plus a `refine` note in the message — it never fabricates an edge or
+/// relation that may not exist in the graph (which would produce a non-matching
+/// antibody). Returns `None` when there is no flagged finding for this
+/// `(agent_id, node_id)`.
+fn build_proposed_antibody_insight(
+    state: &mut SessionState,
+    agent_id: &str,
+    node_id: &str,
+) -> Option<surgical::ProactiveInsight> {
+    let mark = state.take_finding(agent_id, node_id)?;
+
+    // Resolve the edited node's live structural signature from the graph.
+    let (node_type_str, label_fragment): (Option<&'static str>, Option<String>) = {
+        let graph = state.graph.read();
+        let mut found: Option<NodeId> = None;
+        for (interned, &nid) in &graph.id_to_node {
+            if graph.strings.resolve(*interned) == node_id {
+                found = Some(nid);
+                break;
+            }
+        }
+        if let Some(nid) = found {
+            let idx = nid.as_usize();
+            let nt = antibody_node_type_str(&graph.nodes.node_type[idx]);
+            let label = graph.strings.resolve(graph.nodes.label[idx]).to_string();
+            (nt, antibody_label_fragment(&label))
+        } else {
+            (None, antibody_label_fragment(node_id))
+        }
+    };
+
+    // Assemble the single seed pattern node. We deliberately emit ONLY the seed
+    // node (no fabricated edges) so the antibody is guaranteed to match at least
+    // structurally-similar nodes; edges/relations would risk a non-matching
+    // pattern unless mined from the real graph vocabulary.
+    let mut seed = serde_json::Map::new();
+    seed.insert("role".to_string(), serde_json::json!("site"));
+    let mut have_constraint = false;
+    if let Some(nt) = node_type_str {
+        seed.insert("node_type".to_string(), serde_json::json!(nt));
+        have_constraint = true;
+    }
+    if let Some(frag) = &label_fragment {
+        seed.insert("label_contains".to_string(), serde_json::json!(frag));
+        have_constraint = true;
+    }
+
+    // Specificity floor honesty: a seed with neither a node_type nor a label
+    // fragment would be below MIN_SPECIFICITY and rejected by antibody_create.
+    // In that degraded case fall back to a structural node_type only when we have
+    // one, else there is genuinely nothing to seed from — surface a refine-only
+    // proposal that the agent must complete by hand.
+    let needs_refine = label_fragment.is_none() || node_type_str.is_none();
+
+    let antibody_name = format!("{}-recurrence", mark.kind);
+    let description = if needs_refine {
+        format!(
+            "Auto-proposed from a fixed `{}` finding at {}. Seed is structural-only — refine the pattern (add a discriminating label_contains and/or an edge) before relying on it.",
+            mark.kind, node_id
+        )
+    } else {
+        format!(
+            "Auto-proposed from a fixed `{}` finding so the next audit catches the same structural bug elsewhere.",
+            mark.kind
+        )
+    };
+
+    let pattern = serde_json::json!({
+        "nodes": [ serde_json::Value::Object(seed) ],
+        "edges": []
+    });
+    let arguments = serde_json::json!({
+        "agent_id": agent_id,
+        "action": "create",
+        "name": antibody_name,
+        "description": description,
+        "severity": mark.severity,
+        "pattern": pattern,
+    });
+    let arguments_str = serde_json::to_string(&arguments).unwrap_or_else(|_| "{}".to_string());
+
+    let message = if !have_constraint {
+        format!(
+            "You just fixed a `{}` finding here. No structural signature could be derived from this node — refine the proposed antibody_create pattern (node_type + label_contains) so the next agent's audit catches this bug elsewhere.",
+            mark.kind
+        )
+    } else if needs_refine {
+        format!(
+            "You just fixed a `{}` finding here. Proposed a ready-to-run antibody_create (structural seed) — refine its label_contains/edges, then send it so the next audit catches this bug elsewhere.",
+            mark.kind
+        )
+    } else {
+        format!(
+            "You just fixed a `{}` finding here. Proposed a ready-to-run antibody_create so the next agent's audit catches the same structural bug elsewhere — send it as-is to seed the antibody.",
+            mark.kind
+        )
+    };
+
+    let severity = match mark.severity.as_str() {
+        "critical" => "critical",
+        "info" => "info",
+        _ => "warning",
+    };
+
+    Some(surgical::ProactiveInsight {
+        severity: severity.to_string(),
+        kind: "proposed_antibody".to_string(),
+        message,
+        confidence: if needs_refine { 0.55 } else { 0.8 },
+        evidence: vec![
+            // evidence[0] is the COMPLETE, ready-to-run antibody_create arguments
+            // object as a compact JSON string — the agent sends it as-is.
+            arguments_str,
+            format!("finding_kind={}", mark.kind),
+            format!("finding_severity={}", mark.severity),
+            format!("flagged_node={}", node_id),
+        ],
+        suggested_tool: Some("antibody_create".to_string()),
+        suggested_target: Some(node_id.to_string()),
+    })
+}
+
+/// Collect candidate external node ids for `file_path` and, for each that has a
+/// flagged finding recorded by `agent_id` this session, emit a `proposed_antibody`
+/// insight. `primary_ids` (e.g. `updated_node_ids`) are checked first; the rest
+/// are gathered from the graph so a symbol-level finding still joins a file-level
+/// write. Consumes each matched finding (proposes once).
+fn propose_antibodies_for_write(
+    state: &mut SessionState,
+    agent_id: &str,
+    file_path: &str,
+    primary_ids: &[String],
+) -> Vec<surgical::ProactiveInsight> {
+    // Build the candidate id set: explicit updated ids + every graph node for the
+    // written file. Dedup while preserving the primary-first order.
+    let mut candidates: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for id in primary_ids {
+        if seen.insert(id.clone()) {
+            candidates.push(id.clone());
+        }
+    }
+    {
+        let graph = state.graph.read();
+        for (_, ext_id) in find_nodes_for_file(&graph, file_path) {
+            if seen.insert(ext_id.clone()) {
+                candidates.push(ext_id);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for id in &candidates {
+        if let Some(insight) = build_proposed_antibody_insight(state, agent_id, id) {
+            out.push(insight);
+        }
+    }
+    out
+}
+
 pub(crate) fn persist_daemon_alerts_from_insights(
     state: &mut SessionState,
     proactive_insights: &[surgical::ProactiveInsight],
@@ -2263,6 +2488,7 @@ pub fn handle_edit_commit(
         lines_removed: apply_output.lines_removed,
         reingested: apply_output.reingested,
         updated_node_ids: apply_output.updated_node_ids,
+        proactive_insights: apply_output.proactive_insights,
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
     })
 }
@@ -2398,7 +2624,42 @@ pub fn handle_apply(
     state.track_agent(&input.agent_id);
 
     let applied_file_path = validated_path.to_string_lossy().to_string();
-    let proactive_insights = daemon_proactive_insights_for_file(state, &applied_file_path, None);
+    let mut proactive_insights =
+        daemon_proactive_insights_for_file(state, &applied_file_path, None);
+    // Antibody auto-propose on fix: if this agent's scan/audit previously flagged
+    // a node in the written file, emit a `proposed_antibody` carrying a
+    // ready-to-run antibody_create so the next agent's audit catches the same
+    // structural bug elsewhere (compounding negative memory). Proposal only — no
+    // silent write to the antibody store.
+    {
+        let mut proposed = propose_antibodies_for_write(
+            state,
+            &input.agent_id,
+            &applied_file_path,
+            &updated_node_ids,
+        );
+        if !proposed.is_empty() {
+            // Keep the standard 3-insight cap, but never let the proposed_antibody
+            // be silently dropped by truncation: prepend the proposals, sort the
+            // remainder, and re-truncate so at least the proposals survive.
+            let mut combined = proposed;
+            combined.append(&mut proactive_insights);
+            combined.sort_by(|a, b| {
+                // proposed_antibody first, then by severity, then confidence.
+                let a_prop = (a.kind != "proposed_antibody") as u8;
+                let b_prop = (b.kind != "proposed_antibody") as u8;
+                a_prop
+                    .cmp(&b_prop)
+                    .then_with(|| {
+                        proactive_severity_rank(&a.severity)
+                            .cmp(&proactive_severity_rank(&b.severity))
+                    })
+                    .then_with(|| b.confidence.total_cmp(&a.confidence))
+            });
+            combined.truncate(3);
+            proactive_insights = combined;
+        }
+    }
     let _ = persist_daemon_alerts_from_insights(
         state,
         &proactive_insights,
@@ -3971,6 +4232,42 @@ pub fn handle_apply_batch(
         insights.truncate(3);
         insights
     };
+    // Antibody auto-propose on fix (batch): for each successfully written file,
+    // if this agent's scan/audit previously flagged a node in it, emit a
+    // `proposed_antibody`. Done after the read-only insight block closes so we
+    // hold `&mut state` for finding consumption. Proposed antibodies are kept
+    // even if the standard cap is hit.
+    let mut proactive_insights = proactive_insights;
+    {
+        let written_files: Vec<String> = results
+            .iter()
+            .filter(|result| result.success)
+            .map(|result| result.file_path.clone())
+            .collect();
+        let mut proposed = Vec::new();
+        for file_path in &written_files {
+            let mut per_file =
+                propose_antibodies_for_write(state, &input.agent_id, file_path, &[]);
+            proposed.append(&mut per_file);
+        }
+        if !proposed.is_empty() {
+            let mut combined = proposed;
+            combined.append(&mut proactive_insights);
+            combined.sort_by(|a, b| {
+                let a_prop = (a.kind != "proposed_antibody") as u8;
+                let b_prop = (b.kind != "proposed_antibody") as u8;
+                a_prop
+                    .cmp(&b_prop)
+                    .then_with(|| {
+                        proactive_severity_rank(&a.severity)
+                            .cmp(&proactive_severity_rank(&b.severity))
+                    })
+                    .then_with(|| b.confidence.total_cmp(&a.confidence))
+            });
+            combined.truncate(3);
+            proactive_insights = combined;
+        }
+    }
     let primary_file_path = results
         .iter()
         .find(|result| result.success)
@@ -5990,5 +6287,232 @@ mod tests {
             );
         }
         std::env::remove_var("M1ND_PROOF_GATE");
+    }
+
+    // -------------------------------------------------------------------------
+    // Antibody auto-propose on fix (gamechanger #6).
+    // -------------------------------------------------------------------------
+
+    /// Build a state whose graph holds a Function node for `target` (with a
+    /// discriminating label so a derived antibody is clean) plus an unrelated
+    /// file node for `other`. Both files are written to disk so apply can touch
+    /// them. Returns the function node's external id.
+    fn build_findings_state(
+        root: &std::path::Path,
+        target: &std::path::Path,
+        other: &std::path::Path,
+    ) -> (SessionState, String) {
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        std::fs::create_dir_all(target.parent().unwrap()).expect("mk target parent");
+        std::fs::write(target, "pub fn handle_login() {}\n").expect("write target");
+        std::fs::create_dir_all(other.parent().unwrap()).expect("mk other parent");
+        std::fs::write(other, "pub fn unrelated() {}\n").expect("write other");
+        let target_str = target.to_string_lossy().to_string();
+        let other_str = other.to_string_lossy().to_string();
+
+        let mut graph = Graph::new();
+        // A symbol (Function) node for the target: type + discriminating label
+        // gives a clean antibody seed (specificity 0.667).
+        let func_ext = format!("function::{target_str}::handle_login");
+        let func = graph
+            .add_node(&func_ext, "handle_login", NodeType::Function, &[], 0.0, 0.0)
+            .expect("add func node");
+        graph.set_node_provenance(
+            func,
+            NodeProvenanceInput {
+                source_path: Some(&target_str),
+                line_start: Some(1),
+                line_end: Some(1),
+                excerpt: None,
+                namespace: None,
+                canonical: true,
+            },
+        );
+        // The unrelated file node (never flagged).
+        let other_node = graph
+            .add_node(
+                &format!("file::{other_str}"),
+                "unrelated.rs",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add other node");
+        graph.set_node_provenance(
+            other_node,
+            NodeProvenanceInput {
+                source_path: Some(&other_str),
+                line_start: Some(1),
+                line_end: Some(1),
+                excerpt: None,
+                namespace: None,
+                canonical: true,
+            },
+        );
+        graph.finalize().expect("finalize graph");
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![root.to_string_lossy().to_string()];
+        state.workspace_root = Some(root.to_string_lossy().to_string());
+        (state, func_ext)
+    }
+
+    /// Pull the proposed_antibody insight out of an apply/edit_commit dispatch
+    /// result, if present.
+    fn extract_proposed_antibody(out: &serde_json::Value) -> Option<serde_json::Value> {
+        let insights = out
+            .get("result")
+            .and_then(|r| r.get("proactive_insights"))
+            .or_else(|| out.get("proactive_insights"))?;
+        insights
+            .as_array()?
+            .iter()
+            .find(|i| i.get("kind").and_then(|k| k.as_str()) == Some("proposed_antibody"))
+            .cloned()
+    }
+
+    #[test]
+    fn antibody_auto_propose_on_fix_then_roundtrip() {
+        let _guard = proof_gate_env_lock();
+        std::env::remove_var("M1ND_PROOF_GATE");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let target = root.join("src/auth.rs");
+        let other = root.join("src/unrelated.rs");
+        let (mut state, func_ext) = build_findings_state(root, &target, &other);
+        let target_str = target.to_string_lossy().to_string();
+        let other_str = other.to_string_lossy().to_string();
+        let agent = "fix-agent";
+
+        // (1) Simulate a scan/audit flagging the function node for this agent.
+        //     (This is exactly what handle_scan now does after assembling a
+        //     finding: note_finding(agent, finding.node_id, pattern, sev, path).)
+        state.note_finding(agent, &func_ext, "auth_boundary", "critical", &target_str);
+        assert!(
+            state.get_finding(agent, &func_ext).is_some(),
+            "finding must be recorded"
+        );
+
+        // (2) Apply (fix) the flagged file through real dispatch.
+        let apply_params = serde_json::json!({
+            "agent_id": agent,
+            "file_path": target_str,
+            "new_content": "pub fn handle_login() { /* validated */ }\n",
+        });
+        let apply_out = crate::server::dispatch_tool(&mut state, "apply", &apply_params)
+            .expect("apply must succeed");
+        let proposed = extract_proposed_antibody(&apply_out)
+            .expect("apply of a flagged node must carry a proposed_antibody");
+        println!(
+            "[probe] proposed_antibody: {}",
+            serde_json::to_string_pretty(&proposed).unwrap()
+        );
+
+        // The ready-to-run antibody_create arguments live in evidence[0].
+        let args_str = proposed
+            .get("evidence")
+            .and_then(|e| e.as_array())
+            .and_then(|a| a.first())
+            .and_then(|v| v.as_str())
+            .expect("evidence[0] must be the antibody_create arguments JSON");
+        let args: serde_json::Value =
+            serde_json::from_str(args_str).expect("antibody_create arguments must be valid JSON");
+        println!(
+            "[probe] antibody_create arguments: {}",
+            serde_json::to_string_pretty(&args).unwrap()
+        );
+        // Schema sanity: required fields present and well-formed.
+        assert_eq!(args.get("agent_id").and_then(|v| v.as_str()), Some(agent));
+        assert!(args.get("pattern").is_some(), "pattern is required for create");
+        let nodes = args
+            .pointer("/pattern/nodes")
+            .and_then(|v| v.as_array())
+            .expect("pattern.nodes must be an array");
+        assert_eq!(nodes.len(), 1, "minimal viable seed = one node");
+        assert_eq!(
+            nodes[0].get("node_type").and_then(|v| v.as_str()),
+            Some("function"),
+            "seed must carry the edited node's structural type"
+        );
+        assert_eq!(
+            nodes[0].get("label_contains").and_then(|v| v.as_str()),
+            Some("handle_login"),
+            "seed must carry a discriminating label fragment"
+        );
+        assert!(
+            args.pointer("/pattern/edges")
+                .and_then(|v| v.as_array())
+                .map(|a| a.is_empty())
+                .unwrap_or(false),
+            "minimal viable seed has no fabricated edges"
+        );
+
+        // (3) Finding consumed: re-applying must NOT re-propose.
+        assert!(
+            state.get_finding(agent, &func_ext).is_none(),
+            "finding must be consumed by the proposal"
+        );
+        let apply_again = crate::server::dispatch_tool(&mut state, "apply", &apply_params)
+            .expect("second apply must succeed");
+        assert!(
+            extract_proposed_antibody(&apply_again).is_none(),
+            "a consumed finding must not re-propose"
+        );
+
+        // (4) Round-trip: feed the proposed arguments to antibody_create through
+        //     dispatch and prove they are ACCEPTED.
+        let create_out = crate::server::dispatch_tool(&mut state, "antibody_create", &args)
+            .expect("proposed antibody_create arguments must be accepted as-is");
+        let antibody_id = create_out
+            .pointer("/result/antibody_id")
+            .or_else(|| create_out.get("antibody_id"))
+            .and_then(|v| v.as_str())
+            .expect("antibody_create must return an antibody_id")
+            .to_string();
+        println!(
+            "[probe] antibody created id={antibody_id}, full result: {}",
+            serde_json::to_string(&create_out).unwrap()
+        );
+
+        // (5) Scan with that antibody and prove it matches at least the seed node.
+        let scan_params = serde_json::json!({
+            "agent_id": agent,
+            "antibody_ids": [antibody_id],
+        });
+        let scan_out = crate::server::dispatch_tool(&mut state, "antibody_scan", &scan_params)
+            .expect("antibody_scan must succeed");
+        let matches = scan_out
+            .pointer("/result/matches")
+            .or_else(|| scan_out.get("matches"))
+            .and_then(|v| v.as_array())
+            .expect("scan must return a matches array");
+        println!("[probe] antibody_scan matches={}", matches.len());
+        assert!(
+            !matches.is_empty(),
+            "the proposed antibody must match at least the seed node, got 0 matches: {}",
+            serde_json::to_string(&scan_out).unwrap()
+        );
+
+        // (6) Editing a DIFFERENT, UNFLAGGED file must propose nothing.
+        let other_apply = serde_json::json!({
+            "agent_id": agent,
+            "file_path": other_str,
+            "new_content": "pub fn unrelated() { /* changed */ }\n",
+        });
+        let other_out = crate::server::dispatch_tool(&mut state, "apply", &other_apply)
+            .expect("apply of unflagged file must succeed");
+        assert!(
+            extract_proposed_antibody(&other_out).is_none(),
+            "an unflagged node must NOT trigger a proposed_antibody"
+        );
+        println!("[probe] unflagged file produced no proposed_antibody (correct)");
     }
 }

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -935,8 +935,7 @@ pub fn handle_activate(
             activated_node_token_estimate,
         );
         let used: usize = kept.iter().map(activated_node_token_estimate).sum();
-        let block =
-            crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
+        let block = crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
         (kept, Some(block))
     } else {
         (activated, None)

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -785,6 +785,7 @@ pub fn handle_activate(
             graph_state,
             recovery,
             agent_runtime_contract,
+            budget: None,
         });
     }
 
@@ -922,6 +923,24 @@ pub fn handle_activate(
         })
         .collect();
     let activated = dedupe_ranked(activated, input.top_k);
+
+    // Context-budget packing: keep the highest-activation nodes (already
+    // rank-ordered by dedupe_ranked) that fit the agent's declared token
+    // budget. Only engages when `token_budget` is provided — otherwise the
+    // output is byte-for-byte unchanged.
+    let (activated, budget) = if let Some(budget_tokens) = input.token_budget {
+        let (kept, dropped) = crate::result_shaping::pack_to_budget(
+            activated,
+            budget_tokens,
+            activated_node_token_estimate,
+        );
+        let used: usize = kept.iter().map(activated_node_token_estimate).sum();
+        let block =
+            crate::result_shaping::budget_block(budget_tokens, used, kept.len(), dropped);
+        (kept, Some(block))
+    } else {
+        (activated, None)
+    };
 
     // Map ghost edges
     let ghost_edges: Vec<GhostEdgeOutput> = result
@@ -1106,7 +1125,27 @@ pub fn handle_activate(
         graph_state,
         recovery,
         agent_runtime_contract,
+        budget,
     })
+}
+
+/// Per-node token ESTIMATE for an activated node, summed over its load-bearing
+/// text fields (label, type, node_id, tags, provenance path/excerpt). Uses the
+/// chars/4 heuristic — an approximation, not exact tokenization.
+fn activated_node_token_estimate(node: &ActivatedNodeOutput) -> usize {
+    let mut chars = node.label.len() + node.node_type.len() + node.node_id.len();
+    for tag in &node.tags {
+        chars += tag.len();
+    }
+    if let Some(prov) = node.provenance.as_ref() {
+        if let Some(path) = prov.source_path.as_deref() {
+            chars += path.len();
+        }
+        if let Some(excerpt) = prov.excerpt.as_deref() {
+            chars += excerpt.len();
+        }
+    }
+    crate::result_shaping::estimate_tokens_from_chars(chars)
 }
 
 /// Handle impact (03-MCP Section 2.2).
@@ -4453,6 +4492,7 @@ mod tests {
                 xlr: false,
                 include_ghost_edges: false,
                 include_structural_holes: false,
+                token_budget: None,
             },
         )
         .expect("activate should succeed");

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -820,10 +820,9 @@ pub fn handle_activate(
         propagation: PropagationConfig::default(),
     };
 
-    let result = {
-        let mut graph = state.graph.write();
-        state.orchestrator.query(&mut graph, &config)?
-    };
+    // Read-only attach takes the immutable read path (query_readonly); read-write
+    // keeps the historical mutate-on-query (plasticity) behavior.
+    let result = state.run_query(&config)?;
 
     state.queries_processed += 1;
     if state.should_persist() {
@@ -1387,10 +1386,8 @@ pub fn handle_missing(
         ..QueryConfig::default()
     };
 
-    let result = {
-        let mut graph = state.graph.write();
-        state.orchestrator.query(&mut graph, &config)?
-    };
+    // Read-only attach takes the immutable read path (query_readonly).
+    let result = state.run_query(&config)?;
 
     let graph = state.graph.read();
 

--- a/m1nd-mcp/tests/test_v04.rs
+++ b/m1nd-mcp/tests/test_v04.rs
@@ -72,6 +72,7 @@ fn build_search_output(query: &str, mode: &str, count: usize) -> SearchOutput {
         graph_state: None,
         recovery: None,
         agent_runtime_contract: None,
+        budget: None,
     }
 }
 


### PR DESCRIPTION
## What changed

Three layers, all behind existing transports and feature flags:

- **Read-only attach** (`--read-only` / `M1ND_READ_ONLY`): a second process loads the snapshot and serves queries through a new zero-mutation `query_readonly`, takes no exclusive lease, skips all persistence, and refuses mutation tools at dispatch. Includes dead-lease GC in the instance registry and a fix for `instance_id` collisions within a single millisecond.
- **`_m1nd` response envelope** (`M1ND_RESPONSE_ENVELOPE`, default on): every tool result carries a one-line summary, suggested next tools, token savings, and `grounded_in` memories near the result nodes.
- **Three agent-first tools**: `orient` (boot-into-task starting context in one call), `am_i_stale` (which working-set files changed on disk since ingest), and `token_budget` packing for `seek` / `search` / `activate`.
- **Shared-graph MCP-over-HTTP** (feature `serve`): a Streamable-HTTP `POST` / `GET` / `DELETE /mcp` endpoint bound to the live shared session, plus `m1nd-mcp --attach <url>` — a thin stdio↔HTTP bridge so multiple stdio hosts share one owner's live graph.

## Why it matters

A second editor window can use m1nd without clobbering the writer's state, and multiple agents can share one live graph — a `memorize` in one is visible to a `seek` in another with no reload — instead of each process spawning a divergent copy.

## How to try it

```bash
# one owner holds the lease + the live graph
m1nd-mcp --serve --no-gui
# each host attaches: no lease, no copy
m1nd-mcp --attach http://127.0.0.1:1337

# or a non-sharing read-only second window
m1nd-mcp --stdio --no-gui --read-only
```

## Verification

- `cargo test -p m1nd-mcp --features serve` green; clippy clean; default and `--no-default-features` builds green.
- Live probes: two separate `--attach` processes sharing one graph (`memorize` in A → `seek` finds it in B, node count grows); `/mcp` `initialize` → session-id → `tools/call` over curl; SSE `notifications/m1nd/graph_changed` delivered on graph mutation and suppressed for reads; read-only attach leaves the snapshot SHA-256 unchanged.

## Known limits

- The shared owner must run `--serve`; a stdio-only owner exposes no HTTP endpoint.
- One coarse session mutex serializes attached agents, so a slow `ingest` can block others up to the tool timeout. Pushing read concurrency down to the graph `RwLock` is future work.
- `--attach auto` discovery and the server→client push relay inside the bridge are not yet implemented (request/response only).
- `M1ND_PROOF_GATE` is a default-off stub.
