### PR TITLE
feat(ingest): behavioral excerpt for code symbols (richer embeddings)

### DIFF
--- a/m1nd-ingest/src/extract/mod.rs
+++ b/m1nd-ingest/src/extract/mod.rs
@@ -371,6 +371,67 @@ pub struct ExtractionResult {
     pub unresolved_refs: Vec<String>,
 }
 
+/// Max source lines folded into a code symbol's excerpt (signature + a few body
+/// lines) and the hard character budget on the joined result.
+pub const EXCERPT_MAX_LINES: usize = 4;
+pub const EXCERPT_MAX_CHARS: usize = 240;
+
+/// Derive a short behavioral excerpt for each non-File symbol from its own source
+/// span (signature + first body lines), so downstream embeddings capture what a
+/// symbol DOES — not just its name (without this, code symbols embed label-only).
+/// Returns `(node_id, excerpt)` pairs; nodes with no usable span are omitted.
+/// Language-agnostic: it slices the file text by the node's `[line, end_line]`
+/// range. Non-UTF-8 content and File nodes are skipped.
+pub fn compute_excerpts(result: &ExtractionResult, content: &[u8]) -> Vec<(String, String)> {
+    let text = match std::str::from_utf8(content) {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out = Vec::new();
+    for node in &result.nodes {
+        if node.node_type == NodeType::File || node.line == 0 {
+            continue;
+        }
+        let start = (node.line as usize) - 1;
+        if start >= lines.len() {
+            continue;
+        }
+        // Cap by the symbol's real end ONLY when the extractor tracked it
+        // (end_line > line). Regex-based extractors leave end_line == line, so
+        // fall back to the line budget to still fold in the first body lines —
+        // the behavioral signal — rather than the signature alone.
+        let upper = if (node.end_line as usize) > (node.line as usize) {
+            (node.end_line as usize).min(lines.len())
+        } else {
+            lines.len()
+        };
+        let stop = (start + EXCERPT_MAX_LINES)
+            .min(upper)
+            .max(start + 1)
+            .min(lines.len());
+        let mut excerpt = String::new();
+        for line in &lines[start..stop] {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !excerpt.is_empty() {
+                excerpt.push(' ');
+            }
+            excerpt.push_str(trimmed);
+            if excerpt.chars().count() >= EXCERPT_MAX_CHARS {
+                break;
+            }
+        }
+        let excerpt: String = excerpt.chars().take(EXCERPT_MAX_CHARS).collect();
+        if !excerpt.is_empty() {
+            out.push((node.id.clone(), excerpt));
+        }
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Extractor — trait for language-specific extraction
 // Replaces: ingest.py PythonExtractor, TypeScriptExtractor, etc.
@@ -387,4 +448,50 @@ pub trait Extractor: Send + Sync {
 
     /// File extensions this extractor handles.
     fn extensions(&self) -> &[&str];
+}
+
+#[cfg(test)]
+mod excerpt_tests {
+    use super::*;
+
+    #[test]
+    fn compute_excerpts_slices_signature_and_body_and_skips_files() {
+        let src = "// header\npub fn drain_inflight(ctx: &Ctx) -> Result<()> {\n    abort_running_work();\n    stop_accepting_tasks();\n}\n";
+        let result = ExtractionResult {
+            nodes: vec![
+                ExtractedNode {
+                    id: "file::x.rs::fn::drain_inflight".into(),
+                    label: "drain_inflight".into(),
+                    node_type: NodeType::Function,
+                    tags: vec![],
+                    line: 2, // the `pub fn ...` line (1-based)
+                    end_line: 5,
+                },
+                ExtractedNode {
+                    id: "file::x.rs".into(),
+                    label: "x.rs".into(),
+                    node_type: NodeType::File,
+                    tags: vec![],
+                    line: 1,
+                    end_line: 5,
+                },
+            ],
+            edges: vec![],
+            unresolved_refs: vec![],
+        };
+        let ex = compute_excerpts(&result, src.as_bytes());
+        // File node is skipped; the function node gets a behavioral excerpt.
+        assert_eq!(ex.len(), 1, "only the non-file symbol gets an excerpt");
+        let (id, text) = &ex[0];
+        assert_eq!(id, "file::x.rs::fn::drain_inflight");
+        assert!(
+            text.contains("drain_inflight"),
+            "excerpt carries the signature: {text}"
+        );
+        assert!(
+            text.contains("abort_running_work"),
+            "excerpt folds in the first body line(s): {text}"
+        );
+        assert!(text.chars().count() <= EXCERPT_MAX_CHARS);
+    }
 }

--- a/m1nd-ingest/src/lib.rs
+++ b/m1nd-ingest/src/lib.rs
@@ -240,7 +240,9 @@ impl Ingestor {
                 detail: format!("thread pool: {}", e),
             })?;
 
-        let extraction_results: Vec<(String, extract::ExtractionResult)> = pool.install(|| {
+        // (file_id, extraction result, [(node_id, behavioral excerpt)])
+        type FileExtraction = (String, extract::ExtractionResult, Vec<(String, String)>);
+        let extraction_results: Vec<FileExtraction> = pool.install(|| {
             walk_result
                 .files
                 .par_iter()
@@ -259,7 +261,10 @@ impl Ingestor {
                         }
                     };
                     let result = extractor.extract(&content, &file_id).ok()?;
-                    Some((file_id, result))
+                    // Behavioral excerpts sliced here while the file content is live,
+                    // so embeddings later see what each symbol DOES, not just its name.
+                    let excerpts = extract::compute_excerpts(&result, &content);
+                    Some((file_id, result, excerpts))
                 })
                 .collect()
         });
@@ -278,9 +283,23 @@ impl Ingestor {
             })
             .collect();
 
+        // Flatten per-file excerpts into a global node_id -> excerpt map (bounded
+        // ~240 chars/node), consumed at provenance time below. FIRST-WINS on a
+        // duplicate id, to match graph insertion: the first node with an id wins
+        // `add_node` (later dups are dropped as DuplicateNode), so the surviving
+        // node must keep ITS OWN excerpt, not a later same-named sibling's.
+        let mut node_excerpts: HashMap<String, String> = HashMap::new();
+        for (_, _, excerpts) in &extraction_results {
+            for (id, excerpt) in excerpts {
+                node_excerpts
+                    .entry(id.clone())
+                    .or_insert_with(|| excerpt.clone());
+            }
+        }
+
         let mut all_nodes: Vec<(String, extract::ExtractedNode)> = Vec::new();
         let mut all_edges = Vec::new();
-        for (file_id, result) in &extraction_results {
+        for (file_id, result, _) in &extraction_results {
             if start.elapsed() > self.config.timeout {
                 eprintln!("[m1nd-ingest] Timeout after {} files", stats.files_parsed);
                 break;
@@ -343,6 +362,7 @@ impl Ingestor {
                                 source_path: Some(source_path),
                                 line_start: Some(node.line),
                                 line_end: Some(node.end_line),
+                                excerpt: node_excerpts.get(&node.id).map(String::as_str),
                                 ..Default::default()
                             },
                         );
@@ -560,6 +580,15 @@ mod tests {
             prov.line_start,
             Some(3),
             "provenance line_start must be the function's real opening line"
+        );
+
+        // The symbol now also carries a behavioral excerpt sliced from its own
+        // source span (signature + body), so embeddings capture what it DOES —
+        // not just its name. (Drives the seek semantic layer end to end.)
+        let excerpt = prov.excerpt.as_deref().unwrap_or("");
+        assert!(
+            excerpt.contains("answer") && excerpt.contains("42"),
+            "provenance excerpt must fold in the signature + body, got {excerpt:?}"
         );
 
         let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
## What

Code symbols (functions, structs, classes) were ingested with **no excerpt**, so the optional embedding layer embedded them by NAME alone (e.g. `drain_inflight`) — missing what they actually *do*. This slices a short behavioral excerpt (signature + first body lines) from each symbol's own source span, so embeddings capture behavior, not just the name. This is the real quality lever for semantic `seek` on code — a bigger win than any lookup-speed change.

## How

- **`extract::compute_excerpts(result, content)`** — for every non-File symbol, joins up to 4 trimmed source lines / 240 chars from `[line, end_line]`, capping by `end_line` only when the extractor tracked it (regex extractors leave `end_line == line`, so the line budget still folds in the first body lines). Skips File nodes and non-UTF-8 content; never slices on byte boundaries.
- **Ingestor** — the excerpt is computed in the extraction closure while the file content is live (no content retained), flattened into a `node_id -> excerpt` map (**first-wins**, matching `add_node`'s first-wins on duplicate ids), and set as `provenance.excerpt`.

`build_embeddings` already embeds `label + excerpt`, so this enriches the embed layer with **zero changes there**, and the content-addressed cache re-embeds only the changed nodes. The doc/adapter ingest paths are separate entrypoints and are unaffected.

## Verification

- Unit test (signature + body folded, File nodes skipped) + extended the provenance ingest test to assert the excerpt end to end through the real `Ingestor`.
- Full `m1nd-ingest` (200) and `m1nd-mcp` (~573) suites green; `cargo clippy --workspace -- -D warnings` + `fmt --check` clean.
- Adversarial review (UTF-8 / bounds / bleed / duplicate-ids / consumers / memory): no blockers; the one duplicate-id wart it found is fixed (first-wins keying).
