### PR TITLE
test(mcp): cover lock access-control + perspective OCC/lifecycle via dispatch_tool

### DIFF
--- a/m1nd-mcp/tests/lock_diff_ownership_and_not_found_errors.rs
+++ b/m1nd-mcp/tests/lock_diff_ownership_and_not_found_errors.rs
@@ -1,0 +1,165 @@
+//! Access-control coverage for the `lock_diff` MCP tool's `require_lock` gate.
+//!
+//! These tests lock the authorization branch in
+//! `m1nd-mcp/src/lock_handlers.rs::require_lock`, which every lock-mutating
+//! tool funnels through. A lock is created by agent `tester` over a real
+//! ingested code node, then `lock_diff` is dispatched with (a) a different
+//! `agent_id` than the owner and (b) a `lock_id` that was never created.
+//! The first must fail with `LockOwnership` (caller != owner) and the second
+//! with `LockNotFound`. Both assert the branch rejects based on the concrete
+//! `agent_id` / `lock_id` input values — not merely on response shape — so a
+//! regression that drops the ownership check or the existence check would turn
+//! these `Err` results into `Ok` and fail the test.
+//!
+//! X-RAY coverage: proves the lock access-control surface is BEDROCK, not a
+//! shape-only facade.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::error::M1ndError;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+
+/// Build a fresh session rooted at `root` (mirrors the shared harness; each
+/// `tests/*.rs` file is its own crate, so the helper is replicated locally).
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+/// Panicking dispatch helper for the happy-path setup calls (ingest / search /
+/// lock_create). The error-path assertions below deliberately use the raw
+/// `dispatch_tool` instead so they can inspect the `Result`.
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+/// Resolve the first searchable node id for `query`, used as the lock root.
+fn search_first_node_id(state: &mut SessionState, query: &str) -> String {
+    call(
+        state,
+        "search",
+        json!({"agent_id":"tester","query":query,"mode":"literal"}),
+    )
+    .get("results")
+    .and_then(|value| value.as_array())
+    .and_then(|value| value.first())
+    .and_then(|value| value.get("node_id"))
+    .and_then(|value| value.as_str())
+    .unwrap_or("")
+    .to_string()
+}
+
+/// Ingest a small code file, create a lock as `tester`, and return
+/// `(state, lock_id)` so each test starts from a genuinely owned lock.
+fn lock_owned_by_tester(root: &Path) -> (SessionState, String) {
+    let src_dir = root.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let src_file = src_dir.join("token_validator.rs");
+    fs::write(
+        &src_file,
+        "pub struct TokenValidator;\n\
+         impl TokenValidator {\n\
+         pub fn validate_request(&self) -> bool { true }\n\
+         }\n",
+    )
+    .unwrap();
+
+    let mut state = build_state(root);
+    call(
+        &mut state,
+        "ingest",
+        json!({
+            "agent_id": "tester",
+            "path": src_file.to_string_lossy().to_string(),
+            "adapter": "code",
+            "mode": "merge"
+        }),
+    );
+
+    let node_id = search_first_node_id(&mut state, "TokenValidator");
+    assert!(
+        !node_id.is_empty(),
+        "ingested code symbol must be searchable so the lock has a real root node"
+    );
+
+    let created = call(
+        &mut state,
+        "lock_create",
+        json!({"agent_id":"tester","scope":"node","root_nodes":[node_id]}),
+    );
+    let lock_id = created
+        .get("lock_id")
+        .and_then(|value| value.as_str())
+        .expect("lock_create must return a lock_id")
+        .to_string();
+    assert!(!lock_id.is_empty(), "created lock id must be non-empty");
+
+    (state, lock_id)
+}
+
+#[test]
+fn lock_diff_rejects_caller_that_does_not_own_the_lock() {
+    let temp = std::env::temp_dir().join("m1nd_lock_diff_ownership_intruder");
+    let _ = fs::remove_dir_all(&temp);
+    fs::create_dir_all(&temp).unwrap();
+
+    let (mut state, lock_id) = lock_owned_by_tester(&temp);
+
+    // Same, existing lock_id — only the agent_id differs from the owner.
+    let result = dispatch_tool(
+        &mut state,
+        "lock_diff",
+        &json!({"agent_id":"intruder","lock_id":lock_id}),
+    );
+
+    assert!(
+        result.is_err(),
+        "lock_diff by a non-owner must be rejected, got Ok: {:?}",
+        result.ok()
+    );
+    assert!(
+        matches!(result, Err(M1ndError::LockOwnership { .. })),
+        "expected LockOwnership for caller != owner, got {:?}",
+        result
+    );
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn lock_diff_rejects_unknown_lock_id() {
+    let temp = std::env::temp_dir().join("m1nd_lock_diff_ownership_missing");
+    let _ = fs::remove_dir_all(&temp);
+    fs::create_dir_all(&temp).unwrap();
+
+    // The owner agent calls, but for a lock_id that was never created.
+    let (mut state, _real_lock_id) = lock_owned_by_tester(&temp);
+
+    let result = dispatch_tool(
+        &mut state,
+        "lock_diff",
+        &json!({"agent_id":"tester","lock_id":"lock-does-not-exist"}),
+    );
+
+    assert!(
+        result.is_err(),
+        "lock_diff for a non-existent lock must be rejected, got Ok: {:?}",
+        result.ok()
+    );
+    assert!(
+        matches!(result, Err(M1ndError::LockNotFound { .. })),
+        "expected LockNotFound for an unknown lock_id, got {:?}",
+        result
+    );
+
+    let _ = fs::remove_dir_all(&temp);
+}

--- a/m1nd-mcp/tests/perspective_inspect_stale_route_set_version_behavior.rs
+++ b/m1nd-mcp/tests/perspective_inspect_stale_route_set_version_behavior.rs
@@ -1,0 +1,206 @@
+//! Behavior lock for the optimistic-concurrency contract shared by
+//! `perspective_start` and `perspective_inspect` in m1nd-mcp.
+//!
+//! `perspective_start` mints a `route_set_version` (call it V) and, when the
+//! focus node has at least one graph edge, returns a non-empty `routes[]`.
+//! `perspective_inspect` then enforces optimistic concurrency: a caller that
+//! supplies a `route_set_version` that does NOT match the stored V is rejected
+//! with an error (`route_set_stale_error`), and the rejection fires before any
+//! route lookup. A caller that supplies the matching V together with
+//! `route_index=1` is accepted and the inspected route reflects the route set
+//! created by `perspective_start` (its `route_id` equals `routes[0].route_id`).
+//!
+//! This is the X-RAY coverage that keeps stale clients from acting on a route
+//! page the engine has already superseded, while keeping the happy path honest:
+//! the inspected route is a function of the freshly created route set, not an
+//! arbitrary non-null shape.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_core::types::{EdgeDirection, FiniteF32, NodeId, NodeType};
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::path::Path;
+
+/// Build an isolated session rooted at `root` (replicates the shared harness;
+/// `tests/*.rs` are separate crates so helpers cannot be imported across files).
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+/// Dispatch a tool that is expected to succeed.
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+/// Seed the graph with two nodes joined by one directed edge so that
+/// `synthesize_routes` can build at least one route from the focus node.
+/// Mirrors the add_node + add_edge + finalize pattern used elsewhere, then
+/// rebuilds engines so the new graph is live for tool dispatch.
+fn seed_graph_with_edge(state: &mut SessionState, focus_external_id: &str) {
+    {
+        let mut graph = state.graph.write();
+        let focus = graph
+            .add_node(
+                focus_external_id,
+                "AlphaNode",
+                NodeType::File,
+                &["code"],
+                1.0,
+                0.1,
+            )
+            .expect("add focus node");
+        let neighbor = graph
+            .add_node(
+                "file::src/beta_node.rs",
+                "BetaNode",
+                NodeType::File,
+                &["code"],
+                1.0,
+                0.1,
+            )
+            .expect("add neighbor node");
+        graph
+            .add_edge(
+                focus,
+                neighbor,
+                "calls",
+                FiniteF32::new(0.8),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.5),
+            )
+            .expect("add edge");
+        // Sanity: ids are the first two nodes in an otherwise empty graph.
+        assert_eq!(focus, NodeId::new(0));
+        assert_eq!(neighbor, NodeId::new(1));
+        graph.finalize().expect("finalize graph");
+    }
+    state.rebuild_engines().expect("rebuild engines");
+}
+
+#[test]
+fn perspective_inspect_rejects_stale_version_and_accepts_matching_version() {
+    let temp = std::env::temp_dir().join("m1nd_perspective_stale_version_behavior");
+    let _ = std::fs::remove_dir_all(&temp);
+    std::fs::create_dir_all(&temp).expect("create temp dir");
+
+    let focus_external_id = "file::src/alpha_node.rs";
+    let mut state = build_state(&temp);
+    seed_graph_with_edge(&mut state, focus_external_id);
+
+    // perspective_start: anchor directly on the focus node so route synthesis
+    // is deterministic and the single edge yields >= 1 route.
+    let start = call(
+        &mut state,
+        "perspective_start",
+        json!({
+            "agent_id": "tester",
+            "query": "AlphaNode",
+            "anchor_node": focus_external_id,
+        }),
+    );
+
+    let perspective_id = start
+        .get("perspective_id")
+        .and_then(|value| value.as_str())
+        .expect("perspective_id in start output")
+        .to_string();
+
+    let version = start
+        .get("route_set_version")
+        .and_then(|value| value.as_u64())
+        .expect("route_set_version in start output");
+
+    let routes = start
+        .get("routes")
+        .and_then(|value| value.as_array())
+        .expect("routes array in start output");
+
+    assert!(
+        !routes.is_empty(),
+        "a focus node with one outgoing edge must yield at least one route; got total_routes={:?}",
+        start.get("total_routes")
+    );
+
+    let first_route_id = routes[0]
+        .get("route_id")
+        .and_then(|value| value.as_str())
+        .expect("route_id on first route")
+        .to_string();
+
+    // --- Stale path: a deliberately wrong version is rejected. ---
+    // `route_set_version` is wall-clock-derived (>> 1), so 1 is guaranteed to
+    // mismatch the stored version. The error is a pure function of the version
+    // mismatch and fires before any route lookup.
+    let stale_version = 1u64;
+    assert_ne!(
+        stale_version, version,
+        "test precondition: stale version must differ from the minted version"
+    );
+
+    let stale_result = dispatch_tool(
+        &mut state,
+        "perspective_inspect",
+        &json!({
+            "agent_id": "tester",
+            "perspective_id": perspective_id,
+            "route_index": 1,
+            "route_set_version": stale_version,
+        }),
+    );
+    assert!(
+        stale_result.is_err(),
+        "perspective_inspect with a stale route_set_version must be rejected, got Ok: {:?}",
+        stale_result.ok()
+    );
+    let stale_error = stale_result.unwrap_err().to_string();
+    assert!(
+        stale_error.contains("stale") && stale_error.contains("route_set_version"),
+        "stale rejection must explain the route_set_version staleness; got: {}",
+        stale_error
+    );
+    assert!(
+        stale_error.contains(&stale_version.to_string()),
+        "stale error must echo the rejected version {}; got: {}",
+        stale_version,
+        stale_error
+    );
+
+    // --- Happy path: the matching version + route_index=1 is accepted and the
+    // inspected route reflects the route set produced by perspective_start. ---
+    let ok = call(
+        &mut state,
+        "perspective_inspect",
+        json!({
+            "agent_id": "tester",
+            "perspective_id": perspective_id,
+            "route_index": 1,
+            "route_set_version": version,
+        }),
+    );
+
+    let inspected_route_id = ok
+        .get("route_id")
+        .and_then(|value| value.as_str())
+        .expect("route_id in inspect output");
+    assert_eq!(
+        inspected_route_id, first_route_id,
+        "inspecting route_index=1 with the matching version must return the first \
+         route minted by perspective_start"
+    );
+    assert_eq!(
+        ok.get("route_index").and_then(|value| value.as_u64()),
+        Some(1),
+        "inspected route_index must be the 1-based index that was requested"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+}

--- a/m1nd-mcp/tests/perspective_lifecycle_behavior.rs
+++ b/m1nd-mcp/tests/perspective_lifecycle_behavior.rs
@@ -1,0 +1,239 @@
+//! Behavioral CRUD lifecycle for the perspective management tools
+//! (`perspective_start` -> `perspective_list` -> `perspective_close`) driven
+//! through the real `dispatch_tool` harness against a populated graph.
+//!
+//! These assertions are value-bound, not vanity: the perspective created from a
+//! known ingested node must become observable in `perspective_list` (same id,
+//! same resolved focus, with the seeded `start` navigation event counted), and
+//! must disappear after `perspective_close`. The contract `proof_state`
+//! reacts to whether the agent has zero perspectives. This locks X-RAY's
+//! stateful navigation surface: create/list/close must reflect the create/close
+//! inputs rather than merely returning well-shaped JSON.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+/// Minimal L1GHT/1 document declaring a single entity, mirroring the
+/// `light_doc` helper used by `tests/test_auto_ingest.rs`.
+fn light_doc(entity: &str, doi: &str) -> String {
+    format!(
+        r#"---
+Protocol: L1GHT/1
+Node: {entity}
+State: active
+Color: amber
+Glyph: *
+Completeness: draft
+Proof: working
+Depends on:
+- {doi}
+Next:
+- validate
+---
+## Contract
+[⍂ entity: {entity}]
+[⟁ depends_on: {doi}]
+[𝔻 evidence: ready]
+"#
+    )
+}
+
+fn first_search_node_id(state: &mut SessionState, query: &str) -> String {
+    call(
+        state,
+        "search",
+        json!({"agent_id": "tester", "query": query, "mode": "literal"}),
+    )
+    .get("results")
+    .and_then(|value| value.as_array())
+    .and_then(|results| results.first())
+    .and_then(|entry| entry.get("node_id"))
+    .and_then(|value| value.as_str())
+    .unwrap_or_default()
+    .to_string()
+}
+
+#[test]
+fn perspective_start_list_close_lifecycle_reflects_inputs() {
+    let temp = std::env::temp_dir().join(format!(
+        "m1nd_perspective_lifecycle_{}_{}",
+        std::process::id(),
+        now_nanos()
+    ));
+    let docs_root = temp.join("docs");
+    fs::create_dir_all(&docs_root).expect("create docs root");
+    let file = docs_root.join("alpha.light.md");
+    fs::write(&file, light_doc("AlphaNode", "10.1000/shared")).expect("write light doc");
+
+    let mut state = build_state(&temp);
+
+    // Populate the graph: the light entity must be ingested and searchable
+    // before any read tool can resolve a focus node.
+    call(
+        &mut state,
+        "ingest",
+        json!({
+            "agent_id": "tester",
+            "path": file.to_string_lossy().to_string(),
+            "adapter": "light",
+            "mode": "merge"
+        }),
+    );
+
+    // The ingested entity is materialized as an external node id whose tail is
+    // the case-folded label. We bind every later assertion to this concrete id.
+    let ingested_node_id = first_search_node_id(&mut state, "AlphaNode");
+    assert!(
+        ingested_node_id.contains("alphanode"),
+        "ingest+search should yield the AlphaNode external id, got `{}`",
+        ingested_node_id
+    );
+
+    // ---- perspective_start: focus must resolve to the ingested node --------
+    // The query is matched (substring, case-sensitive) against external ids,
+    // so we seed with the case-folded label the ingester actually wrote.
+    let start = call(
+        &mut state,
+        "perspective_start",
+        json!({"agent_id": "tester", "query": "alphanode"}),
+    );
+
+    let perspective_id = start
+        .get("perspective_id")
+        .and_then(|value| value.as_str())
+        .expect("perspective_id present")
+        .to_string();
+    assert!(
+        !perspective_id.is_empty(),
+        "perspective_start must return a non-empty perspective_id"
+    );
+    assert_eq!(
+        start.get("focus_node").and_then(|value| value.as_str()),
+        Some(ingested_node_id.as_str()),
+        "focus_node must resolve to the ingested AlphaNode external id, not null"
+    );
+
+    // ---- perspective_list: the created perspective is observable -----------
+    let list = call(
+        &mut state,
+        "perspective_list",
+        json!({"agent_id": "tester"}),
+    );
+    let perspectives = list
+        .get("perspectives")
+        .and_then(|value| value.as_array())
+        .expect("perspectives array present");
+
+    let listed = perspectives
+        .iter()
+        .filter(|entry| {
+            entry.get("perspective_id").and_then(|value| value.as_str())
+                == Some(perspective_id.as_str())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        listed.len(),
+        1,
+        "perspective_list must contain EXACTLY the created perspective_id `{}`, got {:?}",
+        perspective_id,
+        perspectives
+    );
+
+    let summary = listed[0];
+    assert_eq!(
+        summary.get("focus_node").and_then(|value| value.as_str()),
+        Some(ingested_node_id.as_str()),
+        "listed perspective must carry the same resolved focus as start"
+    );
+    assert!(
+        summary
+            .get("nav_event_count")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0)
+            >= 1,
+        "the seeded `start` navigation event must be counted (nav_event_count >= 1)"
+    );
+
+    // ---- perspective_close: closed==true ----------------------------------
+    let close = call(
+        &mut state,
+        "perspective_close",
+        json!({"agent_id": "tester", "perspective_id": perspective_id.clone()}),
+    );
+    assert_eq!(
+        close.get("closed").and_then(|value| value.as_bool()),
+        Some(true),
+        "perspective_close must report closed==true for the existing perspective"
+    );
+
+    // ---- perspective_list after close: agent has zero perspectives ---------
+    let list_after = call(
+        &mut state,
+        "perspective_list",
+        json!({"agent_id": "tester"}),
+    );
+    let remaining = list_after
+        .get("perspectives")
+        .and_then(|value| value.as_array())
+        .expect("perspectives array present after close");
+    assert!(
+        remaining.is_empty(),
+        "perspective_list must be EMPTY after closing the only perspective, got {:?}",
+        remaining
+    );
+    assert_eq!(
+        list_after
+            .get("proof_state")
+            .and_then(|value| value.as_str()),
+        Some("blocked"),
+        "with zero perspectives the contract must surface proof_state==blocked"
+    );
+
+    // ---- contract reacts to a genuinely unknown agent ---------------------
+    let unknown = call(
+        &mut state,
+        "perspective_list",
+        json!({"agent_id": "agent-with-no-perspectives"}),
+    );
+    assert!(
+        unknown
+            .get("perspectives")
+            .and_then(|value| value.as_array())
+            .map(|value| value.is_empty())
+            .unwrap_or(false),
+        "unknown agent_id must yield an empty perspectives array"
+    );
+    assert_eq!(
+        unknown.get("proof_state").and_then(|value| value.as_str()),
+        Some("blocked"),
+        "unknown agent_id (zero perspectives) must surface proof_state==blocked"
+    );
+
+    let _ = fs::remove_dir_all(&temp);
+}
+
+fn now_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## O que

Testes de integração de **comportamento** pelo harness real `dispatch_tool` para duas áreas de handler load-bearing mas subcobertas (m1nd-mcp estava em 69%; `perspective_handlers` 16%, `lock_handlers` 53%):

- **lock_diff — controle de acesso:** agente não-dono recebe `LockOwnership`; `lock_id` inexistente recebe `LockNotFound` (o gate `require_lock`, distinguindo os dois variantes corretamente).
- **perspective — concorrência otimista (OCC):** `route_set_version` stale é rejeitado; a versão correta inspeciona a rota criada (route_id/index refletem o `start`).
- **perspective — ciclo de vida:** `start → list → close`, onde o `list` observa a perspectiva criada e depois a perde, e `proof_state` vira `blocked` quando vazio.

## Disciplina
- **Todo assert é value-bound a um input conhecido** (não shape/não-null). Um 4º teste (lock lifecycle) foi **dropado** porque o agente assumiu errado o contrato de baseline — não shipo teste com expectativa de contrato incerta.
- Usa o harness existente `SessionState::initialize` + `dispatch_tool`; aditivo, só teste, sem editar fonte.
- Surfado pela varredura de cobertura do X-RAY; **revisão adversarial 3/3 KEEP** (cada assert traçado contra o contrato real do handler).

Gates locais verdes: 4 testes (2+1+1), `clippy --tests -D warnings`, `fmt --check`. Mesma série de #141/#143/#145/#146/#147.