### PR TITLE
fix(core): taint boundary that is an entry seed is a hit, not a miss

### DIFF
--- a/m1nd-core/src/taint.rs
+++ b/m1nd-core/src/taint.rs
@@ -262,6 +262,16 @@ impl TaintEngine {
             .map(|p| p.node_id.clone())
             .collect();
 
+        // Seeds (entry points) carry maximal taint by definition — they ARE the
+        // injection points. The epidemic predictions exclude seeds (and truncate
+        // to top_k), so without this a boundary that coincides with a seed would
+        // be misreported as a missed boundary with probability 0.0.
+        let seed_ext_ids: HashSet<&str> = entry_node_ids
+            .iter()
+            .filter_map(|nid| node_to_ext.get(nid.as_usize()).map(String::as_str))
+            .filter(|s| !s.is_empty())
+            .collect();
+
         // Scan all nodes for boundary patterns
         let mut boundary_hits = Vec::new();
         let mut boundary_misses = Vec::new();
@@ -273,13 +283,18 @@ impl TaintEngine {
 
             let boundary_type = detect_boundary_type(&label, &boundary_patterns, &custom_patterns);
             if let Some(btype) = boundary_type {
-                let taint_reached = infected_nodes.contains(ext_id);
-                let prob = epidemic_result
-                    .predictions
-                    .iter()
-                    .find(|p| p.node_id == *ext_id)
-                    .map(|p| p.infection_probability)
-                    .unwrap_or(0.0);
+                let is_seed = seed_ext_ids.contains(ext_id.as_str());
+                let taint_reached = is_seed || infected_nodes.contains(ext_id);
+                let prob = if is_seed {
+                    1.0
+                } else {
+                    epidemic_result
+                        .predictions
+                        .iter()
+                        .find(|p| p.node_id == *ext_id)
+                        .map(|p| p.infection_probability)
+                        .unwrap_or(0.0)
+                };
 
                 let check = BoundaryCheck {
                     node_id: ext_id.to_string(),

--- a/m1nd-core/tests/taint_seed_boundary.rs
+++ b/m1nd-core/tests/taint_seed_boundary.rs
@@ -1,0 +1,72 @@
+//! Regression: a security boundary that is itself an entry (seed) node must be
+//! reported as a HIT with maximal taint, not as a missed boundary.
+//!
+//! `TaintEngine::analyze` derived `taint_reached`/`infection_probability` purely
+//! from the epidemic predictions. But the epidemic excludes the seed nodes from
+//! its predictions (and truncates to top_k), so a boundary node that coincides
+//! with an injection point (e.g. a `validate_*` function called directly with
+//! user input) was pushed into `boundary_misses` with probability 0.0. That
+//! falsely reports a security boundary as bypassed when taint is in fact
+//! maximally present at it, and inflates the risk score.
+//!
+//! A seed carries maximal taint by definition, so a boundary that is a seed is a
+//! HIT with probability 1.0. (Surfaced by the X-RAY adversarial bug hunt; proven
+//! failing-then-passing.)
+
+use m1nd_core::graph::Graph;
+use m1nd_core::taint::{TaintConfig, TaintEngine};
+use m1nd_core::types::{EdgeDirection, FiniteF32, NodeId, NodeType};
+
+fn add(g: &mut Graph, ext: &str, label: &str) {
+    g.add_node(ext, label, NodeType::Function, &["svc"], 0.0, 0.1)
+        .unwrap();
+}
+
+#[test]
+fn boundary_that_is_an_entry_seed_is_a_hit_not_a_miss() {
+    // Node 0's label matches the UserInput boundary pattern "validate" AND it is
+    // the entry/seed (the injection point). Node 1 is a plain downstream node.
+    let mut g = Graph::new();
+    add(&mut g, "svc::validate_request", "validate_request");
+    add(&mut g, "svc::handler", "handler");
+    g.add_edge(
+        NodeId::new(0),
+        NodeId::new(1),
+        "calls",
+        FiniteF32::new(0.9),
+        EdgeDirection::Forward,
+        false,
+        FiniteF32::new(0.5),
+    )
+    .unwrap();
+    g.finalize().unwrap();
+
+    // Default taint_type is UserInput, whose patterns include "validate".
+    let config = TaintConfig::default();
+    let result = TaintEngine::analyze(&g, &[NodeId::new(0)], &config).unwrap();
+
+    let in_misses = result
+        .boundary_misses
+        .iter()
+        .any(|b| b.label == "validate_request");
+    assert!(
+        !in_misses,
+        "a boundary that is the seed must NOT be reported as a miss; misses={:?}",
+        result.boundary_misses
+    );
+
+    let hit = result
+        .boundary_hits
+        .iter()
+        .find(|b| b.label == "validate_request")
+        .expect("the seed boundary must be reported as a HIT");
+    assert!(
+        hit.taint_reached,
+        "the seed boundary must have taint_reached == true"
+    );
+    assert!(
+        hit.infection_probability >= 0.99,
+        "the seed carries maximal taint, expected probability ~1.0, got {}",
+        hit.infection_probability
+    );
+}


### PR DESCRIPTION
## Bug (HIGH, security-relevant — do registro do X-RAY)
`TaintEngine::analyze` derivava `taint_reached`/`infection_probability` só das predictions do epidemic, que **excluem os nós seed**. Então um boundary de segurança que coincide com um ponto de injeção (ex.: `validate_*` chamado direto com input do usuário) caía em `boundary_misses` com prob 0.0 — **reportando falsamente o boundary como bypassado** quando o taint está maximamente presente nele, e inflando o `risk_score`.

## Fix
Seeds carregam taint máximo por definição → um boundary que é seed agora é **HIT com prob 1.0**. `seed_ext_ids` construído de `entry_node_ids` via `node_to_ext` (com `.get()`, sem panic em índice fora de range).

## Prova
Teste de regressão (`tests/taint_seed_boundary.rs`): um nó seed cujo label casa "validate" deve ser HIT prob 1.0. **Falhava no código pré-fix** (seed em `boundary_misses` com `taint_reached:false, infection_probability:0.0`), passa depois.

## Escopo honesto
Isto corrige o **modo seed** (o mais grave e determinístico). Um **segundo modo** — boundary genuinamente infectado mas ranqueado **abaixo do top_k=200** do epidemic, ainda classificado como miss — fica como **follow-up HIGH explícito** no registro (`~/xray/docs/BUG_REGISTER_2026-06-27.md`); fix recomendado: parar de truncar as predictions pro taint (que quer cobertura total, já roda com `burnout_threshold:1.0`).

## Verificação
`cargo test -p m1nd-core` + `-p m1nd-mcp` inteiros **verdes**, `clippy --tests -D warnings` + `fmt --check` limpos. Achado pela caça adversarial do X-RAY; **revisão adversarial do fix** APROVADA (modo seed correto/completo; modo top_k recomendado como follow-up).

3º fix de bug da série (#147 overflow, #151 resonance, este). **2 dos 2 HIGH agora endereçados** (resonance fechado; taint seed-mode fechado + top_k registrado).