### PR TITLE
feat(release): enable embed (semantic recall) by default in the shipped server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ plasticity_state.json
 antibodies.json
 tremor_state.json
 trust_state.json
+# OPTIONAL `embed` feature: content-addressed embedding cache (+ its atomic temp),
+# written beside the snapshot; runtime-regenerated, never commit.
+embeddings_cache.bin
+embeddings_cache.tmp
 # X-RAY append-only audit ledger — runtime state (one JSON line per committed
 # bulk write), written beside the graph snapshot. Not a *.json match (.jsonl),
 # so it needs its own rule; never commit it.

--- a/docs/AGENT-TASKNOTES.md
+++ b/docs/AGENT-TASKNOTES.md
@@ -19,6 +19,11 @@ The rule:
 
 ### 2026-06-24 — OPTIONAL real local embeddings for `seek` (first cut, OFF by default)
 
+- UPDATE 2026-06-27: `embed` is now ON by default in `m1nd-mcp` (the shipped
+  server has semantic recall out of the box; model fetched on first use, graceful
+  trigram fallback). The embedding cache is gitignored as a runtime artifact and
+  is not written when empty. Build a lean binary with `--no-default-features
+  --features serve`.
 - Context: `seek`'s "semantic" slot was character-trigram TF-IDF over labels —
   it cannot match intent queries whose words never appear in the node label.
 - First cut: a cargo feature `embed` (OFF by default; `m1nd-core/embed`,

--- a/m1nd-core/src/semantic.rs
+++ b/m1nd-core/src/semantic.rs
@@ -699,13 +699,17 @@ impl SemanticEngine {
         // Best-effort persist (atomic temp+rename); never fatal. Only the
         // writable (lease-holding) owner persists — read-only attachers reuse the
         // cache but never write it, keeping a single writer per cache file.
-        if let (true, Some(p)) = (persist, cache_path) {
-            match next.save(p) {
-                Ok(()) => eprintln!(
-                    "[m1nd embed] cache {hits} reused / {misses} new of {n} nodes -> {}",
-                    p.display()
-                ),
-                Err(e) => eprintln!("[m1nd embed] cache save failed: {e}; continuing"),
+        // Skip writing an EMPTY cache (e.g. an empty graph or model-less build):
+        // pointless I/O that would needlessly dirty the runtime dir for no gain.
+        if persist && !next.entries.is_empty() {
+            if let Some(p) = cache_path {
+                match next.save(p) {
+                    Ok(()) => eprintln!(
+                        "[m1nd embed] cache {hits} reused / {misses} new of {n} nodes -> {}",
+                        p.display()
+                    ),
+                    Err(e) => eprintln!("[m1nd embed] cache save failed: {e}; continuing"),
+                }
             }
         }
 

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -7,10 +7,14 @@ license = "MIT"
 repository = "https://github.com/maxkle1nz/m1nd"
 
 [features]
-default = ["serve"]
+# `embed` is ON by default so the shipped server has semantic recall out of the
+# box. Build a lean, embeddings-free binary with `--no-default-features --features serve`.
+default = ["serve", "embed"]
 serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:tokio-stream", "dep:futures", "dep:reqwest"]
-# OPTIONAL: enable real local static embeddings in `seek` (forwards to m1nd-core).
-# OFF by default — model2vec dep is not compiled unless this is on.
+# Real local static embeddings in `seek` (semantic recall by meaning), forwarded
+# to m1nd-core. The model (~29 MB, model2vec/potion-base-8M) is fetched on first
+# use and cached; if it cannot load, `seek` falls back to trigram matching
+# (graceful — no hard failure).
 embed = ["m1nd-core/embed"]
 
 [dependencies]

--- a/skills/m1nd-operator/references/tool-families.md
+++ b/skills/m1nd-operator/references/tool-families.md
@@ -33,17 +33,18 @@ This is the compact capability inventory for the current `m1nd` shape. Use the l
 - `scan_all`: run all structural patterns in one call.
 - `timeline`: temporal history, churn, velocity, stability, and co-change shape.
 
-> `seek` semantic recall: when the server binary is built with the optional
-> `embed` feature (and a model is present), `seek` also matches by MEANING —
-> embeddings over each symbol's doc-comment + signature + body — so it surfaces a
-> node whose intent matches even with ZERO shared tokens (e.g. a query "secure
-> channel" reaching `fn qz9wb` documented as "TLS encrypted tunnel"). The
-> response's `embeddings_used` tells you whether this fired (`false` = trigram /
-> keyword fallback — still useful, just lexical). These are fast STATIC
-> embeddings (model2vec) — a real upgrade over trigrams but NOT transformer-grade.
-> When `seek` returns no results, `filtering_reason` states why (empty graph /
-> scope-or-type filtered everything / nothing cleared the relevance threshold) —
-> adjust the query or scope instead of re-running blind.
+> `seek` semantic recall: the server ships with the `embed` feature ON by
+> default, so `seek` matches by MEANING — embeddings over each symbol's
+> doc-comment + signature + body — surfacing a node whose intent matches even
+> with ZERO shared tokens (e.g. a query "secure channel" reaching `fn qz9wb`
+> documented as "TLS encrypted tunnel"). The model (~29 MB) is fetched on first
+> use and cached; if it can't load, `seek` falls back to trigram matching. The
+> response's `embeddings_used` tells you whether semantic recall actually fired
+> (`false` = trigram/keyword fallback — still useful, just lexical). These are
+> fast STATIC embeddings (model2vec) — a real upgrade over trigrams but NOT
+> transformer-grade. When `seek` returns no results, `filtering_reason` states
+> why (empty graph / scope-or-type filtered everything / nothing cleared the
+> relevance threshold) — adjust the query or scope instead of re-running blind.
 
 ## Change-Risk And Plan Validation
 


### PR DESCRIPTION
## What
`seek`'s **semantic recall** (embeddings over each symbol's doc-comment + signature + body) shipped behind the **OFF-by-default `embed` feature**, so the *installed* m1nd never had it. This turns it **ON by default** in `m1nd-mcp` — the prebuilt release binary **and** `cargo install m1nd-mcp` now get semantic recall out of the box.

## Changes
- `m1nd-mcp` `default = ["serve", "embed"]`. Lean binary still available via `--no-default-features --features serve`.
- The model (~29 MB, model2vec/potion-base-8M) is **fetched on first use** and cached; if it can't load, `seek` **falls back to trigram** (graceful — no hard failure).
- Treat the embedding cache as a proper **runtime artifact**: skip writing it when **empty** (no pointless I/O / dirty runtime dir), and **gitignore** `embeddings_cache.bin` (+ its atomic `.tmp`) alongside `graph_snapshot.json` etc. *(This also fixed the `collect_git_state_reports_clean_repo` audit test, which the empty-graph cache write was dirtying.)*
- Docs updated (operator skill + AGENT-TASKNOTES) to reflect the new default.

## ⚠️ Reviewer note — this is the real cross-platform test
CI now compiles the `embed` path (`model2vec-rs` + `hf-hub`) on **all three OSes** for the first time (the feature was never built in CI before). The Windows build is the thing to watch. Locally verified on macOS: full suite green, clippy/fmt clean.

## Tradeoffs (intentional, Max-approved)
Bigger binary (~56 MB), heavier build, and a one-time ~29 MB model fetch on first semantic seek. Fully reversible (revert the default line). The cache (#131) keeps it warm/cheap after first use.
