### PR TITLE
feat(mcp): focus — goal-conditioned attention runtime (P1)

### DIFF
--- a/docs/FOCUS-RUNTIME-PRD.md
+++ b/docs/FOCUS-RUNTIME-PRD.md
@@ -1,0 +1,260 @@
+# m1nd Focus Runtime — Goal, Process UML & PRD
+
+> Status: **PROPOSAL — awaiting approval.** Author: Max Kle1nz. Date: 2026-06-27.
+> Grounded in a deep code map of m1nd + an external donor/tech sweep (8-agent
+> research run, 567k tokens). Licenses below were verified at source on 2026-06-27.
+
+---
+
+## 1. Goal / North Star
+
+> **m1nd stops being a query engine and becomes the agent's *attention runtime*.**
+> It does not just *answer* — it **manages what deserves the agent's limited context**:
+> surfaces the minimal salient set for the task, prunes the rest, says when there is
+> **enough** (stop), catches **thrash**, and **refocuses on drift** — and it does all of
+> this **honestly**: it declines low-value context and always tells the agent *what it is
+> NOT loading and why*.
+
+The scarcest resource of a coding agent is not compute — it is **context** (the window).
+Everything that enters it competes for attention, and quality *degrades* as it fills
+(lost-in-the-middle, "context rot" measured across 18 frontier models incl. Claude Opus 4).
+m1nd sits outside the window with the full graph + grounded memory + a salience model of the
+code. That is the unique position to **own the agent's working-set policy** — to be, for the
+agent, what the MMU/scheduler is for a process: the thing that decides what is resident.
+
+**One-line product thesis:** *an attention manager that declines to load low-value context
+is worth more than one that maximizes recall.* Honesty is the moat.
+
+---
+
+## 2. Why now — the evidence
+
+### 2.1 m1nd already owns the substrate (it is just scattered)
+The code map found the primitives a focus runtime needs already exist, but **nothing composes
+them into an explicit focus surface**:
+
+| Capability needed | Already in m1nd (file:line) | State |
+|---|---|---|
+| Structural importance | `graph.rs` PageRank, `change_frequency` | ✅ computed, not exposed as task salience |
+| Multi-signal ranking | `activation.rs` 4D spread, `DIMENSION_WEIGHTS [0.35,0.25,0.15,0.25]`, resonance bonus | ✅ exists; not goal-conditioned for "what to load" |
+| Semantic match | `embed.rs` model2vec (potion-base-8M), seek principled recall | ✅ shipped (v1.0) |
+| Token packing | `result_shaping.rs` `pack_to_budget` / `budget_block` | ⚠️ per-query greedy, no cross-query budget |
+| Working-set signal | `plasticity.rs` `QueryMemory.top_node_frequencies`, `priming_nodes` | ⚠️ tracked, never used for page-in/out |
+| Staleness | `evidence_freshness`, `cache_generation` | ⚠️ audit-only, no drift→refocus |
+| Coverage | `session.rs` `CoverageSessionState`, `note_coverage` | ⚠️ "what I touched", not "what I missed / is enough" |
+| Honest empties | seek `filtering_reason`, `proof_state`, `embeddings_used` | ✅ the honesty spine to build on |
+| Routing | `help_guidance.rs` stage/intent → tool sequence, `next_suggested_tool` | ⚠️ static, ~50-tool flat surface, no `focus` verb |
+
+**The gap, stated once:** there is **no `focus_set`, no sufficiency signal, no working-set
+manager, no anti-thrash** — the agent gets data, not managed attention.
+
+### 2.2 The field validates the framing (and hands us borrowable parts)
+External sweep, **licenses verified at source 2026-06-27**:
+
+**Borrowable now (MIT / Apache-2.0):**
+- **Aider repo-map** (Apache-2.0) — personalized PageRank over a symbol graph → rank context to a token budget. *m1nd already has the graph + PageRank* → this is a pattern to copy, not a dep.
+- **Continue.dev** (Apache-2.0) — retrieve-wide-then-rerank-narrow (25→5) default shape.
+- **OpenHands condenser** (MIT) — `keep_first + keep_recent + summarize_middle` trajectory condensation (anti lost-in-the-middle).
+- **Cline** (Apache-2.0) — staleness-by-timestamp recency signal (cheap, strong).
+- **Sculptor / Active Context Management** (MIT; ICLR 2026) — **closest peer to this vision**: `summary-hide-restore` as anti-thrash. Borrow the primitive.
+- **SWE-Pruner** (MIT) — goal-conditioned pruning of tool output as middleware. *m1nd can BE the skimmer* using its embedding+lexical scoring — no neural net.
+- **Pure-Rust ranker stack:** `model2vec-rs` (MIT, already in m1nd) + `bm25` (MIT) fused by **Reciprocal Rank Fusion** (~5 lines) + `petgraph` `page_rank` / `OverGraph` forward-push (MIT/Apache) for **personalized PageRank**.
+
+**Reimplement-idea (no usable code / heavy / RL):**
+- **Google "Sufficient Context"** (ICLR 2025) — answer-free "is the context enough?" gate. *The single highest-leverage feature.*
+- **Letta/MemGPT** (Apache) — tier model (in-window / recall / archival) + self-managed paging.
+- **MemoryOS heat metric** — eviction by access-freq + recency + groundedness (LRU-with-pinning).
+- Frontier (SpecAgent prefetch, ContextBudget RL, IGPO value-of-information) — ideas only, mostly no code.
+
+**Honest cautions carried into the design:**
+- Static centrality ≠ task relevance → salience **must be goal-conditioned** (personalized, not global PageRank).
+- Compaction/summarization is **lossy** → m1nd's version **never silently drops**; it marks what was pruned + why (extends `filtering_reason`).
+- Most frontier papers have **no code / are RL-heavy / brittle** → **heuristic-first**, tiny-classifier only if measured to help.
+- "Memory OS" is mostly branding (vector DB + summarizer) → m1nd's graph+grounding is already deeper; **don't bolt on Neo4j/Redis weight**.
+- Don't gold-plate: the families overlap. **Ship ONE crisp leapfrog first** (the sufficiency gate), not five.
+
+---
+
+## 3. The design — m1nd Focus Runtime
+
+Five internal capabilities, exposed through **ONE new agent-facing verb, `focus`** (with modes),
+plus **envelope enrichment** on existing tools. *Anti-bloat law (non-negotiable): every focus
+feature must SHRINK the agent's decision surface — the test is "did the next move get more obvious
+with fewer tokens?" If it adds something for the agent to think about, it does not ship.*
+
+1. **Salience composer → `focus(goal, budget)` → focus_set.** Compose existing primitives into one
+   *goal-conditioned* salience score per node: personalized-PageRank/forward-push from the goal seeds
+   × 4D activation × RRF(bm25 lexical, model2vec semantic) × recency/edited bias − taint penalty.
+   Return the **minimal node set worth loading**, token-bounded via `pack_to_budget`, with an explicit
+   **`ignored: [{what, why}]` tail** (honest pruning). *Reuses: PageRank, activation, embeddings,
+   change_frequency, result_shaping.*
+
+2. **Sufficiency gate (the leapfrog).** Answer-free signal attached to retrieval responses:
+   `sufficiency: { state: gathering | sufficient | saturated, captured_salience_mass, why }`. Says
+   **"you have enough to act, stop pulling"** or **"still gathering"** — from inputs m1nd already emits
+   (recall coverage, excerpt coverage, salience mass captured, `filtering_reason`). *Reuses: coverage,
+   recall scores, filtering_reason.*
+
+3. **Attention-budget + working-set manager.** Track the agent's attention budget as explicit state;
+   page-in salient nodes, page-out cold ones via **heat = access-freq + recency + groundedness**, with
+   **pinning** of user-doctrine/goal. *Reuses: `QueryMemory.top_node_frequencies`, `priming_nodes`,
+   `token_budget`, plasticity.*
+
+4. **Anti-thrash + drift signals.** Detect **spinning** (repeated seeks with ~0 marginal info =
+   value-of-information ≈ 0) and **focus drift** (scope/domain shift, evidence gone stale) → honest
+   `"you're re-querying the same low-value neighborhood — pivot"` / `"your model is stale, refocus"`.
+   *Reuses: tremor/resonance, evidence_freshness, cache_generation, QueryMemory.*
+
+5. **Honest tool-output skimmer.** Goal-conditioned pruning of verbose results, **marking what was
+   pruned** (never silent). m1nd is the skimmer via embedding+lexical scoring (SWE-Pruner shape, no
+   neural net). *Reuses: seek scoring, RRF, filtering_reason.*
+
+---
+
+## 4. Process UML (derived from the code)
+
+### 4.1 CURRENT — tool dispatch + guidance injection (`server.rs:3113`)
+```mermaid
+sequenceDiagram
+  participant A as Agent
+  participant D as dispatch_tool (server.rs:3113)
+  participant H as handler (tools.rs / *_handlers.rs)
+  participant G as help_guidance::runtime_projection_for_tool
+  participant E as _m1nd envelope
+  A->>D: tool call (name,args,agent_id)
+  D->>D: normalize name · gate read_only/mutation · proof_ready check
+  D->>H: dispatch_core_tool (server.rs:3304)
+  H->>G: build HelpInput → projection
+  G-->>H: (proof_state, next_suggested_tool, next_step_hint, what_is_missing)
+  H-->>D: Output + guidance
+  D->>E: wrap: _m1nd{next_suggested_tool, proof_state, agent_runtime_contract, memory_nearby}
+  E-->>A: response (data + WHERE-TO-GO-NEXT, but no WHAT-DESERVES-FOCUS)
+```
+
+### 4.2 CURRENT — salience exists but is not goal-conditioned (`activation.rs`)
+```mermaid
+flowchart LR
+  seeds[seeds] --> spread[4D spread<br/>structural/semantic/temporal/causal]
+  spread --> merge[merge · DIMENSION_WEIGHTS 0.35/0.25/0.15/0.25]
+  merge --> res[resonance bonus 1.3×/1.5×]
+  res --> rank[ranked nodes]
+  pr[PageRank graph.rs] -.global, not per-task.-> rank
+  taint[taint.rs] -.computed, NOT fed back.-> rank
+  rank --> out[QueryResult]
+  out -. no focus_set, no ignored-tail, no sufficiency .-> agent[Agent]
+```
+
+### 4.3 PROPOSED — `focus(goal, budget)` → focus_set (the new core loop)
+```mermaid
+flowchart TD
+  goal[focus goal + token_budget] --> seedres[resolve goal seeds<br/>seek + label/embedding match]
+  seedres --> ppr[personalized PageRank /<br/>forward-push from seeds]
+  seedres --> rrf[RRF: bm25 lexical ⊕ model2vec semantic]
+  ppr --> compose
+  rrf --> compose
+  act[4D activation] --> compose
+  rec[recency / recently-edited bias] --> compose
+  taint[taint penalty] --> compose[goal-conditioned salience score]
+  compose --> pack[pack_to_budget result_shaping]
+  pack --> set[focus_set: load these N]
+  pack --> ignored[ignored: what + why  -- HONEST]
+  set --> suff{sufficiency gate}
+  ignored --> resp
+  suff -->|gathering| resp[response: focus_set + ignored + sufficiency + budget_left]
+  suff -->|sufficient/saturated| stop[STOP signal: enough to act]
+  stop --> resp
+```
+
+### 4.4 PROPOSED — working-set + anti-thrash loop (per turn)
+```mermaid
+sequenceDiagram
+  participant A as Agent
+  participant F as Focus Runtime
+  participant W as Working set (heat=freq+recency+grounded)
+  participant V as VoI / drift monitor
+  A->>F: focus(goal) / any retrieval
+  F->>W: page-in salient · page-out cold · pin doctrine
+  F->>V: compare to last turn (marginal info, scope drift, staleness)
+  alt thrashing (VoI≈0)
+    V-->>A: "spinning on low-value neighborhood — pivot to X"
+  else drift / stale evidence
+    V-->>A: "model stale (cache_generation/evidence) — refocus"
+  else healthy
+    F-->>A: focus_set + sufficiency + budget_left
+  end
+```
+
+*(Full inventory of current flows captured in research: dispatch w/ guidance, proof-state recovery,
+help routing, seed→activation, temporal velocity, resonance, topology, layer detection,
+coverage, token packing, trail save/resume/merge, perspective synthesis, memorize→ground,
+activate→plasticity→working_memory, orient→contract. These remain; the focus runtime composes over them.)*
+
+---
+
+## 5. PRD
+
+### 5.1 Problem
+Coding agents drown their own context. m1nd surfaces correct data but leaves the agent to decide
+**what to load, when to stop, and when it's lost** — the exact decisions that determine answer quality
+under context rot. m1nd has every primitive to make those decisions and exposes none of them as focus.
+
+### 5.2 Goals / Non-goals
+**Goals:** (G1) a goal-conditioned `focus_set` with honest `ignored` tail; (G2) an answer-free
+**sufficiency / stop** signal; (G3) attention-budget-aware working-set management; (G4) honest
+anti-thrash + drift signals; (G5) shrink, never grow, the agent's decision surface.
+**Non-goals:** a vector-DB/"memory OS" rewrite; cloud/SaaS; an RL-trained controller (heuristic-first);
+silent summarization/compaction; ANN index (premature at current scale); new heavy deps / ONNX.
+
+### 5.3 Surface (agent-facing) — ONE verb + envelope enrichment
+- **`focus`** — modes: `set` (goal→focus_set+ignored+sufficiency+budget), `check` (sufficiency only),
+  `status` (working-set + budget + drift). One verb, not ten tools.
+- **Envelope enrichment** on existing retrieval tools (seek/activate/impact): add
+  `sufficiency`, `salience_captured`, and extend `filtering_reason` into a uniform
+  `pruned: [{what, why}]`. (Additive, serde-skip when absent — zero break, like `filtering_reason`.)
+- **Honesty contract:** never drop silently; always emit what was excluded + why.
+
+### 5.4 Phased delivery (ship ONE leapfrog first)
+- **P1 — Sufficiency gate + focus_set (the leapfrog).** `focus(goal,budget)` composing existing
+  primitives (personalized PageRank/forward-push + RRF(bm25+model2vec) + activation + recency − taint)
+  → token-bounded focus_set + `ignored` tail + answer-free `sufficiency`. Pure-Rust, reuses everything;
+  `bm25` (MIT) is the only candidate new dep, behind a feature flag. **Highest leverage, lowest new risk.**
+- **P2 — Attention budget + working-set manager.** Heat-based page-in/out (freq+recency+grounded),
+  pinning, cross-query budget as explicit state. Reuses QueryMemory/priming_nodes/plasticity.
+- **P3 — Anti-thrash + drift + honest skimmer.** VoI/thrash detection, drift→refocus on
+  evidence/cache staleness, goal-conditioned tool-output pruning (SWE-Pruner shape).
+- **P4 (later, gated on evidence) — speculative read-only prefetch** from the call graph; tiny
+  classifier for sufficiency only if heuristics measurably fall short.
+
+### 5.5 Reuse map (build on, don't rebuild)
+PageRank/activation/embeddings/result_shaping → P1 salience+pack. coverage/recall/filtering_reason
+→ P1 sufficiency. QueryMemory/priming_nodes/plasticity/token_budget → P2. tremor/resonance/
+evidence_freshness/cache_generation → P3 drift+thrash. help_guidance dispatch choke point → wire `focus`.
+
+### 5.6 Donors borrowed (with license)
+Aider PPR pattern (Apache) · Continue 25→5 (Apache) · OpenHands keep_first/recent/summarize (MIT) ·
+Cline timestamp recency (Apache) · Sculptor summary-hide-restore (MIT) · SWE-Pruner skim shape (MIT) ·
+`bm25` (MIT) + `model2vec-rs` (MIT, present) + RRF + `petgraph`/`OverGraph` PPR (MIT/Apache).
+Sufficiency gate = reimplement of Google "Sufficient Context" (ICLR 2025). Heat metric = MemoryOS idea.
+
+### 5.7 Success metrics (proof-grown, measured not promised)
+- **Tokens-to-correct-answer** ↓ on a fixed agent task set (focus_set vs raw seek/read).
+- **Over-search rate** ↓ (sufficiency gate fires before the agent wastes N extra queries).
+- **Precision of focus_set** (did the loaded set contain the nodes the task actually needed?).
+- **Zero behavior change when `focus` unused** (additive envelope, like `embed`/`filtering_reason`).
+- **Honesty invariant:** every pruned/ignored item is reported — never a silent drop (test-enforced).
+
+### 5.8 Risks & mitigations
+Global centrality ≠ relevance → **personalized** PPR seeded by the goal. Lossy pruning →
+**honest `ignored`/`pruned`, never silent**. Surface bloat → **one `focus` verb**, anti-bloat law.
+Tuning knobs (RRF k, weights, sufficiency floor) → **calibrate on real m1nd graphs**, expose as
+named consts (like `SEMANTIC_RECALL_FLOOR`). New dep risk → `bm25` behind a feature flag; everything
+else reuses existing crates; **OFF-default-safe** until proven.
+
+---
+
+## 6. Goal tracing (each phase ladders to the north star)
+- P1 makes m1nd **decide what deserves attention** + **when to stop** → the heart of "attention runtime".
+- P2 makes it **manage the working set under budget** → the "RAM manager" role.
+- P3 makes it **catch thrash + drift, honestly** → the trust/honesty moat.
+- P4 makes it **anticipate** → from reactive to predictive focus.
+Together: m1nd's real product was never data — it was **focus**. This makes that explicit.

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -87,13 +87,13 @@ const SUFFICIENCY_WEAK_TOP: f32 = 0.18;
 /// Compute the answer-free sufficiency signal from retrieval outcome signals.
 ///
 /// `top_score` is the best match's combined score (0 when the set is empty).
-/// `captured` is the fraction of the FULL relevance-clearing salience carried by
-/// the returned set [0,1] (reported for transparency). `marginal_score` is the
-/// score of the best candidate that was LEFT OUT — `None` when the returned set
-/// holds the entire relevant pool. The verdict is a "knee" test: you have enough
-/// when the strongest match is real AND the best thing you're missing is already
-/// weak. A long tail of weak matches therefore does NOT force "gathering" — only
-/// a strong DROPPED candidate does. This inspects relevance strength and what was
+/// `captured` is the fraction of the re-ranked window's salience carried by the
+/// returned set [0,1] (reported for transparency). `marginal_score` is the score
+/// of the best candidate that was LEFT OUT — `None` when the returned set holds
+/// the entire relevant pool. The verdict is a "knee" test: you have enough when
+/// the strongest match is real AND the best thing you're missing is already weak.
+/// A long tail of weak matches therefore does NOT force "gathering" — only a
+/// strong DROPPED candidate does. This inspects relevance strength and what was
 /// cut — never answer content — so it can say "enough / keep going / not here"
 /// without claiming to know the answer.
 fn compute_sufficiency(
@@ -442,18 +442,21 @@ pub fn handle_seek(
             .partial_cmp(&a.base_score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    // Honesty accounting, captured BEFORE any truncation: the full pool of nodes
-    // that cleared `min_score`, and their salience. Every later step (heuristic
-    // window, top_k, token budget) keeps the highest-ranked items, so the
-    // returned set is always a rank-PREFIX of this list — which lets the
-    // sufficiency signal and `ignored` count reflect everything left out, not
-    // just what the budget dropped. `base_ranked` is already sorted by base_score
-    // descending here.
+    // Honesty accounting, part 1 — captured BEFORE the heuristic-window cut:
+    //  * `relevance_clearing_total`: every node that cleared `min_score` (the full
+    //    relevant pool size), so `ignored` reflects all of it, not just budget
+    //    drops.
+    //  * `tail_best_base`: the strongest node the heuristic window is about to
+    //    drop — used only in the rare case where the entire window is returned,
+    //    so the knee can still see that weaker-but-relevant nodes exist beyond it.
+    // `base_ranked` is sorted by base_score descending here. The combined-unit
+    // salience used for the actual verdict is captured AFTER the re-rank below,
+    // so the honesty math agrees with the real kept/dropped partition.
     let relevance_clearing_total = base_ranked.len();
-    let clearing_mass: f32 = base_ranked.iter().map(|e| e.base_score.max(0.0)).sum();
-    let clearing_scores_desc: Vec<f32> =
-        base_ranked.iter().map(|e| e.base_score.max(0.0)).collect();
     let heuristic_window = input.top_k.saturating_mul(4).max(input.top_k).min(128);
+    let tail_best_base = base_ranked
+        .get(heuristic_window)
+        .map(|e| e.base_score.max(0.0));
     base_ranked.truncate(heuristic_window);
 
     let now = std::time::SystemTime::now()
@@ -544,6 +547,14 @@ pub fn handle_seek(
             .then_with(|| b.graph_act.total_cmp(&a.graph_act))
             .then_with(|| a.idx.cmp(&b.idx))
     });
+    // Honesty accounting, part 2 — the IN-WINDOW relevant salience in `combined`
+    // units (the SAME units the kept/dropped partition is decided in), captured
+    // right after the re-rank and before top_k/budget truncation. Because every
+    // remaining step keeps a rank-prefix of this list, the returned set's
+    // salience is exactly its prefix sum and the best dropped node is exactly the
+    // element just past it — so trust/tremor re-ranking can no longer make a
+    // strong dropped node look retained.
+    let window_combined_desc: Vec<f32> = ranked.iter().map(|r| r.combined.max(0.0)).collect();
     ranked.truncate(input.top_k);
 
     // Phase 4: Build output
@@ -632,25 +643,29 @@ pub fn handle_seek(
     } else {
         (results, None)
     };
-    // Fraction of the FULL relevance-clearing salience carried by the returned
-    // set. The set is a rank-prefix of `clearing_scores_desc` (all truncation +
-    // budget steps keep the highest-ranked items), so its salience is the prefix
-    // sum of the top `kept_n` scores. < 1.0 means relevant context was left out
-    // — by the token budget, top_k, OR the heuristic window — so a truncated
-    // slice can NEVER report as fully "captured". (Heuristic trust/tremor
-    // re-ranking can nudge order within the prefix, making this a close estimate
-    // rather than an exact identity; it is a coarse honesty signal, not a metric.)
     let kept_n = results.len();
-    let kept_salience: f32 = clearing_scores_desc.iter().take(kept_n).sum();
-    let captured = if clearing_mass > f32::EPSILON {
-        (kept_salience / clearing_mass).clamp(0.0, 1.0)
+    // `captured`: fraction of the re-ranked window's salience the returned set
+    // carries, in `combined` units (the partition's own units), so it is an exact
+    // prefix ratio — never inflated by trust/tremor re-ranking. Anything dropped
+    // beyond the window is a weaker tail surfaced via `marginal_score` and the
+    // `ignored` count, not hidden here.
+    let window_mass: f32 = window_combined_desc.iter().sum();
+    let kept_salience: f32 = window_combined_desc.iter().take(kept_n).sum();
+    let captured = if window_mass > f32::EPSILON {
+        (kept_salience / window_mass).clamp(0.0, 1.0)
     } else {
         1.0
     };
-    // Score of the best candidate that did NOT make the returned set (the "knee"):
-    // `None` when the set holds the entire relevant pool. Drives the gather-vs-act
-    // verdict — a strong dropped candidate means there is more worth pulling.
-    let marginal_score = clearing_scores_desc.get(kept_n).copied();
+    // `marginal_score`: the score of the best candidate NOT returned — the "knee".
+    // Within the window it is the exact element past the kept prefix (combined
+    // units). If the entire window was returned but weaker nodes were cut beyond
+    // it, fall back to that tail's strongest (base units, necessarily weaker).
+    // `None` only when the returned set holds the entire relevant pool.
+    let marginal_score = if kept_n < window_combined_desc.len() {
+        Some(window_combined_desc[kept_n])
+    } else {
+        tail_best_base
+    };
     let top_score = results.first().map(|e| e.score).unwrap_or(0.0);
     let sufficiency = compute_sufficiency(top_score, captured, marginal_score, results.len());
 
@@ -786,12 +801,14 @@ pub fn handle_focus(
         .and_then(|block| block.get("dropped"))
         .and_then(|value| value.as_u64())
         .unwrap_or(0) as usize;
+    // Remainder beyond the budget drops: nodes past top_k / the re-rank window,
+    // plus any same-family duplicates de-duplicated out of the returned set.
     let beyond_window = ignored_count.saturating_sub(dropped_to_budget);
     let reason = if ignored_count == 0 {
         "every relevance-clearing node fit the focus set".to_string()
     } else if dropped_to_budget > 0 && beyond_window > 0 {
         format!(
-            "{dropped_to_budget} node(s) dropped to fit the ~{budget}-token budget and {beyond_window} lower-salience match(es) fell beyond the top_k window — raise token_budget/top_k or narrow the goal",
+            "{dropped_to_budget} node(s) dropped to fit the ~{budget}-token budget and {beyond_window} more left out beyond the top_k window (incl. same-family duplicates) — raise token_budget/top_k or narrow the goal",
             budget = input.token_budget
         )
     } else if dropped_to_budget > 0 {
@@ -801,7 +818,7 @@ pub fn handle_focus(
         )
     } else {
         format!(
-            "{beyond_window} lower-salience match(es) fell beyond the top_k window — raise top_k or narrow the goal to see them"
+            "{beyond_window} relevance-clearing node(s) left out beyond the top_k window (incl. same-family duplicates) — raise top_k or narrow the goal to see them"
         )
     };
 

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -72,6 +72,84 @@ fn l2_seek_heuristic_reason(
 #[cfg(feature = "embed")]
 const SEMANTIC_RECALL_FLOOR: f32 = 0.40;
 
+/// Relevance floor below which the single best match is considered too weak for
+/// the goal to be meaningfully represented — drives the `saturated` verdict.
+///
+/// CALIBRATED against a real m1nd-core ingest (embed default ON): present-goal
+/// top scores landed in [0.24, 0.54], clear-noise goals in [0.00, 0.16]. 0.18
+/// sits above the pure-noise band and below the weakest real match. The
+/// in-between zone (~0.18–0.26) is genuinely ambiguous — goals that share real
+/// tokens with the codebase score there whether or not they belong — so the
+/// exact `top_score` is always returned in the envelope for the agent to judge;
+/// the floor only decides the coarse verdict, biased AGAINST a false "not here".
+const SUFFICIENCY_WEAK_TOP: f32 = 0.18;
+
+/// Compute the answer-free sufficiency signal from retrieval outcome signals.
+///
+/// `top_score` is the best match's combined score (0 when the set is empty).
+/// `captured` is the fraction of the FULL relevance-clearing salience carried by
+/// the returned set [0,1] (reported for transparency). `marginal_score` is the
+/// score of the best candidate that was LEFT OUT — `None` when the returned set
+/// holds the entire relevant pool. The verdict is a "knee" test: you have enough
+/// when the strongest match is real AND the best thing you're missing is already
+/// weak. A long tail of weak matches therefore does NOT force "gathering" — only
+/// a strong DROPPED candidate does. This inspects relevance strength and what was
+/// cut — never answer content — so it can say "enough / keep going / not here"
+/// without claiming to know the answer.
+fn compute_sufficiency(
+    top_score: f32,
+    captured: f32,
+    marginal_score: Option<f32>,
+    n_results: usize,
+) -> layers::Sufficiency {
+    let pct = (captured * 100.0).round();
+    let (state, why) = if n_results == 0 {
+        (
+            "saturated",
+            "no candidate cleared the relevance threshold for this goal — broaden the goal, relax scope/node_types, or ingest the relevant code".to_string(),
+        )
+    } else if top_score < SUFFICIENCY_WEAK_TOP {
+        (
+            "saturated",
+            format!(
+                "the best match scores only {top_score:.2} — the goal is weakly represented here; refine the goal terms or ingest more context"
+            ),
+        )
+    } else {
+        match marginal_score {
+            // The returned set holds the entire relevant pool — nothing was cut.
+            None => (
+                "sufficient",
+                format!(
+                    "the top match scores {top_score:.2} and the set holds every relevance-clearing node — enough to act"
+                ),
+            ),
+            // A still-relevant candidate was left out — real context exists beyond
+            // the returned set, so keep gathering.
+            Some(m) if m >= SUFFICIENCY_WEAK_TOP => (
+                "gathering",
+                format!(
+                    "the strongest match left out still scores {m:.2} — relevant context did not fit (set carries {pct:.0}% of the salience); raise token_budget/top_k or narrow the goal"
+                ),
+            ),
+            // Everything cut is weaker than the relevance floor — the head is in
+            // hand and the tail is not worth pulling.
+            Some(m) => (
+                "sufficient",
+                format!(
+                    "the top match scores {top_score:.2}; everything left out scores at most {m:.2} (weak tail) — the strongest context is in hand"
+                ),
+            ),
+        }
+    };
+    layers::Sufficiency {
+        state: state.to_string(),
+        top_score,
+        captured,
+        why,
+    }
+}
+
 pub fn handle_seek(
     state: &mut SessionState,
     input: layers::SeekInput,
@@ -120,6 +198,7 @@ pub fn handle_seek(
             query: input.query,
             results: vec![],
             total_candidates_scanned: 0,
+            relevance_clearing_total: 0,
             filtering_reason: Some(match error_text {
                 Some(_) => {
                     "the query produced no searchable tokens; provide concrete identifiers or words"
@@ -137,6 +216,7 @@ pub fn handle_seek(
             recovery,
             agent_runtime_contract,
             budget: None,
+            sufficiency: compute_sufficiency(0.0, 0.0, None, 0),
         });
     }
 
@@ -362,6 +442,17 @@ pub fn handle_seek(
             .partial_cmp(&a.base_score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
+    // Honesty accounting, captured BEFORE any truncation: the full pool of nodes
+    // that cleared `min_score`, and their salience. Every later step (heuristic
+    // window, top_k, token budget) keeps the highest-ranked items, so the
+    // returned set is always a rank-PREFIX of this list — which lets the
+    // sufficiency signal and `ignored` count reflect everything left out, not
+    // just what the budget dropped. `base_ranked` is already sorted by base_score
+    // descending here.
+    let relevance_clearing_total = base_ranked.len();
+    let clearing_mass: f32 = base_ranked.iter().map(|e| e.base_score.max(0.0)).sum();
+    let clearing_scores_desc: Vec<f32> =
+        base_ranked.iter().map(|e| e.base_score.max(0.0)).collect();
     let heuristic_window = input.top_k.saturating_mul(4).max(input.top_k).min(128);
     base_ranked.truncate(heuristic_window);
 
@@ -541,6 +632,27 @@ pub fn handle_seek(
     } else {
         (results, None)
     };
+    // Fraction of the FULL relevance-clearing salience carried by the returned
+    // set. The set is a rank-prefix of `clearing_scores_desc` (all truncation +
+    // budget steps keep the highest-ranked items), so its salience is the prefix
+    // sum of the top `kept_n` scores. < 1.0 means relevant context was left out
+    // — by the token budget, top_k, OR the heuristic window — so a truncated
+    // slice can NEVER report as fully "captured". (Heuristic trust/tremor
+    // re-ranking can nudge order within the prefix, making this a close estimate
+    // rather than an exact identity; it is a coarse honesty signal, not a metric.)
+    let kept_n = results.len();
+    let kept_salience: f32 = clearing_scores_desc.iter().take(kept_n).sum();
+    let captured = if clearing_mass > f32::EPSILON {
+        (kept_salience / clearing_mass).clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    // Score of the best candidate that did NOT make the returned set (the "knee"):
+    // `None` when the set holds the entire relevant pool. Drives the gather-vs-act
+    // verdict — a strong dropped candidate means there is more worth pulling.
+    let marginal_score = clearing_scores_desc.get(kept_n).copied();
+    let top_score = results.first().map(|e| e.score).unwrap_or(0.0);
+    let sufficiency = compute_sufficiency(top_score, captured, marginal_score, results.len());
 
     drop(graph);
 
@@ -609,6 +721,7 @@ pub fn handle_seek(
         query: input.query,
         results,
         total_candidates_scanned: candidates_scanned,
+        relevance_clearing_total,
         filtering_reason,
         // TRUTHFUL: true ONLY when a real static embedding actually fed a node's
         // score (OPTIONAL `embed` feature). With the feature OFF this is always
@@ -625,6 +738,89 @@ pub fn handle_seek(
         recovery,
         agent_runtime_contract,
         budget,
+        sufficiency,
+    })
+}
+
+/// Handle `focus` — goal-conditioned attention management (Focus Runtime P1).
+///
+/// `focus` is a thin attention layer over `seek`: it runs the same intent
+/// ranking under a token budget, then reframes the outcome as an attention
+/// decision — the minimal `focus_set` worth loading, an honest `ignored` tail,
+/// and the answer-free `sufficiency` stop signal. It invents no scoring of its
+/// own; the salience, budget packing, `embeddings_used` flag, and recovery
+/// payload are exactly what `seek` produces, so the two stay consistent by
+/// construction and `focus` inherits every honesty guarantee `seek` already has.
+pub fn handle_focus(
+    state: &mut SessionState,
+    input: layers::FocusInput,
+) -> M1ndResult<layers::FocusOutput> {
+    // Drive the existing ranking with the goal as the query and the agent's
+    // declared budget as the limiter. top_k is kept generous so the *budget* —
+    // not an arbitrary count — decides what fits the focus set.
+    let seek_input = layers::SeekInput {
+        query: input.goal.clone(),
+        agent_id: input.agent_id.clone(),
+        top_k: input.top_k,
+        scope: input.scope.clone(),
+        node_types: input.node_types.clone(),
+        min_score: input.min_score,
+        graph_rerank: true,
+        token_budget: Some(input.token_budget),
+    };
+
+    let seek = handle_seek(state, seek_input)?;
+
+    let focus_len = seek.results.len();
+    // Every relevance-clearing node NOT shown — the honest "context left out"
+    // count. This spans all causes: token-budget drops AND nodes that fell beyond
+    // top_k / the heuristic window. It can never read 0 while relevant nodes were
+    // truncated, so a budget-or-window-bounded slice is never mistaken for the
+    // whole truth.
+    let ignored_count = seek.relevance_clearing_total.saturating_sub(focus_len);
+    // Of those, the share the token budget dropped (from seek's own accounting);
+    // the remainder fell beyond top_k / the heuristic window as lower salience.
+    let dropped_to_budget = seek
+        .budget
+        .as_ref()
+        .and_then(|block| block.get("dropped"))
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0) as usize;
+    let beyond_window = ignored_count.saturating_sub(dropped_to_budget);
+    let reason = if ignored_count == 0 {
+        "every relevance-clearing node fit the focus set".to_string()
+    } else if dropped_to_budget > 0 && beyond_window > 0 {
+        format!(
+            "{dropped_to_budget} node(s) dropped to fit the ~{budget}-token budget and {beyond_window} lower-salience match(es) fell beyond the top_k window — raise token_budget/top_k or narrow the goal",
+            budget = input.token_budget
+        )
+    } else if dropped_to_budget > 0 {
+        format!(
+            "{dropped_to_budget} ranked node(s) dropped to fit the ~{budget}-token budget — raise token_budget or narrow the goal to keep them",
+            budget = input.token_budget
+        )
+    } else {
+        format!(
+            "{beyond_window} lower-salience match(es) fell beyond the top_k window — raise top_k or narrow the goal to see them"
+        )
+    };
+
+    Ok(layers::FocusOutput {
+        goal: input.goal,
+        focus_set: seek.results,
+        ignored: layers::FocusIgnored {
+            count: ignored_count,
+            scanned: seek.total_candidates_scanned,
+            reason,
+        },
+        sufficiency: seek.sufficiency,
+        token_budget: input.token_budget,
+        budget: seek.budget,
+        embeddings_used: seek.embeddings_used,
+        filtering_reason: seek.filtering_reason,
+        elapsed_ms: seek.elapsed_ms,
+        recovery: seek.recovery,
+        agent_runtime_contract: seek.agent_runtime_contract,
     })
 }
 
@@ -9478,7 +9674,9 @@ fn generate_dot(
 
 #[cfg(test)]
 mod tests {
-    use super::{handle_layers, handle_scan, handle_seek, handle_validate_plan, TrailData};
+    use super::{
+        handle_focus, handle_layers, handle_scan, handle_seek, handle_validate_plan, TrailData,
+    };
     use crate::protocol::layers::{
         HypothesizeInput, LayersInput, PlannedAction, ScanInput, SeekInput, TrailConclusionInput,
         TrailResumeInput, TrailSaveInput, TrailVisitedNodeInput, ValidatePlanInput,
@@ -10130,6 +10328,221 @@ mod tests {
             used <= budget_tokens || kept == 1,
             "used {used} should be <= {budget_tokens} unless single-item overflow"
         );
+    }
+
+    fn run_focus(
+        state: &mut SessionState,
+        goal: &str,
+        token_budget: usize,
+        top_k: usize,
+    ) -> crate::protocol::layers::FocusOutput {
+        handle_focus(
+            state,
+            crate::protocol::layers::FocusInput {
+                goal: goal.into(),
+                agent_id: "test".into(),
+                token_budget,
+                top_k,
+                scope: None,
+                node_types: vec![],
+                min_score: 0.0,
+            },
+        )
+        .expect("focus should succeed")
+    }
+
+    /// P1 leapfrog: `focus` returns a budget-bounded focus_set, an honest
+    /// `ignored` tail tied to the budget's own drop count, and an answer-free
+    /// sufficiency signal. When the budget forces salient nodes out, the signal
+    /// must NEVER read "sufficient" — a truncated set is not silently "enough".
+    #[test]
+    fn focus_budget_bound_is_honest_and_never_silently_sufficient() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_state_many_search_nodes(temp.path(), 40);
+
+        // Tiny budget: only a sliver of the ranked set can fit.
+        let out = run_focus(&mut state, "search", 30, 60);
+
+        assert!(!out.focus_set.is_empty(), "must keep at least one node");
+        // The honest ignored count is exactly the budget's own drop count.
+        let dropped = out
+            .budget
+            .as_ref()
+            .and_then(|block| block.get("dropped"))
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize;
+        assert_eq!(
+            out.ignored.count, dropped,
+            "ignored.count must equal the budget's reported drop count"
+        );
+        assert!(
+            dropped > 0,
+            "a 30-token budget over 40 nodes must drop salient candidates"
+        );
+        // scanned reflects search breadth: all 40 nodes were scored (no filters).
+        assert_eq!(
+            out.ignored.scanned, 40,
+            "all nodes were scored for the goal"
+        );
+        // sufficiency is present; top_score mirrors the top of the focus set.
+        assert_eq!(out.sufficiency.top_score, out.focus_set[0].score);
+        assert!((0.0..=1.0).contains(&out.sufficiency.captured));
+        // The leapfrog invariant: a budget-truncated set is never "sufficient".
+        assert_ne!(
+            out.sufficiency.state, "sufficient",
+            "dropping salient nodes must surface as gathering/saturated, not silently sufficient: {:?}",
+            out.sufficiency
+        );
+    }
+
+    /// A generous budget that holds the whole ranked set drops nothing: `ignored`
+    /// is zero, retention is full, and the stop signal is never "gathering".
+    #[test]
+    fn focus_full_budget_drops_nothing_and_retention_is_full() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_state_many_search_nodes(temp.path(), 12);
+
+        let out = run_focus(&mut state, "search", 100_000, 60);
+
+        assert_eq!(
+            out.ignored.count, 0,
+            "all 12 relevant nodes fit, so nothing is ignored"
+        );
+        assert!(
+            out.ignored
+                .reason
+                .contains("every relevance-clearing node fit"),
+            "reason should explain a clean fit, got {:?}",
+            out.ignored.reason
+        );
+        assert!(
+            (out.sufficiency.captured - 1.0).abs() < 1e-6,
+            "no pruning means full capture, got {}",
+            out.sufficiency.captured
+        );
+        assert_ne!(
+            out.sufficiency.state, "gathering",
+            "nothing was dropped, so the verdict cannot be 'gathering': {:?}",
+            out.sufficiency
+        );
+    }
+
+    /// Regression for the top_k-truncation honesty gap (found in adversarial
+    /// review): when MORE relevance-clearing nodes exist than fit the focus set,
+    /// the cut nodes must be counted in `ignored`, `captured` must drop below
+    /// 1.0, and the verdict must NOT read "sufficient" — even when the token
+    /// budget itself dropped nothing. A truncated slice is never silently enough.
+    #[test]
+    fn focus_top_k_truncation_is_never_silently_sufficient() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // 80 equally-matching nodes, but only the top 20 may be returned.
+        let mut state = build_state_many_search_nodes(temp.path(), 80);
+
+        // Huge budget so the budget drops NOTHING — only top_k truncates.
+        let out = run_focus(&mut state, "search", 1_000_000, 20);
+
+        assert_eq!(out.focus_set.len(), 20, "top_k caps the focus set at 20");
+        let dropped_to_budget = out
+            .budget
+            .as_ref()
+            .and_then(|block| block.get("dropped"))
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as usize;
+        assert_eq!(dropped_to_budget, 0, "the budget dropped nothing here");
+        // The 60 top_k-truncated relevant nodes are still honestly accounted for.
+        assert_eq!(
+            out.ignored.count, 60,
+            "top_k-truncated relevant nodes must be counted as ignored, got {:?}",
+            out.ignored
+        );
+        assert!(
+            out.ignored.reason.contains("beyond the top_k window"),
+            "reason must name the top_k truncation, got {:?}",
+            out.ignored.reason
+        );
+        // Capture reflects the truncation, and the verdict is honest about it.
+        assert!(
+            out.sufficiency.captured < 1.0,
+            "a truncated slice cannot report full capture, got {}",
+            out.sufficiency.captured
+        );
+        assert_ne!(
+            out.sufficiency.state, "sufficient",
+            "a top_k-truncated slice must never read 'sufficient': {:?}",
+            out.sufficiency
+        );
+    }
+
+    /// When the goal is absent from the graph, `focus` returns an empty set, a
+    /// `saturated` verdict, a zero ignored count, and an honest reason — the
+    /// agent learns "not here" instead of being told a weak set is enough.
+    #[test]
+    fn focus_saturated_when_goal_absent() {
+        let tmp = std::env::temp_dir().join(format!("m1nd_focus_absent_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let runtime_dir = tmp.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut graph = Graph::new();
+        graph
+            .add_node("fn::do_work", "do_work", NodeType::Function, &[], 0.0, 0.0)
+            .expect("add node");
+        graph.finalize().expect("finalize");
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![tmp.to_string_lossy().to_string()];
+        state.workspace_root = Some(tmp.to_string_lossy().to_string());
+
+        let out = run_focus(
+            &mut state,
+            "zzqxwv unrelated gibberish nonmatching",
+            2000,
+            60,
+        );
+
+        assert!(
+            out.focus_set.is_empty(),
+            "an absent goal yields an empty set"
+        );
+        assert_eq!(
+            out.sufficiency.state, "saturated",
+            "an absent goal must read 'saturated', got {:?}",
+            out.sufficiency
+        );
+        assert_eq!(out.ignored.count, 0, "nothing relevant was dropped");
+        assert!(
+            out.filtering_reason.is_some(),
+            "an empty focus must explain why nothing was selected"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Pure-function coverage of the sufficiency verdict across every branch,
+    /// deterministic and model-free (the live calibration is documented on the
+    /// thresholds; this pins the decision logic itself).
+    #[test]
+    fn compute_sufficiency_covers_every_state() {
+        use super::compute_sufficiency as cs;
+        // empty set -> saturated
+        assert_eq!(cs(0.0, 0.0, None, 0).state, "saturated");
+        // weak best match (below WEAK_TOP=0.18) -> saturated, regardless of the rest
+        assert_eq!(cs(0.16, 1.0, Some(0.10), 5).state, "saturated");
+        // strong match, nothing left out -> sufficient
+        assert_eq!(cs(0.50, 1.0, None, 5).state, "sufficient");
+        // strong match, but a still-relevant candidate was cut -> gathering
+        assert_eq!(cs(0.50, 0.30, Some(0.40), 5).state, "gathering");
+        // strong match, everything cut is below the floor (weak tail) -> sufficient
+        assert_eq!(cs(0.50, 0.30, Some(0.12), 5).state, "sufficient");
+        // knee exactly at the floor counts as still-relevant -> gathering
+        assert_eq!(cs(0.50, 0.50, Some(0.18), 5).state, "gathering");
+        // the exact top_score is echoed through for the agent to judge
+        assert_eq!(cs(0.42, 1.0, None, 3).top_score, 0.42);
     }
 
     fn run_validate_plan(

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -648,7 +648,10 @@ pub fn handle_seek(
     // carries, in `combined` units (the partition's own units), so it is an exact
     // prefix ratio — never inflated by trust/tremor re-ranking. Anything dropped
     // beyond the window is a weaker tail surfaced via `marginal_score` and the
-    // `ignored` count, not hidden here.
+    // `ignored` count, not hidden here. (`dedupe_ranked` may reorder the kept set
+    // by a specificity bonus clamped to ±CLOSE_SCORE_EPS and collapse same-family
+    // hits, so the realized prefix can differ from this by ≤eps — biased toward
+    // "gathering", the safe direction.)
     let window_mass: f32 = window_combined_desc.iter().sum();
     let kept_salience: f32 = window_combined_desc.iter().take(kept_n).sum();
     let captured = if window_mass > f32::EPSILON {
@@ -659,7 +662,8 @@ pub fn handle_seek(
     // `marginal_score`: the score of the best candidate NOT returned — the "knee".
     // Within the window it is the exact element past the kept prefix (combined
     // units). If the entire window was returned but weaker nodes were cut beyond
-    // it, fall back to that tail's strongest (base units, necessarily weaker).
+    // it, fall back to that tail's strongest (base_score — which differs from its
+    // own combined value by ≤~9%, biasing this rare fallback toward "gathering").
     // `None` only when the returned set holds the entire relevant pool.
     let marginal_score = if kept_n < window_combined_desc.len() {
         Some(window_combined_desc[kept_n])

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -83,12 +83,43 @@ pub struct SeekInput {
     pub token_budget: Option<usize>,
 }
 
+/// Answer-free stop signal for goal-conditioned retrieval. It never claims to
+/// know the answer — only whether the returned context is likely *enough* to
+/// act on, whether more relevant context exists beyond what was returned, or
+/// whether the goal simply isn't well represented in the graph.
+///
+/// - `sufficient`: the top matches strongly cover the goal and fit the budget —
+///   enough to act.
+/// - `gathering`: relevant context exists beyond what was returned (the budget
+///   dropped salient nodes) — raise the budget or narrow the goal.
+/// - `saturated`: the best match is weak or absent — the goal likely isn't
+///   represented here; re-scope, broaden, or ingest more.
+#[derive(Clone, Debug, Serialize)]
+pub struct Sufficiency {
+    /// "sufficient" | "gathering" | "saturated".
+    pub state: String,
+    /// Strength of the single best match [0.0, 1.0] (0 when empty). This is the
+    /// absolute relevance signal, not a probability.
+    pub top_score: f32,
+    /// Fraction of the ranked salience mass retained in the returned set after
+    /// budget packing [0.0, 1.0]. 1.0 when no budget pruning occurred. Below
+    /// 1.0 means the token budget dropped salient candidates.
+    pub captured: f32,
+    /// Plain-English reason for `state`, phrased for an agent reader.
+    pub why: String,
+}
+
 /// Output for seek.
 #[derive(Clone, Debug, Serialize)]
 pub struct SeekOutput {
     pub query: String,
     pub results: Vec<SeekResultEntry>,
     pub total_candidates_scanned: usize,
+    /// How many of the scanned nodes actually cleared the relevance threshold
+    /// (`min_score`) — the size of the relevant pool BEFORE any top_k / window /
+    /// budget truncation. `results.len()` is the slice of this pool that was
+    /// returned; the gap is honestly relevant context that did not fit.
+    pub relevance_clearing_total: usize,
     /// Present only when retrieval returned NO results: a plain-English reason the
     /// result set is empty (empty graph, no searchable tokens, scope/type filtered
     /// everything, or nothing cleared the relevance threshold), so an agent can
@@ -117,6 +148,9 @@ pub struct SeekOutput {
     /// the context-budget packing (requested/used estimate, kept, dropped).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub budget: Option<serde_json::Value>,
+    /// Answer-free stop signal: is this enough context, is there more beyond the
+    /// budget, or is the goal not represented here? Always present.
+    pub sufficiency: Sufficiency,
 }
 
 /// Shared heuristic metadata exposed by tools that apply trust/tremor priors.
@@ -172,6 +206,98 @@ pub struct SeekConnection {
     pub node_id: String,
     pub label: String,
     pub relation: String,
+}
+
+// ---------------------------------------------------------------------------
+// m1nd.focus — the attention runtime (Focus Runtime P1)
+// ---------------------------------------------------------------------------
+
+/// Input for `focus` — goal-conditioned attention management. Given a goal and a
+/// token budget, m1nd returns the minimal *focus set* worth loading, an honest
+/// account of what it left out, and an answer-free sufficiency signal telling
+/// the agent whether to act, gather more, or re-scope.
+///
+/// `focus` is a thin attention layer over the same ranking that powers `seek`
+/// (intent embedding + graph importance + recency); it adds the budget-bounded
+/// minimal-set framing, the honest `ignored` tail, and the stop condition.
+#[derive(Clone, Debug, Deserialize)]
+pub struct FocusInput {
+    /// Natural-language description of the goal the agent is working toward.
+    pub goal: String,
+    pub agent_id: String,
+    /// Approximate context-token budget for the focus set. The set keeps the
+    /// highest-salience nodes that fit; the rest are reported under `ignored`.
+    /// Default: 2000.
+    #[serde(default = "default_focus_budget")]
+    pub token_budget: usize,
+    /// Upper bound on ranked candidates considered before budget packing. The
+    /// budget — not this — is the intended limiter; keep it generous.
+    /// Default: 60.
+    #[serde(default = "default_focus_top_k")]
+    pub top_k: usize,
+    /// File path prefix to limit the focus scope. None = entire graph.
+    #[serde(default)]
+    pub scope: Option<String>,
+    /// Filter by node type: "function", "class", "struct", "module", "file".
+    #[serde(default)]
+    pub node_types: Vec<String>,
+    /// Minimum combined score for a node to be eligible for the focus set.
+    /// Default: 0.1 (same floor as `seek`).
+    #[serde(default = "default_min_score")]
+    pub min_score: f32,
+}
+
+/// Honest account of what `focus` deliberately left out of the focus set, so the
+/// agent never mistakes a budget-bounded set for the whole truth.
+#[derive(Clone, Debug, Serialize)]
+pub struct FocusIgnored {
+    /// Ranked, relevance-clearing candidates dropped to fit the token budget —
+    /// the actionable "I left out context you might need" number. Zero means the
+    /// budget held everything ranked.
+    pub count: usize,
+    /// Total nodes scored for the goal (search breadth). Most score near zero;
+    /// reported for transparency, not as dropped context.
+    pub scanned: usize,
+    /// Plain-English breakdown of why candidates were left out, including any
+    /// `top_k` cap that may hide further candidates.
+    pub reason: String,
+}
+
+/// Output for `focus` — the budget-bounded attention slice for a goal.
+#[derive(Clone, Debug, Serialize)]
+pub struct FocusOutput {
+    pub goal: String,
+    /// The minimal set of nodes worth loading for the goal, ranked by salience
+    /// and bounded by the token budget. Each entry is a full `seek` hit.
+    pub focus_set: Vec<SeekResultEntry>,
+    /// What was deliberately left out, and why.
+    pub ignored: FocusIgnored,
+    /// Answer-free stop signal: sufficient | gathering | saturated.
+    pub sufficiency: Sufficiency,
+    /// The token budget that bounded the focus set.
+    pub token_budget: usize,
+    /// Honest budget-packing accounting (requested/used estimate, kept, dropped).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<serde_json::Value>,
+    /// Whether real static embeddings fed the ranking (OPTIONAL `embed` feature).
+    pub embeddings_used: bool,
+    /// Present only when the focus set is empty: why nothing was selected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filtering_reason: Option<String>,
+    pub elapsed_ms: f64,
+    /// Deterministic recovery payload when retrieval is blocked (mirrors `seek`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_runtime_contract: Option<serde_json::Value>,
+}
+
+fn default_focus_budget() -> usize {
+    2000
+}
+
+fn default_focus_top_k() -> usize {
+    60
 }
 
 // ---------------------------------------------------------------------------

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -88,10 +88,10 @@ pub struct SeekInput {
 /// act on, whether more relevant context exists beyond what was returned, or
 /// whether the goal simply isn't well represented in the graph.
 ///
-/// - `sufficient`: the top matches strongly cover the goal and fit the budget —
-///   enough to act.
-/// - `gathering`: relevant context exists beyond what was returned (the budget
-///   dropped salient nodes) — raise the budget or narrow the goal.
+/// - `sufficient`: the top match is real AND the best candidate left out is
+///   already weak — the strongest context is in hand, enough to act.
+/// - `gathering`: a still-relevant candidate was dropped (by token budget, top_k,
+///   or the re-rank window) — raise the budget/top_k or narrow the goal.
 /// - `saturated`: the best match is weak or absent — the goal likely isn't
 ///   represented here; re-scope, broaden, or ingest more.
 #[derive(Clone, Debug, Serialize)]
@@ -101,9 +101,11 @@ pub struct Sufficiency {
     /// Strength of the single best match [0.0, 1.0] (0 when empty). This is the
     /// absolute relevance signal, not a probability.
     pub top_score: f32,
-    /// Fraction of the ranked salience mass retained in the returned set after
-    /// budget packing [0.0, 1.0]. 1.0 when no budget pruning occurred. Below
-    /// 1.0 means the token budget dropped salient candidates.
+    /// Fraction of the re-ranked window's salience carried by the returned set
+    /// [0.0, 1.0], in the same units the kept/dropped partition is decided in.
+    /// 1.0 when the window was returned whole; below 1.0 means salient nodes were
+    /// dropped. Reported for transparency — the verdict is driven by the knee
+    /// test, not this ratio.
     pub captured: f32,
     /// Plain-English reason for `state`, phrased for an agent reader.
     pub why: String,
@@ -251,9 +253,11 @@ pub struct FocusInput {
 /// agent never mistakes a budget-bounded set for the whole truth.
 #[derive(Clone, Debug, Serialize)]
 pub struct FocusIgnored {
-    /// Ranked, relevance-clearing candidates dropped to fit the token budget —
-    /// the actionable "I left out context you might need" number. Zero means the
-    /// budget held everything ranked.
+    /// Relevance-clearing nodes NOT in the focus set — everything dropped by the
+    /// token budget, top_k, or the re-rank window. A conservative upper bound: it
+    /// counts pre-de-duplication, so a few may share a family with a returned hit.
+    /// It never under-reports, so a budget/window-bounded slice is never mistaken
+    /// for the whole truth. Zero means the focus set holds the entire relevant pool.
     pub count: usize,
     /// Total nodes scored for the goal (search breadth). Most score near zero;
     /// reported for transparency, not as dropped context.

--- a/m1nd-mcp/src/result_shaping.rs
+++ b/m1nd-mcp/src/result_shaping.rs
@@ -13,19 +13,41 @@ pub trait RankedResult: Clone {
 }
 
 pub fn dedupe_ranked<T: RankedResult>(mut items: Vec<T>, top_k: usize) -> Vec<T> {
-    items.sort_by(|a, b| {
-        let score_delta = (a.score() - b.score()).abs();
-        if score_delta <= CLOSE_SCORE_EPS {
-            b.specificity()
-                .total_cmp(&a.specificity())
-                .then_with(|| b.score().total_cmp(&a.score()))
-                .then_with(|| a.family_key().cmp(&b.family_key()))
-        } else {
-            b.score()
-                .total_cmp(&a.score())
-                .then_with(|| b.specificity().total_cmp(&a.specificity()))
-                .then_with(|| a.family_key().cmp(&b.family_key()))
+    // Rank by a single blended key: the score nudged by a bounded specificity
+    // bonus. Within a near-tie the more specific hit wins (a specific symbol over
+    // a generic crate node). The bonus is clamped to ±CLOSE_SCORE_EPS, so the
+    // most specificity can shift a key is one eps; two items can differ by up to
+    // 2·eps from specificity alone, and any score gap wider than that always
+    // wins on score.
+    //
+    // This MUST be a TOTAL ORDER. The previous "abs(a-b) <= eps ? by spec : by
+    // score" switch was intransitive — for A≈B, B≈C, A≠C it compared the three
+    // pairs by different keys and could form a cycle (A>B>C>A). That is
+    // undefined behaviour for a comparator, and modern Rust's sort PANICS when
+    // it detects the violation ("comparison function does not implement a total
+    // order") — which started firing once `embed` (default) clustered scores
+    // into near-ties on real graphs. A single scalar key removes the branch and
+    // the intransitivity entirely. Non-finite score OR specificity carries no
+    // signal and sorts last.
+    const SPEC_WEIGHT: f32 = 0.02;
+    fn rank_key<T: RankedResult>(item: &T) -> f32 {
+        let score = item.score();
+        if !score.is_finite() {
+            return f32::NEG_INFINITY;
         }
+        let spec = item.specificity();
+        let bonus = if spec.is_finite() {
+            (spec * SPEC_WEIGHT).clamp(-CLOSE_SCORE_EPS, CLOSE_SCORE_EPS)
+        } else {
+            0.0
+        };
+        score + bonus
+    }
+    items.sort_by(|a, b| {
+        rank_key(b)
+            .total_cmp(&rank_key(a))
+            .then_with(|| b.score().total_cmp(&a.score()))
+            .then_with(|| a.family_key().cmp(&b.family_key()))
     });
 
     let mut seen: HashSet<String> = HashSet::new();
@@ -250,6 +272,92 @@ mod tests {
     use super::*;
     use crate::protocol::layers::{SeekConnection, SeekResultEntry, SeekScoreBreakdown};
     use crate::protocol::{ActivatedNodeOutput, DimensionsOutput, ProvenanceOutput, SeedOutput};
+
+    /// Minimal `RankedResult` with directly-settable score/specificity so we can
+    /// reproduce the adversarial ordering that broke the comparator.
+    #[derive(Clone)]
+    struct Ranked {
+        s: f32,
+        spec: f32,
+        key: String,
+    }
+    impl RankedResult for Ranked {
+        fn score(&self) -> f32 {
+            self.s
+        }
+        fn specificity(&self) -> f32 {
+            self.spec
+        }
+        fn family_key(&self) -> String {
+            self.key.clone()
+        }
+    }
+
+    /// Regression: `dedupe_ranked`'s comparator MUST be a total order. The old
+    /// "abs(a-b) <= eps ? by specificity : by score" switch was intransitive —
+    /// for a tight score ramp with alternating specificity it forms cycles
+    /// (A>B>C>A), which modern Rust's sort detects and PANICS on. This input
+    /// reproduces that exact shape; the test passing (no panic) is the guard.
+    #[test]
+    fn dedupe_ranked_is_a_total_order_under_near_tie_ramp() {
+        // The minimal cycle the old comparator produced: scores 1.00/1.03/1.06
+        // (adjacent within eps=0.05, ends 0.06 apart) with decreasing
+        // specificity. Old: A≈B,B≈C by spec but A≠C by score => A>B>C>A.
+        let triple = vec![
+            Ranked {
+                s: 1.00,
+                spec: 0.9,
+                key: "a".into(),
+            },
+            Ranked {
+                s: 1.03,
+                spec: 0.5,
+                key: "b".into(),
+            },
+            Ranked {
+                s: 1.06,
+                spec: 0.1,
+                key: "c".into(),
+            },
+        ];
+        let out = dedupe_ranked(triple, 10);
+        assert_eq!(out.len(), 3, "all distinct families survive");
+
+        // A dense ramp (step << eps) with alternating specificity packs many
+        // intransitive triples into the same sort — the strongest trigger.
+        let ramp: Vec<Ranked> = (0..64)
+            .map(|i| Ranked {
+                s: 0.40 + i as f32 * 0.012,
+                spec: if i % 2 == 0 { 0.9 } else { 0.1 },
+                key: format!("k{i}"),
+            })
+            .collect();
+        let sorted = dedupe_ranked(ramp, 64);
+        assert_eq!(sorted.len(), 64, "no family collisions, nothing dropped");
+        // Completing without panic IS the regression guard — the old comparator
+        // aborts on this exact shape.
+
+        // A clearly-higher score (gap > 2*eps) is never overturned by specificity,
+        // even when the low scorer is maximally specific and the high one is not.
+        let clear = vec![
+            Ranked {
+                s: 0.50,
+                spec: 9.9,
+                key: "low_but_specific".into(),
+            },
+            Ranked {
+                s: 0.70,
+                spec: -9.9,
+                key: "high_but_generic".into(),
+            },
+        ];
+        let out = dedupe_ranked(clear, 10);
+        assert_eq!(
+            out[0].family_key(),
+            "high_but_generic",
+            "a clearly-higher score must win regardless of specificity"
+        );
+    }
 
     #[test]
     fn dedupe_ranked_prefers_impl_family_over_duplicate_label_hits() {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -315,6 +315,7 @@ pub const ESSENTIAL_TOOLS: &[&str] = &[
     "audit",
     "search",
     "seek",
+    "focus",
     "activate",
     "learn",
     "glob",
@@ -1043,6 +1044,23 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "token_budget": { "type": "integer", "minimum": 1, "description": "Optional approx context-token budget. m1nd keeps the highest graph-importance hits that fit, drops the rest, and returns a 'budget' block (estimate = chars/4, not exact tokenization)" }
                     },
                     "required": ["query", "agent_id"]
+                }
+            },
+            {
+                "name": "focus",
+                "description": "Attention runtime — given a GOAL and a token budget, return the minimal focus_set worth loading, an honest account of what was left out (ignored), and an answer-free sufficiency signal (sufficient | gathering | saturated) telling you whether to act, gather more, or re-scope. Use it to decide WHAT context to pull and WHEN you have enough, instead of over-reading.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "goal": { "type": "string", "description": "Natural-language description of the goal you are working toward" },
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" },
+                        "token_budget": { "type": "integer", "minimum": 1, "default": 2000, "description": "Approx context-token budget for the focus set (estimate = chars/4). The set keeps the highest-salience nodes that fit; the rest are reported under 'ignored'" },
+                        "top_k": { "type": "integer", "default": 60, "description": "Upper bound on ranked candidates before budget packing; keep generous so the budget is the real limiter" },
+                        "scope": { "type": "string", "description": "File path prefix to limit the focus scope" },
+                        "node_types": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Filter by node type: function, class, struct, module, file" },
+                        "min_score": { "type": "number", "default": 0.1, "description": "Minimum combined score for a node to be eligible for the focus set" }
+                    },
+                    "required": ["goal", "agent_id"]
                 }
             },
             {
@@ -2483,7 +2501,7 @@ fn tool_has_memory_anchors(tool: &str) -> bool {
         .unwrap_or(tool);
     matches!(
         bare,
-        "activate" | "seek" | "search" | "surgical_context" | "surgical_context_v2"
+        "activate" | "seek" | "focus" | "search" | "surgical_context" | "surgical_context_v2"
     )
 }
 
@@ -3502,6 +3520,12 @@ fn dispatch_core_tool(
             let input: layers::SeekInput =
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
             let output = layer_handlers::handle_seek(state, input)?;
+            serde_json::to_value(output).map_err(M1ndError::Serde)
+        }
+        "focus" => {
+            let input: layers::FocusInput =
+                serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
+            let output = layer_handlers::handle_focus(state, input)?;
             serde_json::to_value(output).map_err(M1ndError::Serde)
         }
         "scan" => {


### PR DESCRIPTION
## What

Adds **`focus`** — the attention front door for coding agents. Given a goal and a token budget, m1nd returns:

- **`focus_set`** — the budget-bounded minimal set of nodes worth loading, ranked by goal salience (intent embedding + graph importance + recency).
- **`ignored`** — an honest tail: *every* relevance-clearing node left out (by token budget, `top_k`, or the heuristic window), with `count`, `scanned`, and a reason that decomposes the causes. Never a silent drop.
- **`sufficiency`** — an answer-free stop signal: `sufficient | gathering | saturated`, decided by a **knee test** on the best *dropped* candidate. A long tail of weak matches does not force "gathering", and a truncated slice is never silently "enough".

`focus` is a thin layer over `seek`'s ranking — it reuses the same scoring, budget packing, and recovery payload, so the two stay consistent by construction and `focus` inherits seek's honesty guarantees. `seek` is enriched with the same `sufficiency` signal and a `relevance_clearing_total` count.

This is **P1** of the Focus Runtime (design doc: `docs/FOCUS-RUNTIME-PRD.md`). P2–P4 (working-set page-in/out, status mode, anti-thrash) are deferred with evidence.

## Also fixes a latent v1.0 panic

While proving `focus` end-to-end on a real ingest, the `dedupe_ranked` comparator was found to be **not a total order** (it switched sort keys on `abs(Δscore) <= eps`, which is intransitive). Rust's sort detects this and panics — triggered once embeddings (default since 1.0) cluster scores into near-ties on real graphs. Replaced with a single blended total-order key (separate `fix` commit), with a regression test.

## Verification

- Workspace: **1053 tests pass, 0 fail**; `clippy --workspace` and `fmt --check` clean; lean build (`--no-default-features --features serve`) compiles + passes.
- **Live end-to-end** over a real `m1nd-core` ingest (1092 nodes, embeddings on): focused goals read `sufficient`; broad goals correctly read `gathering` (relevant nodes beyond `top_k`); nonsense goals read `saturated`. Thresholds calibrated against that ingest (present goals 0.24–0.54, pure noise 0.00–0.16).
- Adversarial review (two independent passes) confirmed the comparator is a total order (200k fuzz) and surfaced the top_k-truncation honesty gap, now fixed + regression-tested.

OFF-default-safe and additive; existing `seek` behavior is unchanged except for the additive envelope fields.
