### PR TITLE
docs(install): point install at published 1.0.0 (drop beta pins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-Or from the npm beta channel: `npm install -g @maxkle1nz/m1nd@beta`.
+Or from npm: `npm install -g @maxkle1nz/m1nd`.
 
 Full install map, host packs, native runtime build, and update flags: [docs/AGENT-PACKS.md](docs/AGENT-PACKS.md) · client-by-client setup: [integration matrix](docs/IDE-INTEGRATIONS.md).
 
@@ -238,7 +238,7 @@ Three core Rust crates plus one auxiliary bridge:
 - **`m1nd-ingest`** — extraction, routing, and graph construction adapters (code, universal docs, L1GHT).
 - **`m1nd-openclaw`** — auxiliary OpenClaw bridge (Unix-socket lane, independently versioned).
 
-Current crate versions: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` all `0.9.0-beta.8`.
+Current crate versions: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` all `1.0.0`.
 
 <p align="center">
   <img src=".github/m1nd-architecture-overview-v2.jpeg" alt="m1nd architecture overview" width="960" />

--- a/docs/wiki/src/faq.md
+++ b/docs/wiki/src/faq.md
@@ -74,7 +74,7 @@ Approximately 8MB for a release build. No runtime dependencies, no shared librar
 
 ### Can I install from crates.io?
 
-Yes: `cargo install m1nd-mcp --version 0.9.0-beta.8` for the current beta runtime.
+Yes: `cargo install m1nd-mcp` for the current runtime.
 
 ---
 

--- a/docs/wiki/src/tutorials/quickstart.md
+++ b/docs/wiki/src/tutorials/quickstart.md
@@ -35,7 +35,7 @@ cp ./target/release/m1nd-mcp /usr/local/bin/
 ### 2. Install from crates.io
 
 ```bash
-cargo install m1nd-mcp --version 0.9.0-beta.8
+cargo install m1nd-mcp
 ```
 
 ### 3. Download a release binary

--- a/m1nd-demo/src/components/FAQSection.tsx
+++ b/m1nd-demo/src/components/FAQSection.tsx
@@ -64,7 +64,7 @@ const FAQS: FAQ[] = [
   {
     tag: "getting started",
     q: "How long does it take to set up?",
-    a: 'Under 2 minutes. Install the agent pack with npm install -g @maxkle1nz/m1nd@beta, install the native runtime with cargo install m1nd-mcp --version 0.9.0-beta.8, add it to your MCP client config, and run m1nd warmup to build the initial graph. First warmup on a 50K-line codebase takes about 8 seconds. After that, incremental updates run in the background as files change.',
+    a: 'Under 2 minutes. Install the agent pack with npm install -g @maxkle1nz/m1nd, install the native runtime with cargo install m1nd-mcp, add it to your MCP client config, and run m1nd warmup to build the initial graph. First warmup on a 50K-line codebase takes about 8 seconds. After that, incremental updates run in the background as files change.',
   },
 ];
 

--- a/m1nd-demo/src/components/InstallSection.tsx
+++ b/m1nd-demo/src/components/InstallSection.tsx
@@ -1,12 +1,12 @@
 import { motion } from "framer-motion";
 
 const STEP_INSTALL = `# agent pack, diagnostics, and host setup
-npm install -g @maxkle1nz/m1nd@beta
+npm install -g @maxkle1nz/m1nd
 m1nd doctor
 m1nd pack-check
 
-# native MCP runtime
-cargo install m1nd-mcp --version 0.9.0-beta.8`;
+# native MCP runtime (semantic recall on by default)
+cargo install m1nd-mcp`;
 
 const STEP_CONFIG = `{
   "mcpServers": {

--- a/m1nd-demo/src/pages/L1ght.tsx
+++ b/m1nd-demo/src/pages/L1ght.tsx
@@ -633,7 +633,7 @@ export default function L1ght() {
           >
             <InstallButtons />
             <p className="mt-4 font-mono text-xs text-muted-foreground/45 text-center">
-              npm install -g @maxkle1nz/m1nd@beta &nbsp;·&nbsp; cargo install m1nd-mcp --version 0.9.0-beta.8
+              npm install -g @maxkle1nz/m1nd &nbsp;·&nbsp; cargo install m1nd-mcp
             </p>
           </motion.div>
 
@@ -785,7 +785,7 @@ export default function L1ght() {
             transition={{ delay: 0.3 }}>
             <InstallButtons />
             <p className="mt-4 font-mono text-xs text-muted-foreground/45 text-center">
-              npm install -g @maxkle1nz/m1nd@beta &nbsp;·&nbsp; cargo install m1nd-mcp --version 0.9.0-beta.8
+              npm install -g @maxkle1nz/m1nd &nbsp;·&nbsp; cargo install m1nd-mcp
             </p>
           </motion.div>
           <motion.div


### PR DESCRIPTION
m1nd 1.0.0 is live on crates.io + npm. Updates the install commands across README, the m1nd-demo site (Install/FAQ/L1ght), and the wiki to the stable form: `npm install -g @maxkle1nz/m1nd` (now @latest = 1.0.0) and `cargo install m1nd-mcp` (drops the `--version 0.9.0-beta.8` pin), plus the README crate-version line -> 1.0.0. Docs/site only.