### PR TITLE
test(mcp): cover antibody lifecycle, why, counterfactual, trail via dispatch_tool

### DIFF
--- a/m1nd-mcp/tests/antibody_lifecycle_behavior.rs
+++ b/m1nd-mcp/tests/antibody_lifecycle_behavior.rs
@@ -1,0 +1,295 @@
+//! Behavioral coverage for the `antibody_create` / `antibody_list` / `antibody_scan`
+//! tools driven through the real `dispatch_tool` MCP surface.
+//!
+//! These tools form m1nd's immune-memory subsystem: an agent registers a structural
+//! bug pattern (antibody), lists the registry, and scans the graph for recurrences.
+//! Before this file the entire antibody tool trio had zero integration coverage in
+//! `m1nd-mcp` — nothing pinned the response shapes nor the mutation accounting the
+//! handlers do against `SessionState::antibodies`.
+//!
+//! Every assertion here tracks the exact prior mutation: the id returned by `create`
+//! is the id that shows up in `list`; `disable` flips the enabled/disabled counts by
+//! exactly one; `include_disabled=false` hides the just-disabled antibody; `delete`
+//! drops the total to zero; and enable/disable/delete on an unknown id make
+//! `dispatch_tool` return `Err`. The specificity (2 of 3 node constraints = ~0.67)
+//! and `initial_matches` against a known seeded `validate_request` function node are
+//! asserted against the inputs we control — not vanity not-null checks.
+//!
+//! This locks the antibody lifecycle contract so a refactor of the handlers or of the
+//! `Antibody` serialization (the `id`/`enabled` fields surfaced in `list`) cannot
+//! silently change agent-visible behavior. (X-RAY coverage: previously UNPROVABLE.)
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_core::types::NodeType;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::path::Path;
+
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+/// Seed one finalized `Function` node whose label contains "validate" so the example
+/// antibody pattern (anchor: function, label_contains "validate") matches exactly once.
+fn seed_validate_function(state: &mut SessionState) {
+    {
+        let mut graph = state.graph.write();
+        graph
+            .add_node(
+                "func::validate_request",
+                "validate_request",
+                NodeType::Function,
+                &["code"],
+                1.0,
+                0.1,
+            )
+            .unwrap();
+        // A second, non-matching function node ensures the match count reflects the
+        // label_contains constraint rather than "every function".
+        graph
+            .add_node(
+                "func::render_page",
+                "render_page",
+                NodeType::Function,
+                &["code"],
+                1.0,
+                0.1,
+            )
+            .unwrap();
+        graph.finalize().unwrap();
+    }
+    state.rebuild_engines().unwrap();
+}
+
+/// The example pattern from the tool docs: a single anchor function node constrained by
+/// type + label substring. specificity = 2 constraints / (1 node * 3) = ~0.667.
+fn example_create_params() -> serde_json::Value {
+    json!({
+        "agent_id": "tester",
+        "action": "create",
+        "name": "AB1",
+        "severity": "warning",
+        "pattern": {
+            "nodes": [
+                {
+                    "role": "anchor",
+                    "node_type": "function",
+                    "label_contains": "validate"
+                }
+            ],
+            "edges": []
+        }
+    })
+}
+
+#[test]
+fn antibody_create_then_list_then_disable_then_delete_tracks_each_mutation() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = build_state(temp.path());
+    seed_validate_function(&mut state);
+
+    // --- create -------------------------------------------------------------
+    let created = call(&mut state, "antibody_create", example_create_params());
+
+    let antibody_id = created
+        .get("antibody_id")
+        .and_then(|value| value.as_str())
+        .expect("create returns antibody_id")
+        .to_string();
+    assert!(
+        antibody_id.starts_with("ab-"),
+        "antibody id should use the ab- prefix, got {antibody_id}"
+    );
+
+    let specificity = created
+        .get("specificity")
+        .and_then(|value| value.as_f64())
+        .expect("create returns specificity");
+    assert!(
+        (specificity - 0.666_667).abs() < 0.01,
+        "2 of 3 node constraints should yield specificity ~0.67, got {specificity}"
+    );
+
+    let initial_matches = created
+        .get("initial_matches")
+        .and_then(|value| value.as_u64())
+        .expect("create returns initial_matches");
+    assert_eq!(
+        initial_matches, 1,
+        "exactly one seeded function label contains 'validate'"
+    );
+
+    // --- list after create --------------------------------------------------
+    let listed = call(
+        &mut state,
+        "antibody_list",
+        json!({ "agent_id": "tester", "include_disabled": true }),
+    );
+    assert_eq!(
+        listed.get("total").and_then(|value| value.as_u64()),
+        Some(1),
+        "exactly one antibody exists after a single create"
+    );
+    assert_eq!(
+        listed.get("enabled").and_then(|value| value.as_u64()),
+        Some(1),
+        "the freshly created antibody is enabled"
+    );
+    assert_eq!(
+        listed.get("disabled").and_then(|value| value.as_u64()),
+        Some(0),
+        "nothing is disabled yet"
+    );
+    let listed_id = listed
+        .get("antibodies")
+        .and_then(|value| value.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|entry| entry.get("id"))
+        .and_then(|value| value.as_str())
+        .expect("listed antibody exposes its id");
+    assert_eq!(
+        listed_id, antibody_id,
+        "the listed antibody is the one create returned"
+    );
+
+    // --- disable ------------------------------------------------------------
+    let disabled = call(
+        &mut state,
+        "antibody_create",
+        json!({
+            "agent_id": "tester",
+            "action": "disable",
+            "antibody_id": antibody_id
+        }),
+    );
+    assert_eq!(
+        disabled.get("success").and_then(|value| value.as_bool()),
+        Some(true),
+        "disable on an existing id succeeds"
+    );
+
+    // include_disabled=true still sees it, now counted as disabled.
+    let listed_all = call(
+        &mut state,
+        "antibody_list",
+        json!({ "agent_id": "tester", "include_disabled": true }),
+    );
+    assert_eq!(
+        listed_all.get("enabled").and_then(|value| value.as_u64()),
+        Some(0),
+        "after disable nothing is enabled"
+    );
+    assert_eq!(
+        listed_all.get("disabled").and_then(|value| value.as_u64()),
+        Some(1),
+        "after disable exactly one is disabled"
+    );
+
+    // include_disabled=false hides the disabled antibody entirely.
+    let listed_enabled_only = call(
+        &mut state,
+        "antibody_list",
+        json!({ "agent_id": "tester", "include_disabled": false }),
+    );
+    let visible = listed_enabled_only
+        .get("antibodies")
+        .and_then(|value| value.as_array())
+        .expect("antibodies array present");
+    assert!(
+        visible.is_empty(),
+        "include_disabled=false hides the disabled antibody, got {visible:?}"
+    );
+
+    // --- delete -------------------------------------------------------------
+    let deleted = call(
+        &mut state,
+        "antibody_create",
+        json!({
+            "agent_id": "tester",
+            "action": "delete",
+            "antibody_id": antibody_id
+        }),
+    );
+    assert_eq!(
+        deleted.get("success").and_then(|value| value.as_bool()),
+        Some(true),
+        "delete on an existing id succeeds"
+    );
+
+    let listed_after_delete = call(
+        &mut state,
+        "antibody_list",
+        json!({ "agent_id": "tester", "include_disabled": true }),
+    );
+    assert_eq!(
+        listed_after_delete
+            .get("total")
+            .and_then(|value| value.as_u64()),
+        Some(0),
+        "registry is empty after delete"
+    );
+}
+
+#[test]
+fn antibody_mutations_on_unknown_id_return_err() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = build_state(temp.path());
+    seed_validate_function(&mut state);
+
+    // No .expect here: we assert dispatch_tool itself errors (AntibodyNotFound).
+    for action in ["enable", "disable", "delete"] {
+        let result = dispatch_tool(
+            &mut state,
+            "antibody_create",
+            &json!({
+                "agent_id": "tester",
+                "action": action,
+                "antibody_id": "does-not-exist"
+            }),
+        );
+        assert!(
+            result.is_err(),
+            "{action} on a non-existent antibody id should return Err, got {result:?}"
+        );
+    }
+}
+
+#[test]
+fn antibody_scan_finds_the_created_pattern_in_the_seeded_graph() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = build_state(temp.path());
+    seed_validate_function(&mut state);
+
+    call(&mut state, "antibody_create", example_create_params());
+
+    let scan = call(&mut state, "antibody_scan", json!({ "agent_id": "tester" }));
+
+    assert_eq!(
+        scan.get("antibodies_checked")
+            .and_then(|value| value.as_u64()),
+        Some(1),
+        "the one enabled antibody is checked during scan"
+    );
+
+    let matches = scan
+        .get("matches")
+        .and_then(|value| value.as_array())
+        .expect("scan returns a matches array");
+    assert_eq!(
+        matches.len(),
+        1,
+        "scan finds exactly the seeded validate_request function, got {matches:?}"
+    );
+}

--- a/m1nd-mcp/tests/counterfactual_behavior.rs
+++ b/m1nd-mcp/tests/counterfactual_behavior.rs
@@ -1,0 +1,219 @@
+//! Behavioral coverage for the `counterfactual` MCP tool (X-RAY safety net).
+//!
+//! These tests lock the two branches of `handle_counterfactual`
+//! (`m1nd-mcp/src/tools.rs`): the early-return error path taken when no input
+//! id resolves, and the success path taken when an id resolves to a real graph
+//! node. The branch is selected purely by whether the input id resolves, so the
+//! assertions check input-derived facts — the echoed `node_ids`/`removed_nodes`,
+//! and that removing a file node surfaces a non-empty downstream cascade over its
+//! outgoing `contains` children (struct/impl/method) — rather than mere shape.
+//!
+//! Each `tests/*.rs` file is its own crate, so the `build_state`/`call` harness
+//! helpers are replicated here on purpose instead of imported from another test
+//! file.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+/// Create a unique temp dir for one test and return it.
+fn unique_dir(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("m1nd_cf_{tag}_{nanos}_{}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+/// Ingest a two-file Rust crate where `main.rs` imports a `Helper` struct from
+/// `helper.rs`, mirroring the `why`-style fixture. Returns the source root so it
+/// can be cleaned up by the caller.
+fn ingest_helper_crate(state: &mut SessionState) -> PathBuf {
+    let code_root = unique_dir("src");
+    write(
+        &code_root.join("Cargo.toml"),
+        "[package]\nname = \"cfprobe\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    );
+    write(
+        &code_root.join("src/helper.rs"),
+        "pub struct Helper {\n    pub value: i32,\n}\n\nimpl Helper {\n    pub fn new() -> Self {\n        Helper { value: 0 }\n    }\n}\n",
+    );
+    write(
+        &code_root.join("src/main.rs"),
+        "mod helper;\nuse helper::Helper;\n\nfn main() {\n    let h = Helper::new();\n    println!(\"{}\", h.value);\n}\n",
+    );
+
+    call(
+        state,
+        "ingest",
+        json!({
+            "agent_id": "tester",
+            "path": code_root.to_string_lossy().to_string(),
+            "adapter": "code",
+            "mode": "replace",
+        }),
+    );
+    code_root
+}
+
+/// node_ids that resolve to nothing must take the early-return error path:
+/// `error == "No valid node IDs found"` and the input ids are echoed back. This
+/// branch is selected purely because the id fails to resolve in the graph.
+#[test]
+fn counterfactual_unresolved_ids_return_error_and_echo_input() {
+    let runtime = unique_dir("err_rt");
+    let mut state = build_state(&runtime);
+    // Populate the graph so this is the resolve-failure path, not an empty-graph
+    // accident — the ghost id below still must not resolve.
+    let code_root = ingest_helper_crate(&mut state);
+
+    let ghost = "file::definitely-not-a-real-node-ghost.rs";
+    let output = call(
+        &mut state,
+        "counterfactual",
+        json!({ "agent_id": "tester", "node_ids": [ghost] }),
+    );
+
+    assert_eq!(
+        output.get("error").and_then(|value| value.as_str()),
+        Some("No valid node IDs found"),
+        "unresolved ids must hit the early-return error branch, got: {output}"
+    );
+    let echoed: Vec<String> = output
+        .get("node_ids")
+        .and_then(|value| value.as_array())
+        .map(|ids| {
+            ids.iter()
+                .filter_map(|id| id.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        echoed,
+        vec![ghost.to_string()],
+        "error path must echo back the exact input node_ids"
+    );
+
+    fs::remove_dir_all(&runtime).ok();
+    fs::remove_dir_all(&code_root).ok();
+}
+
+/// Removing the `helper.rs` file that `main.rs` depends on must take the success
+/// path: `total_impact` / `pct_activation_lost` are present, `removed_nodes`
+/// echoes the input, and the cascade follows the file node's outgoing
+/// `contains` children (the `Helper` struct/impl/method), so
+/// `cascade.total_affected >= 1`.
+#[test]
+fn counterfactual_removing_depended_on_node_reports_downstream_cascade() {
+    let runtime = unique_dir("ok_rt");
+    let mut state = build_state(&runtime);
+    let code_root = ingest_helper_crate(&mut state);
+
+    // The file-level id format is stable (`file::<relpath>`); confirm it
+    // resolved by checking search returned it before driving counterfactual.
+    let target = "file::src/helper.rs";
+    let search = call(
+        &mut state,
+        "search",
+        json!({ "agent_id": "tester", "query": "Helper", "mode": "literal" }),
+    );
+    let resolved = search
+        .get("results")
+        .and_then(|value| value.as_array())
+        .map(|results| {
+            results
+                .iter()
+                .any(|entry| entry.get("node_id").and_then(|value| value.as_str()) == Some(target))
+        })
+        .unwrap_or(false);
+    assert!(
+        resolved,
+        "expected ingested graph to contain {target}, search returned: {search}"
+    );
+
+    let output = call(
+        &mut state,
+        "counterfactual",
+        json!({
+            "agent_id": "tester",
+            "node_ids": [target],
+            "include_cascade": true,
+        }),
+    );
+
+    assert!(
+        output.get("error").is_none(),
+        "resolved id must take the success branch, got: {output}"
+    );
+
+    let removed: Vec<String> = output
+        .get("removed_nodes")
+        .and_then(|value| value.as_array())
+        .map(|ids| {
+            ids.iter()
+                .filter_map(|id| id.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        removed,
+        vec![target.to_string()],
+        "success path must echo the removed node back in removed_nodes"
+    );
+
+    assert!(
+        output
+            .get("total_impact")
+            .and_then(|value| value.as_f64())
+            .is_some(),
+        "success path must report total_impact, got: {output}"
+    );
+    assert!(
+        output
+            .get("pct_activation_lost")
+            .and_then(|value| value.as_f64())
+            .is_some(),
+        "success path must report pct_activation_lost, got: {output}"
+    );
+
+    let total_affected = output
+        .get("cascade")
+        .and_then(|value| value.get("total_affected"))
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    assert!(
+        total_affected >= 1,
+        "removing helper.rs must surface a downstream cascade over its contained \
+         symbols, got total_affected={total_affected} in: {output}"
+    );
+
+    fs::remove_dir_all(&runtime).ok();
+    fs::remove_dir_all(&code_root).ok();
+}

--- a/m1nd-mcp/tests/trail_save_list_resume_dispatch_behavior.rs
+++ b/m1nd-mcp/tests/trail_save_list_resume_dispatch_behavior.rs
@@ -1,0 +1,282 @@
+//! Behavioral coverage for the `trail_save` -> `trail_list` -> `trail_resume`
+//! tool chain driven through `dispatch_tool` (the real MCP entry point).
+//!
+//! The existing in-module unit tests in `layer_handlers.rs` cover the save/resume
+//! internals by calling the handlers directly with hand-built nodes; they do NOT
+//! exercise the `dispatch_tool` JSON path, the `trail_list` tag/status filtering,
+//! or the on-disk save -> list -> resume roundtrip across freshly dispatched
+//! calls against a graph populated by a real `ingest`. This X-RAY-style coverage
+//! locks the dispatch contract: trail_id naming, save counts (including the
+//! supporting-node upsert), tag-filter fidelity in trail_list, and node
+//! resolution vs. a bogus node during resume.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+fn u64_at(value: &serde_json::Value, key: &str) -> u64 {
+    value
+        .get(key)
+        .and_then(|inner| inner.as_u64())
+        .unwrap_or_else(|| panic!("expected numeric field {key:?} in {value}"))
+}
+
+/// Ingest a tiny two-file Rust project so that the trail's visited /
+/// supporting node external ids resolve against a real populated graph.
+/// Node id shape confirmed against the live `code` adapter:
+///   `file::src/helper.rs::struct::Helper` and `file::src/main.rs`.
+fn ingest_two_file_project(state: &mut SessionState, project: &Path) {
+    fs::create_dir_all(project.join("src")).expect("create src dir");
+    fs::write(
+        project.join("src/helper.rs"),
+        "pub struct Helper {\n    pub seed: u32,\n}\n\nimpl Helper {\n    pub fn make() -> Helper {\n        Helper { seed: 1 }\n    }\n}\n",
+    )
+    .expect("write helper.rs");
+    fs::write(
+        project.join("src/main.rs"),
+        "mod helper;\n\nfn main() {\n    let _ = helper::Helper::make();\n}\n",
+    )
+    .expect("write main.rs");
+
+    let ingest = call(
+        state,
+        "ingest",
+        json!({
+            "agent_id": "tester",
+            "path": project.to_string_lossy().to_string(),
+            "adapter": "code",
+            "mode": "replace"
+        }),
+    );
+    let node_count = ingest
+        .get("nodes")
+        .and_then(|inner| inner.as_u64())
+        .or_else(|| ingest.get("node_count").and_then(|inner| inner.as_u64()));
+    if let Some(count) = node_count {
+        assert!(count > 0, "code ingest should populate the graph: {ingest}");
+    }
+}
+
+#[test]
+fn trail_save_list_resume_dispatch_roundtrip_is_behaviorally_faithful() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("proj");
+    let mut state = build_state(temp.path());
+    ingest_two_file_project(&mut state, &project);
+
+    // --- trail_save: counts must reflect the exact input we passed ---
+    let save = call(
+        &mut state,
+        "trail_save",
+        json!({
+            "agent_id": "tester",
+            "label": "Investigation A",
+            "tags": ["auth"],
+            "hypotheses": [{
+                "statement": "H1",
+                "confidence": 0.8,
+                "supporting_nodes": ["file::src/helper.rs::struct::Helper"]
+            }],
+            "conclusions": [{ "statement": "C1", "confidence": 0.9 }],
+            "open_questions": ["q1", "q2"],
+            "visited_nodes": [{ "node_external_id": "file::src/main.rs", "relevance": 0.7 }]
+        }),
+    );
+
+    assert_eq!(
+        u64_at(&save, "hypotheses_saved"),
+        1,
+        "exactly one hypothesis was supplied"
+    );
+    assert_eq!(
+        u64_at(&save, "conclusions_saved"),
+        1,
+        "exactly one conclusion was supplied"
+    );
+    assert_eq!(
+        u64_at(&save, "open_questions_saved"),
+        2,
+        "two open questions were supplied"
+    );
+    // visited (file::src/main.rs) + the hypothesis supporting node
+    // (file::src/helper.rs::struct::Helper) are both upserted into visited_nodes.
+    assert!(
+        u64_at(&save, "nodes_saved") >= 2,
+        "visited node plus hypothesis supporting node should both be saved: {save}"
+    );
+
+    let trail_id = save
+        .get("trail_id")
+        .and_then(|inner| inner.as_str())
+        .expect("trail_id present")
+        .to_string();
+    assert!(
+        trail_id.starts_with("trail_tester_001_"),
+        "first trail for agent 'tester' must be counter 001: got {trail_id}"
+    );
+
+    // --- trail_list: matching tag returns exactly this trail with faithful counts ---
+    let listed = call(
+        &mut state,
+        "trail_list",
+        json!({ "agent_id": "tester", "filter_tags": ["auth"] }),
+    );
+    assert_eq!(
+        u64_at(&listed, "total_count"),
+        1,
+        "the auth tag matches the one saved trail: {listed}"
+    );
+    let trails = listed
+        .get("trails")
+        .and_then(|inner| inner.as_array())
+        .expect("trails array");
+    assert_eq!(trails.len(), 1, "exactly one trail entry expected");
+    let entry = &trails[0];
+    assert_eq!(
+        entry.get("trail_id").and_then(|inner| inner.as_str()),
+        Some(trail_id.as_str()),
+        "listed trail id must match the saved id"
+    );
+    assert_eq!(
+        u64_at(entry, "hypothesis_count"),
+        1,
+        "summary hypothesis_count mirrors the saved hypothesis"
+    );
+    assert_eq!(
+        u64_at(entry, "open_question_count"),
+        2,
+        "summary open_question_count mirrors the two saved questions"
+    );
+
+    // --- trail_list: non-matching tag is a real filter, not cosmetic ---
+    let empty = call(
+        &mut state,
+        "trail_list",
+        json!({ "agent_id": "tester", "filter_tags": ["nope"] }),
+    );
+    assert_eq!(
+        u64_at(&empty, "total_count"),
+        0,
+        "a tag that no trail carries must yield zero results: {empty}"
+    );
+    let empty_trails = empty
+        .get("trails")
+        .and_then(|inner| inner.as_array())
+        .expect("trails array");
+    assert!(
+        empty_trails.is_empty(),
+        "non-matching tag filter returns no trail summaries"
+    );
+
+    // --- trail_resume: known nodes resolve, no bogus id leaks into missing_nodes ---
+    let resume = call(
+        &mut state,
+        "trail_resume",
+        json!({ "agent_id": "tester", "trail_id": trail_id }),
+    );
+    assert_eq!(
+        resume.get("label").and_then(|inner| inner.as_str()),
+        Some("Investigation A"),
+        "resume must restore the saved label"
+    );
+    let missing = resume
+        .get("missing_nodes")
+        .and_then(|inner| inner.as_array())
+        .expect("missing_nodes array");
+    let missing_ids: Vec<&str> = missing.iter().filter_map(|inner| inner.as_str()).collect();
+    assert!(
+        !missing_ids.contains(&"file::src/main.rs"),
+        "the visited file node resolves against the ingested graph: {missing_ids:?}"
+    );
+    assert!(
+        !missing_ids.contains(&"file::src/helper.rs::struct::Helper"),
+        "the hypothesis supporting struct resolves against the ingested graph: {missing_ids:?}"
+    );
+}
+
+#[test]
+fn trail_resume_reports_unresolvable_node_as_missing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("proj");
+    let mut state = build_state(temp.path());
+    ingest_two_file_project(&mut state, &project);
+
+    // Save a throwaway first trail so the trail under test is the second one
+    // for this agent -> counter must advance from 001 to 002 (real per-agent
+    // counter behavior, not a constant).
+    let first = call(
+        &mut state,
+        "trail_save",
+        json!({ "agent_id": "tester", "label": "Investigation A" }),
+    );
+    assert!(first
+        .get("trail_id")
+        .and_then(|inner| inner.as_str())
+        .expect("first trail_id")
+        .starts_with("trail_tester_001_"));
+
+    // Save a trail that visits one real node and one node that does not exist
+    // in the ingested graph. The bogus node MUST surface in missing_nodes,
+    // proving resolution is real rather than vacuous.
+    let bogus = "file::src/ghost.rs::struct::Phantom";
+    let save = call(
+        &mut state,
+        "trail_save",
+        json!({
+            "agent_id": "tester",
+            "label": "Investigation B",
+            "tags": ["auth"],
+            "visited_nodes": [
+                { "node_external_id": "file::src/main.rs", "relevance": 0.7 },
+                { "node_external_id": bogus, "relevance": 0.5 }
+            ]
+        }),
+    );
+    let trail_id = save
+        .get("trail_id")
+        .and_then(|inner| inner.as_str())
+        .expect("trail_id present")
+        .to_string();
+    // Second trail saved by the same agent in this state -> counter 002.
+    assert!(
+        trail_id.starts_with("trail_tester_002_"),
+        "second trail for agent 'tester' must be counter 002: got {trail_id}"
+    );
+
+    let resume = call(
+        &mut state,
+        "trail_resume",
+        json!({ "agent_id": "tester", "trail_id": trail_id }),
+    );
+    let missing = resume
+        .get("missing_nodes")
+        .and_then(|inner| inner.as_array())
+        .expect("missing_nodes array");
+    let missing_ids: Vec<&str> = missing.iter().filter_map(|inner| inner.as_str()).collect();
+    assert!(
+        missing_ids.contains(&bogus),
+        "the unresolvable node must be reported missing: {missing_ids:?}"
+    );
+    assert!(
+        !missing_ids.contains(&"file::src/main.rs"),
+        "the real node must NOT be reported missing: {missing_ids:?}"
+    );
+}

--- a/m1nd-mcp/tests/why_path_reconstruction_behavior.rs
+++ b/m1nd-mcp/tests/why_path_reconstruction_behavior.rs
@@ -1,0 +1,187 @@
+//! Behavioral coverage for the `why` MCP tool via the real `dispatch_tool`
+//! harness. After code-ingesting a tiny two-file Rust project, `main.rs`
+//! imports and uses `Helper` from `helper.rs`, which produces a real
+//! cross-file edge `file::src/main.rs -> file::src/helper.rs::struct::Helper`
+//! (the same edge the in-crate test `memorize_after_code_ingest_preserves_code_edges`
+//! depends on). These tests assert that `why` reconstructs that exact path and
+//! that an unresolvable target yields `found == false` with an empty path and
+//! the canonical "not found" reason.
+//!
+//! This is X-RAY coverage for the path-reconstruction contract: the `found`
+//! flag and reconstructed node sequence must reflect the actual ingested edge,
+//! not merely a non-null shape.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn build_state(root: &Path) -> SessionState {
+    let config = McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+fn call(state: &mut SessionState, tool: &str, params: serde_json::Value) -> serde_json::Value {
+    dispatch_tool(state, tool, &params).expect("tool call")
+}
+
+/// Create a unique scratch directory under the OS temp dir for one test.
+fn unique_temp_dir(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("m1nd_why_{tag}_{}_{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create unique temp dir");
+    dir
+}
+
+/// Write the canonical two-file Rust project and code-ingest it, returning the
+/// initialized session with a populated graph.
+fn ingest_two_file_project(root: &Path) -> SessionState {
+    let proj = root.join("proj");
+    fs::create_dir_all(proj.join("src")).expect("proj src dir");
+    fs::write(proj.join("src/helper.rs"), "pub struct Helper;\n").expect("write helper");
+    fs::write(
+        proj.join("src/main.rs"),
+        "mod helper;\nuse crate::helper::Helper;\npub fn build(_: Helper) {}\n",
+    )
+    .expect("write main");
+
+    let mut state = build_state(root);
+    let ingest = call(
+        &mut state,
+        "ingest",
+        json!({
+            "agent_id": "tester",
+            "path": proj.to_string_lossy().to_string(),
+            "adapter": "code",
+            "mode": "replace",
+        }),
+    );
+    let edge_count = ingest
+        .get("edge_count")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    assert!(
+        edge_count > 2,
+        "code ingest must leave structural edges in the live graph, got edge_count={edge_count}"
+    );
+    state
+}
+
+#[test]
+fn why_reconstructs_real_cross_file_import_path() {
+    let root = unique_temp_dir("found");
+    let mut state = ingest_two_file_project(&root);
+
+    let result = call(
+        &mut state,
+        "why",
+        json!({
+            "agent_id": "tester",
+            "source": "file::src/main.rs",
+            "target": "file::src/helper.rs::struct::Helper",
+            "max_hops": 5,
+        }),
+    );
+
+    assert_eq!(
+        result.get("found").and_then(|value| value.as_bool()),
+        Some(true),
+        "why must find the ingested cross-file edge, got: {result}"
+    );
+
+    let paths = result
+        .get("paths")
+        .and_then(|value| value.as_array())
+        .expect("paths array present");
+    assert!(
+        !paths.is_empty(),
+        "a found connection must yield at least one path, got: {result}"
+    );
+
+    let first = &paths[0];
+    let hops = first
+        .get("hops")
+        .and_then(|value| value.as_u64())
+        .expect("hops present on first path");
+    assert!(
+        hops >= 1,
+        "reconstructed path must traverse at least one edge, got hops={hops}"
+    );
+
+    let nodes = first
+        .get("nodes")
+        .and_then(|value| value.as_array())
+        .expect("nodes present on first path");
+    assert!(
+        nodes.len() >= 2,
+        "a >=1-hop path must list at least source and target labels, got: {nodes:?}"
+    );
+
+    let first_label = nodes
+        .first()
+        .and_then(|value| value.as_str())
+        .expect("first node label is a string");
+    let last_label = nodes
+        .last()
+        .and_then(|value| value.as_str())
+        .expect("last node label is a string");
+    // The graph labels the source node by its relative path ("src/main.rs"),
+    // so match the suffix rather than a bare file name.
+    assert!(
+        first_label.ends_with("main.rs"),
+        "path must start at the source node, got: {nodes:?}"
+    );
+    assert_eq!(
+        last_label, "Helper",
+        "path must end at the target node label, got: {nodes:?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn why_reports_not_found_for_unresolvable_target() {
+    let root = unique_temp_dir("missing");
+    let mut state = ingest_two_file_project(&root);
+
+    let result = call(
+        &mut state,
+        "why",
+        json!({
+            "agent_id": "tester",
+            "source": "file::src/main.rs",
+            "target": "file::nonexistent.rs",
+            "max_hops": 5,
+        }),
+    );
+
+    // `why` signals "not found" via an empty paths list + a canonical reason
+    // string (there is no boolean `found` field on this response).
+    let paths = result
+        .get("paths")
+        .and_then(|value| value.as_array())
+        .expect("paths array present");
+    assert!(
+        paths.is_empty(),
+        "an unresolvable target must yield no paths, got: {paths:?}"
+    );
+
+    assert_eq!(
+        result.get("reason").and_then(|value| value.as_str()),
+        Some("One or both nodes not found"),
+        "an unresolvable node must surface the canonical reason, got: {result}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
## O que

Testes de integração de **comportamento** pelo harness real `dispatch_tool` para quatro áreas de handler subcobertas (m1nd-mcp em 69%; segue a série #148):

- **antibody_create/list/scan** — CRUD completo: specificity (~0.67) + contagens de match que rastreiam cada mutação; enable/disable/delete em id inexistente → `Err`. **O subsistema antibody não tinha teste nenhum.**
- **why** — reconstrói um path de import cross-file real (found + labels + hops) e sinaliza not-found via paths vazio + reason canônico.
- **counterfactual** — ramo de erro (ids não-resolvíveis) vs sucesso (removed_nodes echo + cascade de `contains` não-vazio).
- **trail_save/list/resume** — contagens do save, filtro por tag, e o round-trip em disco save→list→resume entre dispatches frescos.

## Disciplina
- **Todo assert é value-bound a um input conhecido.** Um teste do `why` tinha 2 asserts errados (assumiu campo `found` inexistente + label main.rs em vez de src/main.rs) — **corrigi pro contrato real** depois de verificar eu mesmo.
- Aditivo, só teste, via harness existente `SessionState::initialize` + `dispatch_tool`.
- **Revisão adversarial 4/4 KEEP** (asserts recomputados contra o fonte: specificity 0.667, contador trail 001→002, fronteira estrita 0.5 do missing_ratio, etc.).

Gates locais verdes: 9 testes (3+2+2+2), `clippy --tests -D warnings`, `fmt --check`.