### PR TITLE
feat(embed): persist per-node embeddings in a content-addressed cache

### DIFF
--- a/docs/AGENT-TASKNOTES.md
+++ b/docs/AGENT-TASKNOTES.md
@@ -34,8 +34,7 @@ The rule:
   trigrams, but NOT transformer-grade (no attention/contextualization). The
   ONNX/bge tier is the path for maximal quality. No string should imply
   transformer semantics.
-- Deferred: persisting embeddings into NodeStorage SoA + the snapshot (today
-  they are recomputed on every build); embedding AST body text (not just the
+- Deferred: embedding AST body text (not just the
   excerpt); and the ONNX/transformer quality tier (runner-up: jina-v2-base-code
   pure-Rust via candle, the right upgrade once nodes carry real bodies + an ANN
   index). The model is gitignored under `m1nd-core/assets/`; it is
@@ -57,6 +56,27 @@ The rule:
     fields
 
 ## Resolved Notes
+
+### 2026-06-24 — embeddings now persist in a content-addressed cache (was: recomputed every build)
+
+- Context: with `embed` on, `SemanticEngine::build` recomputed every node's
+  static embedding on every boot and re-ingest — a model load + N encodes each
+  time, the main cost of keeping `embed` warm.
+- Resolution: a new `embed_cache.rs` sidecar (`EmbeddingCache`, bincode, atomic
+  temp+rename) keyed by a STABLE FNV-1a hash of `(model_id, label+excerpt)`.
+  `SemanticEngine::build_with_cache(graph, weights, cache_path, persist)` loads
+  the warm cache and reuses any vector whose `(model, text)` is unchanged,
+  re-embedding only changed/new nodes, then persists EXACTLY the current graph's
+  entries (self-pruning — no stale / cross-repo growth). The in-memory map stays
+  keyed by `NodeId`, so the `seek` path is untouched. The cache lives next to the
+  snapshot in `runtime_dir`, derived in `SessionState::initialize` and refreshed
+  by `rebuild_engines`. Advisory: any version/model/dim mismatch or corruption →
+  full recompute (never a wrong vector). `model_id` folds the weights-file byte
+  length, so an in-place model swap invalidates the cache. Read-only attachers
+  REUSE the cache but never write it (`persist=false`) — one writer per file,
+  honoring the read-only contract. All OFF by default behind `embed`.
+- Still deferred: NodeStorage SoA embedding fields + an ANN index over the
+  persisted vectors (the next unlock — vector search over the whole graph).
 
 ### 2026-05-06 — agents need one startup verdict, not stitched diagnostics
 

--- a/m1nd-core/src/embed.rs
+++ b/m1nd-core/src/embed.rs
@@ -51,6 +51,10 @@ pub trait Embedder: Send + Sync {
 pub struct Model2VecEmbedder {
     model: Arc<StaticModel>,
     dim: usize,
+    /// Stable identity of the loaded model (resolved local directory path or
+    /// Hugging Face repo id). Recorded into the embedding cache header so a
+    /// cache built with a different model is transparently ignored.
+    id: String,
 }
 
 impl Model2VecEmbedder {
@@ -86,6 +90,7 @@ impl Model2VecEmbedder {
         Ok(Self {
             model: Arc::new(model),
             dim,
+            id: repo.to_string(),
         })
     }
 
@@ -111,10 +116,26 @@ impl Model2VecEmbedder {
         // Probe the output dimension once via a trivial encode.
         let probe = model.encode_single("dim probe");
         let dim = probe.len();
+        // Lightweight content fingerprint: fold the weights-file byte length into
+        // the identity so an in-place model swap at the same path (different
+        // weights) changes `model_id` and invalidates any stale embedding cache.
+        // Size is stable (no mtime churn); a same-size, different-weights swap is
+        // astronomically unlikely for safetensors.
+        let weights_len = std::fs::metadata(dir.join("model.safetensors"))
+            .map(|m| m.len())
+            .unwrap_or(0);
         Ok(Self {
             model: Arc::new(model),
             dim,
+            id: format!("{}#{weights_len}", dir.display()),
         })
+    }
+
+    /// Stable identity string of the loaded model (resolved directory path or
+    /// Hugging Face repo id). Recorded into the embedding cache header so a
+    /// cache produced by a different model is transparently ignored.
+    pub fn model_id(&self) -> &str {
+        &self.id
     }
 }
 

--- a/m1nd-core/src/embed_cache.rs
+++ b/m1nd-core/src/embed_cache.rs
@@ -1,0 +1,155 @@
+// === crates/m1nd-core/src/embed_cache.rs ===
+//
+// OPTIONAL `embed` feature: a content-addressed, on-disk cache of per-node
+// static embeddings, so a warm restart or re-ingest reuses vectors instead of
+// recomputing them. Entries are keyed by a STABLE hash of (model_id, node text)
+// — see [`content_key`] — and the whole file is validated against the live
+// model identity + dimension on load. It is purely advisory: any version /
+// model / dim mismatch or corruption is ignored and embeddings are recomputed,
+// so there is never a wrong-vector hazard (ZERO behavior change on a miss).
+//
+// Mirrors the plasticity sidecar discipline (atomic temp + rename write), and
+// uses `bincode` (already a dependency, same as `snapshot_bin`) for a compact
+// binary payload — embeddings are dense f32 blobs, not worth JSON.
+
+use std::collections::HashMap;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{M1ndError, M1ndResult};
+
+/// Bump when the on-disk layout changes incompatibly. A version mismatch makes
+/// [`EmbeddingCache::load_compatible`] return `None` (full recompute).
+pub const EMBED_CACHE_VERSION: u32 = 1;
+
+/// On-disk embedding cache. `entries` maps a stable content hash of
+/// (model_id, text) to its L2-normalized vector.
+#[derive(Serialize, Deserialize)]
+pub struct EmbeddingCache {
+    /// Layout version — see [`EMBED_CACHE_VERSION`].
+    pub version: u32,
+    /// Identity of the model that produced these vectors (see
+    /// `Model2VecEmbedder::model_id`). A mismatch invalidates the whole file.
+    pub model_id: String,
+    /// Output dimension of the vectors. A mismatch invalidates the whole file.
+    pub dim: u32,
+    /// content_key(model_id, text) -> L2-normalized vector.
+    pub entries: HashMap<u64, Box<[f32]>>,
+}
+
+impl EmbeddingCache {
+    /// An empty cache stamped with the current model identity + dimension.
+    pub fn new(model_id: String, dim: u32) -> Self {
+        Self {
+            version: EMBED_CACHE_VERSION,
+            model_id,
+            dim,
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Load a cache from disk, returning it ONLY if it deserializes cleanly AND
+    /// matches the given model identity + dimension. Any I/O error, corruption,
+    /// version mismatch, model mismatch, or dim mismatch yields `None`, which
+    /// the caller treats as "recompute everything" (advisory cache).
+    pub fn load_compatible(path: &Path, model_id: &str, dim: u32) -> Option<Self> {
+        let bytes = std::fs::read(path).ok()?;
+        let cache: EmbeddingCache = bincode::deserialize(&bytes).ok()?;
+        if cache.version != EMBED_CACHE_VERSION || cache.model_id != model_id || cache.dim != dim {
+            return None;
+        }
+        Some(cache)
+    }
+
+    /// Atomically persist the cache (temp + rename), mirroring the plasticity
+    /// sidecar's FM-PL-008 discipline. Callers treat failure as non-fatal.
+    pub fn save(&self, path: &Path) -> M1ndResult<()> {
+        let bytes =
+            bincode::serialize(self).map_err(|e| M1ndError::PersistenceFailed(e.to_string()))?;
+
+        let temp_path = path.with_extension("tmp");
+        {
+            let file = std::fs::File::create(&temp_path)?;
+            let mut writer = BufWriter::new(file);
+            writer.write_all(&bytes)?;
+            writer.flush()?;
+        }
+        std::fs::rename(&temp_path, path)?;
+        Ok(())
+    }
+}
+
+/// Stable FNV-1a 64-bit hash of (model_id, text). Deterministic across runs,
+/// builds, and platforms — unlike `std`'s `DefaultHasher` (random/unspecified
+/// seed) — so it is safe to persist as a cache key. A `0xff` separator byte
+/// between the two parts prevents boundary-collision aliasing.
+pub fn content_key(model_id: &str, text: &str) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = OFFSET;
+    for &b in model_id.as_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    h ^= 0xff;
+    h = h.wrapping_mul(PRIME);
+    for &b in text.as_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_key_is_deterministic_and_discriminating() {
+        let a = content_key("model-x", "graceful shutdown on cancel");
+        let b = content_key("model-x", "graceful shutdown on cancel");
+        let c = content_key("model-x", "strawberry cheesecake");
+        let d = content_key("model-y", "graceful shutdown on cancel");
+        assert_eq!(
+            a, b,
+            "same (model, text) must hash identically across calls"
+        );
+        assert_ne!(a, c, "different text must (practically) differ");
+        assert_ne!(a, d, "different model must (practically) differ");
+    }
+
+    #[test]
+    fn cache_round_trips_and_validates_identity() {
+        let tmp = std::env::temp_dir().join(format!(
+            "m1nd_embcache_test_{}.bin",
+            content_key("t", "round-trip")
+        ));
+
+        let mut cache = EmbeddingCache::new("local/potion-base-8M".to_string(), 256);
+        let k = content_key("local/potion-base-8M", "hello world");
+        let vec: Box<[f32]> = vec![0.1f32; 256].into_boxed_slice();
+        cache.entries.insert(k, vec.clone());
+        cache.save(&tmp).expect("save");
+
+        // Exact identity match -> Some, with entries preserved byte-for-byte.
+        let loaded = EmbeddingCache::load_compatible(&tmp, "local/potion-base-8M", 256)
+            .expect("compatible load");
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries.get(&k).map(|v| &v[..]), Some(&vec[..]));
+
+        // Model mismatch -> None (recompute).
+        assert!(
+            EmbeddingCache::load_compatible(&tmp, "other/model", 256).is_none(),
+            "model mismatch must invalidate the cache"
+        );
+        // Dim mismatch -> None (recompute).
+        assert!(
+            EmbeddingCache::load_compatible(&tmp, "local/potion-base-8M", 512).is_none(),
+            "dim mismatch must invalidate the cache"
+        );
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+}

--- a/m1nd-core/src/lib.rs
+++ b/m1nd-core/src/lib.rs
@@ -7,6 +7,8 @@ pub mod counterfactual;
 pub mod domain;
 #[cfg(feature = "embed")]
 pub mod embed;
+#[cfg(feature = "embed")]
+pub mod embed_cache;
 pub mod epidemic;
 pub mod error;
 pub mod flow;

--- a/m1nd-core/src/query.rs
+++ b/m1nd-core/src/query.rs
@@ -116,9 +116,26 @@ impl QueryOrchestrator {
     /// Build orchestrator from a graph. Initialises all subsystems.
     /// Replaces: engine_v2.py ConnectomeEngine.__init__()
     pub fn build(graph: &Graph) -> M1ndResult<Self> {
+        Self::build_with_cache(graph, None, false)
+    }
+
+    /// Like [`QueryOrchestrator::build`], but threads an optional embedding cache
+    /// path into the semantic engine (see [`SemanticEngine::build_with_cache`]).
+    /// The cache is written back only when `persist` is true (read-only sessions
+    /// pass `false`). Both args are ignored when the `embed` feature is off.
+    pub fn build_with_cache(
+        graph: &Graph,
+        cache_path: Option<&std::path::Path>,
+        persist: bool,
+    ) -> M1ndResult<Self> {
         let engine = HybridEngine::new();
         let xlr = AdaptiveXlrEngine::with_defaults();
-        let semantic = SemanticEngine::build(graph, SemanticWeights::default())?;
+        let semantic = SemanticEngine::build_with_cache(
+            graph,
+            SemanticWeights::default(),
+            cache_path,
+            persist,
+        )?;
         let temporal = TemporalEngine::build(graph)?;
         let topology = TopologyAnalyzer::with_defaults();
         let resonance = ResonanceEngine::with_defaults();

--- a/m1nd-core/src/semantic.rs
+++ b/m1nd-core/src/semantic.rs
@@ -575,10 +575,35 @@ pub struct SemanticEngine {
     pub embedder: Option<std::sync::Arc<crate::embed::Model2VecEmbedder>>,
 }
 
+/// Result of [`SemanticEngine::build_embeddings`]: per-node embeddings keyed by
+/// `NodeId`, plus the loaded embedder for query-time encoding.
+#[cfg(feature = "embed")]
+type EmbeddingBuild = (
+    HashMap<NodeId, Box<[f32]>>,
+    Option<std::sync::Arc<crate::embed::Model2VecEmbedder>>,
+);
+
 impl SemanticEngine {
     /// Build all three indexes from the graph.
     /// Replaces: semantic_v2.py SemanticEngine.__init__()
     pub fn build(graph: &Graph, weights: SemanticWeights) -> M1ndResult<Self> {
+        Self::build_with_cache(graph, weights, None, false)
+    }
+
+    /// Like [`SemanticEngine::build`], but when the `embed` feature is on and
+    /// `cache_path` is `Some`, per-node embeddings are loaded from a
+    /// content-addressed on-disk cache (keyed by a stable hash of model id +
+    /// node text), reusing unchanged vectors instead of recomputing them; only
+    /// changed/new nodes are re-embedded. The updated cache is written back ONLY
+    /// when `persist` is true — read-only attachers pass `false` so they reuse
+    /// the cache but never write it (one writer per file; honors the read-only
+    /// contract). `cache_path`/`persist` are ignored when the `embed` feature is off.
+    pub fn build_with_cache(
+        graph: &Graph,
+        weights: SemanticWeights,
+        cache_path: Option<&std::path::Path>,
+        persist: bool,
+    ) -> M1ndResult<Self> {
         let ngram = CharNgramIndex::build(graph, NGRAM_SIZE)?;
         let cooccurrence =
             CoOccurrenceIndex::build(graph, WALK_LENGTH, WALKS_PER_NODE, WINDOW_SIZE)?;
@@ -590,7 +615,9 @@ impl SemanticEngine {
         // vendored locally, we log and leave the map empty so `seek` cleanly
         // falls back to the legacy trigram path (ZERO behavior change).
         #[cfg(feature = "embed")]
-        let (embeddings, embedder) = Self::build_embeddings(graph);
+        let (embeddings, embedder) = Self::build_embeddings(graph, cache_path, persist);
+        #[cfg(not(feature = "embed"))]
+        let _ = (cache_path, persist); // unused without the embed feature
 
         Ok(Self {
             ngram,
@@ -605,16 +632,19 @@ impl SemanticEngine {
     }
 
     /// OPTIONAL `embed` feature: load the static embedder and embed every node's
-    /// (label + excerpt) text. Returns an empty map + None embedder if the model
-    /// cannot be loaded — never fails the build.
+    /// (label + excerpt) text, reusing a content-addressed on-disk cache when
+    /// `cache_path` is `Some`. The updated cache is persisted only when `persist`
+    /// is true (the lease-holding writer); read-only attachers load-but-never-write.
+    /// Returns an empty map + None embedder if the model cannot be loaded — never
+    /// fails the build.
     #[cfg(feature = "embed")]
     fn build_embeddings(
         graph: &Graph,
-    ) -> (
-        HashMap<NodeId, Box<[f32]>>,
-        Option<std::sync::Arc<crate::embed::Model2VecEmbedder>>,
-    ) {
+        cache_path: Option<&std::path::Path>,
+        persist: bool,
+    ) -> EmbeddingBuild {
         use crate::embed::{Embedder, Model2VecEmbedder};
+        use crate::embed_cache::{content_key, EmbeddingCache};
 
         let embedder = match Model2VecEmbedder::from_default() {
             Ok(e) => std::sync::Arc::new(e),
@@ -624,8 +654,20 @@ impl SemanticEngine {
             }
         };
 
+        let model_id = embedder.model_id().to_string();
+        let dim = embedder.dim() as u32;
+
+        // Warm cache: reuse vectors whose (model, text) are unchanged. Any
+        // version/model/dim mismatch or corruption yields None (full recompute).
+        let warm = cache_path.and_then(|p| EmbeddingCache::load_compatible(p, &model_id, dim));
+
         let n = graph.num_nodes() as usize;
         let mut map: HashMap<NodeId, Box<[f32]>> = HashMap::with_capacity(n);
+        // Persisted set = EXACTLY the current graph's entries (self-pruning: no
+        // stale accumulation across re-ingests or repos sharing a cache file).
+        let mut next = EmbeddingCache::new(model_id.clone(), dim);
+        let (mut hits, mut misses) = (0usize, 0usize);
+
         for i in 0..n {
             let label = graph.strings.resolve(graph.nodes.label[i]);
             let text = match graph.nodes.provenance[i].excerpt {
@@ -639,8 +681,34 @@ impl SemanticEngine {
                 }
                 None => label.to_string(),
             };
-            map.insert(NodeId::new(i as u32), embedder.embed(&text));
+            let key = content_key(&model_id, &text);
+            let vec: Box<[f32]> = match warm.as_ref().and_then(|c| c.entries.get(&key)) {
+                Some(v) if v.len() == dim as usize => {
+                    hits += 1;
+                    v.clone()
+                }
+                _ => {
+                    misses += 1;
+                    embedder.embed(&text)
+                }
+            };
+            next.entries.entry(key).or_insert_with(|| vec.clone());
+            map.insert(NodeId::new(i as u32), vec);
         }
+
+        // Best-effort persist (atomic temp+rename); never fatal. Only the
+        // writable (lease-holding) owner persists — read-only attachers reuse the
+        // cache but never write it, keeping a single writer per cache file.
+        if let (true, Some(p)) = (persist, cache_path) {
+            match next.save(p) {
+                Ok(()) => eprintln!(
+                    "[m1nd embed] cache {hits} reused / {misses} new of {n} nodes -> {}",
+                    p.display()
+                ),
+                Err(e) => eprintln!("[m1nd embed] cache save failed: {e}; continuing"),
+            }
+        }
+
         (map, Some(embedder))
     }
 

--- a/m1nd-core/tests/embed_cache_warm.rs
+++ b/m1nd-core/tests/embed_cache_warm.rs
@@ -1,0 +1,148 @@
+#![cfg(feature = "embed")]
+//! Integration proof for the on-disk embedding cache (OPTIONAL `embed` feature).
+//!
+//! A warm `SemanticEngine::build_with_cache` must CONSULT the cache: a preseeded
+//! sentinel vector (one the model would never emit) is returned verbatim for the
+//! matching node, proving a real cache HIT — while a node absent from the cache
+//! is freshly embedded (a MISS) and the build re-persists exactly the current
+//! graph's entries (self-pruning).
+//!
+//! Skipped when the model blob is not vendored locally (e.g. CI without Git-LFS),
+//! matching the `embed.rs` unit-test convention — never failed for a missing model.
+
+use m1nd_core::builder::GraphBuilder;
+use m1nd_core::embed::{Embedder, Model2VecEmbedder};
+use m1nd_core::embed_cache::{content_key, EmbeddingCache};
+use m1nd_core::semantic::SemanticEngine;
+use m1nd_core::types::{NodeType, SemanticWeights};
+
+fn model_available() -> bool {
+    Model2VecEmbedder::default_model_dir()
+        .join("model.safetensors")
+        .exists()
+}
+
+#[test]
+fn warm_build_reuses_preseeded_cache_vector() {
+    if !model_available() {
+        eprintln!("SKIP warm_build_reuses_preseeded_cache_vector: model not vendored");
+        return;
+    }
+
+    // Identity of the live model — exactly what build_embeddings records.
+    let emb = Model2VecEmbedder::from_default().expect("load model");
+    let model_id = emb.model_id().to_string();
+    let dim = emb.dim();
+
+    // Tiny graph: a node we will preseed, and a node we will not.
+    let mut b = GraphBuilder::new();
+    let sentinel = b
+        .add_node(
+            "n_sentinel",
+            "sentinel_probe_label",
+            NodeType::Function,
+            &[],
+        )
+        .expect("add sentinel node");
+    let fresh = b
+        .add_node(
+            "n_fresh",
+            "totally_different_label",
+            NodeType::Function,
+            &[],
+        )
+        .expect("add fresh node");
+    let graph = b.finalize().expect("finalize graph");
+
+    // Preseed the cache with a NON-normalized marker (all 7.0) the model could
+    // never produce, keyed by the sentinel node's embed text (label, no excerpt).
+    let cache_path = std::env::temp_dir().join(format!(
+        "m1nd_embed_warm_{}.bin",
+        content_key(&model_id, "sentinel_probe_label")
+    ));
+    let _ = std::fs::remove_file(&cache_path);
+    let mut seed = EmbeddingCache::new(model_id.clone(), dim as u32);
+    let marker: Box<[f32]> = vec![7.0f32; dim].into_boxed_slice();
+    seed.entries.insert(
+        content_key(&model_id, "sentinel_probe_label"),
+        marker.clone(),
+    );
+    seed.save(&cache_path).expect("seed cache");
+
+    let engine = SemanticEngine::build_with_cache(
+        &graph,
+        SemanticWeights::default(),
+        Some(&cache_path),
+        true, // persist = true (writable owner)
+    )
+    .expect("build with cache");
+
+    // Cache HIT: the sentinel node is the preseeded marker verbatim.
+    let got_sentinel = engine
+        .embeddings
+        .get(&sentinel)
+        .expect("sentinel node embedded");
+    assert_eq!(
+        &got_sentinel[..],
+        &marker[..],
+        "warm build must return the preseeded cache vector (cache HIT)"
+    );
+
+    // Cache MISS: the fresh node is a real, L2-normalized embedding.
+    let got_fresh = engine.embeddings.get(&fresh).expect("fresh node embedded");
+    let norm: f32 = got_fresh.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        (norm - 1.0).abs() < 1e-3,
+        "cache-missed node must be a real L2-normalized embedding, got norm {norm}"
+    );
+
+    // Self-pruning persist: the saved cache holds EXACTLY the current graph's two
+    // node texts (both the reused sentinel and the newly embedded fresh node).
+    let reload = EmbeddingCache::load_compatible(&cache_path, &model_id, dim as u32)
+        .expect("saved cache still compatible");
+    assert_eq!(
+        reload.entries.len(),
+        2,
+        "cache must hold exactly the 2 nodes"
+    );
+    assert!(
+        reload
+            .entries
+            .contains_key(&content_key(&model_id, "totally_different_label")),
+        "freshly embedded node must be persisted into the cache"
+    );
+
+    let _ = std::fs::remove_file(&cache_path);
+}
+
+/// Read-only sessions (persist=false) must REUSE a warm cache but NEVER write
+/// one — the major adversarial-review finding. A non-persisting build over a
+/// fresh (nonexistent) cache path must leave no file behind.
+#[test]
+fn non_persisting_build_never_writes_cache() {
+    if !model_available() {
+        eprintln!("SKIP non_persisting_build_never_writes_cache: model not vendored");
+        return;
+    }
+
+    let mut b = GraphBuilder::new();
+    b.add_node("n_ro", "read_only_probe_label", NodeType::Function, &[])
+        .expect("add node");
+    let graph = b.finalize().expect("finalize graph");
+
+    let cache_path = std::env::temp_dir().join("m1nd_embed_nopersist_probe.bin");
+    let _ = std::fs::remove_file(&cache_path);
+
+    let _engine = SemanticEngine::build_with_cache(
+        &graph,
+        SemanticWeights::default(),
+        Some(&cache_path),
+        false, // persist = false (read-only attacher)
+    )
+    .expect("build without persist");
+
+    assert!(
+        !cache_path.exists(),
+        "persist=false (read-only) must not write the cache file"
+    );
+}

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -310,6 +310,9 @@ pub struct SessionState {
     pub graph_path: PathBuf,
     /// Path to plasticity state file.
     pub plasticity_path: PathBuf,
+    /// Path to the on-disk embedding cache (OPTIONAL `embed` feature). Derived
+    /// from the runtime root; reused across warm boots and re-ingests.
+    pub embeddings_cache_path: PathBuf,
     /// Per-agent session tracking.
     pub sessions: HashMap<String, AgentSession>,
     /// In-memory preview states for Ultra Edit phase 1.
@@ -1186,17 +1189,8 @@ impl SessionState {
         config: &crate::server::McpConfig,
         domain: DomainConfig,
     ) -> M1ndResult<Self> {
-        // Build all engines from graph
-        let orchestrator = QueryOrchestrator::build(&graph)?;
-        let temporal = TemporalEngine::build(&graph)?;
-        let counterfactual = CounterfactualEngine::with_defaults();
-        let topology = TopologyAnalyzer::with_defaults();
-        let resonance = ResonanceEngine::with_defaults();
-        let plasticity =
-            PlasticityEngine::new(&graph, m1nd_core::plasticity::PlasticityConfig::default());
-
-        let shared = Arc::new(parking_lot::RwLock::new(graph));
-
+        // Resolve the runtime root up front so the embedding cache (and its
+        // directory) exist before any engine build writes to them.
         let runtime_root = config.runtime_dir.clone().unwrap_or_else(|| {
             config
                 .graph_source
@@ -1205,6 +1199,27 @@ impl SessionState {
                 .to_path_buf()
         });
         std::fs::create_dir_all(&runtime_root)?;
+        // OPTIONAL `embed` feature: per-node embeddings are cached on disk next
+        // to the snapshot so a warm boot reuses them instead of recomputing.
+        // Ignored entirely when the `embed` feature is off.
+        let embeddings_cache_path = runtime_root.join("embeddings_cache.bin");
+
+        // Build all engines from graph (semantic reuses the embedding cache).
+        // Only the writable owner persists the cache; a read-only attacher reuses
+        // it but never writes (honoring the read-only "persistence disabled" contract).
+        let orchestrator = QueryOrchestrator::build_with_cache(
+            &graph,
+            Some(&embeddings_cache_path),
+            !config.read_only,
+        )?;
+        let temporal = TemporalEngine::build(&graph)?;
+        let counterfactual = CounterfactualEngine::with_defaults();
+        let topology = TopologyAnalyzer::with_defaults();
+        let resonance = ResonanceEngine::with_defaults();
+        let plasticity =
+            PlasticityEngine::new(&graph, m1nd_core::plasticity::PlasticityConfig::default());
+
+        let shared = Arc::new(parking_lot::RwLock::new(graph));
         let (workspace_root, workspace_root_source) =
             Self::infer_workspace_root(config, &runtime_root);
         let instance_mode = if config.read_only {
@@ -1242,6 +1257,7 @@ impl SessionState {
             last_persist_time: None,
             graph_path: config.graph_source.clone(),
             plasticity_path: config.plasticity_state.clone(),
+            embeddings_cache_path,
             sessions: HashMap::new(),
             edit_previews: HashMap::new(),
             // Perspective MCP state
@@ -1543,7 +1559,11 @@ impl SessionState {
         // Scope the read lock so it's dropped before &mut self methods
         {
             let graph = self.graph.read();
-            self.orchestrator = QueryOrchestrator::build(&graph)?;
+            self.orchestrator = QueryOrchestrator::build_with_cache(
+                &graph,
+                Some(&self.embeddings_cache_path),
+                !self.read_only,
+            )?;
             self.temporal = TemporalEngine::build(&graph)?;
             self.plasticity =
                 PlasticityEngine::new(&graph, m1nd_core::plasticity::PlasticityConfig::default());


### PR DESCRIPTION
## What

With the optional `embed` feature on, every boot and re-ingest recomputed each node's static embedding (model load + N encodes) — the main cost of keeping `embed` warm. This adds an on-disk cache so unchanged nodes are reused and only changed/new nodes are re-embedded. Warm boots become near-instant; re-ingests only re-embed what changed.

## How

- **`embed_cache.rs`** — `EmbeddingCache` (bincode, atomic temp+rename) keyed by a stable FNV-1a hash of `(model_id, label+excerpt)`. `load_compatible()` rejects any version/model/dim mismatch or corruption, so a stale cache never yields a wrong vector — it just recomputes.
- **`SemanticEngine::build_with_cache(graph, weights, cache_path, persist)`** — loads the warm cache, reuses matching vectors, re-embeds the rest, and writes back exactly the current graph's entries (self-pruning). The in-memory map stays keyed by `NodeId`; the `seek` path is unchanged.
- Threaded through `QueryOrchestrator` and `SessionState`; the cache lives next to the snapshot in the runtime dir and refreshes on boot and re-ingest.
- `model_id` folds the weights-file byte length, so an in-place model swap invalidates the cache.
- **Read-only attachers reuse the cache but never write it** (one writer per file, honoring the read-only "persistence disabled" contract).

## Safety

OFF by default behind `embed`; the non-embed build is byte-identical. The cache is advisory — any doubt → recompute, never a wrong vector. Self-pruning means no unbounded growth or cross-repo contamination.

## Tests

- Unit: cache round-trip + identity validation; hash determinism/discrimination.
- Integration (vendored model): a preseeded sentinel vector is returned verbatim (cache HIT proven), a fresh node is a real L2-normalized embedding, and a `persist=false` build leaves no file (read-only never writes).
- Full `m1nd-core --features embed` and `m1nd-mcp` suites green; clippy clean.
