### PR TITLE
docs/site: unify positioning, honest reproducible benchmark, current install

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Every row is hedged to exactly what was measured. m1nd does not lead with saving
 
 | Claim | Result | Source / hedge |
 |---|---|---|
-| `activate` / `impact` latency | sub-µs `activate`, sub-ms `impact` | Criterion benchmarks in `m1nd-core/benches/` on a 1K-node synthetic graph — [methodology](https://m1nd.world/wiki/benchmarks.html); treat as order-of-magnitude. |
+| `activate` / `impact` latency | ~1µs `activate`, sub-µs `impact` on a 1K-node synthetic graph | Criterion benches — **reproduce it yourself: `cargo bench -p m1nd-core`** (measured `activate_1k_nodes` ≈1.4µs, `impact_depth3` ≈0.5µs on an Apple-silicon Mac); [methodology](https://m1nd.world/wiki/benchmarks.html); order-of-magnitude, hardware-dependent. |
 | Language matrix | calls + cross-file imports for 10 languages (+ Ruby cross-file) | Verified end-to-end in a single polyglot ingest; per-language tests in `m1nd-ingest`. See [Language Coverage](#language-coverage). |
 | Post-write validation sample | 12/12 classified correctly | Internal runtime check. |
 | Seeded bug-hunt | 16/20 in the first accepted `humanize` seeded-defect round (m1nd-trained); `m1nd-basic` and direct each 8/15 | Internal product evidence, `public_claim_worthy=false` — not a universal benchmark. |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src=".github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">A Local Mission Runtime for Coding Agents</h1>
+<h1 align="center">Operational Intelligence for Coding Agents</h1>
 
 <p align="center">
   <strong>Your coding agent stops starting blind.</strong><br/>
@@ -36,7 +36,7 @@
 
 ---
 
-**m1nd is a local mission runtime for coding agents — it governs the operating loop, not just retrieval.**
+**m1nd is operational intelligence for coding agents — it governs the operating loop, not just retrieval.**
 
 > grep finds text. Vector search finds similar chunks. `m1nd` gives agents a local graph of what connects, what changed, what breaks, what drifted, and where to resume.
 

--- a/m1nd-demo/src/components/FAQSection.tsx
+++ b/m1nd-demo/src/components/FAQSection.tsx
@@ -64,7 +64,7 @@ const FAQS: FAQ[] = [
   {
     tag: "getting started",
     q: "How long does it take to set up?",
-    a: 'Under 2 minutes. Install the agent pack with npm install -g @maxkle1nz/m1nd@beta, install the native runtime with cargo install m1nd-mcp --version 0.9.0-beta.2, add it to your MCP client config, and run m1nd warmup to build the initial graph. First warmup on a 50K-line codebase takes about 8 seconds. After that, incremental updates run in the background as files change.',
+    a: 'Under 2 minutes. Install the agent pack with npm install -g @maxkle1nz/m1nd@beta, install the native runtime with cargo install m1nd-mcp --version 0.9.0-beta.8, add it to your MCP client config, and run m1nd warmup to build the initial graph. First warmup on a 50K-line codebase takes about 8 seconds. After that, incremental updates run in the background as files change.',
   },
 ];
 

--- a/m1nd-demo/src/components/InstallSection.tsx
+++ b/m1nd-demo/src/components/InstallSection.tsx
@@ -6,7 +6,7 @@ m1nd doctor
 m1nd pack-check
 
 # native MCP runtime
-cargo install m1nd-mcp --version 0.9.0-beta.2`;
+cargo install m1nd-mcp --version 0.9.0-beta.8`;
 
 const STEP_CONFIG = `{
   "mcpServers": {

--- a/m1nd-demo/src/components/SpeedSection.tsx
+++ b/m1nd-demo/src/components/SpeedSection.tsx
@@ -170,7 +170,7 @@ export function SpeedSection() {
           <p className="text-sm text-muted-foreground/70 max-w-sm">
             Less file waste. Instant connection to anywhere in the code.
             <br />
-            <span className="text-primary/80 font-medium">Saves time. Saves money.</span>
+            <span className="text-primary/80 font-medium">Fewer tokens, lower cost — measured, not promised.</span>
           </p>
         </motion.div>
       </div>

--- a/m1nd-demo/src/pages/L1ght.tsx
+++ b/m1nd-demo/src/pages/L1ght.tsx
@@ -633,7 +633,7 @@ export default function L1ght() {
           >
             <InstallButtons />
             <p className="mt-4 font-mono text-xs text-muted-foreground/45 text-center">
-              npm install -g @maxkle1nz/m1nd@beta &nbsp;·&nbsp; cargo install m1nd-mcp --version 0.9.0-beta.2
+              npm install -g @maxkle1nz/m1nd@beta &nbsp;·&nbsp; cargo install m1nd-mcp --version 0.9.0-beta.8
             </p>
           </motion.div>
 
@@ -785,7 +785,7 @@ export default function L1ght() {
             transition={{ delay: 0.3 }}>
             <InstallButtons />
             <p className="mt-4 font-mono text-xs text-muted-foreground/45 text-center">
-              npm install -g @maxkle1nz/m1nd@beta &nbsp;·&nbsp; cargo install m1nd-mcp --version 0.9.0-beta.2
+              npm install -g @maxkle1nz/m1nd@beta &nbsp;·&nbsp; cargo install m1nd-mcp --version 0.9.0-beta.8
             </p>
           </motion.div>
           <motion.div


### PR DESCRIPTION
## What changed

- **Positioning unified** on "Operational Intelligence for Coding Agents": the README hero (h1 + opening line) now matches the site, which was already built around that line in its title / OG / Twitter / JSON-LD.
- **Honest, reproducible benchmark**: running the cited Criterion benches shows `activate_1k_nodes` ≈ 1.4µs (the README said "sub-µs activate" — optimistic) and `impact_depth3` ≈ 0.5µs (the README said "sub-ms impact" — it actually undersold; impact is sub-µs). Corrected, and added the one-line reproduce command (`cargo bench -p m1nd-core`).
- **Savings stays on-brand**: one SpeedSection line ("Saves time. Saves money.") → "Fewer tokens, lower cost — measured, not promised.", consistent with the README's stance that savings are evidence, not a headline.
- **Current install**: the site told users `cargo install m1nd-mcp --version 0.9.0-beta.2`, behind the crate published on crates.io (`0.9.0-beta.8`). Bumped in InstallSection, the FAQ, and the l1ght page so `cargo install m1nd-mcp` pulls the current runtime.

## Verification

Site `npm run build` green. Benchmark numbers measured locally on Apple silicon; reproduce with `cargo bench -p m1nd-core`.
