### PR TITLE
fix(ingest): disambiguate same-name function ids in TS/Java/Go/Python extractors

### DIFF
--- a/m1nd-ingest/src/extract/go.rs
+++ b/m1nd-ingest/src/extract/go.rs
@@ -140,7 +140,10 @@ impl Extractor for GoExtractor {
                 true
             } else if let Some(caps) = self.re_method.captures(line) {
                 let name = caps.get(1).unwrap().as_str();
-                let node_id = format!("{}::fn::{}", file_id, name);
+                // Disambiguate same-named defs in one file (a method named `Run` on
+                // two types, or a method sharing a free func's name) so add_node
+                // does not drop the sibling. First keeps the clean id.
+                let node_id = super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                 nodes.push(ExtractedNode {
                     id: node_id.clone(),
                     label: name.to_string(),
@@ -160,7 +163,7 @@ impl Extractor for GoExtractor {
                 true
             } else if let Some(caps) = self.re_func.captures(line) {
                 let name = caps.get(1).unwrap().as_str();
-                let node_id = format!("{}::fn::{}", file_id, name);
+                let node_id = super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                 nodes.push(ExtractedNode {
                     id: node_id.clone(),
                     label: name.to_string(),
@@ -538,6 +541,37 @@ func processData(d []byte) []byte {
         assert!(result.edges.iter().any(|e| e.relation == "calls"));
         assert!(result.edges.iter().any(|e| e.relation == "imports"));
         assert!(result.edges.iter().any(|e| e.relation == "contains"));
+    }
+
+    #[test]
+    fn go_same_name_methods_in_one_file_get_distinct_ids() {
+        // A method named `Run` defined on two different types in one file. Both must
+        // survive as DISTINCT function nodes — without id disambiguation the second
+        // collides on `…::fn::Run` and add_node drops it.
+        let src = "package main\n\nfunc (a *A) Run() {}\nfunc (b *B) Run() {}\n";
+        let result = extract(src);
+        let run_ids: Vec<&str> = result
+            .nodes
+            .iter()
+            .filter(|n| n.label == "Run" && n.node_type == NodeType::Function)
+            .map(|n| n.id.as_str())
+            .collect();
+        assert_eq!(
+            run_ids.len(),
+            2,
+            "expected two distinct `Run` method nodes, got ids {:?}",
+            run_ids
+        );
+        assert!(
+            run_ids.contains(&"file::testfile.go::fn::Run"),
+            "first occurrence should keep the clean id: {:?}",
+            run_ids
+        );
+        assert!(
+            run_ids.contains(&"file::testfile.go::fn::Run#2"),
+            "second occurrence should be disambiguated to `#2`: {:?}",
+            run_ids
+        );
     }
 
     #[test]

--- a/m1nd-ingest/src/extract/java.rs
+++ b/m1nd-ingest/src/extract/java.rs
@@ -166,7 +166,10 @@ impl Extractor for JavaExtractor {
                 true
             } else if let Some(caps) = self.re_method.captures(line) {
                 let name = caps.get(1).unwrap().as_str();
-                let node_id = format!("{}::fn::{}", file_id, name);
+                // Disambiguate same-named defs in one file (Java overloads, or two
+                // classes each with a `run` method) so add_node does not drop the
+                // sibling. First keeps the clean id; later siblings get `#2`/`#3`.
+                let node_id = super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                 nodes.push(ExtractedNode {
                     id: node_id.clone(),
                     label: name.to_string(),
@@ -526,6 +529,38 @@ public class Service {
             !has_edge(&result, "calls", "ref::this"),
             "Must NOT emit calls for `this` keyword. Edges: {:?}",
             result.edges
+        );
+    }
+
+    #[test]
+    fn java_same_name_methods_in_one_file_get_distinct_ids() {
+        // Two classes in one file each declare a `run` method. Both must survive as
+        // DISTINCT function nodes — without id disambiguation the second collides on
+        // `…::fn::run` and add_node drops it (the method vanishes from the graph).
+        let src = "public class A {\n    public void run() {}\n}\nclass B {\n    public void run() {}\n}\n";
+        let result = extract(src);
+        let run_ids: Vec<&str> = result
+            .nodes
+            .iter()
+            .filter(|n| n.label == "run" && n.node_type == NodeType::Function)
+            .map(|n| n.id.as_str())
+            .collect();
+        assert_eq!(
+            run_ids.len(),
+            2,
+            "expected two distinct `run` method nodes, got ids {:?}",
+            run_ids
+        );
+        // First keeps the clean (line-less) id for back-compat; the sibling is `#2`.
+        assert!(
+            run_ids.contains(&"file::testfile.java::fn::run"),
+            "first occurrence should keep the clean id: {:?}",
+            run_ids
+        );
+        assert!(
+            run_ids.contains(&"file::testfile.java::fn::run#2"),
+            "second occurrence should be disambiguated to `#2`: {:?}",
+            run_ids
         );
     }
 

--- a/m1nd-ingest/src/extract/mod.rs
+++ b/m1nd-ingest/src/extract/mod.rs
@@ -371,6 +371,33 @@ pub struct ExtractionResult {
     pub unresolved_refs: Vec<String>,
 }
 
+/// Make a node id unique within a single file's extraction. Function/method ids
+/// are `file::…::fn::<name>` with NO line, so two same-named definitions in ONE
+/// file (TS overloads / two class methods named `process`, Java overloads, Go
+/// methods named `Run` on two types, Python methods named `save` in two classes)
+/// otherwise collide on one id. `Graph::add_node` keys on the id and returns
+/// `Err(DuplicateNode)`, and the ingest loader drops the duplicate — so the
+/// later same-named sibling silently vanishes from the graph (invisible to
+/// impact/why/seek). The FIRST occurrence keeps the clean id (back-compat:
+/// line-less `…::fn::name` queries still resolve to it); later siblings get a
+/// `#2`, `#3`, … suffix so every distinct definition exists and is addressable.
+/// The node `label` stays `name`, so search/seek still match by label. Mirrors
+/// `RustExtractor::unique_fn_id` but takes a node slice so the regex extractors
+/// (which build a bare `Vec<ExtractedNode>`) can share it.
+pub fn unique_node_id(nodes: &[ExtractedNode], base_id: &str) -> String {
+    if !nodes.iter().any(|n| n.id == base_id) {
+        return base_id.to_string();
+    }
+    let mut n = 2u32;
+    loop {
+        let candidate = format!("{base_id}#{n}");
+        if !nodes.iter().any(|node| node.id == candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 /// Max source lines folded into a code symbol's excerpt (signature + a few body
 /// lines) and the hard character budget on the joined result.
 pub const EXCERPT_MAX_LINES: usize = 4;

--- a/m1nd-ingest/src/extract/python.rs
+++ b/m1nd-ingest/src/extract/python.rs
@@ -115,7 +115,10 @@ impl Extractor for PythonExtractor {
                 last_node_id = Some(node_id);
             } else if let Some(caps) = self.re_func.captures(line) {
                 let name = caps.get(1).unwrap().as_str();
-                let node_id = format!("{}::fn::{}", file_id, name);
+                // Disambiguate same-named defs in one file (two class methods named
+                // `save`, a redefined top-level fn) so add_node does not drop the
+                // sibling. First keeps the clean id; later siblings get `#2`/`#3`.
+                let node_id = super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                 nodes.push(ExtractedNode {
                     id: node_id.clone(),
                     label: name.to_string(),
@@ -289,5 +292,44 @@ impl Extractor for PythonExtractor {
 
     fn extensions(&self) -> &[&str] {
         &["py", "pyi"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::Extractor;
+
+    #[test]
+    fn python_same_name_methods_in_one_file_get_distinct_ids() {
+        // Two classes in one file each define a `save` method. Both must survive as
+        // DISTINCT function nodes — without id disambiguation the second collides on
+        // `…::fn::save` and add_node drops it (the method vanishes from the graph).
+        let src = "class A:\n    def save(self):\n        pass\nclass B:\n    def save(self):\n        pass\n";
+        let result = PythonExtractor::new()
+            .extract(src.as_bytes(), "file::testfile.py")
+            .unwrap();
+        let save_ids: Vec<&str> = result
+            .nodes
+            .iter()
+            .filter(|n| n.label == "save" && n.node_type == NodeType::Function)
+            .map(|n| n.id.as_str())
+            .collect();
+        assert_eq!(
+            save_ids.len(),
+            2,
+            "expected two distinct `save` method nodes, got ids {:?}",
+            save_ids
+        );
+        assert!(
+            save_ids.contains(&"file::testfile.py::fn::save"),
+            "first occurrence should keep the clean id: {:?}",
+            save_ids
+        );
+        assert!(
+            save_ids.contains(&"file::testfile.py::fn::save#2"),
+            "second occurrence should be disambiguated to `#2`: {:?}",
+            save_ids
+        );
     }
 }

--- a/m1nd-ingest/src/extract/typescript.rs
+++ b/m1nd-ingest/src/extract/typescript.rs
@@ -168,7 +168,10 @@ impl Extractor for TypeScriptExtractor {
                 });
             } else if let Some(caps) = self.re_func.captures(line) {
                 let name = caps.get(1).unwrap().as_str();
-                let node_id = format!("{}::fn::{}", file_id, name);
+                // Disambiguate same-named defs in one file (TS function overloads
+                // with bodies, or two class methods named `process`) so add_node
+                // does not drop the sibling. First keeps the clean id.
+                let node_id = super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                 nodes.push(ExtractedNode {
                     id: node_id.clone(),
                     label: name.to_string(),
@@ -188,7 +191,7 @@ impl Extractor for TypeScriptExtractor {
                 pending_fn = Some((node_id, brace_depth));
             } else if let Some(caps) = self.re_arrow.captures(line) {
                 let name = caps.get(1).unwrap().as_str();
-                let node_id = format!("{}::fn::{}", file_id, name);
+                let node_id = super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                 nodes.push(ExtractedNode {
                     id: node_id.clone(),
                     label: name.to_string(),
@@ -215,7 +218,8 @@ impl Extractor for TypeScriptExtractor {
                 // control-flow that also reads `kw (...) {` — those are NOT methods.
                 let name = caps.get(1).unwrap().as_str();
                 if !Self::is_control_keyword(name) {
-                    let node_id = format!("{}::fn::{}", file_id, name);
+                    let node_id =
+                        super::unique_node_id(&nodes, &format!("{}::fn::{}", file_id, name));
                     nodes.push(ExtractedNode {
                         id: node_id.clone(),
                         label: name.to_string(),
@@ -652,6 +656,43 @@ mod tests {
         assert!(
             calls.contains(&(caller_id, "ref::step")),
             "step should be caller-sourced: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn ts_same_name_methods_in_one_file_get_distinct_ids() {
+        // Two classes in one file each declare a `process` method. Both must survive
+        // as DISTINCT function nodes — without id disambiguation the second collides
+        // on `…::fn::process` and add_node drops it (the method vanishes).
+        let ext = TypeScriptExtractor::new();
+        let result = ext
+            .extract(
+                b"class A {\n    process() {\n    }\n}\nclass B {\n    process() {\n    }\n}\n",
+                "file::src/dup.ts",
+            )
+            .unwrap();
+        let ids: Vec<&str> = result
+            .nodes
+            .iter()
+            .filter(|n| n.label == "process" && n.node_type == NodeType::Function)
+            .map(|n| n.id.as_str())
+            .collect();
+        assert_eq!(
+            ids.len(),
+            2,
+            "expected two distinct `process` method nodes, got ids {:?}",
+            ids
+        );
+        // First keeps the clean (line-less) id for back-compat; the sibling is `#2`.
+        assert!(
+            ids.contains(&"file::src/dup.ts::fn::process"),
+            "first occurrence should keep the clean id: {:?}",
+            ids
+        );
+        assert!(
+            ids.contains(&"file::src/dup.ts::fn::process#2"),
+            "second occurrence should be disambiguated to `#2`: {:?}",
+            ids
         );
     }
 


### PR DESCRIPTION
Mirrors the Rust fix ([#168](https://github.com/maxkle1nz/m1nd/pull/168)) across the other four extractors. Function/method node ids were `file::…::fn::<name>` with **no line**, so same-named defs in one file (TS overloads / two class methods named `process`, Java overloads, Go methods named `Run` on two types, Python methods named `save` in two classes) collided on one id → `add_node` returns `DuplicateNode`, the loader drops it, and the later sibling **silently vanished from the graph** (invisible to impact/why/seek).

**Fix:** factor a shared `unique_node_id(&[ExtractedNode], base_id)` in `extract/mod.rs` (the regex extractors build a bare `Vec<ExtractedNode>`, so a slice signature is the common shape) and wrap every function/method mint site in TS/Java/Go/Python. First occurrence keeps the clean id (line-less queries still resolve); later siblings get `#2`/`#3`. `rust_lang`'s working `unique_fn_id` left untouched (no churn of proven code).

**Proof:** each language proven to collide (pre-fix 1 distinct id → post-fix 2) with a unit test each (`{ts,java,go,python}_same_name_methods_in_one_file_get_distinct_ids`). `cargo test --workspace` **1076/0**, clippy `-D warnings` clean, fmt clean. Verified independently by the orchestrator. Cycle 8 (Frente A) of the continuous-improvement engine.