### PR TITLE
fix(core): avoid u32 overflow in community density for huge communities

### DIFF
--- a/m1nd-core/src/topology.rs
+++ b/m1nd-core/src/topology.rs
@@ -259,7 +259,13 @@ impl CommunityDetector {
         (0..num_comm)
             .map(|c| {
                 let nc = node_counts[c];
-                let max_internal = if nc > 1 { nc * (nc - 1) } else { 1 };
+                // Widen to u64: for a community of >= 65_537 nodes, nc * (nc - 1)
+                // exceeds u32::MAX and overflows (panic in debug, wrap in release).
+                let max_internal: u64 = if nc > 1 {
+                    nc as u64 * (nc as u64 - 1)
+                } else {
+                    1
+                };
                 let density = if max_internal > 0 {
                     internal[c] as f32 / max_internal as f32
                 } else {

--- a/m1nd-core/tests/topology_density_overflow.rs
+++ b/m1nd-core/tests/topology_density_overflow.rs
@@ -1,0 +1,52 @@
+//! Regression: community density must not overflow for very large communities.
+//!
+//! `CommunityDetector::community_stats` computes `max_internal = nc * (nc - 1)`
+//! where `nc: u32` is the community node count. When m1nd ingests a large repo
+//! and Louvain collapses >= 65_537 nodes into one community, `nc * (nc - 1)`
+//! exceeds `u32::MAX` and overflows (debug: panic; release: a wrong, wrapped
+//! density). This builds exactly that community and asserts a finite, in-range
+//! density instead.
+//!
+//! (Surfaced by the X-RAY adversarial bug hunt.)
+
+use m1nd_core::graph::Graph;
+use m1nd_core::topology::{CommunityDetector, CommunityResult};
+use m1nd_core::types::{CommunityId, FiniteF32, NodeType};
+
+#[test]
+fn community_density_does_not_overflow_for_huge_community() {
+    // 65_537 is the smallest count where nc * (nc - 1) exceeds u32::MAX:
+    // 65_537 * 65_536 = 4_295_032_832 > 4_294_967_295.
+    let n: u32 = 65_537;
+
+    let mut g = Graph::new();
+    for i in 0..n {
+        g.add_node(&format!("n{i}"), "n", NodeType::Function, &[], 0.0, 0.0)
+            .expect("add_node");
+    }
+    g.finalize().expect("finalize");
+
+    // Every node in a single community — what Louvain yields when a dense graph
+    // fully collapses. No edges are needed: the overflow is in the max-internal
+    // term, which is computed before any density division.
+    let result = CommunityResult {
+        assignments: vec![CommunityId(0); n as usize],
+        num_communities: 1,
+        modularity: FiniteF32::new(0.0),
+        passes: 1,
+    };
+
+    let stats = CommunityDetector::community_stats(&g, &result);
+    assert_eq!(stats.len(), 1, "exactly one community expected");
+
+    let density = stats[0].density.get();
+    assert!(density.is_finite(), "density must be finite, got {density}");
+    assert!(
+        (0.0..=1.0).contains(&density),
+        "density must stay in [0, 1], got {density}"
+    );
+    assert_eq!(
+        stats[0].node_count, n,
+        "node_count must match the community"
+    );
+}


### PR DESCRIPTION
## Bug
`CommunityDetector::community_stats` calculava `max_internal = nc * (nc - 1)` em **u32**, onde `nc` é a contagem de nós da comunidade. Uma comunidade com **≥ 65.537 nós** (um repo grande colapsando numa única comunidade Louvain) estoura `u32::MAX`:
- **debug:** panic (`attempt to multiply with overflow` em `topology.rs:262`)
- **release:** densidade errada (wrap silencioso)

## Fix
Widening do termo pra **u64** (`nc as u64 * (nc as u64 - 1)`). O caminho normal (comunidades pequenas) produz valores idênticos — zero mudança de comportamento ali.

## Prova (proof-grown)
Teste de regressão novo (`tests/topology_density_overflow.rs`) constrói uma comunidade de 65.537 nós e assere densidade finita em [0,1]. **O teste dá panic no código pré-fix** e passa depois — provei rodando os dois lados.

## Proveniência
Achado pela **caça adversarial de bugs do X-RAY** (mesma noite dos PRs de cobertura #141/#143/#145/#146): 12 auditores Opus → refutação por 2 céticos independentes. Este sobreviveu 2/2 e foi reverificado por mim contra o fonte + pelo teste falha-depois-passa.

Gates locais verdes: teste de overflow 1/1, regressão topology 4/4, `clippy --tests -D warnings`, `fmt --check`.