### PR TITLE
refactor(mcp): collapse 11 duplicate now_ms helpers into one shared util::now_ms

### DIFF
--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -6,6 +6,7 @@ use crate::protocol::auto_ingest::{
 use crate::scope::normalize_path_text;
 use crate::session::SessionState;
 use crate::universal_docs;
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use m1nd_ingest::document_router::{DocumentFormat, DocumentRouter};
 use m1nd_ingest::merge::{collect_source_claims, prune_source_claims, SourceClaims};
@@ -203,13 +204,6 @@ impl AutoIngestState {
         Ok(normalized)
     }
 
-    fn now_ms() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| duration.as_millis() as u64)
-            .unwrap_or(0)
-    }
-
     fn append_event(
         &mut self,
         runtime_root: &Path,
@@ -225,7 +219,7 @@ impl AutoIngestState {
             status: status.to_string(),
             format,
             detail,
-            timestamp_ms: Self::now_ms(),
+            timestamp_ms: now_ms(),
         };
         self.persistent.events_seen += 1;
         self.persistent.recent_events.push(event.clone());
@@ -256,7 +250,7 @@ impl AutoIngestState {
         path: String,
         kind: PendingChangeKind,
     ) {
-        let now_ms = Self::now_ms();
+        let now_ms = now_ms();
         let mut pending = pending.lock();
         pending
             .entry(path.clone())
@@ -478,7 +472,7 @@ impl AutoIngestState {
     }
 
     fn take_ready_changes(&mut self, force: bool) -> Vec<PendingChange> {
-        let now_ms = Self::now_ms();
+        let now_ms = now_ms();
         let debounce_ms = self.persistent.debounce_ms;
         let mut pending = self.pending.lock();
         let ready_keys: Vec<String> = pending
@@ -916,7 +910,7 @@ impl AutoIngestState {
                             namespace: self.persistent.namespace.clone(),
                             fingerprint,
                             claims,
-                            last_ingested_ms: Self::now_ms(),
+                            last_ingested_ms: now_ms(),
                         },
                     );
                     self.persistent.ingests_applied += 1;
@@ -939,7 +933,7 @@ impl AutoIngestState {
             state.notify_watchers(crate::perspective::state::WatchTrigger::Ingest);
         }
 
-        self.persistent.last_tick_ms = Some(Self::now_ms());
+        self.persistent.last_tick_ms = Some(now_ms());
         self.persist(&state.runtime_root)?;
 
         Ok(AutoIngestTickOutput {

--- a/m1nd-mcp/src/boot_memory_handlers.rs
+++ b/m1nd-mcp/src/boot_memory_handlers.rs
@@ -1,8 +1,8 @@
 use crate::session::{BootMemoryEntry, SessionState};
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Deserialize)]
 pub struct BootMemoryInput {
@@ -111,13 +111,6 @@ fn status_payload(state: &SessionState) -> Value {
         "path": state.boot_memory_path.to_string_lossy(),
         "keys": keys,
     })
-}
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
 }
 
 #[cfg(test)]

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -1,20 +1,13 @@
 use crate::protocol::layers;
 use crate::scope::normalize_path_text;
 use crate::session::{DaemonAlert, DaemonTrackedFile, FileInventoryEntry, SessionState};
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use serde_json::json;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|value| value.as_millis() as u64)
-        .unwrap_or(0)
-}
 
 fn simple_content_hash(path: &Path) -> Option<String> {
     let bytes = std::fs::read(path).ok()?;

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -28,6 +28,7 @@ use crate::instance_registry::{
 };
 use crate::server::{all_tool_schemas, dispatch_tool, tool_schemas, McpConfig};
 use crate::session::{ApplyBatchProgressSink, SessionState};
+use crate::util::now_ms;
 
 // ---------------------------------------------------------------------------
 // Event log: append-only JSON lines file for cross-process SSE (Option B)
@@ -654,14 +655,6 @@ fn truncate_json(value: &serde_json::Value, max_chars: usize) -> serde_json::Val
     } else {
         serde_json::Value::String(format!("{}...(truncated)", &s[..max_chars]))
     }
-}
-
-/// Current timestamp in milliseconds since epoch.
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 /// Build a JSON error payload for tool execution timeouts.

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -1,3 +1,4 @@
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -6,7 +7,6 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tokio::task::JoinHandle;
 use tokio::time::{interval, Duration};
@@ -635,13 +635,6 @@ fn save_json_atomic<T: Serialize>(path: &Path, value: &T) -> M1ndResult<()> {
     fs::write(&temp, json)?;
     fs::rename(temp, path)?;
     Ok(())
-}
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 /// Build the reachable base URL for a registry entry, applying the same rule the

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -10,6 +10,7 @@ pub mod protocol;
 pub mod server;
 pub mod session;
 pub mod tools;
+pub mod util;
 
 // Perspective MCP — stateful navigation layer (12-PERSPECTIVE-SYNTHESIS)
 pub mod boot_memory_handlers;

--- a/m1nd-mcp/src/light_author_handlers.rs
+++ b/m1nd-mcp/src/light_author_handlers.rs
@@ -5,21 +5,12 @@
 
 use crate::protocol::core::IngestInput;
 use crate::session::SessionState;
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-/// Unix epoch milliseconds — same helper pattern as the sibling handler modules
-/// (`boot_memory_handlers::now_ms`, `lock_handlers::now_ms`, …).
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
 
 // ---------------------------------------------------------------------------
 // serde default helpers

--- a/m1nd-mcp/src/lock_handlers.rs
+++ b/m1nd-mcp/src/lock_handlers.rs
@@ -6,6 +6,7 @@ use crate::perspective::keys::{edge_content_key, normalize_bidi_endpoints};
 use crate::perspective::state::*;
 use crate::protocol::lock::*;
 use crate::session::SessionState;
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use m1nd_core::types::EdgeIdx;
 use std::collections::{HashMap, HashSet};
@@ -13,13 +14,6 @@ use std::collections::{HashMap, HashSet};
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
 
 /// Validate lock ownership and return reference, or error.
 fn require_lock<'a>(

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -37,6 +37,7 @@ use parking_lot::Mutex;
 use crate::http_server::{AppState, SseEvent};
 use crate::protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 use crate::server::handle_mcp_method;
+use crate::util::now_ms;
 
 /// Per-spec MCP session header name (case-insensitive on the wire).
 const MCP_SESSION_HEADER: &str = "mcp-session-id";
@@ -175,14 +176,6 @@ pub type McpSessionRegistry = Arc<Mutex<HashMap<String, McpTransportSession>>>;
 /// Build a fresh, empty MCP session registry.
 pub fn new_mcp_session_registry() -> McpSessionRegistry {
     Arc::new(Mutex::new(HashMap::new()))
-}
-
-/// Current timestamp in milliseconds since epoch.
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 /// Monotonic counter so two ids minted in the same millisecond differ.

--- a/m1nd-mcp/src/mission_handlers.rs
+++ b/m1nd-mcp/src/mission_handlers.rs
@@ -3,13 +3,13 @@ use crate::protocol::layers::{
     MissionVerifyInput,
 };
 use crate::session::SessionState;
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const STATE_SCHEMA: &str = "m1nd-mission-control-state-v1";
 const START_SCHEMA: &str = "m1nd-mission-start-v0";
@@ -529,13 +529,6 @@ fn invalid_start<T>(detail: &str) -> M1ndResult<T> {
         tool: "mission_start".into(),
         detail: detail.to_string(),
     })
-}
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
 }
 
 fn build_mission_id(now: u64, agent_id: &str, task: &str) -> String {

--- a/m1nd-mcp/src/perspective_handlers.rs
+++ b/m1nd-mcp/src/perspective_handlers.rs
@@ -12,6 +12,7 @@ use crate::perspective::state::*;
 use crate::perspective::validation::*;
 use crate::protocol::perspective::*;
 use crate::session::SessionState;
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use m1nd_core::types::EdgeIdx;
 use std::collections::HashSet;
@@ -19,13 +20,6 @@ use std::collections::HashSet;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
 
 fn perspective_not_found_error(tool: &str, agent_id: &str, perspective_id: &str) -> M1ndError {
     M1ndError::InvalidParams {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -14,6 +14,7 @@ use crate::session::SessionState;
 use crate::surgical_handlers;
 use crate::tools;
 use crate::universal_docs;
+use crate::util::now_ms;
 use m1nd_core::domain::DomainConfig;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
@@ -24,7 +25,6 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
 // MCP protocol instructions — injected into initialize response so agents
@@ -3899,13 +3899,6 @@ fn dispatch_core_tool(
             name: tool_name.to_string(),
         }),
     }
-}
-
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|value| value.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 /// MCP protocol version this server implements/prefers.

--- a/m1nd-mcp/src/universal_docs.rs
+++ b/m1nd-mcp/src/universal_docs.rs
@@ -5,6 +5,7 @@ use crate::protocol::auto_ingest::{
     DocumentResolveOutput,
 };
 use crate::session::SessionState;
+use crate::util::now_ms;
 use m1nd_core::error::{M1ndError, M1ndResult};
 use m1nd_core::graph::{Graph, NodeProvenanceInput};
 use m1nd_core::types::NodeId;
@@ -846,13 +847,6 @@ fn compute_drift(
         findings,
         summary,
     })
-}
-
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 fn expected_node_ids(document: &CanonicalDocument, namespace: &str) -> Vec<String> {

--- a/m1nd-mcp/src/util.rs
+++ b/m1nd-mcp/src/util.rs
@@ -1,0 +1,34 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Unix epoch milliseconds; 0 if the clock is before the epoch.
+pub(crate) fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::now_ms;
+
+    #[test]
+    fn now_ms_returns_recent_epoch_millis() {
+        // A timestamp after 2023-11-14 (1_700_000_000_000 ms) and no later than
+        // a fresh reading proves the helper returns plausible, monotonic-ish
+        // wall-clock epoch millis rather than 0 or a bogus value.
+        let observed = now_ms();
+        let upper = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is after the unix epoch")
+            .as_millis() as u64;
+        assert!(
+            observed > 1_700_000_000_000,
+            "now_ms() should be a recent epoch-millis value, got {observed}"
+        );
+        assert!(
+            observed <= upper,
+            "now_ms() ({observed}) must not exceed a fresh reading ({upper})"
+        );
+    }
+}


### PR DESCRIPTION
## What

Collapse the duplicate private \`fn now_ms() -> u64\` helpers scattered across \`m1nd-mcp\` into a single shared \`pub(crate) fn now_ms()\` in a new \`m1nd-mcp/src/util.rs\` module.

12 local copies removed across 12 files (the 11 free functions plus the \`AutoIngestState::now_ms\` associated fn). All call sites now resolve to \`crate::util::now_ms\`.

## Why

The same "Unix epoch millis, 0 on error" helper was reimplemented ~12 times in 3 stylistic variants. One shared, documented, tested helper removes the duplication.

## Behavior-preserving

Every removed copy was verified to return **0 on the (impossible-in-practice) pre-epoch error path** — both the \`unwrap_or_default()\` and \`unwrap_or(0)\` variants yield 0 — so the canonical form is exactly equivalent. No call-site semantics change.

\`trail_now_ms()\` in \`layer_handlers.rs\` is intentionally left untouched (different name, different file).

## Proof

- New unit test \`util::tests::now_ms_returns_recent_epoch_millis\` asserts the helper returns a plausible recent epoch-millis (\`> 1_700_000_000_000\` and \`<=\` a fresh reading).
- Full local gate green: \`cargo fmt --check\`, \`cargo clippy --workspace --all-targets -- -D warnings\` (0 warnings), \`cargo test --workspace\` (0 failed), battery \`--suite m1nd\` 28/28.
- Orphaned \`use std::time::{SystemTime, UNIX_EPOCH}\` imports left behind by the deletions were removed (5 files).