### PR TITLE
fix(core): include seed taint in TaintSummary max (Codex P2 on #152)

### DIFF
--- a/m1nd-core/src/taint.rs
+++ b/m1nd-core/src/taint.rs
@@ -368,11 +368,15 @@ impl TaintEngine {
             boundary_hits: boundary_hits.len(),
             boundary_misses: boundary_misses.len(),
             leaks_found: leaks.len(),
+            // Entry seeds are infected at probability 1.0 by definition; include
+            // them so the summary maximum cannot contradict a seed boundary that
+            // is (correctly) reported as a 1.0 hit.
             max_infection_probability: epidemic_result
                 .predictions
                 .first()
                 .map(|p| p.infection_probability)
-                .unwrap_or(0.0),
+                .unwrap_or(0.0)
+                .max(if entry_node_ids.is_empty() { 0.0 } else { 1.0 }),
             elapsed_ms,
         };
 

--- a/m1nd-core/src/taint.rs
+++ b/m1nd-core/src/taint.rs
@@ -368,15 +368,18 @@ impl TaintEngine {
             boundary_hits: boundary_hits.len(),
             boundary_misses: boundary_misses.len(),
             leaks_found: leaks.len(),
-            // Entry seeds are infected at probability 1.0 by definition; include
-            // them so the summary maximum cannot contradict a seed boundary that
-            // is (correctly) reported as a 1.0 hit.
+            // Resolved entry seeds are infected at probability 1.0 by definition;
+            // include them so the summary maximum cannot contradict a seed
+            // boundary (correctly) reported as a 1.0 hit. Gate on the *resolved*
+            // seed set, not the raw input: if a caller passes only out-of-range
+            // ids they resolve to nothing, and the max must stay at the (empty)
+            // prediction max, not be forced to 1.0.
             max_infection_probability: epidemic_result
                 .predictions
                 .first()
                 .map(|p| p.infection_probability)
                 .unwrap_or(0.0)
-                .max(if entry_node_ids.is_empty() { 0.0 } else { 1.0 }),
+                .max(if seed_ext_ids.is_empty() { 0.0 } else { 1.0 }),
             elapsed_ms,
         };
 

--- a/m1nd-core/tests/taint_seed_boundary.rs
+++ b/m1nd-core/tests/taint_seed_boundary.rs
@@ -80,3 +80,35 @@ fn boundary_that_is_an_entry_seed_is_a_hit_not_a_miss() {
         hit.infection_probability
     );
 }
+
+#[test]
+fn out_of_range_seed_does_not_fake_maximal_taint() {
+    // A caller passing only an out-of-range NodeId resolves to no seed in the
+    // graph (flow/epidemic skip it). The summary maximum must NOT be forced to
+    // 1.0 on the strength of a non-empty input slice alone — it must reflect the
+    // resolved seed set, which is empty here.
+    let mut g = Graph::new();
+    add(&mut g, "svc::a", "handler_a");
+    add(&mut g, "svc::b", "handler_b");
+    g.add_edge(
+        NodeId::new(0),
+        NodeId::new(1),
+        "calls",
+        FiniteF32::new(0.9),
+        EdgeDirection::Forward,
+        false,
+        FiniteF32::new(0.5),
+    )
+    .unwrap();
+    g.finalize().unwrap();
+
+    let config = TaintConfig::default();
+    // 9999 is out of range for a 2-node graph -> resolves to nothing.
+    let result = TaintEngine::analyze(&g, &[NodeId::new(9999)], &config).unwrap();
+
+    assert!(
+        result.summary.max_infection_probability < 0.99,
+        "no seed resolved, so the summary maximum must not be forced to 1.0; got {}",
+        result.summary.max_infection_probability
+    );
+}

--- a/m1nd-core/tests/taint_seed_boundary.rs
+++ b/m1nd-core/tests/taint_seed_boundary.rs
@@ -69,4 +69,14 @@ fn boundary_that_is_an_entry_seed_is_a_hit_not_a_miss() {
         "the seed carries maximal taint, expected probability ~1.0, got {}",
         hit.infection_probability
     );
+
+    // The summary must not contradict the boundary hits: if a boundary is
+    // reported at probability 1.0, the summary maximum cannot be lower.
+    assert!(
+        result.summary.max_infection_probability >= hit.infection_probability,
+        "summary.max_infection_probability ({}) must not be below a reported \
+         boundary hit ({})",
+        result.summary.max_infection_probability,
+        hit.infection_probability
+    );
 }


### PR DESCRIPTION
## Contexto
O Codex apontou um P2 no #152: ao reportar um boundary-seed a probabilidade `1.0`, eu **não atualizei** `summary.max_infection_probability` (que vinha só das predictions do epidemic, que excluem seeds). Resultado: o summary podia reportar **0.63** enquanto um hit dizia **1.0** — dado de risco contraditório.

**Por que uma PR separada:** o #152 mergeou por auto-merge **antes** do meu commit do summary fix (`a83ca0f`) registrar (corrida de auto-merge). Então este fix vai num PR limpo sobre a main atual (cherry-pick de a83ca0f).

## Fix
`max_infection_probability` agora inclui os seeds (infectados a 1.0 por definição) → não pode mais ficar abaixo de um boundary hit a 1.0.

## Prova
Teste `taint_seed_boundary` estendido com assert de consistência (`summary.max >= hit`): **falhava** antes (summary 0.63 vs hit 1.0), passa depois. `clippy --tests -D warnings` + `fmt --check` limpos.