### PR TITLE
docs(operator): document seek semantic recall + filtering_reason

### DIFF
--- a/skills/m1nd-operator/references/tool-families.md
+++ b/skills/m1nd-operator/references/tool-families.md
@@ -33,6 +33,18 @@ This is the compact capability inventory for the current `m1nd` shape. Use the l
 - `scan_all`: run all structural patterns in one call.
 - `timeline`: temporal history, churn, velocity, stability, and co-change shape.
 
+> `seek` semantic recall: when the server binary is built with the optional
+> `embed` feature (and a model is present), `seek` also matches by MEANING —
+> embeddings over each symbol's doc-comment + signature + body — so it surfaces a
+> node whose intent matches even with ZERO shared tokens (e.g. a query "secure
+> channel" reaching `fn qz9wb` documented as "TLS encrypted tunnel"). The
+> response's `embeddings_used` tells you whether this fired (`false` = trigram /
+> keyword fallback — still useful, just lexical). These are fast STATIC
+> embeddings (model2vec) — a real upgrade over trigrams but NOT transformer-grade.
+> When `seek` returns no results, `filtering_reason` states why (empty graph /
+> scope-or-type filtered everything / nothing cleared the relevance threshold) —
+> adjust the query or scope instead of re-running blind.
+
 ## Change-Risk And Plan Validation
 
 - `impact`: blast radius from a node.


### PR DESCRIPTION
## What
The operator skill didn't mention the optional `embed` **semantic recall** or the honest response fields shipped this week, so agents can't leverage them. Adds a concise note to the *Retrieval By Intent* tool family.

## The note covers
- `seek` matches by **meaning** when the binary is built with `embed` (embeddings over each symbol's doc-comment + signature + body) — surfacing nodes with **zero shared tokens**.
- `embeddings_used` signals whether semantic recall fired (`false` = trigram/keyword fallback).
- Honest caveat: **static embeddings (model2vec), not transformer-grade**.
- `filtering_reason` explains an empty result so an agent adjusts instead of re-querying blind.

Docs-only (markdown in `skills/`); no code paths touched.
