### PR TITLE
test(core): cover 8 load-bearing under-tested m1nd-core modules

### DIFF
--- a/m1nd-core/tests/domain_half_life_table_invariants.rs
+++ b/m1nd-core/tests/domain_half_life_table_invariants.rs
@@ -1,0 +1,213 @@
+//! Locks the DomainConfig half-life table: per-type overrides, default fallback,
+//! and the finite-&-positive invariant that keeps the LN2/half_life decay rate in
+//! temporal.rs from dividing by zero or NaN-poisoning. Surfaced by the X-RAY
+//! coverage sweep over m1nd-core::domain.
+//!
+//! Each profile (code/music/memory/light/generic) is checked so that:
+//!
+//! * a mapped NodeType returns exactly its declared override;
+//! * an unmapped NodeType falls back to `default_half_life`;
+//! * every returned half-life is finite and strictly positive.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::types::NodeType;
+
+/// Every NodeType variant the engine can stamp on a node. `Custom` carries a
+/// payload byte, so it is exercised separately below.
+const FIXED_NODE_TYPES: &[NodeType] = &[
+    NodeType::File,
+    NodeType::Directory,
+    NodeType::Function,
+    NodeType::Class,
+    NodeType::Struct,
+    NodeType::Enum,
+    NodeType::Type,
+    NodeType::Module,
+    NodeType::Reference,
+    NodeType::Concept,
+    NodeType::Material,
+    NodeType::Process,
+    NodeType::Product,
+    NodeType::Supplier,
+    NodeType::Regulatory,
+    NodeType::System,
+    NodeType::Cost,
+];
+
+/// The decay rate in temporal.rs is `LN2 / half_life`; a zero, negative, NaN, or
+/// infinite half-life would divide-by-zero or poison every downstream score.
+/// Assert the invariant holds for every node type across every profile.
+fn assert_all_half_lives_finite_positive(config: &DomainConfig, profile: &str) {
+    for &node_type in FIXED_NODE_TYPES {
+        let hl = config.half_life_for(node_type);
+        assert!(
+            hl.is_finite(),
+            "{profile}: half_life_for({node_type:?}) must be finite, got {hl}"
+        );
+        assert!(
+            hl > 0.0,
+            "{profile}: half_life_for({node_type:?}) must be > 0, got {hl}"
+        );
+    }
+
+    // Custom(_) is also a stampable type and must obey the same invariant.
+    for payload in [0u8, 7, 255] {
+        let node_type = NodeType::Custom(payload);
+        let hl = config.half_life_for(node_type);
+        assert!(
+            hl.is_finite(),
+            "{profile}: half_life_for(Custom({payload})) must be finite, got {hl}"
+        );
+        assert!(
+            hl > 0.0,
+            "{profile}: half_life_for(Custom({payload})) must be > 0, got {hl}"
+        );
+    }
+}
+
+/// Confirm that each explicitly-mapped (NodeType -> half-life) override is
+/// returned verbatim. These constants encode the intended decay schedule for the
+/// profile; drifting them silently would change retention behavior.
+fn assert_overrides(config: &DomainConfig, profile: &str, overrides: &[(NodeType, f32)]) {
+    for &(node_type, expected) in overrides {
+        let actual = config.half_life_for(node_type);
+        assert_eq!(
+            actual, expected,
+            "{profile}: half_life_for({node_type:?}) override mismatch"
+        );
+    }
+}
+
+#[test]
+fn code_profile_overrides_and_invariants() {
+    let config = DomainConfig::code();
+    assert_overrides(
+        &config,
+        "code",
+        &[
+            (NodeType::File, 168.0),
+            (NodeType::Function, 336.0),
+            (NodeType::Class, 504.0),
+            (NodeType::Struct, 504.0),
+            (NodeType::Enum, 504.0),
+            (NodeType::Module, 720.0),
+            (NodeType::Directory, 720.0),
+            (NodeType::Type, 504.0),
+        ],
+    );
+    // Cost is unmapped in the code profile -> must fall back to the default.
+    assert_eq!(
+        config.half_life_for(NodeType::Cost),
+        config.default_half_life,
+        "code: unmapped NodeType::Cost must use default_half_life"
+    );
+    assert_all_half_lives_finite_positive(&config, "code");
+}
+
+#[test]
+fn music_profile_overrides_and_invariants() {
+    let config = DomainConfig::music();
+    assert_overrides(
+        &config,
+        "music",
+        &[
+            (NodeType::System, 720.0),
+            (NodeType::Process, 336.0),
+            (NodeType::Material, 168.0),
+            (NodeType::Concept, 504.0),
+        ],
+    );
+    // File is unmapped in the music profile -> must fall back to the default.
+    assert_eq!(
+        config.half_life_for(NodeType::File),
+        config.default_half_life,
+        "music: unmapped NodeType::File must use default_half_life"
+    );
+    assert_all_half_lives_finite_positive(&config, "music");
+}
+
+#[test]
+fn memory_profile_overrides_and_invariants() {
+    let config = DomainConfig::memory();
+    assert_overrides(
+        &config,
+        "memory",
+        &[
+            (NodeType::File, 1008.0),
+            (NodeType::Module, 720.0),
+            (NodeType::Concept, 720.0),
+            (NodeType::Process, 168.0),
+            (NodeType::Reference, 336.0),
+            (NodeType::System, 840.0),
+        ],
+    );
+    // Function is unmapped in the memory profile -> must fall back to the default.
+    assert_eq!(
+        config.half_life_for(NodeType::Function),
+        config.default_half_life,
+        "memory: unmapped NodeType::Function must use default_half_life"
+    );
+    assert_all_half_lives_finite_positive(&config, "memory");
+}
+
+#[test]
+fn light_profile_overrides_and_invariants() {
+    let config = DomainConfig::light();
+    assert_overrides(
+        &config,
+        "light",
+        &[
+            (NodeType::File, 1440.0),
+            (NodeType::Module, 1080.0),
+            (NodeType::Concept, 1080.0),
+            (NodeType::Process, 720.0),
+            (NodeType::Reference, 840.0),
+            (NodeType::System, 1440.0),
+        ],
+    );
+    // Cost is unmapped in the light profile -> must fall back to the default.
+    assert_eq!(
+        config.half_life_for(NodeType::Cost),
+        config.default_half_life,
+        "light: unmapped NodeType::Cost must use default_half_life"
+    );
+    assert_all_half_lives_finite_positive(&config, "light");
+}
+
+#[test]
+fn generic_profile_uses_default_for_every_type() {
+    let config = DomainConfig::generic();
+    // The generic profile ships an empty half_lives map: EVERY node type must
+    // resolve to default_half_life.
+    for &node_type in FIXED_NODE_TYPES {
+        assert_eq!(
+            config.half_life_for(node_type),
+            config.default_half_life,
+            "generic: {node_type:?} must resolve to default_half_life (empty map)"
+        );
+    }
+    assert_all_half_lives_finite_positive(&config, "generic");
+}
+
+#[test]
+fn every_profile_default_half_life_is_finite_positive() {
+    let profiles: &[(&str, DomainConfig)] = &[
+        ("code", DomainConfig::code()),
+        ("music", DomainConfig::music()),
+        ("memory", DomainConfig::memory()),
+        ("light", DomainConfig::light()),
+        ("generic", DomainConfig::generic()),
+    ];
+    for (profile, config) in profiles {
+        assert!(
+            config.default_half_life.is_finite(),
+            "{profile}: default_half_life must be finite, got {}",
+            config.default_half_life
+        );
+        assert!(
+            config.default_half_life > 0.0,
+            "{profile}: default_half_life must be > 0, got {}",
+            config.default_half_life
+        );
+    }
+}

--- a/m1nd-core/tests/plasticity_priming_signal_behavior.rs
+++ b/m1nd-core/tests/plasticity_priming_signal_behavior.rs
@@ -1,0 +1,253 @@
+//! Behavioral lock for the query-memory priming heuristic in `plasticity.rs`.
+//!
+//! `QueryMemory::get_priming_signal` / `top_node_frequencies` (re-exported by
+//! `PlasticityEngine::get_priming` / `top_node_access_frequencies`) are the
+//! cheap "what has this agent been paying attention to" signal that the MCP
+//! tool layer (`m1nd-mcp/.../tools.rs`) relies on to bias activation toward
+//! frequently co-activated nodes. The math is subtle (seed-sharing gate,
+//! self-exclusion, max-normalization, 0.01 floor, 50/`n` caps) and had no
+//! direct behavioral coverage, so a quiet regression would silently degrade
+//! priming without failing any other test.
+//!
+//! This locks the contracts the implementation explicitly claims:
+//!
+//! * a node that co-activates with a seed is boosted; a never-seen node is not;
+//! * every emitted signal is finite and bounded to `(0.01, 1.0]`;
+//! * `top_node_frequencies(n)` returns at most `n` entries, sorted by
+//!   frequency descending, and only nodes that were actually accessed;
+//! * empty seeds and no-shared-seed queries yield no priming.
+//!
+//! (Surfaced by the X-RAY proof-coverage pass.)
+
+use m1nd_core::plasticity::{QueryMemory, QueryRecord};
+use m1nd_core::types::{FiniteF32, NodeId};
+
+/// Build a `QueryRecord` from raw u32 ids; timestamp is irrelevant to priming.
+fn record(query_text: &str, seeds: &[u32], activated: &[u32]) -> QueryRecord {
+    QueryRecord {
+        query_text: query_text.to_string(),
+        seeds: seeds.iter().copied().map(NodeId::new).collect(),
+        activated_nodes: activated.iter().copied().map(NodeId::new).collect(),
+        timestamp: 0.0,
+    }
+}
+
+/// Co-activated neighbours are boosted; never-seen nodes are absent entirely.
+#[test]
+fn priming_boosts_co_activated_more_than_never_seen() {
+    let mut memory = QueryMemory::new(16, 64);
+
+    // Seed `alpha` (id 1) repeatedly co-activates `gamma` (id 3) and, less
+    // often, `delta` (id 4). Node `omega` (id 50) never appears anywhere.
+    memory.record(record("q1", &[1], &[1, 3, 4]));
+    memory.record(record("q2", &[1], &[1, 3]));
+    memory.record(record("q3", &[1], &[1, 3]));
+
+    let signal = memory.get_priming_signal(&[NodeId::new(1)], FiniteF32::new(0.5));
+
+    let score_of = |id: u32| {
+        signal
+            .iter()
+            .find(|(n, _)| *n == NodeId::new(id))
+            .map(|(_, s)| s.get())
+    };
+
+    let gamma = score_of(3).expect("frequently co-activated node must be primed");
+    let delta = score_of(4).expect("occasionally co-activated node must be primed");
+
+    // The most frequent co-activation outranks the rarer one.
+    assert!(
+        gamma > delta,
+        "frequently co-activated node should outrank rarer one: gamma={gamma} delta={delta}"
+    );
+
+    // A node never observed in any query gets no priming at all.
+    assert!(
+        score_of(50).is_none(),
+        "never-seen node must not appear in the priming signal"
+    );
+
+    // The seed itself is excluded from its own priming signal.
+    assert!(
+        score_of(1).is_none(),
+        "seed node must be excluded from its own priming signal"
+    );
+}
+
+/// Every emitted signal is finite and bounded to `(0.01, 1.0]`, and the top
+/// entry equals the requested boost strength after max-normalization.
+#[test]
+fn priming_signals_are_finite_and_bounded() {
+    let mut memory = QueryMemory::new(16, 64);
+    memory.record(record("q1", &[1], &[1, 3, 4, 5]));
+    memory.record(record("q2", &[1], &[1, 3, 4]));
+    memory.record(record("q3", &[1], &[1, 3]));
+
+    let boost = FiniteF32::new(0.7);
+    let signal = memory.get_priming_signal(&[NodeId::new(1)], boost);
+
+    assert!(
+        !signal.is_empty(),
+        "shared-seed query with co-activations must produce a non-empty signal"
+    );
+
+    for (node, score) in &signal {
+        let value = score.get();
+        assert!(
+            value.is_finite(),
+            "priming score for {node:?} must be finite, got {value}"
+        );
+        // Implementation filters scores <= 0.01 and caps at 1.0.
+        assert!(
+            value > 0.01 && value <= 1.0,
+            "priming score for {node:?} must lie in (0.01, 1.0], got {value}"
+        );
+    }
+
+    // Results are sorted by score descending, and the max-normalized top score
+    // equals the boost strength (the most-co-activated node hits the ceiling).
+    let top = signal[0].1.get();
+    assert!(
+        (top - boost.get()).abs() < 1e-6,
+        "max-normalized top priming score should equal boost strength {}, got {top}",
+        boost.get()
+    );
+    for window in signal.windows(2) {
+        assert!(
+            window[0].1 >= window[1].1,
+            "priming signal must be sorted by score descending"
+        );
+    }
+}
+
+/// Boost strengths above 1.0 are clamped: no signal can exceed 1.0.
+#[test]
+fn priming_clamps_excessive_boost_to_one() {
+    let mut memory = QueryMemory::new(8, 32);
+    memory.record(record("q1", &[1], &[1, 2]));
+    memory.record(record("q2", &[1], &[1, 2]));
+
+    let signal = memory.get_priming_signal(&[NodeId::new(1)], FiniteF32::new(5.0));
+    assert!(
+        !signal.is_empty(),
+        "expected a primed neighbour for the shared seed"
+    );
+    for (node, score) in &signal {
+        assert!(
+            score.get() <= 1.0,
+            "priming score for {node:?} must be clamped to <= 1.0, got {}",
+            score.get()
+        );
+    }
+}
+
+/// Empty seeds and queries that share no seed produce no priming.
+#[test]
+fn priming_requires_shared_seeds() {
+    let mut memory = QueryMemory::new(8, 32);
+    memory.record(record("q1", &[1], &[1, 3, 4]));
+
+    // No seeds at all -> empty.
+    assert!(
+        memory
+            .get_priming_signal(&[], FiniteF32::new(0.5))
+            .is_empty(),
+        "empty seed set must yield no priming"
+    );
+
+    // A seed that never co-occurred with any recorded seed -> empty.
+    assert!(
+        memory
+            .get_priming_signal(&[NodeId::new(99)], FiniteF32::new(0.5))
+            .is_empty(),
+        "a seed sharing nothing with recorded queries must yield no priming"
+    );
+}
+
+/// `top_node_frequencies(n)` returns at most `n` entries, sorted by frequency
+/// descending, containing only nodes that were actually accessed.
+#[test]
+fn top_node_frequencies_are_capped_and_sorted() {
+    let mut memory = QueryMemory::new(32, 64);
+
+    // Node 2 appears in 4 records, node 3 in 3, node 4 in 2, node 5 in 1.
+    // Node 9 is never activated.
+    memory.record(record("q1", &[1], &[2, 3, 4, 5]));
+    memory.record(record("q2", &[1], &[2, 3, 4]));
+    memory.record(record("q3", &[1], &[2, 3]));
+    memory.record(record("q4", &[1], &[2]));
+
+    // Cap is honoured: at most `n` entries even though 4 distinct nodes exist.
+    let top2 = memory.top_node_frequencies(2);
+    assert_eq!(
+        top2.len(),
+        2,
+        "top_node_frequencies(2) must return at most 2 entries, got {}",
+        top2.len()
+    );
+
+    // Full ordering: descending by frequency.
+    let all = memory.top_node_frequencies(100);
+    for window in all.windows(2) {
+        assert!(
+            window[0].1 >= window[1].1,
+            "frequencies must be sorted descending: {:?} before {:?}",
+            window[0],
+            window[1]
+        );
+    }
+
+    // The two highest-frequency nodes are exactly 2 (freq 4) then 3 (freq 3).
+    assert_eq!(
+        top2[0],
+        (NodeId::new(2), 4),
+        "most-accessed node must be node 2 with frequency 4"
+    );
+    assert_eq!(
+        top2[1],
+        (NodeId::new(3), 3),
+        "second-most-accessed node must be node 3 with frequency 3"
+    );
+
+    // Only accessed nodes appear; the never-activated node 9 is absent.
+    assert!(
+        all.iter()
+            .all(|(node, freq)| *freq > 0 && *node != NodeId::new(9)),
+        "top_node_frequencies must exclude nodes with zero accesses"
+    );
+}
+
+/// The ring buffer evicts the oldest record at capacity and decrements its
+/// frequency contribution, so stale accesses stop influencing the top list.
+#[test]
+fn ring_buffer_eviction_decays_old_frequencies() {
+    // Capacity 2: the third record overwrites the first.
+    let mut memory = QueryMemory::new(2, 32);
+    memory.record(record("q1", &[1], &[7])); // node 7 accessed once
+    memory.record(record("q2", &[1], &[8])); // node 8 accessed once
+    memory.record(record("q3", &[1], &[8])); // overwrites q1, node 7 evicted
+
+    let freqs = memory.top_node_frequencies(10);
+    let freq_of = |id: u32| {
+        freqs
+            .iter()
+            .find(|(n, _)| *n == NodeId::new(id))
+            .map(|(_, f)| *f)
+    };
+
+    assert_eq!(
+        freq_of(7),
+        None,
+        "evicted record's node should drop out of the frequency list"
+    );
+    assert_eq!(
+        freq_of(8),
+        Some(2),
+        "node 8 was accessed in both surviving records, frequency should be 2"
+    );
+    assert_eq!(
+        memory.len(),
+        2,
+        "ring buffer at capacity 2 must hold exactly 2 live records"
+    );
+}

--- a/m1nd-core/tests/query_orchestrator_readonly_detectors_behavior.rs
+++ b/m1nd-core/tests/query_orchestrator_readonly_detectors_behavior.rs
@@ -1,0 +1,267 @@
+//! Locks the read-only query surface of `query::QueryOrchestrator`: that
+//! `query_readonly` leaves a shared `Graph` byte-for-byte untouched (its whole
+//! reason to exist for concurrent readers) and that `detect_ghost_edges` /
+//! `detect_structural_holes` only ever name in-graph `NodeId`s and stay
+//! panic-free on an empty activation set. Surfaced by the X-RAY coverage sweep.
+//!
+//! Why it matters:
+//! * `query_readonly` is the path a second, read-only m1nd process uses against
+//!   a graph other readers depend on — a stray mutation would corrupt them.
+//! * the two detectors return `NodeId`s that callers index straight back into
+//!   the graph; an out-of-range id would be an out-of-bounds bug downstream.
+
+use m1nd_core::activation::{ActivatedNode, ActivationResult};
+use m1nd_core::graph::Graph;
+use m1nd_core::query::{QueryConfig, QueryOrchestrator};
+use m1nd_core::types::{EdgeDirection, FiniteF32, Generation, NodeId, NodeType};
+
+/// Build a small connected graph (a star plus a couple of leaves) and finalize
+/// it so the CSR is populated. Returns the finalized graph.
+fn build_small_graph() -> Graph {
+    let mut graph = Graph::new();
+
+    // A hub plus four spokes — enough degree to give the detectors something to
+    // chew on without depending on the heavier ingest pipeline.
+    let hub = graph
+        .add_node("hub", "hub", NodeType::Function, &["core"], 0.0, 1.0)
+        .expect("add hub");
+    let alpha = graph
+        .add_node("alpha", "alpha", NodeType::Function, &["core"], 0.0, 1.0)
+        .expect("add alpha");
+    let beta = graph
+        .add_node("beta", "beta", NodeType::Function, &["core"], 0.0, 1.0)
+        .expect("add beta");
+    let gamma = graph
+        .add_node("gamma", "gamma", NodeType::Function, &["core"], 0.0, 1.0)
+        .expect("add gamma");
+    let delta = graph
+        .add_node("delta", "delta", NodeType::Function, &["core"], 0.0, 1.0)
+        .expect("add delta");
+
+    for target in [alpha, beta, gamma, delta] {
+        graph
+            .add_edge(
+                hub,
+                target,
+                "calls",
+                FiniteF32::new(1.0),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(1.0),
+            )
+            .expect("add edge from hub");
+    }
+    // One extra edge to give a non-hub node out-degree too.
+    graph
+        .add_edge(
+            alpha,
+            beta,
+            "calls",
+            FiniteF32::new(1.0),
+            EdgeDirection::Forward,
+            false,
+            FiniteF32::new(1.0),
+        )
+        .expect("add edge alpha->beta");
+
+    graph.finalize().expect("finalize graph");
+    graph
+}
+
+/// Snapshot the mutation-visible state of a graph: the monotonic generation
+/// counter (bumped on every structural mutation), node/edge counts, and the
+/// live edge weights (what plasticity would rewrite).
+fn graph_fingerprint(graph: &Graph) -> (Generation, u32, usize, Vec<FiniteF32>) {
+    (
+        graph.generation,
+        graph.num_nodes(),
+        graph.num_edges(),
+        graph.edge_plasticity.current_weight.clone(),
+    )
+}
+
+/// Hand-build an activation result over real node ids so the detectors get a
+/// deterministic, two-dimension activation set without running the full engine.
+fn activation_over(nodes: &[(NodeId, [f32; 4])]) -> ActivationResult {
+    let activated = nodes
+        .iter()
+        .map(|(node, dims)| {
+            let dimensions = [
+                FiniteF32::new(dims[0]),
+                FiniteF32::new(dims[1]),
+                FiniteF32::new(dims[2]),
+                FiniteF32::new(dims[3]),
+            ];
+            let active_dimension_count = dims.iter().filter(|d| **d > 0.01).count() as u8;
+            // Combined score: just the max contributing dimension, kept in (0,1].
+            let activation = FiniteF32::new(dims.iter().cloned().fold(0.0_f32, f32::max));
+            ActivatedNode {
+                node: *node,
+                activation,
+                dimensions,
+                active_dimension_count,
+            }
+        })
+        .collect();
+
+    ActivationResult {
+        activated,
+        seeds: Vec::new(),
+        elapsed_ns: 0,
+        xlr_fallback_used: false,
+    }
+}
+
+#[test]
+fn query_readonly_does_not_mutate_the_graph() {
+    let graph = build_small_graph();
+    let orchestrator = QueryOrchestrator::build(&graph).expect("build orchestrator");
+
+    let before = graph_fingerprint(&graph);
+
+    let config = QueryConfig {
+        query: "hub".to_string(),
+        agent_id: "test-agent".to_string(),
+        include_ghost_edges: true,
+        include_structural_holes: true,
+        ..Default::default()
+    };
+
+    // `query_readonly` takes `&Graph`; the borrow checker already forbids a
+    // structural write, but we additionally pin the observable state so a future
+    // change that smuggles in interior mutation (atomics on edge weights, the
+    // generation counter) is caught.
+    let result = orchestrator
+        .query_readonly(&graph, &config)
+        .expect("query_readonly succeeds");
+
+    let after = graph_fingerprint(&graph);
+    assert_eq!(
+        before, after,
+        "query_readonly must not mutate generation, counts, or edge weights"
+    );
+
+    // The read-only path deliberately zeroes plasticity (Step 8 skipped).
+    assert_eq!(
+        result.plasticity.edges_strengthened, 0,
+        "read-only query must not strengthen edges"
+    );
+    assert_eq!(
+        result.plasticity.edges_decayed, 0,
+        "read-only query must not decay edges"
+    );
+
+    // Every NodeId named in the result must be a real in-graph node.
+    let n = graph.num_nodes();
+    for node in &result.activation.activated {
+        assert!(
+            node.node.0 < n,
+            "activated node id {} out of range (n={n})",
+            node.node.0
+        );
+    }
+    for ghost in &result.ghost_edges {
+        assert!(
+            ghost.source.0 < n && ghost.target.0 < n,
+            "ghost edge references out-of-range node(s)"
+        );
+    }
+    for hole in &result.structural_holes {
+        assert!(
+            hole.node.0 < n,
+            "structural hole references out-of-range node {}",
+            hole.node.0
+        );
+    }
+}
+
+#[test]
+fn detectors_reference_only_in_graph_node_ids() {
+    let graph = build_small_graph();
+    let orchestrator = QueryOrchestrator::build(&graph).expect("build orchestrator");
+    let n = graph.num_nodes();
+
+    // alpha(1) and gamma(3) share two dimensions and are NOT directly connected
+    // in our graph (only hub->gamma and alpha->beta exist), so they are a prime
+    // ghost-edge candidate. Give the hub's neighbours strong activation while
+    // leaving the hub cold to also provoke a structural hole.
+    let alpha = graph.resolve_id("alpha").expect("alpha exists");
+    let beta = graph.resolve_id("beta").expect("beta exists");
+    let gamma = graph.resolve_id("gamma").expect("gamma exists");
+    let delta = graph.resolve_id("delta").expect("delta exists");
+
+    let activation = activation_over(&[
+        (alpha, [0.9, 0.9, 0.0, 0.0]),
+        (beta, [0.8, 0.8, 0.0, 0.0]),
+        (gamma, [0.7, 0.7, 0.0, 0.0]),
+        (delta, [0.6, 0.6, 0.0, 0.0]),
+    ]);
+
+    let ghosts = orchestrator
+        .detect_ghost_edges(&graph, &activation)
+        .expect("detect_ghost_edges");
+    for ghost in &ghosts {
+        assert!(
+            ghost.source.0 < n && ghost.target.0 < n,
+            "ghost edge endpoints must be valid node ids"
+        );
+        assert_ne!(
+            ghost.source, ghost.target,
+            "a ghost edge must connect two distinct nodes"
+        );
+        assert!(
+            ghost.shared_dimensions.len() >= 2,
+            "ghost edge must share at least two dimensions by construction"
+        );
+        assert!(
+            ghost.strength.get() >= 0.0 && ghost.strength.get() <= 1.0,
+            "ghost strength must be clamped to [0,1]"
+        );
+    }
+
+    let holes = orchestrator
+        .detect_structural_holes(&graph, &activation, FiniteF32::new(0.3))
+        .expect("detect_structural_holes");
+    for hole in &holes {
+        assert!(
+            hole.node.0 < n,
+            "structural hole node id {} out of range (n={n})",
+            hole.node.0
+        );
+        // A hole is, by definition, a node that was itself inactive — the four
+        // activated nodes above must therefore never appear as holes.
+        assert!(
+            ![alpha, beta, gamma, delta].contains(&hole.node),
+            "an activated node must not be reported as a structural hole"
+        );
+    }
+}
+
+#[test]
+fn empty_activation_yields_empty_detector_output_without_panic() {
+    let graph = build_small_graph();
+    let orchestrator = QueryOrchestrator::build(&graph).expect("build orchestrator");
+
+    let empty = ActivationResult {
+        activated: Vec::new(),
+        seeds: Vec::new(),
+        elapsed_ns: 0,
+        xlr_fallback_used: false,
+    };
+
+    let ghosts = orchestrator
+        .detect_ghost_edges(&graph, &empty)
+        .expect("detect_ghost_edges on empty activation");
+    assert!(
+        ghosts.is_empty(),
+        "no activated nodes can produce no ghost edges"
+    );
+
+    let holes = orchestrator
+        .detect_structural_holes(&graph, &empty, FiniteF32::new(0.3))
+        .expect("detect_structural_holes on empty activation");
+    assert!(
+        holes.is_empty(),
+        "with zero activation no node has activated neighbours, so no holes"
+    );
+}

--- a/m1nd-core/tests/snapshot_json_roundtrip.rs
+++ b/m1nd-core/tests/snapshot_json_roundtrip.rs
@@ -1,0 +1,178 @@
+//! Round-trip + error coverage for the JSON graph snapshot (`snapshot`).
+//!
+//! `snapshot::{save_graph, load_graph}` is the JSON persistence path production
+//! actually defaults to (`graph_snapshot.json`, written by the m1nd daemon/ingest),
+//! yet the JSON `save_graph`/`load_graph` pair had ZERO test coverage — only the
+//! compact binary path (`snapshot_bin`) and plasticity state were locked. A silent
+//! regression in the JSON format would corrupt the graph the engine reloads on
+//! every restart.
+//!
+//! This locks the contracts the implementation claims:
+//!
+//! * a graph (nodes + edges + tags + provenance) survives save -> load with
+//!   `num_nodes`/`num_edges`/labels/tags/provenance/edge-weights semantically
+//!   intact;
+//! * `load_graph` on a missing path returns `Err` (not panic);
+//! * `load_graph` on malformed JSON returns `Err` (not panic).
+//!
+//! (Surfaced by the X-RAY proof-coverage pass.)
+
+use m1nd_core::graph::{Graph, NodeProvenanceInput};
+use m1nd_core::snapshot::{load_graph, save_graph};
+use m1nd_core::types::{EdgeDirection, FiniteF32, NodeId, NodeType};
+
+/// Build a small but representative graph: two function nodes, distinctive tags,
+/// provenance on one node, and a weighted directed edge between them.
+fn sample_graph() -> Graph {
+    let mut graph = Graph::new();
+    let alpha = graph
+        .add_node(
+            "file::a.rs::fn::alpha",
+            "alpha",
+            NodeType::Function,
+            &["rust", "rust:visibility:pub", "xray:state:bedrock"],
+            1_718_000_000.0,
+            0.5,
+        )
+        .unwrap();
+    let beta = graph
+        .add_node(
+            "file::a.rs::fn::beta",
+            "beta",
+            NodeType::Struct,
+            &["rust"],
+            1_718_000_001.0,
+            0.0,
+        )
+        .unwrap();
+    graph.set_node_provenance(
+        alpha,
+        NodeProvenanceInput {
+            source_path: Some("a.rs"),
+            line_start: Some(3),
+            line_end: Some(9),
+            ..Default::default()
+        },
+    );
+    graph
+        .add_edge(
+            alpha,
+            beta,
+            "calls",
+            FiniteF32::new(0.75),
+            EdgeDirection::Forward,
+            false,
+            FiniteF32::new(0.25),
+        )
+        .unwrap();
+    graph.finalize().unwrap();
+    graph
+}
+
+/// Read the weight of the (single) outgoing edge of `node`, going through the same
+/// public CSR surface `snapshot::save_graph` itself serializes from.
+fn first_out_edge_weight(graph: &Graph, node: NodeId) -> f32 {
+    let range = graph.csr.out_range(node);
+    let idx = range.start;
+    graph
+        .csr
+        .read_weight(m1nd_core::types::EdgeIdx::new(idx as u32))
+        .get()
+}
+
+#[test]
+fn json_snapshot_round_trips_nodes_edges_tags_provenance_weights() {
+    let dir = std::env::temp_dir().join("m1nd_snapshot_json_rt");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("graph_snapshot.json");
+
+    let original = sample_graph();
+    save_graph(&original, &path).expect("json save_graph");
+    assert!(
+        std::fs::metadata(&path)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false),
+        "json snapshot file should be written and non-empty"
+    );
+
+    let loaded = load_graph(&path).expect("json load_graph");
+
+    assert_eq!(
+        loaded.num_nodes(),
+        original.num_nodes(),
+        "node count must survive the JSON round-trip"
+    );
+    assert_eq!(
+        loaded.num_edges(),
+        original.num_edges(),
+        "edge count must survive the JSON round-trip"
+    );
+
+    // Node identity + label + tags must survive.
+    let alpha = loaded
+        .resolve_id("file::a.rs::fn::alpha")
+        .expect("node external_id must survive");
+    let alpha_label = loaded.strings.resolve(loaded.nodes.label[alpha.as_usize()]);
+    assert_eq!(alpha_label, "alpha", "node label must survive");
+
+    let tags = loaded.node_tags(alpha);
+    assert!(
+        tags.contains(&"xray:state:bedrock"),
+        "tags must survive: {tags:?}"
+    );
+    assert!(
+        tags.contains(&"rust:visibility:pub"),
+        "all tags must survive: {tags:?}"
+    );
+
+    // Provenance must survive.
+    let prov = loaded.resolve_node_provenance(alpha);
+    assert_eq!(
+        prov.line_start,
+        Some(3),
+        "provenance line_start must survive"
+    );
+    assert_eq!(prov.line_end, Some(9), "provenance line_end must survive");
+
+    // Second node, with a distinct NodeType, must survive.
+    let beta = loaded
+        .resolve_id("file::a.rs::fn::beta")
+        .expect("second node must survive");
+    assert_eq!(
+        loaded.nodes.node_type[beta.as_usize()],
+        NodeType::Struct,
+        "node_type must survive the JSON round-trip"
+    );
+
+    // Edge weight must survive semantically (load goes through add_edge + finalize).
+    let weight = first_out_edge_weight(&loaded, alpha);
+    assert!(
+        (weight - 0.75).abs() < 1e-6,
+        "edge weight must survive the JSON round-trip, got {weight}"
+    );
+}
+
+#[test]
+fn json_load_missing_file_is_error_not_panic() {
+    let missing = std::env::temp_dir().join("m1nd_snapshot_json_missing_xyz.json");
+    let _ = std::fs::remove_file(&missing);
+    assert!(
+        load_graph(&missing).is_err(),
+        "loading a missing JSON snapshot must return Err, not panic"
+    );
+}
+
+#[test]
+fn json_load_malformed_is_error_not_panic() {
+    let dir = std::env::temp_dir().join("m1nd_snapshot_json_malformed");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("garbage.json");
+    std::fs::write(&path, b"{ this is not valid graph json ]]").unwrap();
+
+    assert!(
+        load_graph(&path).is_err(),
+        "loading malformed JSON must return Err, not panic"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/m1nd-core/tests/synonym_expander_behavior.rs
+++ b/m1nd-core/tests/synonym_expander_behavior.rs
@@ -1,0 +1,204 @@
+//! Locks `SynonymExpander` (semantic.rs) expand/are_synonyms/build invariants the
+//! prod synonym-boost query relies on; surfaced by the X-RAY coverage sweep.
+//!
+//! `SemanticEngine::query` expands each query token through `expand` and boosts
+//! nodes whose labels match a synonym (not the original token). That boost is only
+//! correct if `expand` is case-insensitive, always echoes the term, pulls in the
+//! rest of the group, dedups, and returns just `[term]` for unknown terms — and if
+//! `are_synonyms` is reflexive, symmetric, intra-group true, cross-group false.
+//!
+//! These are pure, deterministic checks: no graph, no I/O.
+
+use m1nd_core::semantic::SynonymExpander;
+
+/// Build a small, explicit two-group expander used by most cases below.
+/// Group 0 is the canonical "fetch" family; group 1 is unrelated.
+fn fetch_and_store_expander() -> SynonymExpander {
+    SynonymExpander::build(vec![
+        vec!["fetch", "get", "retrieve"],
+        vec!["store", "save", "persist"],
+    ])
+    .expect("building from non-overlapping groups must succeed")
+}
+
+#[test]
+fn expand_is_case_insensitive_and_includes_self_and_group() {
+    let expander = fetch_and_store_expander();
+
+    // Upper-case input must resolve to the same lowercased group as lower-case.
+    let from_upper = expander.expand("GET");
+    let from_lower = expander.expand("get");
+
+    // The term itself (lowercased) is always first / present.
+    assert!(
+        from_upper.contains(&"get".to_string()),
+        "expand must always include the (lowercased) term itself, got {from_upper:?}"
+    );
+
+    // The other group members come along, regardless of input casing.
+    for member in ["fetch", "retrieve"] {
+        assert!(
+            from_upper.contains(&member.to_string()),
+            "expand(\"GET\") must include group member {member:?}, got {from_upper:?}"
+        );
+    }
+
+    // Case-insensitivity: same set of results from "GET" and "get".
+    let mut upper_sorted = from_upper.clone();
+    let mut lower_sorted = from_lower.clone();
+    upper_sorted.sort();
+    lower_sorted.sort();
+    assert_eq!(
+        upper_sorted, lower_sorted,
+        "expand must be case-insensitive: \"GET\" and \"get\" should expand identically"
+    );
+
+    // The fetch group has exactly 3 distinct members, so expansion has 3 entries.
+    assert_eq!(
+        from_upper.len(),
+        3,
+        "expand of a 3-member group must yield exactly its 3 members, got {from_upper:?}"
+    );
+}
+
+#[test]
+fn expand_dedups_and_is_self_first() {
+    // A group that names the same term twice (with mixed casing) must not yield
+    // duplicates after expansion.
+    let expander = SynonymExpander::build(vec![vec!["alpha", "Alpha", "beta"]])
+        .expect("build with case-duplicated terms must succeed");
+
+    let expanded = expander.expand("alpha");
+
+    // First entry is always the queried term itself.
+    assert_eq!(
+        expanded.first(),
+        Some(&"alpha".to_string()),
+        "expand must place the queried term first, got {expanded:?}"
+    );
+
+    // No value appears twice.
+    let mut seen = expanded.clone();
+    seen.sort();
+    let before = seen.len();
+    seen.dedup();
+    assert_eq!(
+        before,
+        seen.len(),
+        "expand must not return duplicate synonyms, got {expanded:?}"
+    );
+
+    // Concretely: {alpha, beta} — the duplicate "Alpha" collapses into "alpha".
+    assert_eq!(
+        seen,
+        vec!["alpha".to_string(), "beta".to_string()],
+        "expand must collapse case-duplicate members, got {expanded:?}"
+    );
+}
+
+#[test]
+fn expand_unknown_term_returns_only_itself() {
+    let expander = fetch_and_store_expander();
+
+    let expanded = expander.expand("UNKNOWN");
+
+    // Unknown term: the only result is the lowercased term, never empty, never a
+    // borrowed group from elsewhere.
+    assert_eq!(
+        expanded,
+        vec!["unknown".to_string()],
+        "expand of an unknown term must return exactly [lowercased term], got {expanded:?}"
+    );
+}
+
+#[test]
+fn are_synonyms_is_reflexive_even_for_unknown_terms() {
+    let expander = fetch_and_store_expander();
+
+    // Reflexive for a known term...
+    assert!(
+        expander.are_synonyms("get", "get"),
+        "are_synonyms must be reflexive for known terms"
+    );
+
+    // ...and for an unknown one (equality short-circuits before group lookup).
+    assert!(
+        expander.are_synonyms("zzz_unknown", "zzz_unknown"),
+        "are_synonyms must be reflexive even for terms not in any group"
+    );
+
+    // Reflexivity is case-insensitive too.
+    assert!(
+        expander.are_synonyms("GET", "get"),
+        "are_synonyms must treat case-different spellings of one term as equal"
+    );
+}
+
+#[test]
+fn are_synonyms_is_symmetric_and_intra_group_true() {
+    let expander = fetch_and_store_expander();
+
+    // Two distinct members of the same group are synonyms, both directions.
+    assert!(
+        expander.are_synonyms("get", "retrieve"),
+        "are_synonyms must be true within a group"
+    );
+    assert!(
+        expander.are_synonyms("retrieve", "get"),
+        "are_synonyms must be symmetric within a group"
+    );
+
+    // Symmetry holds across casing as well.
+    assert!(
+        expander.are_synonyms("FETCH", "Retrieve"),
+        "are_synonyms must be case-insensitive and symmetric"
+    );
+}
+
+#[test]
+fn are_synonyms_is_false_across_groups() {
+    let expander = fetch_and_store_expander();
+
+    // "get" is in the fetch group; "save" is in the store group → not synonyms.
+    assert!(
+        !expander.are_synonyms("get", "save"),
+        "are_synonyms must be false for terms in different groups"
+    );
+    assert!(
+        !expander.are_synonyms("save", "get"),
+        "are_synonyms must be false (symmetric) for cross-group terms"
+    );
+
+    // A known term and a completely unknown term are not synonyms.
+    assert!(
+        !expander.are_synonyms("get", "absent_term"),
+        "are_synonyms must be false when one term is unknown"
+    );
+}
+
+#[test]
+fn build_default_groups_known_code_synonyms() {
+    // The built-in defaults back the prod synonym boost; spot-check a code-domain
+    // group documented in DEFAULT_SYNONYM_GROUPS so a silent table edit is caught.
+    let expander =
+        SynonymExpander::build_default().expect("build_default must succeed with bundled groups");
+
+    // "function" family is grouped together in the defaults.
+    assert!(
+        expander.are_synonyms("function", "method"),
+        "default groups must keep function/method synonymous"
+    );
+    let expanded = expander.expand("FUNCTION");
+    for member in ["function", "fn", "method", "func"] {
+        assert!(
+            expanded.contains(&member.to_string()),
+            "default expand(\"FUNCTION\") must include {member:?}, got {expanded:?}"
+        );
+    }
+
+    // Cross-family terms from the defaults must stay distinct.
+    assert!(
+        !expander.are_synonyms("function", "class"),
+        "default groups must keep function and class in separate groups"
+    );
+}

--- a/m1nd-core/tests/temporal_cochange_predict_ranking.rs
+++ b/m1nd-core/tests/temporal_cochange_predict_ranking.rs
@@ -1,0 +1,185 @@
+//! Locks the ranking/exclusion invariant of `temporal::CoChangeMatrix::predict`
+//! (surfaced by the X-RAY coverage sweep): predictions are sorted by coupling
+//! strength descending, capped at `k`, never include the queried node itself,
+//! and an un-coupled node returns an empty Vec instead of panicking.
+
+use m1nd_core::builder::GraphBuilder;
+use m1nd_core::temporal::CoChangeMatrix;
+use m1nd_core::types::{NodeId, NodeType};
+
+/// Build a graph of isolated file nodes (no edges) so `bootstrap` yields empty
+/// rows. This isolates the prediction logic from the structural BFS seed, making
+/// the learned co-change observations the sole source of predictions.
+fn isolated_graph(node_ids: &[&str]) -> (m1nd_core::graph::Graph, Vec<NodeId>) {
+    let mut builder = GraphBuilder::new();
+    let mut ids = Vec::new();
+    for ext in node_ids {
+        let nid = builder
+            .add_node(ext, ext, NodeType::File, &[])
+            .expect("add_node");
+        ids.push(nid);
+    }
+    let graph = builder.finalize().expect("finalize graph");
+    (graph, ids)
+}
+
+#[test]
+fn predict_is_sorted_descending_excludes_self_and_caps_at_k() {
+    let (graph, ids) = isolated_graph(&[
+        "file::alpha.rs",
+        "file::beta.rs",
+        "file::gamma.rs",
+        "file::delta.rs",
+    ]);
+    let (alpha, beta, gamma, delta) = (ids[0], ids[1], ids[2], ids[3]);
+
+    let mut matrix = CoChangeMatrix::bootstrap(&graph, 500_000).expect("bootstrap");
+
+    // No edges -> bootstrap learned nothing structural for these nodes.
+    assert!(
+        matrix.predict(alpha, 10).is_empty(),
+        "fresh bootstrap on an edgeless graph must yield no co-change partners"
+    );
+
+    // Drive deterministic couplings from alpha. record_co_change uses a 0.1 base
+    // strength and strengthens existing pairs by +0.1, so repeating an
+    // observation makes that partner rank higher.
+    // gamma observed 3x (strongest), beta 2x, delta 1x (weakest).
+    for _ in 0..3 {
+        matrix
+            .record_co_change(alpha, gamma, 0.0)
+            .expect("record alpha->gamma");
+    }
+    for _ in 0..2 {
+        matrix
+            .record_co_change(alpha, beta, 0.0)
+            .expect("record alpha->beta");
+    }
+    matrix
+        .record_co_change(alpha, delta, 0.0)
+        .expect("record alpha->delta");
+
+    let ranked = matrix.predict(alpha, 10);
+    assert_eq!(
+        ranked.len(),
+        3,
+        "all three distinct partners should be returned when k exceeds the row size"
+    );
+
+    // Invariant 1: sorted by strength descending.
+    for pair in ranked.windows(2) {
+        assert!(
+            pair[0].strength >= pair[1].strength,
+            "predict output must be sorted by coupling strength descending"
+        );
+    }
+
+    // Invariant 2: ranking matches observation frequency (gamma > beta > delta).
+    assert_eq!(
+        ranked[0].target, gamma,
+        "the most-frequently co-changed partner must rank first"
+    );
+    assert_eq!(
+        ranked[2].target, delta,
+        "the least-frequently co-changed partner must rank last"
+    );
+
+    // Invariant 3: the queried node does not appear among its own predictions.
+    // NOTE: this holds because the observations never record a self co-change
+    // (alpha->alpha); `predict` itself does not filter self, so this asserts the
+    // realistic-data behavior, not a defensive guard in the engine.
+    assert!(
+        ranked.iter().all(|entry| entry.target != alpha),
+        "predict should not surface the queried node as its own co-change partner"
+    );
+
+    // Invariant 4: top_k truncates the result.
+    let top1 = matrix.predict(alpha, 1);
+    assert_eq!(top1.len(), 1, "predict must return at most k entries");
+    assert_eq!(
+        top1[0].target, gamma,
+        "the single returned entry must be the strongest partner"
+    );
+}
+
+#[test]
+fn predict_on_never_cochanged_node_returns_empty_without_panic() {
+    let (graph, ids) = isolated_graph(&["file::alpha.rs", "file::beta.rs"]);
+    let (alpha, beta) = (ids[0], ids[1]);
+
+    let mut matrix = CoChangeMatrix::bootstrap(&graph, 500_000).expect("bootstrap");
+    matrix
+        .record_co_change(alpha, beta, 0.0)
+        .expect("record alpha->beta");
+
+    // beta was only ever a *target*, never a source: its row is empty.
+    assert!(
+        matrix.predict(beta, 10).is_empty(),
+        "a node that was never a co-change source must predict nothing"
+    );
+
+    // An out-of-bounds NodeId must return empty rather than panic.
+    let out_of_bounds = NodeId::new(9_999);
+    assert!(
+        matrix.predict(out_of_bounds, 10).is_empty(),
+        "predicting on an out-of-range node must return empty, not panic"
+    );
+
+    // top_k of zero is a degenerate but valid request: it returns nothing.
+    assert!(
+        matrix.predict(alpha, 0).is_empty(),
+        "predict with k=0 must return an empty Vec"
+    );
+}
+
+#[test]
+fn populate_from_commit_groups_resolves_ids_and_feeds_predictions() {
+    let (graph, ids) = isolated_graph(&["file::alpha.rs", "file::beta.rs", "file::gamma.rs"]);
+    let (alpha, beta, gamma) = (ids[0], ids[1], ids[2]);
+
+    let mut matrix = CoChangeMatrix::bootstrap(&graph, 500_000).expect("bootstrap");
+
+    // Two commits: the first couples all three files, the second couples
+    // alpha+beta again. The group form accepts bare paths (the "file::" prefix
+    // is added internally) and resolves them to NodeIds via the graph.
+    let commit_groups = vec![
+        vec![
+            "alpha.rs".to_string(),
+            "beta.rs".to_string(),
+            "gamma.rs".to_string(),
+        ],
+        vec!["alpha.rs".to_string(), "beta.rs".to_string()],
+    ];
+    matrix
+        .populate_from_commit_groups(&graph, &commit_groups)
+        .expect("populate_from_commit_groups");
+
+    assert!(
+        matrix.num_entries() > 0,
+        "populating from commit groups must create co-change entries"
+    );
+
+    let ranked = matrix.predict(alpha, 10);
+    let targets: Vec<NodeId> = ranked.iter().map(|entry| entry.target).collect();
+    assert!(
+        targets.contains(&beta) && targets.contains(&gamma),
+        "alpha's predictions must include both files it co-changed with"
+    );
+    assert!(
+        ranked.iter().all(|entry| entry.target != alpha),
+        "self-exclusion must hold for commit-group-derived predictions"
+    );
+
+    // beta co-changed with alpha twice but gamma only once, so beta should
+    // rank alpha above gamma in beta's row.
+    let beta_ranked = matrix.predict(beta, 10);
+    assert!(
+        !beta_ranked.is_empty(),
+        "beta participated in commits and must have predictions"
+    );
+    let beta_top = beta_ranked[0].target;
+    assert_eq!(
+        beta_top, alpha,
+        "the partner co-changed most often must rank first for beta"
+    );
+}

--- a/m1nd-core/tests/topology_community_partition_completeness.rs
+++ b/m1nd-core/tests/topology_community_partition_completeness.rs
@@ -1,0 +1,205 @@
+//! Locks the partition-completeness invariant of `topology::CommunityDetector`
+//! (surfaced by the X-RAY coverage sweep): every node gets a community, two
+//! dense clusters joined by a single bridge land in distinct communities,
+//! modularity stays finite and >= 0, per-community node counts sum to
+//! `num_nodes`, and degenerate (single-node / empty) graphs never panic.
+
+use m1nd_core::error::M1ndError;
+use m1nd_core::graph::Graph;
+use m1nd_core::topology::CommunityDetector;
+use m1nd_core::types::{EdgeDirection, FiniteF32, NodeId, NodeType};
+
+/// Add a plain node and return its id, panicking on the (impossible-here)
+/// duplicate-id path so a regression there is loud.
+fn node(graph: &mut Graph, external_id: &str) -> NodeId {
+    graph
+        .add_node(external_id, external_id, NodeType::Function, &[], 0.0, 0.0)
+        .expect("add_node should succeed for a fresh external id")
+}
+
+/// Add an undirected-weighted edge with a fixed positive weight.
+fn link(graph: &mut Graph, source: NodeId, target: NodeId) {
+    graph
+        .add_edge(
+            source,
+            target,
+            "calls",
+            FiniteF32::new(1.0),
+            EdgeDirection::Bidirectional,
+            false,
+            FiniteF32::ZERO,
+        )
+        .expect("add_edge should succeed between existing nodes");
+}
+
+/// Build two dense 4-cliques (alpha + beta clusters) joined by ONE bridge edge.
+/// Returns the finalized graph plus the two cluster id-vectors.
+fn two_clusters_one_bridge() -> (Graph, Vec<NodeId>, Vec<NodeId>) {
+    let mut graph = Graph::new();
+
+    let alpha: Vec<NodeId> = (0..4)
+        .map(|i| node(&mut graph, &format!("alpha-{i}")))
+        .collect();
+    let beta: Vec<NodeId> = (0..4)
+        .map(|i| node(&mut graph, &format!("beta-{i}")))
+        .collect();
+
+    // Dense intra-cluster edges (every pair) for both clusters.
+    for cluster in [&alpha, &beta] {
+        for a in 0..cluster.len() {
+            for b in (a + 1)..cluster.len() {
+                link(&mut graph, cluster[a], cluster[b]);
+            }
+        }
+    }
+
+    // Exactly one bridge connecting the two clusters.
+    link(&mut graph, alpha[0], beta[0]);
+
+    graph.finalize().expect("finalize should succeed");
+    (graph, alpha, beta)
+}
+
+#[test]
+fn detect_partitions_every_node_and_separates_clusters() {
+    let (graph, alpha, beta) = two_clusters_one_bridge();
+    let detector = CommunityDetector::with_defaults();
+
+    let result = detector
+        .detect(&graph)
+        .expect("detect should succeed on a non-empty graph");
+
+    // Partition completeness: one assignment slot per node.
+    assert_eq!(
+        result.assignments.len(),
+        graph.num_nodes() as usize,
+        "detect must assign a community to every node",
+    );
+
+    // Community ids are renumbered contiguously 0..num_communities.
+    for assignment in &result.assignments {
+        assert!(
+            assignment.0 < result.num_communities,
+            "every assignment must reference a contiguous community id",
+        );
+    }
+    assert!(
+        result.num_communities >= 2,
+        "two dense clusters joined by one bridge must yield at least two communities",
+    );
+
+    // Each cluster must be internally homogeneous...
+    let alpha_comm = result.assignments[alpha[0].as_usize()];
+    for n in &alpha {
+        assert_eq!(
+            result.assignments[n.as_usize()],
+            alpha_comm,
+            "all alpha-cluster nodes must share one community",
+        );
+    }
+    let beta_comm = result.assignments[beta[0].as_usize()];
+    for n in &beta {
+        assert_eq!(
+            result.assignments[n.as_usize()],
+            beta_comm,
+            "all beta-cluster nodes must share one community",
+        );
+    }
+
+    // ...and the two clusters must land in DISTINCT communities.
+    assert_ne!(
+        alpha_comm, beta_comm,
+        "the bridged dense clusters must be detected as separate communities",
+    );
+
+    // Modularity must be finite and non-negative for a clearly modular graph.
+    let modularity = result.modularity.get();
+    assert!(
+        modularity.is_finite(),
+        "modularity Q must be finite, got {modularity}",
+    );
+    assert!(
+        modularity >= 0.0,
+        "modularity Q must be >= 0 for a clearly clustered graph, got {modularity}",
+    );
+}
+
+#[test]
+fn community_stats_node_counts_sum_to_num_nodes() {
+    let (graph, _alpha, _beta) = two_clusters_one_bridge();
+    let detector = CommunityDetector::with_defaults();
+    let result = detector.detect(&graph).expect("detect should succeed");
+
+    let stats = CommunityDetector::community_stats(&graph, &result);
+
+    assert_eq!(
+        stats.len(),
+        result.num_communities as usize,
+        "community_stats must report one entry per community",
+    );
+
+    let total_nodes: u32 = stats.iter().map(|s| s.node_count).sum();
+    assert_eq!(
+        total_nodes,
+        graph.num_nodes(),
+        "per-community node counts must sum to num_nodes (partition completeness)",
+    );
+
+    // Density is a ratio in [0, 1] and finite for every community.
+    for s in &stats {
+        let density = s.density.get();
+        assert!(
+            density.is_finite() && (0.0..=1.0).contains(&density),
+            "density must be a finite ratio in [0,1], got {density}",
+        );
+    }
+}
+
+#[test]
+fn single_node_graph_does_not_panic() {
+    let mut graph = Graph::new();
+    let _solo = node(&mut graph, "solo");
+    graph.finalize().expect("finalize should succeed");
+
+    let detector = CommunityDetector::with_defaults();
+    // A single isolated node has no edges (two_m == 0): detect returns Ok with
+    // each node in its own community rather than panicking.
+    let result = detector
+        .detect(&graph)
+        .expect("single-node graph must not error");
+
+    assert_eq!(
+        result.assignments.len(),
+        1,
+        "single-node graph must still assign exactly one community slot",
+    );
+    assert!(
+        result.modularity.get().is_finite(),
+        "single-node modularity must be finite",
+    );
+
+    let stats = CommunityDetector::community_stats(&graph, &result);
+    let total: u32 = stats.iter().map(|s| s.node_count).sum();
+    assert_eq!(
+        total, 1,
+        "stats for a single-node graph must count one node"
+    );
+}
+
+#[test]
+fn empty_graph_returns_err_not_panic() {
+    let mut graph = Graph::new();
+    graph
+        .finalize()
+        .expect("finalize of empty graph should succeed");
+
+    let detector = CommunityDetector::with_defaults();
+    let err = detector
+        .detect(&graph)
+        .expect_err("empty graph must return Err, not a result or panic");
+
+    assert!(
+        matches!(err, M1ndError::EmptyGraph),
+        "empty-graph detect must return M1ndError::EmptyGraph, got {err:?}",
+    );
+}

--- a/m1nd-core/tests/xlr_spectral_overlap_behavior.rs
+++ b/m1nd-core/tests/xlr_spectral_overlap_behavior.rs
@@ -1,0 +1,167 @@
+//! Locks `AdaptiveXlrEngine::spectral_overlap` bucketed-overlap math (surfaced by the X-RAY coverage sweep):
+//! empty-signal immunity, self-overlap == 1.0, disjoint == 0.0, partial in (0,1), result always finite in [0,1].
+//!
+//! `spectral_overlap` is the spectral-immunity helper inside the adaptive
+//! differential pass. It buckets hot/cold frequency sets into `SPECTRAL_BUCKETS`
+//! bins of width `10.0 / SPECTRAL_BUCKETS` and returns
+//! `sum(min(hot_bucket, cold_bucket)) / sum(hot_bucket)`. These tests pin the
+//! arithmetic so a future refactor of the bucketing cannot silently shift the
+//! overlap score that downstream gating depends on.
+//!
+//! Notes on the buckets used below (`bucket_width = 10.0 / 20 = 0.5`):
+//! - `0.10` and `0.20` both land in bucket 0 (`floor(f / 0.5) == 0`).
+//! - `1.10` lands in bucket 2 (`floor(1.10 / 0.5) == 2`).
+//! - `2.60` lands in bucket 5 (`floor(2.60 / 0.5) == 5`).
+//!
+//! The bucket width mirrors the source (`10.0 / SPECTRAL_BUCKETS`); these
+//! midpoint frequencies are chosen to sit safely inside their buckets at the
+//! current bucket count, avoiding rounding ambiguity at boundaries.
+
+use m1nd_core::types::FiniteF32;
+use m1nd_core::xlr::{AdaptiveXlrEngine, SPECTRAL_BUCKETS};
+
+/// Width of a single spectral bucket, mirroring the helper's own derivation.
+const BUCKET_WIDTH: f32 = 10.0 / SPECTRAL_BUCKETS as f32;
+
+/// Build a frequency whose bucket index is exactly `bucket`, placed at the
+/// bucket's midpoint so float rounding cannot drift it into a neighbor.
+fn freq_in_bucket(bucket: usize) -> FiniteF32 {
+    let midpoint = (bucket as f32 + 0.5) * BUCKET_WIDTH;
+    FiniteF32::new(midpoint)
+}
+
+#[test]
+fn empty_hot_returns_zero() {
+    let cold = vec![freq_in_bucket(0), freq_in_bucket(2)];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&[], &cold);
+    assert_eq!(
+        overlap,
+        FiniteF32::ZERO,
+        "empty hot signal must yield zero overlap (spectral immunity)"
+    );
+}
+
+#[test]
+fn empty_cold_returns_zero() {
+    let hot = vec![freq_in_bucket(0), freq_in_bucket(2)];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&hot, &[]);
+    assert_eq!(
+        overlap,
+        FiniteF32::ZERO,
+        "empty cold signal must yield zero overlap (spectral immunity)"
+    );
+}
+
+#[test]
+fn both_empty_returns_zero() {
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&[], &[]);
+    assert_eq!(
+        overlap,
+        FiniteF32::ZERO,
+        "two empty signals must yield zero overlap"
+    );
+}
+
+#[test]
+fn identical_frequency_sets_overlap_is_one() {
+    let freqs = vec![
+        freq_in_bucket(0),
+        freq_in_bucket(2),
+        freq_in_bucket(5),
+        freq_in_bucket(2),
+    ];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&freqs, &freqs);
+    assert_eq!(
+        overlap,
+        FiniteF32::ONE,
+        "identical hot/cold frequency sets must overlap fully (== 1.0)"
+    );
+}
+
+#[test]
+fn fully_disjoint_buckets_overlap_is_zero() {
+    // Hot occupies buckets {0}, cold occupies buckets {2, 5}: no shared bucket.
+    let hot = vec![freq_in_bucket(0)];
+    let cold = vec![freq_in_bucket(2), freq_in_bucket(5)];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&hot, &cold);
+    assert_eq!(
+        overlap,
+        FiniteF32::ZERO,
+        "disjoint frequency buckets must produce zero overlap"
+    );
+}
+
+#[test]
+fn partial_overlap_is_strictly_between_zero_and_one() {
+    // Hot occupies buckets {0, 2}; cold occupies bucket {0}.
+    // min per bucket: bucket0 -> min(1,1)=1, bucket2 -> min(1,0)=0.
+    // hot_total = 2 -> overlap = 1 / 2 = 0.5.
+    let hot = vec![freq_in_bucket(0), freq_in_bucket(2)];
+    let cold = vec![freq_in_bucket(0)];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&hot, &cold).get();
+    assert!(
+        overlap > 0.0 && overlap < 1.0,
+        "partial overlap must lie strictly in (0,1), got {overlap}"
+    );
+    assert!(
+        (overlap - 0.5).abs() < 1e-6,
+        "expected exactly 0.5 for one-of-two shared buckets, got {overlap}"
+    );
+}
+
+#[test]
+fn overlap_is_normalized_by_hot_total_not_cold() {
+    // Hot has a single frequency in bucket 0; cold floods bucket 0 with many.
+    // overlap = min(1, 3) / 1 = 1.0 -> denominator is hot_total, capped at 1.0.
+    let hot = vec![freq_in_bucket(0)];
+    let cold = vec![freq_in_bucket(0), freq_in_bucket(0), freq_in_bucket(0)];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&hot, &cold);
+    assert_eq!(
+        overlap,
+        FiniteF32::ONE,
+        "overlap normalizes by hot_total; a hot bucket fully covered by cold scores 1.0"
+    );
+}
+
+#[test]
+fn result_is_always_finite_and_in_unit_interval() {
+    // A spread of cases, including frequencies above the 10.0 bucketing ceiling
+    // which must clamp into the last bucket rather than escape the range.
+    let cases: Vec<(Vec<FiniteF32>, Vec<FiniteF32>)> = vec![
+        (vec![freq_in_bucket(0)], vec![freq_in_bucket(0)]),
+        (
+            vec![freq_in_bucket(0), freq_in_bucket(5)],
+            vec![freq_in_bucket(5)],
+        ),
+        (
+            vec![FiniteF32::new(50.0), FiniteF32::new(99.0)],
+            vec![FiniteF32::new(123.0)],
+        ),
+        (vec![FiniteF32::ZERO], vec![FiniteF32::ZERO]),
+    ];
+    for (hot, cold) in &cases {
+        let value = AdaptiveXlrEngine::spectral_overlap(hot, cold).get();
+        assert!(
+            value.is_finite(),
+            "overlap must always be finite, got {value} for hot={hot:?} cold={cold:?}"
+        );
+        assert!(
+            (0.0..=1.0).contains(&value),
+            "overlap must stay in [0,1], got {value} for hot={hot:?} cold={cold:?}"
+        );
+    }
+}
+
+#[test]
+fn frequencies_above_ceiling_clamp_into_last_bucket() {
+    // Both far above the 10.0 ceiling -> both clamp into bucket SPECTRAL_BUCKETS-1,
+    // making them identical from the bucketing's point of view -> full overlap.
+    let hot = vec![FiniteF32::new(42.0)];
+    let cold = vec![FiniteF32::new(999.0)];
+    let overlap = AdaptiveXlrEngine::spectral_overlap(&hot, &cold);
+    assert_eq!(
+        overlap,
+        FiniteF32::ONE,
+        "over-ceiling frequencies clamp into the final bucket and overlap fully"
+    );
+}


### PR DESCRIPTION
## O que

Adiciona **41 testes comportamentais** em 8 módulos do `m1nd-core` que a produção usa mas tinham pouca ou nenhuma cobertura direta. Os alvos foram **surfados pela varredura de cobertura de prova do X-RAY** (`cargo-llvm-cov --workspace`, mesma série de #141/#143) e escolhidos por serem **load-bearing de verdade** (têm callers reais fora de testes).

| módulo | trava |
|---|---|
| `snapshot.rs` | round-trip JSON do grafo + plasticity (persistência **default** de produção) |
| `domain.rs` | invariantes da tabela de half-life do `DomainConfig` (dirige o decaimento temporal) |
| `semantic.rs` | `SynonymExpander` expand/are_synonyms (boost de sinônimo do query) |
| `temporal.rs` | ranking/exclusão do `CoChangeMatrix::predict` (motor do `predict`) |
| `xlr.rs` | matemática de bucket do `spectral_overlap` (caminho default do query) |
| `topology.rs` | completude de partição do `CommunityDetector` |
| `query.rs` | `query_readonly` não-muta o grafo + safety de NodeId dos detectores |
| `plasticity.rs` | sinal de priming do `QueryMemory` + eviction do ring-buffer |

## Disciplina (proof-grown)
- **Aditivo, só teste.** Nenhum código de produção tocado.
- Asserts numéricos (xlr, temporal, domain, plasticity) **recomputados à mão contra o fonte** e revisados adversarialmente — 8/8 KEEP, zero vanity.
- Módulos **OVERGROWTH** (zero callers: `save/load_co_change_matrix`, `GraphBuilder` cujos callers são só `#[cfg(test)]`, `diff.rs`) foram **deixados sem teste de propósito** em vez de inflar a métrica.

Gates locais verdes: `cargo test -p m1nd-core` (41/41), `clippy --tests -D warnings`, `fmt --check`.