### PR TITLE
feat(memory): surface authored-age + source-agent on recall (honest memory labeling)

### DIFF
--- a/m1nd-ingest/src/l1ght_adapter.rs
+++ b/m1nd-ingest/src/l1ght_adapter.rs
@@ -44,6 +44,11 @@ struct HeaderMeta {
     glyph: Option<String>,
     completeness: Option<String>,
     proof: Option<String>,
+    /// Provenance stamped by the `memorize` writer (Move 1): when this memory was
+    /// written (Unix millis) and which agent authored it. Absent on legacy files —
+    /// honestly "unknown", never faked.
+    created: Option<String>,
+    source_agent: Option<String>,
     depends_on: Vec<String>,
     next: Vec<String>,
 }
@@ -181,8 +186,14 @@ impl L1ghtIngestAdapter {
     fn push_node(
         nodes: &mut Vec<L1ghtNodeRecord>,
         seen: &mut HashSet<String>,
-        record: L1ghtNodeRecord,
+        mut record: L1ghtNodeRecord,
+        prov_tags: &[String],
     ) {
+        // Stamp the file's provenance (Created/Source-Agent, parsed from the
+        // frontmatter) onto every node from that file, so any recall hit — file,
+        // section, or claim node — carries the authored-age + source labels.
+        // Absent on legacy files: `prov_tags` is empty, so nothing is added.
+        record.tags.extend(prov_tags.iter().cloned());
         if seen.insert(record.id.clone()) {
             nodes.push(record);
         }
@@ -253,6 +264,12 @@ impl L1ghtIngestAdapter {
             } else if let Some(value) = trimmed.strip_prefix("Proof:") {
                 meta.proof = Some(value.trim().to_string());
                 current_list = None;
+            } else if let Some(value) = trimmed.strip_prefix("Created:") {
+                meta.created = Some(value.trim().to_string());
+                current_list = None;
+            } else if let Some(value) = trimmed.strip_prefix("Source-Agent:") {
+                meta.source_agent = Some(value.trim().to_string());
+                current_list = None;
             } else if trimmed == "Depends on:" {
                 current_list = Some("depends_on");
             } else if trimmed == "Next:" {
@@ -297,6 +314,20 @@ impl L1ghtIngestAdapter {
             .unwrap_or(&rel_path)
             .to_string();
 
+        let lines: Vec<&str> = text.lines().collect();
+        let header_meta = Self::parse_header(&lines[..lines.len().min(40)]);
+
+        // Provenance tags (Created/Source-Agent) parsed from the frontmatter, to
+        // be stamped on every node from this file so recall can label the hit.
+        // Mirrors how `light:confidence:<v>` is already encoded as a tag.
+        let mut prov_tags: Vec<String> = Vec::new();
+        if let Some(created) = &header_meta.created {
+            prov_tags.push(format!("light:created:{}", created.trim()));
+        }
+        if let Some(source_agent) = &header_meta.source_agent {
+            prov_tags.push(format!("light:source_agent:{}", source_agent.trim()));
+        }
+
         Self::push_node(
             nodes,
             node_seen,
@@ -314,10 +345,9 @@ impl L1ghtIngestAdapter {
                 namespace: self.namespace.clone(),
                 canonical: true,
             },
+            &prov_tags,
         );
 
-        let lines: Vec<&str> = text.lines().collect();
-        let header_meta = Self::parse_header(&lines[..lines.len().min(40)]);
         let section_re = Regex::new(r"^##\s+(.+?)\s*$").unwrap();
         let tag_re = Regex::new(r"\[(?P<tag>[^\]]+)\]").unwrap();
 
@@ -353,6 +383,7 @@ impl L1ghtIngestAdapter {
                         namespace: self.namespace.clone(),
                         canonical: true,
                     },
+                    &prov_tags,
                 );
                 let relation = match key {
                     "protocol" => "defines_protocol",
@@ -401,6 +432,7 @@ impl L1ghtIngestAdapter {
                     namespace: self.namespace.clone(),
                     canonical: true,
                 },
+                &prov_tags,
             );
             Self::push_edge(
                 edges,
@@ -441,6 +473,7 @@ impl L1ghtIngestAdapter {
                     namespace: self.namespace.clone(),
                     canonical: true,
                 },
+                &prov_tags,
             );
             Self::push_edge(
                 edges,
@@ -490,6 +523,7 @@ impl L1ghtIngestAdapter {
                         namespace: self.namespace.clone(),
                         canonical: true,
                     },
+                    &prov_tags,
                 );
                 Self::push_edge(
                     edges,
@@ -590,6 +624,7 @@ impl L1ghtIngestAdapter {
                         namespace: self.namespace.clone(),
                         canonical: true,
                     },
+                    &prov_tags,
                 );
 
                 // Epistemic markers attach to the preceding claim; others attach to
@@ -738,5 +773,42 @@ mod confidence_tests {
     #[test]
     fn unknown_confidence_is_neutral() {
         assert!((A::parse_confidence("banana") - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parses_created_and_source_agent_frontmatter() {
+        let lines = [
+            "---",
+            "Protocol: L1GHT/1.0",
+            "Node: AuthSystem",
+            "State: verified",
+            "Created: 1700000000000",
+            "Source-Agent: agent-B",
+            "---",
+        ];
+        let meta = A::parse_header(&lines);
+        assert_eq!(meta.created.as_deref(), Some("1700000000000"));
+        assert_eq!(meta.source_agent.as_deref(), Some("agent-B"));
+    }
+
+    #[test]
+    fn absent_provenance_frontmatter_is_none() {
+        // Legacy frontmatter: no Created / Source-Agent → honestly None, never faked.
+        let lines = [
+            "---",
+            "Protocol: L1GHT/1.0",
+            "Node: LegacyNode",
+            "State: authored",
+            "---",
+        ];
+        let meta = A::parse_header(&lines);
+        assert!(
+            meta.created.is_none(),
+            "Created must be None on legacy files"
+        );
+        assert!(
+            meta.source_agent.is_none(),
+            "Source-Agent must be None on legacy files"
+        );
     }
 }

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -611,9 +611,34 @@ pub fn handle_seek(
             let nt = l2_node_type_str(&graph.nodes.node_type[i]);
             let ext_id = &node_to_ext[i];
             let prov = graph.resolve_node_provenance(nid);
-            let tags: Vec<String> = graph.nodes.tags[i]
+            let all_tags: Vec<String> = graph.nodes.tags[i]
                 .iter()
                 .map(|&ti| graph.strings.resolve(ti).to_string())
+                .collect();
+
+            // Honest recall labeling: lift the provenance tags the light adapter
+            // stamps (`light:created:<ms>`, `light:source_agent:<id>`) out of the
+            // tag set so they surface as explicit hit fields instead of polluting
+            // the intent summary. `tags` (sans provenance) still feeds the summary.
+            let mut authored_ms_ago: Option<u64> = None;
+            let mut source_agent: Option<String> = None;
+            let tags: Vec<String> = all_tags
+                .into_iter()
+                .filter(|t| {
+                    if let Some(created) = t.strip_prefix("light:created:") {
+                        // Age = now − authored. A missing/unparsable Created leaves
+                        // the age absent (honest "unknown"), never faked to "now".
+                        if let Ok(created_ms) = created.trim().parse::<u64>() {
+                            authored_ms_ago = Some(trail_now_ms().saturating_sub(created_ms));
+                        }
+                        false
+                    } else if let Some(agent) = t.strip_prefix("light:source_agent:") {
+                        source_agent = Some(agent.trim().to_string());
+                        false
+                    } else {
+                        true
+                    }
+                })
                 .collect();
 
             // Gather connections (outgoing edges, capped at 5)
@@ -663,6 +688,8 @@ pub fn handle_seek(
                 line_start: prov.line_start,
                 line_end: prov.line_end,
                 excerpt: prov.excerpt,
+                authored_ms_ago,
+                source_agent,
                 connections,
             }
         })
@@ -12760,5 +12787,166 @@ def5678|2026-03-23 09:00:00 +0000|max kle1nz|feat: add benchmark harness
         );
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // -----------------------------------------------------------------------
+    // HONEST RECALL LABELING (memory move 2): a memorized claim must recall
+    // with its authored-age + source-agent surfaced as explicit hit fields,
+    // derived from the `Created`/`Source-Agent` frontmatter the writer stamps.
+    // -----------------------------------------------------------------------
+
+    fn build_light_seek_session(root: &std::path::Path) -> SessionState {
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+    }
+
+    fn ingest_light_dir(state: &mut SessionState, dir: &std::path::Path) {
+        let ingest = crate::protocol::core::IngestInput {
+            path: dir.to_string_lossy().to_string(),
+            agent_id: "test".into(),
+            incremental: false,
+            adapter: "light".into(),
+            mode: "merge".into(),
+            namespace: Some("light".into()),
+            include_dotfiles: false,
+            dotfile_patterns: vec![],
+        };
+        crate::tools::handle_ingest(state, ingest).expect("light ingest");
+    }
+
+    #[test]
+    fn seek_surfaces_authored_age_and_source_agent_on_memory_hit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let proj = temp.path().join("mem");
+        std::fs::create_dir_all(&proj).expect("mem dir");
+
+        // A memory authored 12 days ago by agent-B, with the exact frontmatter the
+        // `memorize` writer stamps (Move 1: Created + Source-Agent).
+        let now_ms = super::trail_now_ms();
+        let twelve_days_ms: u64 = 12 * 24 * 60 * 60 * 1000;
+        let created = now_ms - twelve_days_ms;
+        let md = format!(
+            "---\nProtocol: L1GHT/1.0\nNode: PaymentRetry\nState: verified\n\
+             Created: {created}\nSource-Agent: agent-B\n---\n\n\
+             # PaymentRetry\n\n## PaymentRetry\n\n\
+             The payment retry uses exponential backoff capped at five attempts.\n\n\
+             [⍂ entity: PaymentRetryBackoff]\n[𝔻 confidence: 0.9]\n"
+        );
+        std::fs::write(proj.join("payment.light.md"), md).expect("write memory");
+
+        let mut state = build_light_seek_session(temp.path());
+        ingest_light_dir(&mut state, &proj);
+
+        let out = handle_seek(
+            &mut state,
+            SeekInput {
+                query: "payment retry backoff".into(),
+                agent_id: "probe".into(),
+                top_k: 20,
+                scope: None,
+                node_types: vec![],
+                min_score: 0.0,
+                graph_rerank: true,
+                conformance_aware: false,
+                token_budget: None,
+            },
+        )
+        .expect("seek ok");
+
+        // At least one hit must carry BOTH provenance labels.
+        let labeled = out
+            .results
+            .iter()
+            .find(|r| r.authored_ms_ago.is_some() && r.source_agent.is_some())
+            .unwrap_or_else(|| {
+                panic!(
+                    "no memory hit carried authored_ms_ago + source_agent; got {:?}",
+                    out.results
+                        .iter()
+                        .map(|r| (&r.label, r.authored_ms_ago, &r.source_agent))
+                        .collect::<Vec<_>>()
+                )
+            });
+
+        // source_agent is exactly the authoring agent.
+        assert_eq!(
+            labeled.source_agent.as_deref(),
+            Some("agent-B"),
+            "source_agent must be the authoring agent"
+        );
+        // authored_ms_ago ≈ 12 days; allow a generous window for elapsed wall-clock.
+        let age = labeled.authored_ms_ago.expect("authored_ms_ago present");
+        assert!(
+            age >= twelve_days_ms && age < twelve_days_ms + 60_000,
+            "authored_ms_ago={age} must be ~12 days (>= {twelve_days_ms}, < +60s)"
+        );
+        // The provenance must NOT leak into the visible intent summary.
+        assert!(
+            !labeled.intent_summary.contains("light:created:")
+                && !labeled.intent_summary.contains("light:source_agent:"),
+            "provenance must not pollute intent_summary, got: {}",
+            labeled.intent_summary
+        );
+    }
+
+    #[test]
+    fn seek_labels_absent_on_legacy_memory_without_created() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let proj = temp.path().join("mem");
+        std::fs::create_dir_all(&proj).expect("mem dir");
+
+        // Legacy memory: no Created / Source-Agent. Age must read as unknown
+        // (absent), never faked to "now".
+        let legacy = "---\nProtocol: L1GHT/1.0\nNode: LegacyClaim\nState: authored\n---\n\n\
+             # LegacyClaim\n\n## LegacyClaim\n\n\
+             The cache eviction policy is least-recently-used.\n\n\
+             [⍂ entity: CacheEvictionLru]\n[𝔻 confidence: 0.8]\n";
+        std::fs::write(proj.join("legacy.light.md"), legacy).expect("write legacy");
+
+        let mut state = build_light_seek_session(temp.path());
+        ingest_light_dir(&mut state, &proj);
+
+        let out = handle_seek(
+            &mut state,
+            SeekInput {
+                query: "cache eviction lru policy".into(),
+                agent_id: "probe".into(),
+                top_k: 20,
+                scope: None,
+                node_types: vec![],
+                min_score: 0.0,
+                graph_rerank: true,
+                conformance_aware: false,
+                token_budget: None,
+            },
+        )
+        .expect("seek ok");
+
+        assert!(
+            !out.results.is_empty(),
+            "legacy memory must still recall fine"
+        );
+        // NO hit may carry faked provenance — absent means unknown, honestly.
+        for r in &out.results {
+            assert!(
+                r.authored_ms_ago.is_none(),
+                "legacy memory hit must have NO authored_ms_ago (got {:?} on {})",
+                r.authored_ms_ago,
+                r.label
+            );
+            assert!(
+                r.source_agent.is_none(),
+                "legacy memory hit must have NO source_agent (got {:?} on {})",
+                r.source_agent,
+                r.label
+            );
+        }
     }
 }

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -224,6 +224,16 @@ pub struct SeekResultEntry {
     pub line_end: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub excerpt: Option<String>,
+    /// Honest recall labeling: for a memory (`.light.md`) hit, how long ago the
+    /// claim was authored, in milliseconds (now − the `Created` frontmatter the
+    /// `memorize` writer stamps). Absent on code nodes and on legacy memories
+    /// with no `Created` — an absent age reads as "unknown age", never as fresh.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authored_ms_ago: Option<u64>,
+    /// Honest recall labeling: which agent authored this memory (the
+    /// `Source-Agent` frontmatter). Absent on code nodes and legacy memories.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_agent: Option<String>,
     /// Connected nodes (callers, callees, importers).
     pub connections: Vec<SeekConnection>,
 }

--- a/m1nd-mcp/src/result_shaping.rs
+++ b/m1nd-mcp/src/result_shaping.rs
@@ -462,6 +462,8 @@ mod tests {
                 line_start: None,
                 line_end: None,
                 excerpt: None,
+                authored_ms_ago: None,
+                source_agent: None,
                 connections: vec![SeekConnection {
                     node_id: "x".into(),
                     label: "x".into(),
@@ -486,6 +488,8 @@ mod tests {
                 line_start: Some(1),
                 line_end: Some(4),
                 excerpt: None,
+                authored_ms_ago: None,
+                source_agent: None,
                 connections: vec![],
             },
         ];


### PR DESCRIPTION
## What

Memory roadmap **Move 2** (NEXTGEN-AGENT-PRD Subsystem D) — **honest recall labeling**. Move 1 (#187) began stamping `Created` + `Source-Agent` into every memorized `.light.md` frontmatter, but that was write-only: the parser never read those keys, so a recall hit was a bare fact. This move makes `seek` SURFACE that provenance, so a memory hit reads as "claim (authored 12d ago, source: agent-B)".

## Changes

- **Parse (was missing):** `l1ght_adapter::parse_header` now reads `Created:` / `Source-Agent:`, stored on `HeaderMeta`. Stamped onto every node from the file as `light:created:<ms>` / `light:source_agent:<id>` tags (the same carrier already used for `light:confidence:<v>`), so any hit — file, section, or claim node — is labelable. Move 1 was write-only; adding the parser was in-scope for this move.
- **Surface on recall:** `SeekResultEntry` gains `authored_ms_ago: Option<u64>` (now − `Created`) and `source_agent: Option<String>`, both `#[serde(skip_serializing_if = "Option::is_none")]`. `handle_seek` lifts the provenance tags out of the tag set into these fields (so they don't pollute `intent_summary`), reusing the file-local `trail_now_ms()` for the age.
- **Honest absence:** legacy memories / code nodes with no `Created` get absent fields — "unknown age", never faked to "now". Backward compatible.

`federate` returns `FederateOutput` (metadata only, no node hits), so there's nothing to label there — federated-graph hits surface through `seek`.

Scope-guarded to labeling only: no staleness verdicts, supersession, or eviction.

## Proof

- `parses_created_and_source_agent_frontmatter` + `absent_provenance_frontmatter_is_none` (adapter parse, present + absent).
- `seek_surfaces_authored_age_and_source_agent_on_memory_hit` — memorize → ingest → seek; asserts `source_agent == "agent-B"`, `authored_ms_ago ≈ 12 days`, and that provenance does NOT leak into `intent_summary`.
- `seek_labels_absent_on_legacy_memory_without_created` — legacy memory recalls fine with both labels absent.

## Gate (full, run to completion)

- `cargo fmt --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: **0 warnings**
- `cargo test --workspace`: **0 failed**
- battery m1nd suite: **28/28**