### PR TITLE
feat(mcp): binary version+sha fingerprint with honest drift warning

### DIFF
--- a/m1nd-mcp/build.rs
+++ b/m1nd-mcp/build.rs
@@ -1,3 +1,38 @@
+use std::process::Command;
+
+/// Best-effort git short SHA (+ `-dirty` suffix) embedded at build time as
+/// `M1ND_GIT_SHA`. Uses ONLY std — no build dependency. MUST NOT fail when
+/// `.git` is absent (crates.io / vendored builds); falls back to "unknown" so
+/// the binary can always answer "what am I?" honestly.
+fn git_sha() -> String {
+    let short = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|sha| !sha.is_empty());
+
+    let Some(mut sha) = short else {
+        return "unknown".to_string();
+    };
+
+    // `git status --porcelain` prints one line per dirty path; any output means
+    // the working tree differs from HEAD, so tag the sha `-dirty`. A failure
+    // here (e.g. no git) is treated as clean — the sha itself is what matters.
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| !out.stdout.is_empty())
+        .unwrap_or(false);
+    if dirty {
+        sha.push_str("-dirty");
+    }
+    sha
+}
+
 fn main() {
     let ui_dist = std::path::Path::new("../m1nd-ui/dist");
 
@@ -11,4 +46,12 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed=../m1nd-ui/dist/index.html");
+
+    // Embed the git sha so the running binary can always declare exactly what it
+    // is (version + sha) and drift-warn against stale binaries. Best-effort
+    // rerun triggers: HEAD move (commit/checkout) and index changes (staging).
+    // These paths may not exist on a non-git build — that is fine.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/index");
+    println!("cargo:rustc-env=M1ND_GIT_SHA={}", git_sha());
 }

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -5,8 +5,19 @@
 
 use clap::Parser;
 
+/// `--version` string: semantic version + embedded git sha, e.g. `1.1.0 (50385cd)`.
+/// The sha is `unknown` on builds without a `.git` (crates.io / vendored). This
+/// makes the binary declare exactly what it is — the first layer of the
+/// version-honesty moat (see `build.rs` / `session::binary_version_info`).
+const LONG_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("M1ND_GIT_SHA"), ")");
+
 #[derive(Parser, Debug)]
-#[command(name = "m1nd-mcp", about = "Neuro-symbolic connectome engine", version)]
+#[command(
+    name = "m1nd-mcp",
+    about = "Neuro-symbolic connectome engine",
+    version,
+    long_version = LONG_VERSION
+)]
 pub struct Cli {
     /// Start HTTP server with embedded web UI
     #[arg(long)]

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -232,10 +232,82 @@ async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: 
     }
 }
 
+/// Pure strict-version decision (no I/O, no exit) so it is unit-testable in
+/// both directions. Returns `Some(one_line_error)` when the process MUST refuse
+/// to start, else `None`.
+///
+/// Refuse iff strict mode is on AND an explicit expectation
+/// (`expected_version` / `expected_sha`) is set and differs from the running
+/// identity. Only the explicit env expectations are consulted here — no graph,
+/// no bound repo — because this runs before any session exists.
+fn strict_version_verdict(
+    strict: bool,
+    running_version: &str,
+    running_sha: &str,
+    expected_version: Option<&str>,
+    expected_sha: Option<&str>,
+) -> Option<String> {
+    if !strict {
+        return None;
+    }
+    let version_mismatch = expected_version
+        .map(|expected| expected.trim() != running_version)
+        .unwrap_or(false);
+    let sha_mismatch = expected_sha
+        .map(|expected| expected.trim() != running_sha)
+        .unwrap_or(false);
+    if version_mismatch || sha_mismatch {
+        Some(format!(
+            "[m1nd-mcp] STRICT VERSION REFUSAL: running {running_version} ({running_sha}) but expected version={} sha={} (M1ND_STRICT_VERSION=1). Refusing to start against a mismatched binary.",
+            expected_version.unwrap_or("<unset>"),
+            expected_sha.unwrap_or("<unset>"),
+        ))
+    } else {
+        None
+    }
+}
+
+/// Strict version-honesty gate (the hardest layer of the honesty moat).
+///
+/// When `M1ND_STRICT_VERSION` is truthy AND an explicit expectation
+/// (`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`) does not match this running
+/// binary, REFUSE to start with a one-line error and a nonzero exit. This is for
+/// harnesses/experiments that must NEVER run the wrong binary (the exact
+/// incident: an old beta.8 binary silently used in an experiment). Uses only the
+/// compile-time identity — no graph, no session, no lease — so it is safe to run
+/// before anything else. Non-strict callers get warnings instead (in the
+/// handshake/selftest honest surface); this only bites when opted in.
+fn enforce_strict_version() {
+    let strict = std::env::var("M1ND_STRICT_VERSION")
+        .map(|v| v != "0" && v != "false" && !v.trim().is_empty())
+        .unwrap_or(false);
+    let expected_version = std::env::var("M1ND_EXPECTED_VERSION")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let expected_sha = std::env::var("M1ND_EXPECTED_SHA")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+
+    if let Some(error) = strict_version_verdict(
+        strict,
+        m1nd_mcp::session::BINARY_VERSION,
+        m1nd_mcp::session::BINARY_GIT_SHA,
+        expected_version.as_deref(),
+        expected_sha.as_deref(),
+    ) {
+        eprintln!("{error}");
+        std::process::exit(2);
+    }
+}
+
 #[tokio::main]
 async fn main() {
     #[cfg(unix)]
     ensure_bwrap_compat_wrapper();
+
+    // Version-honesty strict gate — refuse a mismatched binary before doing any
+    // work (see `enforce_strict_version`). No-op unless M1ND_STRICT_VERSION is set.
+    enforce_strict_version();
 
     let cli = Cli::parse();
 
@@ -312,5 +384,46 @@ async fn main() {
         }
     } else {
         run_stdio_server(config, event_log, cli.no_gui, cli.port).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strict_version_verdict;
+
+    #[test]
+    fn strict_off_never_refuses_even_on_mismatch() {
+        // Strict disabled => warn-only elsewhere, never a startup refusal.
+        assert!(strict_version_verdict(false, "1.1.0", "abc", Some("0.0.1"), None).is_none());
+    }
+
+    #[test]
+    fn strict_on_refuses_version_mismatch() {
+        let verdict = strict_version_verdict(true, "1.1.0", "abc123", Some("0.0.0-beta.8"), None);
+        let msg = verdict.expect("strict + mismatch must refuse");
+        assert!(msg.contains("STRICT VERSION REFUSAL"));
+        assert!(msg.contains("1.1.0"));
+        assert!(msg.contains("0.0.0-beta.8"));
+    }
+
+    #[test]
+    fn strict_on_refuses_sha_mismatch() {
+        let verdict = strict_version_verdict(true, "1.1.0", "abc123", None, Some("deadbee"));
+        assert!(verdict.expect("sha mismatch refuses").contains("deadbee"));
+    }
+
+    #[test]
+    fn strict_on_allows_exact_match() {
+        // Strict but everything matches => no refusal.
+        assert!(
+            strict_version_verdict(true, "1.1.0", "abc123", Some("1.1.0"), Some("abc123"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn strict_on_with_no_expectation_allows() {
+        // Strict on but no expectation set => nothing to compare, allow start.
+        assert!(strict_version_verdict(true, "1.1.0", "abc123", None, None).is_none());
     }
 }

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -502,13 +502,180 @@ const MANAGED_RUNTIME_PATH_MARKERS: &[&str] = &[
     "\\sessions\\ppid-",
 ];
 
+/// The running binary's semantic version, from Cargo at compile time.
+pub const BINARY_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The running binary's git short sha (+`-dirty`), embedded by `build.rs`.
+/// `"unknown"` on builds without a `.git` (crates.io / vendored).
+pub const BINARY_GIT_SHA: &str = env!("M1ND_GIT_SHA");
+
+/// Parse the `version = "x.y.z"` value from a `Cargo.toml`'s `[package]` table
+/// using only std. Returns the first `version = "..."` at zero indentation
+/// (package-level, not a dependency's nested version) — good enough for the
+/// warn-only self-repo lag heuristic. `None` if no such line is found.
+pub(crate) fn parse_cargo_package_version(cargo_toml: &str) -> Option<String> {
+    for line in cargo_toml.lines() {
+        // Package-level keys sit at column 0; a dependency's inline `version =`
+        // is always indented or on a `dep = { version = ... }` line.
+        if !line.starts_with("version") {
+            continue;
+        }
+        let rest = line["version".len()..].trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim();
+        // Strip surrounding quotes (single or double).
+        let value = rest
+            .strip_prefix('"')
+            .and_then(|s| s.split('"').next())
+            .or_else(|| rest.strip_prefix('\'').and_then(|s| s.split('\'').next()));
+        if let Some(value) = value {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
 impl SessionState {
+    /// The version the bound repo's own `m1nd-mcp/Cargo.toml` declares, if a
+    /// bound root (workspace_root, else any ingest root) actually contains one.
+    /// This is the "am I testing against an old m1nd binary?" signal: the repo
+    /// on disk says version X but this running binary is version Y. String
+    /// compare only, warn-only — see [`SessionState::binary_version_info`].
+    fn self_repo_declared_version(&self) -> Option<String> {
+        let mut roots: Vec<&str> = Vec::new();
+        if let Some(ws) = self.workspace_root.as_deref() {
+            roots.push(ws);
+        }
+        for root in &self.ingest_roots {
+            roots.push(root.as_str());
+        }
+        for root in roots {
+            let manifest = PathBuf::from(root).join("m1nd-mcp").join("Cargo.toml");
+            if let Ok(contents) = std::fs::read_to_string(&manifest) {
+                if let Some(version) = parse_cargo_package_version(&contents) {
+                    return Some(version);
+                }
+            }
+        }
+        None
+    }
+
+    /// Honest binary identity + drift detection, the core of the version-honesty
+    /// moat. Always returns `binary_version` + `binary_git_sha`. When any drift
+    /// signal fires it adds a `binary_drift` block; otherwise `binary_drift` is
+    /// `null`. Three warn-first signals, all additive, none flips a verdict:
+    ///
+    ///   1. `M1ND_EXPECTED_VERSION` set and != running version.
+    ///   2. `M1ND_EXPECTED_SHA` set and != running sha.
+    ///   3. self-repo lag: the bound repo's `m1nd-mcp/Cargo.toml` declares a
+    ///      version different from the running binary (`binary_lags_repo`) —
+    ///      catches "experiment ran against a stale m1nd binary".
+    ///
+    /// Returns `(identity_json, drift_summary)` where `drift_summary` is a short
+    /// one-line human warning when any signal fired, else `None`. Callers splice
+    /// `drift_summary` into their honest notes/non_claims without changing the
+    /// trust verdict.
+    pub fn binary_version_info(&self) -> (serde_json::Value, Option<String>) {
+        let running_version = BINARY_VERSION;
+        let running_sha = BINARY_GIT_SHA;
+
+        let expected_version = std::env::var("M1ND_EXPECTED_VERSION")
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+        let expected_sha = std::env::var("M1ND_EXPECTED_SHA")
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+
+        let version_mismatch = expected_version
+            .as_deref()
+            .map(|expected| expected.trim() != running_version)
+            .unwrap_or(false);
+        let sha_mismatch = expected_sha
+            .as_deref()
+            .map(|expected| expected.trim() != running_sha)
+            .unwrap_or(false);
+
+        let repo_version = self.self_repo_declared_version();
+        let repo_lags = repo_version
+            .as_deref()
+            .map(|repo| repo != running_version)
+            .unwrap_or(false);
+
+        let drift = version_mismatch || sha_mismatch || repo_lags;
+
+        let identity = if drift {
+            let mut warnings: Vec<String> = Vec::new();
+            if version_mismatch {
+                warnings.push(format!(
+                    "expected version {} but running {}",
+                    expected_version.as_deref().unwrap_or(""),
+                    running_version
+                ));
+            }
+            if sha_mismatch {
+                warnings.push(format!(
+                    "expected sha {} but running {}",
+                    expected_sha.as_deref().unwrap_or(""),
+                    running_sha
+                ));
+            }
+            if repo_lags {
+                warnings.push(format!(
+                    "bound repo m1nd-mcp/Cargo.toml declares {} but running {} (binary_lags_repo — likely testing against a stale binary)",
+                    repo_version.as_deref().unwrap_or(""),
+                    running_version
+                ));
+            }
+            serde_json::json!({
+                "binary_version": running_version,
+                "binary_git_sha": running_sha,
+                "binary_drift": {
+                    "schema": "m1nd-binary-drift-v0",
+                    "drift_detected": true,
+                    "expected_version": expected_version,
+                    "expected_sha": expected_sha,
+                    "running_version": running_version,
+                    "running_sha": running_sha,
+                    "version_mismatch": version_mismatch,
+                    "sha_mismatch": sha_mismatch,
+                    "binary_lags_repo": repo_lags,
+                    "repo_declared_version": repo_version,
+                    "warning": warnings.join("; "),
+                },
+            })
+        } else {
+            serde_json::json!({
+                "binary_version": running_version,
+                "binary_git_sha": running_sha,
+                "binary_drift": serde_json::Value::Null,
+            })
+        };
+
+        let summary = if drift {
+            Some(format!(
+                "binary_drift: this m1nd-mcp is {running_version} ({running_sha}) which does not match the expected/repo binary — verify you are not testing against a stale binary"
+            ))
+        } else {
+            None
+        };
+
+        (identity, summary)
+    }
+
     pub fn binding_fingerprint(&self) -> serde_json::Value {
+        let (binary_info, _drift_summary) = self.binary_version_info();
         let graph = self.graph.read();
         serde_json::json!({
             "schema": "m1nd-binding-fingerprint-v0",
             "process_id": std::process::id(),
             "current_exe": std::env::current_exe().ok().map(|path| path.to_string_lossy().to_string()),
+            "binary_version": binary_info["binary_version"],
+            "binary_git_sha": binary_info["binary_git_sha"],
+            "binary_drift": binary_info["binary_drift"],
             "runtime_root": self.runtime_root.to_string_lossy(),
             "graph_path": self.graph_path.to_string_lossy(),
             "plasticity_path": self.plasticity_path.to_string_lossy(),
@@ -1037,7 +1204,8 @@ impl SessionState {
                 "process_id": std::process::id(),
                 "binary": {
                     "name": "m1nd-mcp",
-                    "version": env!("CARGO_PKG_VERSION"),
+                    "version": BINARY_VERSION,
+                    "git_sha": BINARY_GIT_SHA,
                 },
                 "current_exe": std::env::current_exe().ok().map(|path| path.to_string_lossy().to_string()),
                 "runtime_root": self.runtime_root.to_string_lossy(),

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -3469,6 +3469,16 @@ pub fn handle_session_handshake(
         )
     };
 
+    // Binary version-honesty: a drift warning rides ALONGSIDE the verdict — it
+    // never changes trust_mode (a stale binary is a warning, not a proof
+    // failure). When drift fires, prepend the one-line warning to next_action so
+    // the honest surface can never silently run a wrong/old binary.
+    let (_binary_info, binary_drift_summary) = state.binary_version_info();
+    let next_action: String = match &binary_drift_summary {
+        Some(warning) => format!("{warning}. Then: {next_action}"),
+        None => next_action.to_string(),
+    };
+
     let doctor_recovery = if degraded_host_tool_surface {
         Some(serde_json::json!({
             "suggested_tool": if can_recover { "recovery_playbook" } else if can_diagnose { "doctor" } else { "" },
@@ -3513,6 +3523,11 @@ pub fn handle_session_handshake(
         "schema": "m1nd-session-handshake-v0",
         "trust_mode": trust_mode,
         "binding_fingerprint": state.binding_fingerprint(),
+        // Version-honesty: the running binary's identity + any drift. Additive,
+        // warn-only — the drift block is null when nothing mismatches. The same
+        // block also lives inside binding_fingerprint; surfaced here at top level
+        // so drift is impossible to miss when reading the handshake verdict.
+        "binary_drift": _binary_info.get("binary_drift").cloned().unwrap_or(serde_json::Value::Null),
         "can_ingest": can_ingest,
         "can_retrieve": can_retrieve,
         "can_recover": can_recover,
@@ -3653,6 +3668,25 @@ pub fn handle_trust_selftest(
         .and_then(|value| value.as_str())
         .unwrap_or(default_next_action);
 
+    // Binary version-honesty. Warn-only: a drifted/stale binary does NOT flip
+    // `ok`/`status`/`verdict` (those stay as the trust machinery decided) — the
+    // warning rides in `binary_drift`, `next_action`, and `non_claims` so the
+    // honest surface can never quietly run an old binary.
+    let (binary_info, binary_drift_summary) = state.binary_version_info();
+    let next_action: String = match &binary_drift_summary {
+        Some(warning) => format!("{warning}. Then: {next_action}"),
+        None => next_action.to_string(),
+    };
+    let mut non_claims: Vec<String> = vec![
+        "trust_selftest does not ingest or mutate the graph.".into(),
+        "trust_selftest does not refresh the host MCP binding.".into(),
+        "trust_selftest does not run a retrieval probe automatically.".into(),
+        "trust_selftest does not replace compiler, tests, or local file truth.".into(),
+    ];
+    if let Some(warning) = &binary_drift_summary {
+        non_claims.push(warning.clone());
+    }
+
     Ok(serde_json::json!({
         "schema": "m1nd-trust-selftest-v0",
         "ok": ok,
@@ -3660,6 +3694,7 @@ pub fn handle_trust_selftest(
         "verdict": verdict,
         "next_action": next_action,
         "binding_fingerprint": state.binding_fingerprint(),
+        "binary_drift": binary_info.get("binary_drift").cloned().unwrap_or(serde_json::Value::Null),
         "graph_state": graph_state,
         "session_handshake": handshake,
         "recovery_playbook": recovery_playbook.unwrap_or(serde_json::Value::Null),
@@ -3670,15 +3705,11 @@ pub fn handle_trust_selftest(
             "needs_ingest": verdict == "needs_ingest",
             "wrong_workspace_binding": verdict == "wrong_workspace_binding",
             "stale_binding_suspected": verdict == "stale_binding_suspected",
+            "binary_drift_detected": binary_drift_summary.is_some(),
             "suspicious_retrieval_evidence": suspicious_retrieval,
             "recovery_playbook_attached": !ok || suspicious_retrieval,
         },
-        "non_claims": [
-            "trust_selftest does not ingest or mutate the graph.",
-            "trust_selftest does not refresh the host MCP binding.",
-            "trust_selftest does not run a retrieval probe automatically.",
-            "trust_selftest does not replace compiler, tests, or local file truth."
-        ],
+        "non_claims": non_claims,
     }))
 }
 
@@ -5590,5 +5621,216 @@ mod tests {
             "garbage → unlimited"
         );
         std::env::remove_var("M1ND_MEMORY_LOAD_CAP");
+    }
+
+    // ---------------------------------------------------------------------
+    // Binary version-honesty: the fingerprint carries version+sha, drift warns
+    // (env-expected + self-repo lag), and strict mode refuses at startup.
+    // ---------------------------------------------------------------------
+
+    /// Clear the version-expectation env so a test starts from a known clean
+    /// slate regardless of what the outer harness set. Caller holds the env lock.
+    fn clear_version_env() {
+        std::env::remove_var("M1ND_EXPECTED_VERSION");
+        std::env::remove_var("M1ND_EXPECTED_SHA");
+    }
+
+    #[test]
+    fn binding_fingerprint_carries_binary_version_and_sha() {
+        let _g = cap_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_version_env();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = build_runtime_state(temp.path());
+
+        let fp = state.binding_fingerprint();
+        // Version is the compile-time crate version, verbatim.
+        assert_eq!(fp["binary_version"], env!("CARGO_PKG_VERSION"));
+        // Sha is the embedded build-time sha; on a git build it is a real short
+        // sha (optionally `-dirty`), on a vendored build it is exactly "unknown".
+        let sha = fp["binary_git_sha"].as_str().expect("sha string");
+        assert!(!sha.is_empty(), "sha never empty");
+        assert_eq!(sha, env!("M1ND_GIT_SHA"));
+        // No expectation set + no self-repo manifest => no drift.
+        assert_eq!(fp["binary_drift"], serde_json::Value::Null);
+        clear_version_env();
+    }
+
+    #[test]
+    fn binary_version_info_no_drift_when_expectation_matches() {
+        let _g = cap_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_version_env();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = build_runtime_state(temp.path());
+
+        // Expectation matches the running binary exactly => no drift, no warning.
+        std::env::set_var("M1ND_EXPECTED_VERSION", env!("CARGO_PKG_VERSION"));
+        std::env::set_var("M1ND_EXPECTED_SHA", env!("M1ND_GIT_SHA"));
+        let (info, summary) = state.binary_version_info();
+        assert_eq!(info["binary_drift"], serde_json::Value::Null);
+        assert!(summary.is_none(), "matched expectation => no warning");
+        clear_version_env();
+    }
+
+    #[test]
+    fn binary_version_info_drifts_when_expected_version_mismatches() {
+        let _g = cap_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_version_env();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = build_runtime_state(temp.path());
+
+        // An old expectation (e.g. the beta.8 incident) => drift block + warning.
+        std::env::set_var("M1ND_EXPECTED_VERSION", "0.0.0-beta.8");
+        let (info, summary) = state.binary_version_info();
+        let drift = &info["binary_drift"];
+        assert_ne!(*drift, serde_json::Value::Null, "drift block present");
+        assert_eq!(drift["drift_detected"], true);
+        assert_eq!(drift["version_mismatch"], true);
+        assert_eq!(drift["sha_mismatch"], false);
+        assert_eq!(drift["expected_version"], "0.0.0-beta.8");
+        assert_eq!(drift["running_version"], env!("CARGO_PKG_VERSION"));
+        assert!(summary.is_some(), "mismatch => human warning");
+        assert!(summary.unwrap().contains("binary_drift"));
+        clear_version_env();
+    }
+
+    #[test]
+    fn trust_selftest_surfaces_binary_drift_without_flipping_verdict() {
+        let _g = cap_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_version_env();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_runtime_state(temp.path());
+
+        std::env::set_var("M1ND_EXPECTED_VERSION", "0.0.0-beta.8");
+        let output = handle_trust_selftest(
+            &mut state,
+            TrustSelftestInput {
+                agent_id: "jimi".into(),
+                observed_tool_count: Some(HOST_BINDING_REQUIRED_TOOLS.len() as u64),
+                available_tools: HOST_BINDING_REQUIRED_TOOLS
+                    .iter()
+                    .map(|tool| (*tool).to_string())
+                    .collect(),
+                missing_tools: vec![],
+                observed_tool: Some("seek".into()),
+                observed_proof_state: Some("triaging".into()),
+                observed_candidates: Some(0),
+                scope: None,
+                error_text: None,
+            },
+        )
+        .expect("trust selftest output");
+
+        // Verdict is UNCHANGED — a stale binary is a warning, not a failure.
+        assert_eq!(output["verdict"], "full_trust");
+        assert_eq!(output["status"], "ok");
+        assert_eq!(output["ok"], true);
+        // But the drift is loud: top-level block, a check flag, warning in
+        // next_action, and an appended non_claim.
+        assert_eq!(output["checks"]["binary_drift_detected"], true);
+        assert_ne!(output["binary_drift"], serde_json::Value::Null);
+        assert_eq!(output["binary_drift"]["version_mismatch"], true);
+        assert!(output["next_action"]
+            .as_str()
+            .expect("next_action string")
+            .contains("binary_drift"));
+        let non_claims = output["non_claims"].as_array().expect("non_claims array");
+        assert!(
+            non_claims.iter().any(|c| c
+                .as_str()
+                .map(|s| s.contains("binary_drift"))
+                .unwrap_or(false)),
+            "drift warning appended to non_claims"
+        );
+        // And it propagates through the embedded handshake too.
+        assert_ne!(
+            output["session_handshake"]["binary_drift"],
+            serde_json::Value::Null
+        );
+        clear_version_env();
+    }
+
+    #[test]
+    fn trust_selftest_no_drift_when_binary_matches() {
+        let _g = cap_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_version_env();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_runtime_state(temp.path());
+
+        let output = handle_trust_selftest(
+            &mut state,
+            TrustSelftestInput {
+                agent_id: "jimi".into(),
+                observed_tool_count: Some(HOST_BINDING_REQUIRED_TOOLS.len() as u64),
+                available_tools: HOST_BINDING_REQUIRED_TOOLS
+                    .iter()
+                    .map(|tool| (*tool).to_string())
+                    .collect(),
+                missing_tools: vec![],
+                observed_tool: Some("seek".into()),
+                observed_proof_state: Some("triaging".into()),
+                observed_candidates: Some(0),
+                scope: None,
+                error_text: None,
+            },
+        )
+        .expect("trust selftest output");
+
+        assert_eq!(output["checks"]["binary_drift_detected"], false);
+        assert_eq!(output["binary_drift"], serde_json::Value::Null);
+        // next_action is the clean full-trust guidance (no drift prefix).
+        assert!(!output["next_action"]
+            .as_str()
+            .expect("next_action string")
+            .contains("binary_drift"));
+        clear_version_env();
+    }
+
+    #[test]
+    fn self_repo_higher_version_flags_binary_lags_repo() {
+        // No env expectation — this signal is purely the bound repo's own
+        // m1nd-mcp/Cargo.toml declaring a version newer than the running binary.
+        let _g = cap_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_version_env();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_runtime_state(temp.path());
+
+        // Fake a checked-out m1nd repo whose manifest is AHEAD of this binary.
+        let repo_mcp = temp.path().join("m1nd-mcp");
+        std::fs::create_dir_all(&repo_mcp).expect("mkdir m1nd-mcp");
+        std::fs::write(
+            repo_mcp.join("Cargo.toml"),
+            "[package]\nname = \"m1nd-mcp\"\nversion = \"999.0.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write fake Cargo.toml");
+        // Bind the workspace to that repo root (build_runtime_state already set
+        // workspace_root to temp.path(); make it explicit for clarity).
+        state.workspace_root = Some(temp.path().to_string_lossy().to_string());
+
+        let (info, summary) = state.binary_version_info();
+        let drift = &info["binary_drift"];
+        assert_ne!(*drift, serde_json::Value::Null, "lag => drift block");
+        assert_eq!(drift["binary_lags_repo"], true);
+        assert_eq!(drift["repo_declared_version"], "999.0.0");
+        assert_eq!(drift["running_version"], env!("CARGO_PKG_VERSION"));
+        // Not an env mismatch, purely the repo-lag signal.
+        assert_eq!(drift["version_mismatch"], false);
+        assert!(summary.expect("warning").contains("binary_drift"));
+        clear_version_env();
+    }
+
+    #[test]
+    fn parse_cargo_package_version_reads_package_level_only() {
+        // Package version at column 0 is read; an indented dependency version is
+        // NOT mistaken for it (the package `version` line wins by appearing first
+        // at zero indentation).
+        let manifest = "[package]\nname = \"m1nd-mcp\"\nversion = \"1.2.3\"\n\n[dependencies]\nserde = { version = \"1\" }\n";
+        assert_eq!(
+            crate::session::parse_cargo_package_version(manifest),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(
+            crate::session::parse_cargo_package_version("[package]\nname = \"x\"\n"),
+            None
+        );
     }
 }

--- a/m1nd-mcp/tests/strict_version_refusal.rs
+++ b/m1nd-mcp/tests/strict_version_refusal.rs
@@ -1,0 +1,43 @@
+//! End-to-end proof of the version-honesty strict gate.
+//!
+//! `M1ND_STRICT_VERSION=1` + an `M1ND_EXPECTED_VERSION` that does not match the
+//! running binary must make the process REFUSE TO START — exit nonzero with a
+//! one-line refusal on stderr, before any server loop, graph, or lease. This is
+//! the hard guarantee for harnesses/experiments that must never run a stale
+//! binary (the beta.8 incident). We spawn the real built binary because only a
+//! spawned process can prove `std::process::exit` actually fired.
+
+use std::process::Command;
+
+/// Path to the compiled binary under test. Cargo sets `CARGO_BIN_EXE_<name>`
+/// for integration tests automatically.
+const BIN: &str = env!("CARGO_BIN_EXE_m1nd-mcp");
+
+#[test]
+fn strict_mode_version_mismatch_refuses_to_start() {
+    let output = Command::new(BIN)
+        .env("M1ND_STRICT_VERSION", "1")
+        .env("M1ND_EXPECTED_VERSION", "0.0.0-beta.8")
+        // Keep the refusal path cheap and hermetic — it exits before any of this
+        // matters, but set them so a regression that slips past the gate can't
+        // touch the developer's real runtime.
+        .env("M1ND_READ_ONLY", "1")
+        .env_remove("M1ND_EXPECTED_SHA")
+        .output()
+        .expect("spawn m1nd-mcp");
+
+    assert!(
+        !output.status.success(),
+        "strict + version mismatch must exit nonzero, got {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("STRICT VERSION REFUSAL"),
+        "expected refusal line on stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("0.0.0-beta.8"),
+        "refusal should name the mismatched expectation, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## What & why

**The incident this prevents:** an old `beta.8` `m1nd-mcp` binary was silently used in an experiment because nothing screamed "I'm old". Stale binaries waste tokens and quietly invalidate experiments. This extends the honesty moat: the binary must always declare exactly what it is (version + git sha) and warn on drift — never lie about what you are.

All changes are **additive** (no existing field changes, no behavior change absent the env vars).

## The three honesty layers

1. **Identity everywhere** — the binary declares `version (sha)`:
   - `build.rs` embeds the git short sha at build time (`std::process::Command` → `git rev-parse --short HEAD` + a `git status --porcelain` `-dirty` suffix). No new dependency; falls back to `"unknown"` when `.git` is absent (crates.io / vendored builds).
   - `--version` now prints e.g. `m1nd-mcp 1.1.0 (50385cd)` (clap `long_version`).
   - `binding_fingerprint` gained `binary_version` + `binary_git_sha` (and a `binary_drift` block). It propagates automatically to `session_handshake`, `trust_selftest`, and `north`. `agent_runtime_contract`'s `session_identity.binary` gained `git_sha`.

2. **Drift warning (warn-first, never a silent lie)** — when `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` is set and mismatches the running binary, the handshake/`trust_selftest` output carries a `binary_drift` block **and** the warning rides in `next_action` + `non_claims`. Verdicts are **unchanged** — a stale binary is a warning, not a proof failure.
   - **Self-repo heuristic** (catches the exact incident): when the bound repo root contains `m1nd-mcp/Cargo.toml`, its `version = "..."` is parsed; if it differs from the running binary → a `binary_lags_repo` warning. This catches "testing m1nd against an old m1nd binary".

3. **Strict refusal** — `M1ND_STRICT_VERSION=1` + a mismatch → the process **exits at startup** (nonzero, one-line error) before any server/graph/lease. For harnesses/experiments that must never run a wrong binary.

## Proof

- Unit + integration tests mirror the existing handshake/selftest styles:
  - fingerprint carries version+sha (sha == embedded env);
  - `M1ND_EXPECTED_VERSION` mismatch → drift block + warning; match → absent;
  - `trust_selftest` surfaces drift **without flipping the verdict**;
  - self-repo higher version → `binary_lags_repo`;
  - strict-mode + mismatch → real spawned-binary startup **refusal** (exit ≠ 0, refusal on stderr).
- Full gate green: `cargo fmt --check` · `cargo clippy --workspace --all-targets -D warnings` (0) · `cargo test --workspace` (0 failed) · battery 28/28.
- `./target/release/m1nd-mcp --version` → `m1nd-mcp 1.1.0 (<sha>)`.
