### PR TITLE
fix(ingest): respect .gitignore (skip vendored/build dirs) — fixes acc timeout + l00p 100x over-ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1003,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1315,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1582,7 @@ name = "m1nd-ingest"
 version = "1.1.0"
 dependencies = [
  "cargo_metadata",
+ "ignore",
  "m1nd-core",
  "quick-xml",
  "rayon",

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -45,6 +45,7 @@ m1nd-core = { path = "../m1nd-core", version = "1.1.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"
+ignore = "0.4"
 rayon = "1.10"
 serde_json = { workspace = true }
 cargo_metadata = { workspace = true }

--- a/m1nd-ingest/src/walker.rs
+++ b/m1nd-ingest/src/walker.rs
@@ -93,7 +93,7 @@ impl DirectoryWalker {
     /// FM-ING-004 fix: checks first 8KB for NUL bytes to detect binary files.
     /// Replaces: ingest.py directory walking logic
     pub fn walk(&self, root: &Path) -> M1ndResult<WalkResult> {
-        use walkdir::WalkDir;
+        use ignore::WalkBuilder;
 
         if !root.exists() {
             return Err(M1ndError::Io(std::io::Error::new(
@@ -146,31 +146,48 @@ impl DirectoryWalker {
             });
         }
 
-        for entry in WalkDir::new(&root_canonical)
+        // Gitignore-aware walk (ignore crate — same walker ripgrep uses).
+        // standard_filters default keeps git_ignore/git_global/git_exclude/ignore/parents ON.
+        // hidden(!include_dotfiles) mirrors the old hidden-dir/file pruning while honoring the
+        // include_dotfiles escape hatch. The filter_entry below preserves the hardcoded
+        // skip_dirs + is_noise_dir_name pruning so noise dirs are dropped even in a repo with
+        // NO .gitignore.
+        let filter_root = root_canonical.clone();
+        let skip_dirs = self.skip_dirs.clone();
+        let include_dotfiles = self.include_dotfiles;
+        let dotfile_patterns = self.dotfile_patterns.clone();
+        let walk = WalkBuilder::new(&root_canonical)
             .follow_links(false)
-            .into_iter()
-            .filter_entry(|e| {
-                if e.file_type().is_dir() {
+            .hidden(!self.include_dotfiles)
+            .filter_entry(move |e| {
+                if e.file_type().is_some_and(|ft| ft.is_dir()) {
                     let name = e.file_name().to_string_lossy();
-                    let rel_path = Self::normalize_rel_path(e.path(), &root_canonical);
+                    let rel_path = Self::normalize_rel_path(e.path(), &filter_root);
                     if is_noise_dir_name(&name) {
                         return false;
                     }
-                    // Skip hidden dirs and configured skip dirs
-                    if name.starts_with('.') && name != "." && !self.allow_hidden_path(&rel_path) {
+                    // Skip hidden dirs and configured skip dirs (mirrors old filter_entry).
+                    let allow_hidden = include_dotfiles
+                        && dotfile_patterns
+                            .iter()
+                            .any(|pattern| Self::dotfile_pattern_matches(pattern, &rel_path));
+                    if name.starts_with('.') && name != "." && !allow_hidden {
                         return false;
                     }
-                    return !self.skip_dirs.iter().any(|s| name == s.as_str());
+                    return !skip_dirs.iter().any(|s| name == s.as_str());
                 }
                 true
             })
-        {
+            .build();
+
+        for entry in walk {
             let entry = match entry {
                 Ok(e) => e,
                 Err(_) => continue, // permission error, broken symlink, etc.
             };
 
-            if !entry.file_type().is_file() {
+            // ignore::DirEntry::file_type is Option (None for stdin/errors) — skip non-files.
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 continue;
             }
 
@@ -351,6 +368,52 @@ mod tests {
             result.files[0].path,
             file.canonicalize().expect("canonical file")
         );
+        std::fs::remove_dir_all(temp).expect("cleanup tempdir");
+    }
+
+    #[test]
+    fn walk_respects_gitignore() {
+        let temp = std::env::temp_dir().join(format!(
+            "m1nd-walker-gitignore-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(temp.join("vendored")).expect("vendored dir");
+        std::fs::create_dir_all(temp.join("src")).expect("src dir");
+        std::fs::write(temp.join(".gitignore"), "vendored/\n").expect("gitignore");
+        std::fs::write(temp.join("vendored").join("junk.rs"), "pub fn junk() {}\n")
+            .expect("junk file");
+        std::fs::write(temp.join("src").join("real.rs"), "pub fn real() {}\n").expect("real file");
+
+        // `git init` makes the .gitignore deterministically honored by the ignore crate.
+        let status = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&temp)
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init failed");
+
+        let walker = DirectoryWalker::new(Vec::new(), Vec::new(), false, Vec::new());
+        let result = walker.walk(&temp).expect("walk gitignore tree");
+
+        let rels: Vec<&str> = result
+            .files
+            .iter()
+            .map(|f| f.relative_path.as_str())
+            .collect();
+
+        assert!(
+            rels.contains(&"src/real.rs"),
+            "expected src/real.rs to be discovered, got {rels:?}"
+        );
+        assert!(
+            !rels.contains(&"vendored/junk.rs"),
+            "expected vendored/junk.rs to be gitignored, got {rels:?}"
+        );
+
         std::fs::remove_dir_all(temp).expect("cleanup tempdir");
     }
 }


### PR DESCRIPTION
## What (surfaced by the cross-repo stress test)
The primary code walker used `walkdir` with only a hardcoded skip list, so it ingested gitignored vendored trees. Measured: `~/l00p` ingested **4001 files / 25,905 nodes** (real code ~40 files — it walked the gitignored `donors/`, 658M); `~/agent-command-center` (1.1G) **timed out** the ingest entirely.

## Fix
Primary walk: `walkdir` → **`ignore::WalkBuilder`** (ripgrep's own gitignore-aware walker — the tool m1nd is measured against). Honors `.gitignore`/`.ignore`/hidden; existing `skip_dirs` kept as belt-and-suspenders for repos with no `.gitignore`.

## Proof (re-probe, verified by orchestrator)
- **l00p: 4001 files → 38 files** (355 nodes) — donors/ excluded.
- **acc: timeout → ingests** (59 files, 226 nodes, 0 errors).
- `cargo fmt --check` ✓ · `clippy --workspace --all-targets -D warnings` ✓ (0) · `cargo test --workspace` → 0 failed (incl. new `walk_respects_gitignore`) · battery **28/28** (m1nd's own ingest unchanged).

Found by the OMEGA cross-repo stress test.