### PR TITLE
feat(seek): explain why an empty result is empty (filtering_reason)

### DIFF
--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -120,6 +120,13 @@ pub fn handle_seek(
             query: input.query,
             results: vec![],
             total_candidates_scanned: 0,
+            filtering_reason: Some(match error_text {
+                Some(_) => {
+                    "the query produced no searchable tokens; provide concrete identifiers or words"
+                        .to_string()
+                }
+                None => format!("the graph is empty ({n} nodes); run `ingest` before querying"),
+            }),
             embeddings_used: false,
             proof_state: "blocked".into(),
             elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
@@ -586,10 +593,23 @@ pub fn handle_seek(
             .collect::<Vec<_>>(),
     );
 
+    let filtering_reason = if !results.is_empty() {
+        None
+    } else if candidates_scanned == 0 {
+        Some(format!(
+            "the active scope/node_types filter excluded all {n} graph node(s) before scoring — relax `scope`/`node_types`, or run `doctor` to check the binding"
+        ))
+    } else {
+        Some(format!(
+            "{candidates_scanned} of {n} node(s) passed scope/type but none cleared the relevance threshold for this query — broaden the query terms or lower `min_score`"
+        ))
+    };
+
     Ok(layers::SeekOutput {
         query: input.query,
         results,
         total_candidates_scanned: candidates_scanned,
+        filtering_reason,
         // TRUTHFUL: true ONLY when a real static embedding actually fed a node's
         // score (OPTIONAL `embed` feature). With the feature OFF this is always
         // false. Previously this aliased `semantic_used` (the trigram path),
@@ -9949,6 +9969,61 @@ mod tests {
             },
         )
         .expect("seek should succeed")
+    }
+
+    #[test]
+    fn seek_empty_result_explains_why_via_filtering_reason() {
+        // A graph with one Function node; a query with no lexical/semantic match
+        // is scored but falls below the relevance threshold, so the result set is
+        // empty WITH a reason — the agent learns why instead of blindly re-querying.
+        let tmp =
+            std::env::temp_dir().join(format!("m1nd_seek_filterreason_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let runtime_dir = tmp.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut graph = Graph::new();
+        graph
+            .add_node("fn::do_work", "do_work", NodeType::Function, &[], 0.0, 0.0)
+            .expect("add node");
+        graph.finalize().expect("finalize");
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![tmp.to_string_lossy().to_string()];
+        state.workspace_root = Some(tmp.to_string_lossy().to_string());
+
+        let out = handle_seek(
+            &mut state,
+            SeekInput {
+                query: "zzqxwv unrelated gibberish nonmatching".into(),
+                agent_id: "t".into(),
+                top_k: 5,
+                scope: None,
+                node_types: vec![],
+                min_score: 0.0,
+                graph_rerank: true,
+                token_budget: None,
+            },
+        )
+        .expect("seek ok");
+
+        assert!(
+            out.results.is_empty(),
+            "a query with no lexical/semantic match should return no results, got {:?}",
+            out.results.iter().map(|r| &r.label).collect::<Vec<_>>()
+        );
+        let reason = out.filtering_reason.as_deref().unwrap_or("");
+        assert!(
+            reason.contains("threshold") || reason.contains("none cleared"),
+            "an empty seek must explain WHY (relevance threshold), got {reason:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// Build a state whose graph has many seek-matching file nodes, so that

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -89,6 +89,12 @@ pub struct SeekOutput {
     pub query: String,
     pub results: Vec<SeekResultEntry>,
     pub total_candidates_scanned: usize,
+    /// Present only when retrieval returned NO results: a plain-English reason the
+    /// result set is empty (empty graph, no searchable tokens, scope/type filtered
+    /// everything, or nothing cleared the relevance threshold), so an agent can
+    /// adjust the query instead of blindly re-querying.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filtering_reason: Option<String>,
     /// Whether embeddings were used (false = fallback to trigram/semantic engine).
     pub embeddings_used: bool,
     /// Coarse proof stage for semantic retrieval:


### PR DESCRIPTION
## What
When `seek` returns no results, an agent often **re-queries blindly**. This adds an honest, plain-English `filtering_reason` to `SeekOutput` so the agent can adjust the query instead of guessing.

## How
`filtering_reason: Option<String>` is populated only when the result set is empty, classified from signals already in hand:
- **empty graph / no searchable tokens** (early-return path),
- the **scope/node_types filter excluded every node** before scoring (`candidates_scanned == 0`),
- **N of M nodes passed scope/type but none cleared the relevance threshold** (`candidates_scanned > 0`).

`#[serde(skip_serializing_if = "Option::is_none")]` → the field appears **only on an empty result**, zero change to populated responses (backward-compatible). No extra work in the hot scoring loop — it reuses `n` and `candidates_scanned`.

## Verification
New test `seek_empty_result_explains_why_via_filtering_reason`: a query with no lexical/semantic match returns empty with the threshold reason (`"1 of 1 node(s) passed scope/type but none cleared the relevance threshold…"`). Full `m1nd-mcp` suite (458) green; `clippy --workspace -D warnings` + `fmt` clean.
