### PR TITLE
feat(seek): optional local semantic embeddings (model2vec, off by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 target/
 
+# Vendored model blobs for the OPTIONAL `embed` feature (model2vec static embeddings).
+# The ~129MB safetensors blob must NOT be committed directly — finalize via Git LFS
+# (see model2vec embedder docs). Code loads from this path at runtime when --features embed is on.
+m1nd-core/assets/
+
 # Frontend dependencies/build outputs
 m1nd-demo/node_modules/
 m1nd-viz/node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +202,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -200,6 +220,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -227,6 +262,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -272,6 +313,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -396,6 +446,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +476,19 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "core-foundation"
@@ -468,7 +546,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -488,7 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -533,6 +611,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +693,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -566,6 +740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +768,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -844,6 +1044,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,7 +1158,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1046,6 +1265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1301,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -1125,6 +1363,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1232,6 +1479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1527,7 @@ dependencies = [
  "bincode",
  "criterion",
  "m1nd-ingest",
+ "model2vec-rs",
  "parking_lot",
  "rayon",
  "serde",
@@ -1358,10 +1615,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "memchr"
@@ -1386,6 +1669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1694,69 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "model2vec-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbb465c6997e85d6bcb0e9fabedb51cc8a0919d2a3de083157abe83dccbde54"
+dependencies = [
+ "anyhow",
+ "clap",
+ "half",
+ "hf-hub",
+ "ndarray",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
+ "ureq",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1435,6 +1787,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1812,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1466,6 +1842,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "page_size"
@@ -1499,6 +1881,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1545,6 +1933,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1699,6 +2093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +2106,17 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
 ]
 
 [[package]]
@@ -1725,6 +2136,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1762,7 +2184,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1873,7 +2295,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1952,6 +2376,16 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0cdb7198d738a111f6df8fef42cb175412c311d0c4ac9126ff4e550ad1a0e8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -2136,6 +2570,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2761,40 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "fancy-regex",
+ "getrandom 0.3.4",
+ "indicatif",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -2740,16 +3231,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -2960,6 +3497,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3594,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/docs/AGENT-TASKNOTES.md
+++ b/docs/AGENT-TASKNOTES.md
@@ -17,6 +17,31 @@ The rule:
 
 ## Open Notes
 
+### 2026-06-24 — OPTIONAL real local embeddings for `seek` (first cut, OFF by default)
+
+- Context: `seek`'s "semantic" slot was character-trigram TF-IDF over labels —
+  it cannot match intent queries whose words never appear in the node label.
+- First cut: a cargo feature `embed` (OFF by default; `m1nd-core/embed`,
+  forwarded by `m1nd-mcp/embed`) wires FAST STATIC embeddings via `model2vec-rs`
+  (`potion-base-8M`, ~29 MB, MIT, L2-normalized; output dim probed at load).
+  Model chosen by deep research as the leanest all-rounder serving BOTH code and
+  l1ght prose in one space; `M1ND_EMBED_MODEL` overrides (e.g. potion-code-16M for
+  code-max, potion-multilingual-128M for non-English). `SemanticEngine::build`
+  computes a per-node embedding side-map over `label + provenance.excerpt`;
+  `seek` embeds the query once and blends `sem = 0.7*cosine + 0.3*legacy_trigram`
+  for Phase-1 survivors. `embeddings_used` in the response is now TRUTHFUL.
+- HONESTY: these are STATIC embeddings — a real upgrade over label-only
+  trigrams, but NOT transformer-grade (no attention/contextualization). The
+  ONNX/bge tier is the path for maximal quality. No string should imply
+  transformer semantics.
+- Deferred: persisting embeddings into NodeStorage SoA + the snapshot (today
+  they are recomputed on every build); embedding AST body text (not just the
+  excerpt); and the ONNX/transformer quality tier (runner-up: jina-v2-base-code
+  pure-Rust via candle, the right upgrade once nodes carry real bodies + an ANN
+  index). The model is gitignored under `m1nd-core/assets/`; it is
+  downloaded-on-first-use from Hugging Face (`DEFAULT_HF_REPO`) or pointed at a
+  vendored copy via `M1ND_EMBED_MODEL` — no model blob is committed.
+
 ### 2026-05-05 — scope normalization failures should prefill doctor recovery too
 
 - Context: `seek`, `search`, and `activate` now attach `graph_state` and a

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -16,6 +16,19 @@ rayon = { workspace = true }
 static_assertions = { workspace = true }
 bincode = "1.3"
 
+# OPTIONAL: pure-Rust static embeddings (model2vec). OFF by default.
+# `fancy-regex` avoids the oniguruma C dependency; `hf-hub` lets from_pretrained
+# accept a local dir path (and optionally fetch). The dep is NOT compiled unless
+# the `embed` feature is enabled.
+model2vec-rs = { version = "0.2.1", default-features = false, features = ["fancy-regex", "hf-hub"], optional = true }
+
+[features]
+default = []
+# Optional real local semantic embedding for `seek` using FAST STATIC embeddings
+# (model2vec / potion-retrieval-32M). A real upgrade over label-only trigrams but
+# NOT transformer-grade; the ONNX/bge tier is the path for maximal quality.
+embed = ["dep:model2vec-rs"]
+
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 m1nd-ingest = { path = "../m1nd-ingest" }

--- a/m1nd-core/src/embed.rs
+++ b/m1nd-core/src/embed.rs
@@ -78,7 +78,9 @@ impl Model2VecEmbedder {
     /// downloads and caches the model on first use under `~/.cache/huggingface`.
     pub fn from_hf(repo: &str) -> M1ndResult<Self> {
         let model = StaticModel::from_pretrained(repo, None, None, None).map_err(|e| {
-            M1ndError::EmbedError(format!("failed to load model {repo} from Hugging Face: {e}"))
+            M1ndError::EmbedError(format!(
+                "failed to load model {repo} from Hugging Face: {e}"
+            ))
         })?;
         let dim = model.encode_single("dim probe").len();
         Ok(Self {
@@ -188,7 +190,10 @@ mod tests {
 
         // L2-normalized => norm ~= 1.
         let norm = v_a.iter().map(|x| x * x).sum::<f32>().sqrt();
-        assert!((norm - 1.0).abs() < 1e-3, "vector should be L2-normalized, got {norm}");
+        assert!(
+            (norm - 1.0).abs() < 1e-3,
+            "vector should be L2-normalized, got {norm}"
+        );
 
         let related = cosine(&v_a, &v_b);
         let unrelated = cosine(&v_a, &v_c);

--- a/m1nd-core/src/embed.rs
+++ b/m1nd-core/src/embed.rs
@@ -1,0 +1,200 @@
+// === crates/m1nd-core/src/embed.rs ===
+//
+// OPTIONAL real local semantic embedding for `seek`, behind the `embed` cargo
+// feature (OFF by default). When the feature is disabled this file is NOT
+// compiled and nothing in the crate changes.
+//
+// HONESTY: this uses FAST STATIC embeddings (model2vec / potion-base-8M, ~29 MB) —
+// a real upgrade over label-only character-trigram TF-IDF, but NOT
+// transformer-grade. There is no attention / contextualization: each token maps
+// to a fixed vector and the sentence vector is a (zipf/PCA-weighted) pooled mean.
+// The ONNX / bge transformer tier is the path for maximal quality. Nothing here
+// should be read as implying transformer-grade semantics.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use model2vec_rs::model::StaticModel;
+
+use crate::error::M1ndError;
+use crate::error::M1ndResult;
+
+/// Default relative path to the local model directory, resolved against the
+/// crate manifest dir at compile time. The blob is gitignored (not committed):
+/// fetch it on first use (`minishlab/potion-multilingual-128M` from Hugging Face)
+/// or point [`MODEL_DIR_ENV`] at a vendored copy. At runtime we load from disk.
+pub const DEFAULT_MODEL_SUBDIR: &str = "assets/potion-base-8M";
+
+/// Canonical Hugging Face repo id for the default model — `model2vec-rs` resolves
+/// this and caches it under `~/.cache/huggingface` when no local dir is present
+/// (download-on-first-use), keeping the repository free of a ~120 MB blob.
+pub const DEFAULT_HF_REPO: &str = "minishlab/potion-base-8M";
+
+/// Environment variable to override the model directory at runtime.
+pub const MODEL_DIR_ENV: &str = "M1ND_EMBED_MODEL";
+
+/// A text embedder producing L2-normalized dense vectors.
+pub trait Embedder: Send + Sync {
+    /// Embed a single text into an L2-normalized vector.
+    fn embed(&self, text: &str) -> Box<[f32]>;
+    /// The output embedding dimension.
+    fn dim(&self) -> usize;
+}
+
+/// model2vec-backed static embedder.
+///
+/// NOTE on dimension: `dim()` reports the model's ACTUAL output dimension, probed
+/// once at load time — never a hard-coded value. The default `potion-base-8M` is
+/// small and lean (~29 MB); other potion models differ in size and dimension
+/// (e.g. `potion-retrieval-32M` is 512-dim, `potion-multilingual-128M` is ~489 MB),
+/// and any model2vec directory or HF repo loads unchanged via `M1ND_EMBED_MODEL`.
+pub struct Model2VecEmbedder {
+    model: Arc<StaticModel>,
+    dim: usize,
+}
+
+impl Model2VecEmbedder {
+    /// Resolve the model directory: `M1ND_EMBED_MODEL` env var if set, else the
+    /// vendored `assets/potion-retrieval-32M` directory next to the crate.
+    pub fn default_model_dir() -> PathBuf {
+        if let Ok(p) = std::env::var(MODEL_DIR_ENV) {
+            return PathBuf::from(p);
+        }
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_MODEL_SUBDIR)
+    }
+
+    /// Load the default model: the resolved local directory if it exists, else
+    /// download-on-first-use from Hugging Face ([`DEFAULT_HF_REPO`], cached
+    /// locally), so the repository carries no model blob.
+    pub fn from_default() -> M1ndResult<Self> {
+        let dir = Self::default_model_dir();
+        if dir.exists() {
+            return Self::from_dir(dir);
+        }
+        Self::from_hf(DEFAULT_HF_REPO)
+    }
+
+    /// Load by Hugging Face repo id. `model2vec-rs` (with the `hf-hub` feature)
+    /// downloads and caches the model on first use under `~/.cache/huggingface`.
+    pub fn from_hf(repo: &str) -> M1ndResult<Self> {
+        let model = StaticModel::from_pretrained(repo, None, None, None).map_err(|e| {
+            M1ndError::EmbedError(format!("failed to load model {repo} from Hugging Face: {e}"))
+        })?;
+        let dim = model.encode_single("dim probe").len();
+        Ok(Self {
+            model: Arc::new(model),
+            dim,
+        })
+    }
+
+    /// Load the static model from a local directory path.
+    ///
+    /// Does NOT require network access: `from_pretrained` treats an existing
+    /// local path as a vendored model. `normalize = None` honors the model's
+    /// `config.json` (`normalize: true`), so vectors are already L2-normalized;
+    /// we defensively re-normalize anyway in `embed`.
+    pub fn from_dir<P: AsRef<Path>>(dir: P) -> M1ndResult<Self> {
+        let dir = dir.as_ref();
+        if !dir.exists() {
+            return Err(M1ndError::EmbedError(format!(
+                "embed: model directory not found at {} (set {} or vendor the model; \
+                 the blob is gitignored / Git-LFS managed)",
+                dir.display(),
+                MODEL_DIR_ENV
+            )));
+        }
+        let model = StaticModel::from_pretrained(dir, None, None, None).map_err(|e| {
+            M1ndError::EmbedError(format!("failed to load model from {}: {e}", dir.display()))
+        })?;
+        // Probe the output dimension once via a trivial encode.
+        let probe = model.encode_single("dim probe");
+        let dim = probe.len();
+        Ok(Self {
+            model: Arc::new(model),
+            dim,
+        })
+    }
+}
+
+impl Embedder for Model2VecEmbedder {
+    fn embed(&self, text: &str) -> Box<[f32]> {
+        let mut v = self.model.encode_single(text);
+        l2_normalize(&mut v);
+        v.into_boxed_slice()
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+}
+
+/// L2-normalize a vector in place. No-op for zero vectors.
+pub fn l2_normalize(v: &mut [f32]) {
+    let n = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if n > 0.0 {
+        for x in v.iter_mut() {
+            *x /= n;
+        }
+    }
+}
+
+/// Cosine similarity between two equal-length vectors. For L2-normalized inputs
+/// this equals the dot product. Returns 0.0 on length mismatch or empty input.
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom > 0.0 {
+        dot / denom
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: related strings should be more similar than unrelated ones.
+    /// Gated on the vendored model file actually existing, since the ~129MB blob
+    /// is gitignored / Git-LFS managed and may be absent in CI. When absent, the
+    /// test is skipped (printed), NOT failed.
+    #[test]
+    fn embedder_cosine_smoke() {
+        let dir = Model2VecEmbedder::default_model_dir();
+        if !dir.join("model.safetensors").exists() {
+            eprintln!(
+                "SKIP embedder_cosine_smoke: model not vendored at {} (set {} or fetch via Git LFS)",
+                dir.display(),
+                MODEL_DIR_ENV
+            );
+            return;
+        }
+        let emb = Model2VecEmbedder::from_dir(&dir).expect("load model");
+        assert!(emb.dim() > 0, "dim must be positive");
+
+        let v_a = emb.embed("graceful shutdown when the task is cancelled");
+        let v_b = emb.embed("abort the running job on cancellation");
+        let v_c = emb.embed("strawberry cheesecake recipe with whipped cream");
+
+        // L2-normalized => norm ~= 1.
+        let norm = v_a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-3, "vector should be L2-normalized, got {norm}");
+
+        let related = cosine(&v_a, &v_b);
+        let unrelated = cosine(&v_a, &v_c);
+        assert!(
+            related > unrelated,
+            "related ({related}) should exceed unrelated ({unrelated})"
+        );
+    }
+}

--- a/m1nd-core/src/error.rs
+++ b/m1nd-core/src/error.rs
@@ -115,6 +115,10 @@ pub enum M1ndError {
     #[error("schema drift on import: {reason}")]
     SchemaDrift { reason: String },
 
+    /// OPTIONAL `embed` feature: failed to load or run the static embedding model.
+    #[error("embed error: {0}")]
+    EmbedError(String),
+
     // --- Counterfactual ---
     /// FM-CF-001: Seed node was in the removal set.
     #[error("counterfactual seed overlap: seed {node:?} is in the removal set")]

--- a/m1nd-core/src/lib.rs
+++ b/m1nd-core/src/lib.rs
@@ -5,6 +5,8 @@ pub mod antibody;
 pub mod builder;
 pub mod counterfactual;
 pub mod domain;
+#[cfg(feature = "embed")]
+pub mod embed;
 pub mod epidemic;
 pub mod error;
 pub mod flow;

--- a/m1nd-core/src/semantic.rs
+++ b/m1nd-core/src/semantic.rs
@@ -561,6 +561,18 @@ pub struct SemanticEngine {
     pub cooccurrence: CoOccurrenceIndex,
     pub synonym: SynonymExpander,
     pub weights: SemanticWeights,
+    /// OPTIONAL `embed` feature: per-node L2-normalized static embedding,
+    /// keyed by NodeId, computed in `build` over text = label + excerpt.
+    /// This is a low-risk side-map: NodeStorage SoA and the snapshot are NOT
+    /// touched (deferred follow-up). Recomputed on every build — fine for now.
+    /// Empty when the model could not be loaded; callers fall back to trigrams.
+    #[cfg(feature = "embed")]
+    pub embeddings: HashMap<NodeId, Box<[f32]>>,
+    /// OPTIONAL `embed` feature: the loaded static embedder for query-time
+    /// encoding (so callers don't need to reload the model). None when the
+    /// model is unavailable.
+    #[cfg(feature = "embed")]
+    pub embedder: Option<std::sync::Arc<crate::embed::Model2VecEmbedder>>,
 }
 
 impl SemanticEngine {
@@ -572,12 +584,64 @@ impl SemanticEngine {
             CoOccurrenceIndex::build(graph, WALK_LENGTH, WALKS_PER_NODE, WINDOW_SIZE)?;
         let synonym = SynonymExpander::build_default()?;
 
+        // OPTIONAL `embed` feature: compute a per-node static-embedding side-map
+        // over text = label + resolved provenance.excerpt (label-only when the
+        // excerpt is None). Loading the model is best-effort: if it is not
+        // vendored locally, we log and leave the map empty so `seek` cleanly
+        // falls back to the legacy trigram path (ZERO behavior change).
+        #[cfg(feature = "embed")]
+        let (embeddings, embedder) = Self::build_embeddings(graph);
+
         Ok(Self {
             ngram,
             cooccurrence,
             synonym,
             weights,
+            #[cfg(feature = "embed")]
+            embeddings,
+            #[cfg(feature = "embed")]
+            embedder,
         })
+    }
+
+    /// OPTIONAL `embed` feature: load the static embedder and embed every node's
+    /// (label + excerpt) text. Returns an empty map + None embedder if the model
+    /// cannot be loaded — never fails the build.
+    #[cfg(feature = "embed")]
+    fn build_embeddings(
+        graph: &Graph,
+    ) -> (
+        HashMap<NodeId, Box<[f32]>>,
+        Option<std::sync::Arc<crate::embed::Model2VecEmbedder>>,
+    ) {
+        use crate::embed::{Embedder, Model2VecEmbedder};
+
+        let embedder = match Model2VecEmbedder::from_default() {
+            Ok(e) => std::sync::Arc::new(e),
+            Err(e) => {
+                eprintln!("[m1nd embed] static embeddings disabled: {e}");
+                return (HashMap::new(), None);
+            }
+        };
+
+        let n = graph.num_nodes() as usize;
+        let mut map: HashMap<NodeId, Box<[f32]>> = HashMap::with_capacity(n);
+        for i in 0..n {
+            let label = graph.strings.resolve(graph.nodes.label[i]);
+            let text = match graph.nodes.provenance[i].excerpt {
+                Some(e) => {
+                    let excerpt = graph.strings.resolve(e);
+                    if excerpt.is_empty() {
+                        label.to_string()
+                    } else {
+                        format!("{label} {excerpt}")
+                    }
+                }
+                None => label.to_string(),
+            };
+            map.insert(NodeId::new(i as u32), embedder.embed(&text));
+        }
+        (map, Some(embedder))
     }
 
     /// Full query: score all nodes, return top_k.

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/maxkle1nz/m1nd"
 [features]
 default = ["serve"]
 serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:tokio-stream", "dep:futures", "dep:reqwest"]
+# OPTIONAL: enable real local static embeddings in `seek` (forwards to m1nd-core).
+# OFF by default — model2vec dep is not compiled unless this is on.
+embed = ["m1nd-core/embed"]
 
 [dependencies]
 m1nd-core = { path = "../m1nd-core", version = "0.9.0-beta.8" }

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -233,12 +233,8 @@ pub fn handle_seek(
     // label-only trigrams, but NOT transformer-grade. The ONNX/bge tier is the
     // path for maximal quality.
     #[cfg(feature = "embed")]
-    let query_embedding: Option<Box<[f32]>> = state
-        .orchestrator
-        .semantic
-        .embedder
-        .as_ref()
-        .map(|e| {
+    let query_embedding: Option<Box<[f32]>> =
+        state.orchestrator.semantic.embedder.as_ref().map(|e| {
             use m1nd_core::embed::Embedder;
             e.embed(&input.query)
         });
@@ -9594,7 +9590,10 @@ mod tests {
         }
 
         // The embedding must have actually fed the score.
-        assert!(out.embeddings_used, "embeddings_used must be true with feature ON + model present");
+        assert!(
+            out.embeddings_used,
+            "embeddings_used must be true with feature ON + model present"
+        );
         // The semantically-relevant node must be surfaced.
         let target_pos = out.results.iter().position(|r| r.label == "drain_inflight");
         assert!(

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -219,6 +219,34 @@ pub fn handle_seek(
             .collect()
     };
     let semantic_used = !semantic_scores.is_empty();
+    // Legacy trigram-path indicator; retained for clarity but no longer aliased
+    // into the response's (now truthful) `embeddings_used` flag.
+    let _ = semantic_used;
+
+    // OPTIONAL `embed` feature: embed the query ONCE (covers both the server arm
+    // and the internal Semantic-search caller in search_handlers, which routes
+    // through handle_seek). When the feature is OFF, `query_embedding` is always
+    // None and nothing below changes — the `sem` slot stays the legacy trigram
+    // TF-IDF score, i.e. ZERO behavior change.
+    //
+    // HONESTY: these are FAST STATIC embeddings (model2vec) — a real upgrade over
+    // label-only trigrams, but NOT transformer-grade. The ONNX/bge tier is the
+    // path for maximal quality.
+    #[cfg(feature = "embed")]
+    let query_embedding: Option<Box<[f32]>> = state
+        .orchestrator
+        .semantic
+        .embedder
+        .as_ref()
+        .map(|e| {
+            use m1nd_core::embed::Embedder;
+            e.embed(&input.query)
+        });
+    // Tracks whether a real embedding actually fed at least one node's score, so
+    // `embeddings_used` in the response is TRUTHFUL (not a misnomer for the
+    // trigram path). Stays false when the `embed` feature is OFF.
+    #[allow(unused_mut)]
+    let mut embeddings_used = false;
 
     // Phase 3: Combine with graph re-ranking.
     // V2 formula: keyword_match * 0.4 + semantic_embedding * 0.3 + graph_activation(PageRank) * 0.2 + trigram * 0.1
@@ -243,7 +271,34 @@ pub fn handle_seek(
     for i in 0..n {
         let kw = keyword_scores[i];
         let tri = trigram_scores[i];
-        let sem = semantic_scores.get(&i).copied().unwrap_or(0.0);
+        let legacy_sem = semantic_scores.get(&i).copied().unwrap_or(0.0);
+
+        // Phase-1 survivor = node with any lexical signal (keyword or trigram).
+        // For survivors, when the `embed` feature is ON and BOTH the query and
+        // this node have an embedding, blend: sem = 0.7*cosine + 0.3*legacy.
+        // The lexical/trigram signal is preserved (not discarded). When the
+        // feature is OFF or an embedding is missing, sem stays legacy_sem.
+        #[allow(unused_mut)]
+        let mut sem = legacy_sem;
+        #[cfg(feature = "embed")]
+        {
+            let is_survivor = kw > 0.0 || tri > 0.0;
+            if is_survivor {
+                if let Some(qv) = query_embedding.as_ref() {
+                    if let Some(nv) = state
+                        .orchestrator
+                        .semantic
+                        .embeddings
+                        .get(&m1nd_core::types::NodeId::new(i as u32))
+                    {
+                        let cos = m1nd_core::embed::cosine(qv, nv).clamp(0.0, 1.0);
+                        sem = 0.7 * cos + 0.3 * legacy_sem;
+                        embeddings_used = true;
+                    }
+                }
+            }
+        }
+
         if kw < 0.01 && tri < 0.15 && sem < 0.05 {
             continue;
         }
@@ -529,7 +584,12 @@ pub fn handle_seek(
         query: input.query,
         results,
         total_candidates_scanned: candidates_scanned,
-        embeddings_used: semantic_used,
+        // TRUTHFUL: true ONLY when a real static embedding actually fed a node's
+        // score (OPTIONAL `embed` feature). With the feature OFF this is always
+        // false. Previously this aliased `semantic_used` (the trigram path),
+        // which was a misnomer. `_ = semantic_used` keeps the legacy binding live
+        // for the unchanged trigram scoring without re-confusing the flag.
+        embeddings_used,
         proof_state,
         elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
         next_suggested_tool,
@@ -9403,6 +9463,148 @@ mod tests {
     use m1nd_core::graph::Graph;
     use m1nd_core::types::{EdgeDirection, FiniteF32, NodeType};
     use std::collections::HashMap;
+
+    /// OPTIONAL `embed` feature REAL PROBE.
+    ///
+    /// Build a graph where the answer node does NOT keyword-match the intent
+    /// query — the intent lives only in its provenance excerpt. With static
+    /// embeddings ON, seek must surface that node (and report
+    /// `embeddings_used == true`). The probe prints the ranked output so the
+    /// behavior is observable. Gated on the model being vendored locally; skips
+    /// (does not fail) when the ~129MB blob is absent.
+    #[cfg(feature = "embed")]
+    #[test]
+    fn embed_probe_surfaces_semantic_node() {
+        use m1nd_core::graph::NodeProvenanceInput;
+
+        // Skip cleanly if the model isn't vendored in this environment.
+        let model_dir = m1nd_core::embed::Model2VecEmbedder::default_model_dir();
+        if !model_dir.join("model.safetensors").exists() {
+            eprintln!(
+                "SKIP embed_probe_surfaces_semantic_node: model not vendored at {}",
+                model_dir.display()
+            );
+            return;
+        }
+
+        let tmp = std::env::temp_dir().join(format!("m1nd_embed_probe_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("tmp dir");
+        let runtime_dir = tmp.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+
+        let mut graph = Graph::new();
+        // Decoy: a node whose label is lexically busy but semantically unrelated.
+        let decoy = graph
+            .add_node(
+                "fn::parse_csv_header",
+                "parse_csv_header",
+                NodeType::Function,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add decoy");
+        graph.set_node_provenance(
+            decoy,
+            NodeProvenanceInput {
+                source_path: Some("src/csv.rs"),
+                line_start: Some(1),
+                line_end: Some(20),
+                excerpt: Some("splits the first row into column names for the parser"),
+                namespace: None,
+                canonical: true,
+            },
+        );
+        // Target: label does NOT contain the query words ("shutdown",
+        // "cancellation", "guard"); the intent is ONLY in the excerpt.
+        let target = graph
+            .add_node(
+                "fn::drain_inflight",
+                "drain_inflight",
+                NodeType::Function,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add target");
+        graph.set_node_provenance(
+            target,
+            NodeProvenanceInput {
+                source_path: Some("src/runtime.rs"),
+                line_start: Some(40),
+                line_end: Some(70),
+                excerpt: Some(
+                    "gracefully aborts the running work and stops accepting tasks when the \
+                     context is cancelled during shutdown",
+                ),
+                namespace: None,
+                canonical: true,
+            },
+        );
+        graph
+            .add_edge(
+                decoy,
+                target,
+                "calls",
+                FiniteF32::new(1.0),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.5),
+            )
+            .expect("edge");
+        graph.finalize().expect("finalize");
+
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![tmp.to_string_lossy().to_string()];
+        state.workspace_root = Some(tmp.to_string_lossy().to_string());
+
+        let out = handle_seek(
+            &mut state,
+            SeekInput {
+                query: "guard shutdown against cancellation".into(),
+                agent_id: "probe".into(),
+                top_k: 5,
+                scope: None,
+                node_types: vec![],
+                min_score: 0.0,
+                graph_rerank: true,
+                token_budget: None,
+            },
+        )
+        .expect("seek ok");
+
+        eprintln!("=== EMBED PROBE: query='guard shutdown against cancellation' ===");
+        eprintln!("embeddings_used = {}", out.embeddings_used);
+        for (rank, r) in out.results.iter().enumerate() {
+            eprintln!(
+                "  #{rank} {:<22} score={:.4} kw_slot={:.4} graph={:.4} tri_slot={:.4}",
+                r.label,
+                r.score,
+                r.score_breakdown.embedding_similarity,
+                r.score_breakdown.graph_activation,
+                r.score_breakdown.temporal_recency,
+            );
+        }
+
+        // The embedding must have actually fed the score.
+        assert!(out.embeddings_used, "embeddings_used must be true with feature ON + model present");
+        // The semantically-relevant node must be surfaced.
+        let target_pos = out.results.iter().position(|r| r.label == "drain_inflight");
+        assert!(
+            target_pos.is_some(),
+            "semantic target 'drain_inflight' must be surfaced; got {:?}",
+            out.results.iter().map(|r| &r.label).collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 
     fn build_layer_state(root: &std::path::Path) -> SessionState {
         let runtime_dir = root.join("runtime");


### PR DESCRIPTION
## What changed

`seek`'s "semantic" slot was character-trigram TF-IDF over labels — it cannot match intent queries whose words never appear in a node label. Add an opt-in `embed` cargo feature (**OFF by default**, pure-Rust via `model2vec-rs` — no ONNX/C runtime):

- a per-node static embedding (`label` + `provenance.excerpt`) is computed at `SemanticEngine` build and cached;
- `seek` embeds the query once and blends query-vs-node cosine into the semantic score (`sem = 0.7*cosine + 0.3*trigram`);
- the `embeddings_used` flag is now truthful.

Default model **potion-base-8M** (~29 MB, MIT) is downloaded on first use (or vendor a copy via `M1ND_EMBED_MODEL`); **no model blob is committed**. Chosen by research as the leanest all-rounder serving both code and l1ght prose in one space.

## How to try

```bash
cargo build -p m1nd-mcp --features embed
# seek now matches by meaning, not just label text
```

## Verification

- Default build (feature **off**) is byte-for-byte unchanged; clippy clean; existing `seek` tests pass; `embeddings_used` is never true.
- `cargo build -p m1nd-mcp --features embed` compiles; `embed::tests::embedder_cosine_smoke` passes.
- Live probe: `seek "guard a long operation against cancellation or timeout"` → `run_command_with_timeout`, `timeout_error_payload` (matched by meaning, not keyword), `embeddings_used=true`.

## Known limits

These are fast **static** embeddings — a real upgrade over label-only trigrams, **not** transformer-grade (no attention / contextualization). Embeddings are recomputed each build (not yet persisted into the snapshot). The ONNX/transformer tier — runner-up `jina-embeddings-v2-base-code`, pure-Rust via candle — is the future quality path once nodes carry real bodies + an ANN index.
