### PR TITLE
fix(activation): activate_temporal reads DomainConfig per-type half-lives (dead table now live)

### DIFF
--- a/m1nd-core/src/activation.rs
+++ b/m1nd-core/src/activation.rs
@@ -495,6 +495,7 @@ pub fn activate_temporal(
     graph: &Graph,
     seeds: &[(NodeId, FiniteF32)],
     weights: &TemporalWeights,
+    domain: &crate::domain::DomainConfig,
 ) -> M1ndResult<DimensionResult> {
     let start = Instant::now();
     let n = graph.num_nodes() as usize;
@@ -503,15 +504,17 @@ pub fn activate_temporal(
         .map(|d| d.as_secs_f64())
         .unwrap_or(0.0);
 
-    let half_life_secs = 168.0 * 3600.0; // 7 days in seconds
-    let k = std::f64::consts::LN_2 / half_life_secs;
-
     let mut scores = Vec::new();
     for &(node, seed_strength) in seeds {
         let idx = node.as_usize();
         if idx >= n {
             continue;
         }
+        // Per-node decay: read the declared half-life for this node's NodeType
+        // from the domain table (hours -> seconds). Types not in the table fall
+        // back to the domain's `default_half_life` via `half_life_for`.
+        let half_life_secs = domain.half_life_for(graph.nodes.node_type[idx]) as f64 * 3600.0;
+        let k = std::f64::consts::LN_2 / half_life_secs;
         let last_mod = graph.nodes.last_modified[idx];
         let age_secs = (now - last_mod).max(0.0);
         let recency = (-k * age_secs).exp() as f32;

--- a/m1nd-core/src/query.rs
+++ b/m1nd-core/src/query.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use crate::activation::*;
 use crate::counterfactual::*;
+use crate::domain::DomainConfig;
 use crate::error::M1ndResult;
 use crate::graph::Graph;
 use crate::plasticity::*;
@@ -158,7 +159,12 @@ impl QueryOrchestrator {
     /// -> merge -> ghost edges -> structural holes -> plasticity update.
     /// Four dimensions run in parallel via rayon.
     /// Replaces: engine_v2.py ConnectomeEngine.query()
-    pub fn query(&mut self, graph: &mut Graph, config: &QueryConfig) -> M1ndResult<QueryResult> {
+    pub fn query(
+        &mut self,
+        graph: &mut Graph,
+        config: &QueryConfig,
+        domain: &DomainConfig,
+    ) -> M1ndResult<QueryResult> {
         let start = Instant::now();
 
         // Step 1: Find seeds
@@ -199,7 +205,7 @@ impl QueryOrchestrator {
         let d2 = activate_semantic(graph, &self.semantic, &config.query, config.top_k)?;
 
         // D3: Temporal
-        let d3 = activate_temporal(graph, &seeds, &TemporalWeights::default())?;
+        let d3 = activate_temporal(graph, &seeds, &TemporalWeights::default(), domain)?;
 
         // D4: Causal
         let d4 = activate_causal(graph, &seeds, &config.propagation)?;
@@ -321,7 +327,12 @@ impl QueryOrchestrator {
     /// The `plasticity` field is set to the same empty/zeroed
     /// [`PlasticityResult`] used by the empty-seeds early return in
     /// [`Self::query`].
-    pub fn query_readonly(&self, graph: &Graph, config: &QueryConfig) -> M1ndResult<QueryResult> {
+    pub fn query_readonly(
+        &self,
+        graph: &Graph,
+        config: &QueryConfig,
+        domain: &DomainConfig,
+    ) -> M1ndResult<QueryResult> {
         let start = Instant::now();
 
         // Zeroed plasticity result — Step 8 is intentionally skipped, so no
@@ -367,7 +378,7 @@ impl QueryOrchestrator {
         let d2 = activate_semantic(graph, &self.semantic, &config.query, config.top_k)?;
 
         // D3: Temporal
-        let d3 = activate_temporal(graph, &seeds, &TemporalWeights::default())?;
+        let d3 = activate_temporal(graph, &seeds, &TemporalWeights::default(), domain)?;
 
         // D4: Causal
         let d4 = activate_causal(graph, &seeds, &config.propagation)?;

--- a/m1nd-core/tests/query_orchestrator_readonly_detectors_behavior.rs
+++ b/m1nd-core/tests/query_orchestrator_readonly_detectors_behavior.rs
@@ -11,6 +11,7 @@
 //!   the graph; an out-of-range id would be an out-of-bounds bug downstream.
 
 use m1nd_core::activation::{ActivatedNode, ActivationResult};
+use m1nd_core::domain::DomainConfig;
 use m1nd_core::graph::Graph;
 use m1nd_core::query::{QueryConfig, QueryOrchestrator};
 use m1nd_core::types::{EdgeDirection, FiniteF32, Generation, NodeId, NodeType};
@@ -132,7 +133,7 @@ fn query_readonly_does_not_mutate_the_graph() {
     // change that smuggles in interior mutation (atomics on edge weights, the
     // generation counter) is caught.
     let result = orchestrator
-        .query_readonly(&graph, &config)
+        .query_readonly(&graph, &config, &DomainConfig::code())
         .expect("query_readonly succeeds");
 
     let after = graph_fingerprint(&graph);

--- a/m1nd-core/tests/temporal_per_type_half_life_behavior.rs
+++ b/m1nd-core/tests/temporal_per_type_half_life_behavior.rs
@@ -1,0 +1,107 @@
+//! Proves the DomainConfig per-NodeType half-life table is now LIVE inside
+//! `activation::activate_temporal`. Before Move 5 the temporal kernel hardcoded
+//! a single 168h (7-day) half-life for every node, so the declared retention
+//! schedule in `DomainConfig` (`half_life_for`) was dead code: a File node and a
+//! Module node decayed identically. This locks two properties:
+//!
+//! * DIFFERENT TYPES DECAY DIFFERENTLY — a Module (720h half-life in the code
+//!   profile) retains more recency than a File (168h) at the same age; the table
+//!   is genuinely consumed.
+//! * NO REGRESSION FOR THE DEFAULT — a File (168h == the old hardcoded constant)
+//!   still produces the exact recency the old `168.0 * 3600.0` formula gave, so
+//!   the fix is a no-op for any type whose declared half-life is already 7 days.
+
+use m1nd_core::activation::activate_temporal;
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_core::types::{FiniteF32, NodeId, NodeType, TemporalWeights};
+
+/// Age (in seconds) applied to every seed node in these tests: 14 days. Large
+/// enough that the half-life difference between File (168h) and Module (720h)
+/// produces a clearly separated recency, small enough to stay well away from
+/// float underflow.
+const AGE_SECS: f64 = 14.0 * 24.0 * 3600.0;
+
+/// Recency-only weights (frequency zeroed) so the assertions read the pure decay
+/// term without the frequency contribution muddying the score.
+fn recency_only_weights() -> TemporalWeights {
+    TemporalWeights {
+        recency: FiniteF32::new(1.0),
+        frequency: FiniteF32::new(0.0),
+    }
+}
+
+/// Build a graph whose nodes all sit at `now - AGE_SECS`, with `change_frequency`
+/// zeroed so only the recency term survives the recency-only weights. Node types
+/// are supplied by the caller; returns the graph and the `NodeId`s in order.
+fn graph_with_types(types: &[(&str, NodeType)]) -> (Graph, Vec<NodeId>) {
+    let mut graph = Graph::new();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    let last_mod = now - AGE_SECS;
+    let mut ids = Vec::new();
+    for (id, node_type) in types {
+        let node = graph
+            .add_node(id, id, *node_type, &[], last_mod, 0.0)
+            .expect("add node");
+        ids.push(node);
+    }
+    graph.finalize().expect("finalize");
+    (graph, ids)
+}
+
+/// Look up the temporal score `activate_temporal` produced for `node`.
+fn score_for(graph: &Graph, node: NodeId, domain: &DomainConfig) -> f32 {
+    let seeds = vec![(node, FiniteF32::new(1.0))];
+    let result = activate_temporal(graph, &seeds, &recency_only_weights(), domain)
+        .expect("activate_temporal");
+    result
+        .scores
+        .iter()
+        .find(|(n, _)| *n == node)
+        .map(|(_, s)| s.get())
+        .expect("node scored")
+}
+
+#[test]
+fn longer_half_life_type_decays_slower_than_shorter() {
+    // In the code profile: File = 168h, Module = 720h. Same age -> the Module
+    // (longer half-life) must retain strictly MORE recency than the File. If the
+    // table were still dead (both 168h), the two would be equal.
+    let domain = DomainConfig::code();
+    let (graph, ids) = graph_with_types(&[("f", NodeType::File), ("m", NodeType::Module)]);
+
+    let file_score = score_for(&graph, ids[0], &domain);
+    let module_score = score_for(&graph, ids[1], &domain);
+
+    assert!(
+        module_score > file_score,
+        "Module (720h half-life) must decay slower than File (168h): \
+         module={module_score} file={file_score}"
+    );
+}
+
+#[test]
+fn default_half_life_type_matches_old_hardcoded_constant() {
+    // File carries a 168h half-life in the code profile — exactly the constant
+    // the old kernel hardcoded for EVERY node. So a File must still produce the
+    // recency the old `168.0 * 3600.0` formula gave: this proves the fix is a
+    // no-op for the default and does not regress ranking for 7-day types.
+    let domain = DomainConfig::code();
+    let (graph, ids) = graph_with_types(&[("f", NodeType::File)]);
+
+    let got = score_for(&graph, ids[0], &domain);
+
+    // Re-derive the pre-fix recency for the same 14-day age.
+    let old_half_life_secs = 168.0 * 3600.0_f64;
+    let k = std::f64::consts::LN_2 / old_half_life_secs;
+    let expected = (-k * AGE_SECS).exp() as f32;
+
+    assert!(
+        (got - expected).abs() < 1e-6,
+        "File (168h) recency must equal the old hardcoded-constant recency: \
+         got={got} expected={expected}"
+    );
+}

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -1405,10 +1405,11 @@ impl SessionState {
     ) -> M1ndResult<m1nd_core::query::QueryResult> {
         if self.read_only {
             let graph = self.graph.read();
-            self.orchestrator.query_readonly(&graph, config)
+            self.orchestrator
+                .query_readonly(&graph, config, &self.domain)
         } else {
             let mut graph = self.graph.write();
-            self.orchestrator.query(&mut graph, config)
+            self.orchestrator.query(&mut graph, config, &self.domain)
         }
     }
 


### PR DESCRIPTION
## What

`activate_temporal` (the D3 temporal-decay kernel in `m1nd-core/src/activation.rs`) hardcoded a single **168h (7-day)** half-life for **every** node, so `DomainConfig`'s per-`NodeType` half-life table (`half_life_for` / the `half_lives` map in `m1nd-core/src/domain.rs`) was **dead code** — a `File` node and a `Module` node decayed identically. The declared retention policy was silently ignored.

## Fix

- Thread `&DomainConfig` into `activate_temporal` and, **inside the seed loop**, look up `half_life_for(graph.nodes.node_type[idx])` per node (hours → seconds via `* 3600.0`). The `default_half_life` fallback in `half_life_for` is preserved for unmapped types.
- Threaded through the two public callers `QueryOrchestrator::query` / `query_readonly`, and their call sites in `SessionState::run_query` (which pass `&self.domain`). The read-only test caller was updated to pass `DomainConfig::code()`.
- No new half-life constants; reuses the existing `domain.rs` table. Minimal, mechanical, behavior-preserving except the intended fix.

## Which types change vs the old 168h constant

For the `code` domain: `File` (168h) is **unchanged** (== old constant, no regression). `Function` (336h), `Class`/`Struct`/`Enum`/`Type` (504h), `Module`/`Directory` (720h) now decay **slower**, and any unmapped type uses `default_half_life` (168h) — matching the old behavior. Other domains (music/memory/light/generic) become live under their own tables.

## Proof

New `m1nd-core/tests/temporal_per_type_half_life_behavior.rs`:
- `longer_half_life_type_decays_slower_than_shorter` — a `Module` (720h) retains strictly more recency than a `File` (168h) at the same age (the table is live). Verified this case **fails** against the reverted hardcoded kernel (both scored 0.25).
- `default_half_life_type_matches_old_hardcoded_constant` — a `File` (168h) still equals the old `168.0 * 3600.0` recency (no default regression).

## Gate

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo test --workspace` — 0 failed
- capability battery (`--suite m1nd`) — **28/28**, head-to-head 16 wins / 12 ties / 0 grep-wins (no ranking regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)