### PR TITLE
feat(mcp): impact surfaces code symbols above containers

### DIFF
--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -1234,13 +1234,35 @@ pub fn handle_impact(state: &mut SessionState, input: ImpactInput) -> M1ndResult
     let max_nodes_cap = input.max_nodes.unwrap_or(150);
     let total_blast_nodes = impact.blast_radius.len();
 
-    // Sort by signal_strength descending before capping
+    // Rank for the cap+display so the agent's real question ("what code is
+    // affected / who calls this") is answered first. Pure signal_strength buries
+    // the actual caller/callee FUNCTIONS under their containing File/Module nodes
+    // (which accumulate more blast energy), so a function caller can land past the
+    // cap. Order by: code SYMBOLS before containers, then nearest hop, then
+    // signal. The output still carries `node_type`, so an agent can re-filter.
+    let type_rank = |idx: usize| -> u8 {
+        if idx >= graph.num_nodes() as usize {
+            return 5;
+        }
+        match format!("{:?}", graph.nodes.node_type[idx]).as_str() {
+            "Function" | "Struct" | "Enum" | "Type" | "Trait" => 0,
+            "Module" => 2,
+            "File" => 3,
+            "Directory" => 4,
+            _ => 1,
+        }
+    };
     let mut sorted_blast = impact.blast_radius.clone();
     sorted_blast.sort_by(|a, b| {
-        b.signal_strength
-            .get()
-            .partial_cmp(&a.signal_strength.get())
-            .unwrap_or(std::cmp::Ordering::Equal)
+        type_rank(a.node.as_usize())
+            .cmp(&type_rank(b.node.as_usize()))
+            .then(a.hop_distance.cmp(&b.hop_distance))
+            .then(
+                b.signal_strength
+                    .get()
+                    .partial_cmp(&a.signal_strength.get())
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
     });
 
     // #3 — Build a lookup of which blast-radius nodes are light:evidenced_by


### PR DESCRIPTION
Follow-up to the call-graph extractor fix (#161). The battery showed `impact` losing to grep: with call edges now present, blast radius was still sorted purely by signal_strength, so caller/callee **functions** sat below their containing File/Module nodes and fell past the display cap.

Rank blast radius **code-symbol-first** (Function/Struct/Enum/Type → Module/File/Directory), then nearest hop, then signal. Output still carries `node_type` for re-filtering. **Verified:** `impact(reverse) dedupe_ranked` lists handle_seek at rank 6 (was 11); impact's head-to-head vs grep moves from a **loss to a tie**. cargo test --workspace 1061/0, clippy+fmt clean, impact tests green.

**Honest limits (seeded, not claimed fixed):** a production caller can still tie with same-signal in-file `#[cfg(test)]` test callers (m1nd's `is_test_source` is path-only → misses in-file test modules), so the battery's strict per-caller pass stays 0/2 until test fns are tagged at extraction; value-receiver method calls (`x.m()`) still need type inference (`propagate`). This change makes impact stop *losing* to grep; surfacing the exact production caller is the next step.