### PR TITLE
release: v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,60 @@ No unreleased changes.
 
 ---
 
+## [1.1.0] — 2026-06-28
+
+A code-intelligence correctness release: a new attention runtime (`focus`), the
+function-level call graph extended across languages, and the cross-file resolver
+hardened so `impact`/`why` bind to the right same-name target. The honest battery
+(m1nd vs `rg` on m1nd's own repo) went from 10/12 to **28/28 with 0 losses to
+grep** across this arc.
+
+### Added
+
+- **`focus(goal, token_budget)` — goal-conditioned attention runtime.** Returns
+  the minimal, budget-bounded working set ranked by goal salience, an honest
+  `ignored` tail (every relevance-clearing node left out is counted, never
+  silently dropped), and an answer-free `sufficiency` signal
+  (`sufficient`/`gathering`/`saturated` via a knee test). `seek` gained the same
+  `sufficiency` envelope.
+- **Conformance-aware attention.** When a ratified X-RAY manifest resolves,
+  `seek`/`focus` bias ranking by intent (erosion-source nodes down, proof-
+  exercised "bedrock" up). Off-by-absence and byte-identical without a manifest.
+
+### Fixed
+
+- **Call graph at function granularity (Rust + TypeScript).** Calls are sourced
+  from the enclosing function (not the file); free-function and lowercase-receiver
+  method calls are followed; `impact` ranks code symbols above containers and
+  production callers above test functions. `impact`/`why` no longer degrade to
+  file-containment noise on code.
+- **Same-name function ids no longer collide (all extractors).** Function nodes
+  used a line-less `file::…::fn::<name>` id, so same-named functions in one file
+  collided and ~6.3% of functions were silently dropped from the graph. Fixed for
+  Rust, TypeScript, Java, Go, Python, and the generic extractor.
+- **Cross-file call resolution.** Proximity prefers same-file > same-directory >
+  cross-crate, and `Type::method()` calls bind to the impl owner via the call
+  qualifier (qualifier-aware resolution) instead of an arbitrary same-name sibling.
+- **`scan` honesty.** `total_matches_validated` counts validation survivors rather
+  than the display `limit` (it was fabricating the raw-vs-validated delta), and
+  documented `mitigated` findings are now visible at the default `severity_min`.
+
+---
+
+## [1.0.0] — 2026-06-27
+
+First stable release.
+
+### Added
+
+- **Semantic recall on by default.** The shipped binary builds with the `embed`
+  feature, so `seek` matches by meaning out of the box (model2vec, ~29 MB
+  fetch-on-first-use, graceful fall-back to trigram if the model can't load). A
+  content-addressed embedding cache is persisted alongside the graph snapshot, and
+  behavioral excerpts (signature + body + doc-comments) feed the embeddings.
+
+---
+
 ## [0.9.0-beta.8] — 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cargo_metadata",
  "m1nd-core",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "axum",
  "clap",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Three things here exist together in no other tool:
 - **Self-verifying memory** — `memorize` anchors findings to real code nodes; `cross_verify` flags them stale when that code changes.
 - **A trust / recovery layer** — every result carries a trust mode; `trust_selftest` and `recovery_playbook` tell the agent when the workspace binding is wrong and how to recover.
 
+Plus an **attention runtime** — `focus` hands the agent the minimal, budget-bounded working set for a goal, with an honest tail of what it left out and a signal for whether that's *enough* context yet.
+
 <p align="center">
   <img src=".github/m1nd-agent-first-map-v2.jpeg" alt="Traditional agent loop vs m1nd-grounded loop" width="960" />
 </p>

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -41,7 +41,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.0.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.1.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -18,8 +18,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.0.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.0.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.1.0" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **v1.1.0** — a code-intelligence correctness release.

**Version:** m1nd-core/-ingest/-mcp + npm `@maxkle1nz/m1nd` → 1.1.0 (openclaw stays 0.1.0); Cargo.lock synced; builds clean.

**Docs:** CHANGELOG gains the 1.1.0 entry **and the retroactive 1.0.0 entry** (it was missing — changelog jumped beta.8 → unreleased). README surfaces `focus` (attention runtime) alongside the graph/memory/trust trifecta.

**What 1.1.0 ships** (all merged since v1.0.0, verified by the honest battery on m1nd's own repo — **10/12 → 28/28, 0 losses to grep**):
- 🆕 `focus` goal-conditioned attention runtime + conformance-aware seek/focus
- 🔗 function-granularity call graph (Rust+TS, method calls) + impact symbol/production-caller ranking
- 🧬 same-name function-id collision fixed across all 6 extractors (~6.3% of fns were being dropped)
- 🎯 cross-file resolution: proximity (same-file>dir>crate) + qualifier-aware `Type::method()`
- 🔍 scan honesty (validated count + mitigated visibility)

Merge order note: this must land together with #175 (qualifier-aware) before the `v1.1.0` tag, so the published build contains the full resolution arc.

🤖 release prep verified by the orchestrator (build + battery + full suite green at each step).