### PR TITLE
chore(release): 1.0.0 prep — drop dead stubs, bump to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "0.9.0-beta.8"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "0.9.0-beta.8"
+version = "1.0.0"
 dependencies = [
  "cargo_metadata",
  "m1nd-core",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "0.9.0-beta.8"
+version = "1.0.0"
 dependencies = [
  "axum",
  "clap",

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "0.9.0-beta.8"
+version = "1.0.0"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "0.9.0-beta.8"
+version = "1.0.0"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -41,7 +41,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "0.9.0-beta.8" }
+m1nd-core = { path = "../m1nd-core", version = "1.0.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "0.9.0-beta.8"
+version = "1.0.0"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -18,8 +18,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "0.9.0-beta.8" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "0.9.0-beta.8" }
+m1nd-core = { path = "../m1nd-core", version = "1.0.0" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.0.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/m1nd-mcp/src/engine_ops.rs
+++ b/m1nd-mcp/src/engine_ops.rs
@@ -410,30 +410,6 @@ pub fn activate_readonly(
     })
 }
 
-/// Read-only impact. No side effects.
-pub fn impact_readonly(
-    state: &SessionState,
-    node: &str,
-    direction: ImpactDirection,
-) -> M1ndResult<ImpactResult> {
-    todo!("impact_readonly: extract from tools::handle_impact")
-}
-
-/// Read-only missing. No side effects.
-pub fn missing_readonly(state: &SessionState, query: &str) -> M1ndResult<MissingResult> {
-    todo!("missing_readonly: extract from tools::handle_missing")
-}
-
-/// Read-only why. No side effects.
-pub fn why_readonly(state: &SessionState, from: &str, to: &str) -> M1ndResult<WhyResult> {
-    todo!("why_readonly: extract from tools::handle_why")
-}
-
-/// Read-only resonate. Only called if remaining budget allows after first 8 calls.
-pub fn resonate_readonly(state: &SessionState, query: &str) -> M1ndResult<ResonateResult> {
-    todo!("resonate_readonly: extract from tools::handle_resonate")
-}
-
 // ---------------------------------------------------------------------------
 // Budget tracking for route synthesis
 // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "0.9.0-beta.8",
+  "version": "1.0.0",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What
Prepares m1nd's **first stable release (1.0.0)**.

- **Removes 4 dead read-only stubs** in `engine_ops.rs` (`impact_readonly`, `missing_readonly`, `why_readonly`, `resonate_readonly`) — unimplemented `todo!()` placeholders with **zero callers** (verified). A 1.0 shouldn't ship panic-stubs, especially when m1nd's own `surgical_handlers` flags `todo!()` as a broken-stub anti-pattern.
- **Bumps** `m1nd-core` / `m1nd-ingest` / `m1nd-mcp` + `package.json` (and the inter-crate dependency specs) to **1.0.0**. `m1nd-openclaw` stays `0.1.0` (separate).

## Readiness (audited)
The 1.0 maturity is there: complete semantic arc (embeddings cache → behavioural excerpts → doc-comments → principled recall → honest empties), **embed ON by default** (#154, CI green on 3 OSes incl. Windows), mature MCP tool surface, working dual-publish pipeline. The audit's two "scares" were non-blockers: the stubs above were dead code (removed here), and the one HIGH dependabot alert is `vite` in `m1nd-ui` **dev** deps (not in the shipped binary/npm package).

## ⚠️ Tag intentionally held
**This PR does NOT cut the release.** The crates.io + npm publish (`release.yml`) fires on a **`v1.0.0` tag**. Holding the merge + tag until the in-flight work from the parallel session on `main` is settled, so 1.0.0 is a deliberate, coordinated cut. `cargo build/test/clippy --workspace -D warnings` + `fmt` all green locally.

Verified: workspace builds at 1.0.0; full `m1nd-mcp` suite green; clippy clean (no orphaned imports from the stub removal); fmt clean.
