### PR TITLE
docs(pathos): checkpoint 3 — v1.1.0 (focus + full resolution arc, battery 28/28)

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -2,8 +2,8 @@
 
 > Read this first. Single source of truth for any chat / subagent / parallel
 > session working on m1nd, so we don't re-derive state or contradict each other.
-> Last checkpoint: 2026-06-28 ~10:15 CEST (checkpoint 2 — 8 cycles merged, battery
-> hardened 12 → 20 @ 20/20, node-id + cross-file resolution-correctness fixes).
+> Last checkpoint: 2026-06-28 ~13:30 CEST (checkpoint 3 — v1.1.0 cut: focus + the
+> full call-graph/resolution arc; honest battery 12 → 28 @ 28/28, 0 grep-losses).
 
 ## North Star
 m1nd = operational intelligence for coding agents. The bar: genuinely BEAT plain
@@ -11,34 +11,34 @@ m1nd = operational intelligence for coding agents. The bar: genuinely BEAT plain
 Run a continuous, chained improvement engine: measure (battery) → fix+test the
 real defect → checkpoint → seed the next cycle. Never sugarcoat results.
 
-## Current State (2026-06-28, checkpoint 2)
-- main has v1.0 + `focus` (attention runtime) + conformance-aware seek + a full
-  call-graph + resolution-correctness arc (8 cycles merged this session). Repo is
-  branch-clean.
+## Current State (2026-06-28, checkpoint 3 — v1.1.0)
+- **v1.1.0 cut.** main (`509bcf3`) bumped to 1.1.0 (core/ingest/mcp + npm;
+  openclaw stays 0.1.0). Tag `v1.1.0` + crates.io/npm publish via `release.yml`
+  fire once the merge-commit CI is green (in flight at this checkpoint) — until
+  the tag lands, everything below is on main but UNRELEASED on crates/npm.
 - **Honest battery** (`scratchpad/m1nd_battery.py`, fresh ingest + ground-truth
-  PASS/FAIL + `rg` head-to-head): hardened 12 → **20 cases @ 20/20**, 0
-  grep-losses. Now covers cross-file binding CORRECTNESS, not just retrieval.
-- **Call-graph + node-id arc (merged #161-#163, #165, #166, #168, #169):**
-  - #161/#165/#166 — Rust+TS function→function `calls` edges (enclosing-fn
-    tracking, free calls, lowercase-receiver method calls).
-  - #162/#163 — `impact` ranks code symbols above containers; test fns tagged +
-    de-prioritized so production callers surface.
-  - #168/#169 — function node ids get a `#N` disambiguator on same-name-in-file
-    collisions (Rust, then TS/Java/Go/Python via shared `unique_node_id`). Fixed
-    ~6.3% of functions being silently dropped from the graph (add_node returns
-    DuplicateNode → loader drops the sibling).
-- **Resolution correctness (merged #167, #170):**
-  - #167 — `scan.total_matches_validated` counted survivors, not the display
-    `limit` (it was fabricating the raw-vs-validated delta).
-  - #170 — `proximity_score` splits ids on `/` too + a SAME_FILE_BONUS, so
-    `calls` resolve same-file > same-dir > cross-crate (fixed ~104 mis-bound
-    `resolve` edges; battery 17/20 → 20/20).
-- **HONESTY NOTE:** an earlier "12/12" rested partly on a LOOSE `impact_propagate`
-  proxy (`expect="propagate"` matched a mis-bound sibling `propagate#N`). The
-  node-id fix is real (proven by node count), but that battery assertion was weak;
-  it's been re-aligned to an honest bar and real cross-file correctness now lives
-  in the rigorous `xfile_*` cases. Hardening the harness is what caught this —
-  trust the 20-case battery, not the old headline number.
+  PASS/FAIL + `rg` head-to-head): hardened 12 → **28 cases @ 28/28**, 0
+  grep-losses. Covers cross-file binding CORRECTNESS + under-measured tools
+  (trace/scan/xray/am_i_stale), not just retrieval.
+- **`focus` attention runtime** (#157/#158): goal-conditioned working set + an
+  honest `ignored` tail + an answer-free `sufficiency` signal; conformance-aware
+  seek/focus bias ranking when an X-RAY manifest resolves.
+- **Call graph (merged #161-#163, #165, #166):** Rust+TS function→function
+  `calls` (enclosing-fn, free calls, lowercase-receiver methods); `impact` ranks
+  code symbols above containers and production callers above test functions.
+- **Node-id collision FIXED across all 6 extractors (#168/#169/#173):** ids carry
+  a `#N` disambiguator on same-name-in-file collisions (shared `unique_node_id`).
+  Was silently dropping ~6.3% of functions (add_node DuplicateNode → loader drop).
+- **Cross-file resolution (#170/#175):** `proximity_score` prefers same-file >
+  same-dir > cross-crate; `Type::method()` / `module::func()` calls bind to the
+  impl owner via the call qualifier (`disambiguate_with_qualifier`) instead of an
+  arbitrary same-name sibling. `impact`/`why` now bind correctly cross-file.
+- **scan honesty (#167/#172):** `total_matches_validated` counts survivors (not
+  the display limit); documented `mitigated` findings visible at default severity.
+- **HONESTY NOTE:** an earlier "12/12" leaned on a LOOSE `impact_propagate` proxy
+  (matched a mis-bound sibling). Hardening the harness caught it; the number that
+  means anything is the **28-case battery with rigorous `xfile_*`/qualified
+  assertions**, not the old headline.
 
 ## Operating Doctrine
 Proof-grown: measure before claiming; verify subagent work yourself (re-run the
@@ -59,24 +59,28 @@ battery gate; orchestrate + verify. Update this file at big checkpoints.
   account silently flips to `velvetside` mid-session → `gh pr create` fails with
   "must be a collaborator". Run `gh auth switch --user maxkle1nz` before EVERY
   push/PR.**
-- Battery is now 20 cases (JSON key `records`, each row has `m1nd_pass`); per-case
+- Battery is now 28 cases (JSON key `records`, each row has `m1nd_pass`); per-case
   `check=lambda res,q,c:` hook + `has_direct_calls_edge` helper enable structural
   cross-file assertions via the live client.
 
 ## Known Problems
-- **Same-name resolution still needs qualifier/type info — the #1 remaining gap.**
-  `proximity` now handles same-file + (same-dir vs cross-crate), but it CANNOT
-  break: (a) same-DIRECTORY same-name ties (the 4 `propagate` impls in
-  activation.rs; `plan_refactoring`'s `detect` binds to temporal.rs not
-  topology.rs), and (b) cross-crate calls whose correct target is in ANOTHER crate
-  (`graph.strings.resolve` → m1nd-core, not the same-dir resolve.rs). Both need the
-  extractor to preserve the call qualifier (`crate::topology::Detector`) or the
-  receiver type — the type-inference problem; design a dedicated cycle.
-- `generic.rs` extractor still has the same id-collision (others fixed in #169).
+- **`x.method()` receiver-variable resolution still needs type inference — the #1
+  remaining gap.** #175 fixed QUALIFIED calls (`Type::method()`, `module::func()`)
+  via the call qualifier, and #170 fixed cross-file proximity (same-file > same-dir
+  > cross-crate). What's left: a bare `x.method()` on a local/field receiver
+  carries NO qualifier in source, so same-name ties (the 4 `propagate` impls; a
+  `detector.detect()` whose type only a `let` binding knows) still fall to
+  proximity/`candidates[0]`. Real fix = receiver-type inference (track `let x: T`
+  / field types / fn return types) — a dedicated, harder cycle. Cross-crate calls
+  whose correct target is in ANOTHER crate (`graph.strings.resolve` → m1nd-core)
+  are the same class.
 - Method-call EDGES exist for Rust (#166) but not TS/Java/Go/Python.
-- `scan.mitigated` status is ~unreachable at default `severity_min=0.3` (7/8
-  patterns have base×0.4 < 0.3) — a tuning/product question, not a code bug.
+- `scan.mitigated` is now visible at default `severity_min` (#172) — note this
+  CHANGED default output (callers see `mitigated` findings; `false_positive` still
+  suppressed). Revertible if undesired.
 - `#[cfg(all(test, …))]` compound predicates aren't tagged via the module path.
+- i18n READMEs (7 langs) + wiki lag the v1.1.0 README (`focus` not yet
+  translated) — post-release follow-up.
 - Auto-freshness: `ingest` doesn't auto-start the watcher (it exists —
   notify + `maybe_tick` — but is opt-in); seeded fix.
 - Multi-session: an X-RAY/Codex guardian also touches this repo — `git fetch`
@@ -91,19 +95,18 @@ pack_to_budget)` ranks `handle_seek` above the `pack_to_budget_*` tests), zero
 regression. CI green on 3 OSes before merge.
 
 ## Next Agent Prompt / next seeds
-1. **Qualifier/type-aware resolution** (the hard, high-value fix): preserve the
-   call qualifier/receiver in the extractor so same-dir same-name + cross-crate
-   ties resolve correctly (would flip `propagate`, `detect`, cross-crate
-   `resolve`). Design-first with a safety valve; battery-gate with a new same-dir
-   tie case (e.g. `plan_refactoring`'s `detect` → topology.rs not temporal.rs).
-2. Keep HARDENING the harness on under-measured tools (trace/scan/xray/perception)
-   then hunt+fix the next real defect — the proven loop: harden → measure →
-   fix+test. (A frente is doing this now as of this checkpoint.)
-3. `generic.rs` id-collision (mirror `unique_node_id`); method-call edges for
-   TS/Java/Go/Python; auto-freshness (opt-out, robust, tested).
-Each cycle: measure → fix+test → update this file → seed the next. Run parallel
-worktree-isolated Opus frentes on non-overlapping surfaces when aggressive (only
-ONE frente edits the shared battery at a time).
+1. **Receiver-type inference for `x.method()`** (the hard, high-value fix): track
+   local/field/return types so unqualified same-name method calls bind to the
+   owner (resolves the `propagate` / `detector.detect()` ties #175 can't reach).
+   Design-first with a safety valve; battery-gate with a new `x.method()` tie case.
+2. **Method-call edges for TS/Java/Go/Python** (mirror Rust #166).
+3. **Auto-freshness** (`ingest` auto-starts the watcher, opt-out, robust, tested).
+4. Keep HARDENING the harness on still-under-measured tools (auto_ingest, coverage
+   sessions) → hunt+fix the next real defect.
+5. Post-release: regenerate the 7 i18n READMEs + wiki for v1.1.0 (`focus`).
+Each cycle: measure → fix+test → update THIS file → seed the next. Run parallel
+worktree-isolated Opus frentes on non-overlapping surfaces; go SOLO if
+rate-limited (a parallel burst tripped the API rate limit this session).
 
 ## Do Not Do
 - Don't edit/build m1nd source while a battery/subagent is building on the shared


### PR DESCRIPTION
Refreshes `docs/PATHOS.md` to the v1.1.0 state: Current State (focus + call-graph + node-id collision fixed across all 6 extractors + cross-file proximity + **qualifier-aware resolution #175** + scan honesty; honest battery **12 → 28 @ 28/28**, 0 grep-losses), Known Problems (the #1 gap is now `x.method()` receiver-variable type inference — qualified calls fixed in #175; generic.rs + scan.mitigated resolved), and the next seeds. Per the truth-hierarchy rule (code > PATHOS > auto-memory).