### PR TITLE
feat(core): normalized co-change coupling (smoothed Jaccard) — calibration-proven over raw counts

### DIFF
--- a/m1nd-core/src/temporal.rs
+++ b/m1nd-core/src/temporal.rs
@@ -30,6 +30,16 @@ pub const CO_CHANGE_DECAY_FACTOR: f32 = 0.95;
 pub const BOOTSTRAP_WEIGHT: f32 = 0.3;
 /// Max entries per row in co-change matrix.
 pub const CO_CHANGE_MAX_ROW: usize = 100;
+/// Additive (Laplace-style) smoothing for the Jaccard co-change strength:
+/// strength = co / (|A ∪ B| + k). Keeps the measure in (0, 1) while damping
+/// tiny-support coincidences — a pair seen exactly once scores 1/3 instead of
+/// saturating at 1.0, and well-supported exclusive couples approach 1.0.
+/// k = 2 is calibration-proven on m1nd's own history: unsmoothed Jaccard
+/// (k = 0) collapsed the act band to one-off pairs, k = 1 left the top
+/// confidence band less precise than the middle, and k = 2 restored a
+/// monotone precision-in-confidence curve while beating raw counts at the
+/// conformal act point.
+pub const CO_CHANGE_JACCARD_SMOOTHING: f32 = 2.0;
 /// Dormant hours threshold.
 pub const DORMANT_HOURS: f64 = 720.0;
 /// Resurrection additive floor.
@@ -50,6 +60,10 @@ pub const RAW_DECAY_FLOOR: f32 = 1e-6;
 pub struct CoChangeEntry {
     pub target: NodeId,
     pub strength: FiniteF32,
+    /// Raw co-change observations behind this entry. Zero for structural
+    /// bootstrap seeds (BFS guesses, not observations); positive once the
+    /// pair has been seen changing together.
+    pub co_count: u32,
 }
 
 /// Sparse co-change matrix with bounded entry count.
@@ -59,6 +73,9 @@ pub struct CoChangeEntry {
 pub struct CoChangeMatrix {
     /// Per-node sorted list of co-change entries.
     rows: Vec<Vec<CoChangeEntry>>,
+    /// Per-node co-change event appearances (commits the node changed in) —
+    /// the marginal counts of the smoothed-Jaccard association.
+    node_counts: Vec<u32>,
     /// Total entries across all rows (for budget enforcement).
     total_entries: u64,
     /// Maximum total entries allowed.
@@ -110,6 +127,7 @@ impl CoChangeMatrix {
                         entries.push(CoChangeEntry {
                             target: tgt,
                             strength: FiniteF32::new(new_strength),
+                            co_count: 0,
                         });
                     }
 
@@ -125,14 +143,56 @@ impl CoChangeMatrix {
 
         Ok(Self {
             rows,
+            node_counts: vec![0; n],
             total_entries,
             budget,
             is_learned: false,
         })
     }
 
+    /// Register one co-change event appearance of `node` (one commit it
+    /// changed in). This is the marginal count of the smoothed-Jaccard
+    /// strength: callers recording pairs outside
+    /// `populate_from_commit_groups` should note each participating node
+    /// once per event, then record the pairs.
+    pub fn note_node_appearance(&mut self, node: NodeId) {
+        let idx = node.as_usize();
+        if idx < self.node_counts.len() {
+            self.node_counts[idx] = self.node_counts[idx].saturating_add(1);
+        }
+    }
+
+    /// Effective coupling strength of an entry in `row_idx`'s row.
+    ///
+    /// Learned entries (`co_count > 0`) get a smoothed-Jaccard association:
+    /// `co / (count(A) + count(B) − co + CO_CHANGE_JACCARD_SMOOTHING)` —
+    /// bounded (0, 1), punishing promiscuous files (large union) and
+    /// tiny-support coincidences (the smoothing dominates small `co`).
+    /// Structural bootstrap seeds (`co_count == 0`) pass their BFS strength
+    /// through unchanged. If appearance counts were never registered (direct
+    /// `record_co_change` without `note_node_appearance`), the union
+    /// saturates to `co` so the denominator stays valid — Jaccard on the
+    /// evidence available.
+    fn entry_strength(&self, row_idx: usize, entry: &CoChangeEntry) -> FiniteF32 {
+        if entry.co_count == 0 {
+            return entry.strength;
+        }
+        let count_a = self.node_counts.get(row_idx).copied().unwrap_or(0) as u64;
+        let count_b = self
+            .node_counts
+            .get(entry.target.as_usize())
+            .copied()
+            .unwrap_or(0) as u64;
+        let co = entry.co_count as u64;
+        let union = (count_a + count_b).saturating_sub(co).max(co);
+        let smoothed = co as f32 / (union as f32 + CO_CHANGE_JACCARD_SMOOTHING);
+        FiniteF32::new(smoothed.clamp(0.0, 1.0))
+    }
+
     /// Record an observed co-change between two nodes.
-    /// Updates coupling strength. Respects budget cap (FM-TMP-001).
+    /// Accumulates the raw pair co-count; the smoothed-Jaccard coupling
+    /// strength is computed on read (`predict`), so it never goes stale as
+    /// the marginal counts grow. Respects budget cap (FM-TMP-001).
     /// Replaces: temporal_v2.py CoChangeMatrix.record_co_change()
     pub fn record_co_change(
         &mut self,
@@ -147,8 +207,8 @@ impl CoChangeMatrix {
 
         // Check if entry already exists
         if let Some(entry) = self.rows[src_idx].iter_mut().find(|e| e.target == target) {
-            // Strengthen existing
-            entry.strength = FiniteF32::new((entry.strength.get() + 0.1).min(1.0));
+            // Strengthen existing: one more joint observation.
+            entry.co_count = entry.co_count.saturating_add(1);
             self.is_learned = true;
             return Ok(());
         }
@@ -160,25 +220,29 @@ impl CoChangeMatrix {
             });
         }
 
+        let new_entry = CoChangeEntry {
+            target,
+            strength: FiniteF32::ZERO,
+            co_count: 1,
+        };
+
         // Row capacity check
         if self.rows[src_idx].len() >= CO_CHANGE_MAX_ROW {
-            // Replace weakest entry
-            if let Some(weakest) = self.rows[src_idx]
+            // Replace the weakest entry — compared by effective strength so
+            // structural seeds and learned pairs compete in the same units.
+            let weakest = self.rows[src_idx]
                 .iter()
                 .enumerate()
-                .min_by(|a, b| a.1.strength.cmp(&b.1.strength))
-                .map(|(i, _)| i)
-            {
-                self.rows[src_idx][weakest] = CoChangeEntry {
-                    target,
-                    strength: FiniteF32::new(0.1),
-                };
+                .min_by(|a, b| {
+                    self.entry_strength(src_idx, a.1)
+                        .cmp(&self.entry_strength(src_idx, b.1))
+                })
+                .map(|(i, _)| i);
+            if let Some(weakest) = weakest {
+                self.rows[src_idx][weakest] = new_entry;
             }
         } else {
-            self.rows[src_idx].push(CoChangeEntry {
-                target,
-                strength: FiniteF32::new(0.1),
-            });
+            self.rows[src_idx].push(new_entry);
             self.total_entries += 1;
         }
 
@@ -187,13 +251,22 @@ impl CoChangeMatrix {
     }
 
     /// Predict co-change partners for a changed node, sorted by coupling strength.
+    /// Learned entries carry the smoothed-Jaccard strength computed against
+    /// the current marginal counts; structural bootstrap seeds keep their
+    /// BFS strength.
     /// Replaces: temporal_v2.py CoChangeMatrix.predict()
     pub fn predict(&self, changed_node: NodeId, top_k: usize) -> Vec<CoChangeEntry> {
         let idx = changed_node.as_usize();
         if idx >= self.rows.len() {
             return Vec::new();
         }
-        let mut entries = self.rows[idx].clone();
+        let mut entries: Vec<CoChangeEntry> = self.rows[idx]
+            .iter()
+            .map(|entry| CoChangeEntry {
+                strength: self.entry_strength(idx, entry),
+                ..*entry
+            })
+            .collect();
         entries.sort_by_key(|entry| std::cmp::Reverse(entry.strength));
         entries.truncate(top_k);
         entries
@@ -214,7 +287,7 @@ impl CoChangeMatrix {
     ) -> M1ndResult<()> {
         for group in commit_groups {
             // Resolve external IDs to NodeIds
-            let node_ids: Vec<NodeId> = group
+            let mut node_ids: Vec<NodeId> = group
                 .iter()
                 .filter_map(|path| {
                     let file_id = if path.starts_with("file::") {
@@ -225,6 +298,14 @@ impl CoChangeMatrix {
                     graph.resolve_id(&file_id)
                 })
                 .collect();
+            node_ids.sort_unstable();
+            node_ids.dedup();
+
+            // One commit appearance per participating node — the marginal
+            // counts of the smoothed-Jaccard strength.
+            for &node in &node_ids {
+                self.note_node_appearance(node);
+            }
 
             // Record co-change for each pair in the group
             for i in 0..node_ids.len() {

--- a/m1nd-core/tests/temporal_cochange_predict_ranking.rs
+++ b/m1nd-core/tests/temporal_cochange_predict_ranking.rs
@@ -41,20 +41,28 @@ fn predict_is_sorted_descending_excludes_self_and_caps_at_k() {
         "fresh bootstrap on an edgeless graph must yield no co-change partners"
     );
 
-    // Drive deterministic couplings from alpha. record_co_change uses a 0.1 base
-    // strength and strengthens existing pairs by +0.1, so repeating an
-    // observation makes that partner rank higher.
-    // gamma observed 3x (strongest), beta 2x, delta 1x (weakest).
+    // Drive deterministic couplings from alpha, simulating six co-change
+    // events (commits): 3x {alpha,gamma}, 2x {alpha,beta}, 1x {alpha,delta}.
+    // Each event notes both participants' appearances (the smoothed-Jaccard
+    // marginal counts), then records the pair. More joint observations mean
+    // a higher smoothed-Jaccard strength, so gamma (3x) ranks above beta
+    // (2x) above delta (1x).
     for _ in 0..3 {
+        matrix.note_node_appearance(alpha);
+        matrix.note_node_appearance(gamma);
         matrix
             .record_co_change(alpha, gamma, 0.0)
             .expect("record alpha->gamma");
     }
     for _ in 0..2 {
+        matrix.note_node_appearance(alpha);
+        matrix.note_node_appearance(beta);
         matrix
             .record_co_change(alpha, beta, 0.0)
             .expect("record alpha->beta");
     }
+    matrix.note_node_appearance(alpha);
+    matrix.note_node_appearance(delta);
     matrix
         .record_co_change(alpha, delta, 0.0)
         .expect("record alpha->delta");
@@ -182,4 +190,107 @@ fn populate_from_commit_groups_resolves_ids_and_feeds_predictions() {
         beta_top, alpha,
         "the partner co-changed most often must rank first for beta"
     );
+}
+
+// ── Smoothed-Jaccard strength: deterministic oracles (hand-computed) ──
+//
+// strength = co / (count(A) + count(B) − co + 2), the additive smoothing
+// keeping one-off coincidences from saturating at 1.0 while the union term
+// punishes promiscuous files.
+
+#[test]
+fn smoothed_jaccard_punishes_promiscuity_and_damps_one_offs() {
+    let (graph, ids) = isolated_graph(&[
+        "file::core.rs",
+        "file::exclusive.rs",
+        "file::promiscuous.rs",
+        "file::noise1.rs",
+        "file::noise2.rs",
+        "file::noise3.rs",
+        "file::lonely1.rs",
+        "file::lonely2.rs",
+    ]);
+    let (core, exclusive, promiscuous) = (ids[0], ids[1], ids[2]);
+    let (lonely1, lonely2) = (ids[6], ids[7]);
+
+    let mut matrix = CoChangeMatrix::bootstrap(&graph, 500_000).expect("bootstrap");
+
+    // exclusive: 2 commits, both with core. promiscuous: 5 commits, 2 with
+    // core and 3 with noise files. lonely1+lonely2: one joint commit only.
+    let groups: Vec<Vec<String>> = vec![
+        vec!["core.rs".into(), "exclusive.rs".into()],
+        vec!["core.rs".into(), "exclusive.rs".into()],
+        vec!["core.rs".into(), "promiscuous.rs".into()],
+        vec!["core.rs".into(), "promiscuous.rs".into()],
+        vec!["promiscuous.rs".into(), "noise1.rs".into()],
+        vec!["promiscuous.rs".into(), "noise2.rs".into()],
+        vec!["promiscuous.rs".into(), "noise3.rs".into()],
+        vec!["lonely1.rs".into(), "lonely2.rs".into()],
+    ];
+    matrix
+        .populate_from_commit_groups(&graph, &groups)
+        .expect("populate");
+
+    // core appears in 4 commits, exclusive in 2, promiscuous in 5.
+    // J(core, exclusive)   = 2 / (4 + 2 − 2 + 2) = 2/6  EXACT
+    // J(core, promiscuous) = 2 / (4 + 5 − 2 + 2) = 2/9  EXACT
+    let ranked = matrix.predict(core, 10);
+    let strength_of = |target| {
+        ranked
+            .iter()
+            .find(|e| e.target == target)
+            .map(|e| e.strength.get())
+    };
+    let s_exclusive = strength_of(exclusive).expect("exclusive must be predicted");
+    let s_promiscuous = strength_of(promiscuous).expect("promiscuous must be predicted");
+    assert!(
+        (s_exclusive - 2.0 / 6.0).abs() < 1e-6,
+        "J(core,exclusive) must be 2/6, got {s_exclusive}"
+    );
+    assert!(
+        (s_promiscuous - 2.0 / 9.0).abs() < 1e-6,
+        "J(core,promiscuous) must be 2/9, got {s_promiscuous}"
+    );
+    assert!(
+        s_exclusive > s_promiscuous,
+        "equal joint counts: the partner with the bigger union must score lower"
+    );
+
+    // One-off pair must NOT saturate at 1.0 (the raw-Jaccard failure mode the
+    // smoothing exists to prevent): J = 1 / (1 + 1 − 1 + 2) = 1/3 EXACT.
+    let lonely_ranked = matrix.predict(lonely1, 10);
+    assert_eq!(lonely_ranked.len(), 1);
+    assert_eq!(lonely_ranked[0].target, lonely2);
+    assert!(
+        (lonely_ranked[0].strength.get() - 1.0 / 3.0).abs() < 1e-6,
+        "one-off pair must score 1/3, got {}",
+        lonely_ranked[0].strength.get()
+    );
+    // The raw support is carried for consumers that filter on it.
+    assert_eq!(lonely_ranked[0].co_count, 1);
+}
+
+#[test]
+fn direct_record_without_appearances_stays_bounded() {
+    // Callers that record pairs without noting appearances (the legacy direct
+    // path) must still get a valid, bounded strength: the union saturates to
+    // the joint count, so strength = co / (co + 2) — never 1.0, never a
+    // degenerate denominator.
+    let (graph, ids) = isolated_graph(&["file::a.rs", "file::b.rs"]);
+    let (a, b) = (ids[0], ids[1]);
+
+    let mut matrix = CoChangeMatrix::bootstrap(&graph, 500_000).expect("bootstrap");
+    for _ in 0..3 {
+        matrix.record_co_change(a, b, 0.0).expect("record a->b");
+    }
+
+    let ranked = matrix.predict(a, 10);
+    assert_eq!(ranked.len(), 1);
+    // 3 / (3 + 2) = 0.6 EXACT.
+    assert!(
+        (ranked[0].strength.get() - 0.6).abs() < 1e-6,
+        "count-only evidence must score co/(co+2), got {}",
+        ranked[0].strength.get()
+    );
+    assert_eq!(ranked[0].co_count, 3);
 }

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -8899,6 +8899,17 @@ struct LabeledPrediction {
     hit: bool,
 }
 
+/// One operating point of the held-out precision-coverage tradeoff: keeping
+/// every prediction with confidence ≥ `threshold` covers `coverage` of the
+/// labeled set at `precision`. A signal change is only an improvement if its
+/// curve dominates at comparable coverage — the single conformal-τ point
+/// cannot show that, so the harness measures the curve too.
+pub struct PrecisionCoveragePoint {
+    pub threshold: f32,
+    pub coverage: f32,
+    pub precision: f32,
+}
+
 /// Outcome of a calibration run, surfaced verbatim in the handler response.
 pub struct CalibrationOutcome {
     pub row: m1nd_core::calibration::CalibrationRow,
@@ -8910,6 +8921,51 @@ pub struct CalibrationOutcome {
     pub act_predictions: usize,
     /// Split date (unix seconds) used to partition train/test.
     pub split_timestamp: f64,
+    /// Precision-coverage tradeoff at ~5% coverage steps (confidence-ranked).
+    pub curve: Vec<PrecisionCoveragePoint>,
+}
+
+/// Measure the held-out precision-coverage curve: sort predictions by
+/// confidence descending and report (threshold, coverage, precision) at
+/// roughly 5% coverage steps. Ties share a confidence value, so each step
+/// extends to the last prediction with that confidence (a threshold rule can
+/// never split ties).
+fn precision_coverage_curve(labeled: &[LabeledPrediction]) -> Vec<PrecisionCoveragePoint> {
+    let n = labeled.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut by_confidence: Vec<&LabeledPrediction> = labeled.iter().collect();
+    by_confidence.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let step = (n as f32 * 0.05).ceil().max(1.0) as usize;
+    let mut points = Vec::new();
+    let mut hits = 0usize;
+    let mut kept = 0usize;
+    let mut next_report = step;
+    while kept < n {
+        let threshold = by_confidence[kept].confidence;
+        // Consume the whole tie-block: a threshold rule keeps all or none.
+        while kept < n && by_confidence[kept].confidence == threshold {
+            hits += usize::from(by_confidence[kept].hit);
+            kept += 1;
+        }
+        if kept >= next_report || kept == n {
+            points.push(PrecisionCoveragePoint {
+                threshold,
+                coverage: kept as f32 / n as f32,
+                precision: hits as f32 / kept as f32,
+            });
+            while next_report <= kept {
+                next_report += step;
+            }
+        }
+    }
+    points
 }
 
 /// Pure calibration core: date-split `commits` at `split_ts`, build a train-only
@@ -9046,6 +9102,7 @@ fn calibrate_predict_from_commits(
         labeled: labeled.len(),
         act_predictions: act_n,
         split_timestamp: split_ts,
+        curve: precision_coverage_curve(&labeled),
     })
 }
 
@@ -9142,6 +9199,17 @@ pub fn handle_calibrate_predict(
         "test_commits": outcome.test_commits,
         "commits_parsed": commits.len(),
         "split_timestamp": outcome.split_timestamp,
+        "precision_coverage_curve": outcome
+            .curve
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "threshold": p.threshold,
+                    "coverage": p.coverage,
+                    "precision": p.precision,
+                })
+            })
+            .collect::<Vec<_>>(),
         "summary": format!(
             "predict/co-change: at {:.0}% coverage, `act` is {:.0}% precise on {} held-out predictions (τ={:.3}, α={:.2})",
             row.coverage * 100.0,
@@ -12976,7 +13044,18 @@ def5678|2026-03-23 09:00:00 +0000|max kle1nz|feat: add benchmark harness
         state.workspace_root = Some(root.to_string_lossy().to_string());
 
         // Directly inject a co-change entry into the orchestrator's temporal matrix
-        // (this is what ghost_edges does after parsing git history).
+        // (this is what ghost_edges does after parsing git history): one
+        // commit-appearance per node, then the pair in both directions.
+        state
+            .orchestrator
+            .temporal
+            .co_change
+            .note_node_appearance(a);
+        state
+            .orchestrator
+            .temporal
+            .co_change
+            .note_node_appearance(b);
         let _ = state
             .orchestrator
             .temporal

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -2089,14 +2089,12 @@ pub fn handle_predict(
     // --- Git-derived co-change fallback (Fix 3) ---
     // ghost_edges writes real git co-change into state.orchestrator.temporal.co_change.
     // If the bootstrap matrix has no entry for this node, merge git-derived entries.
-    // Apply min_co_change_count filter (default 2, ~strength >= 0.2) to suppress
-    // one-off coincidental pairs.
-    let min_strength = {
-        let count = input.min_co_change_count.unwrap_or(2).max(1);
-        // Each co-change observation adds 0.1 to strength starting from 0.1,
-        // so N observations ≈ strength 0.1 * N (capped at 1.0).
-        (count as f32 * 0.1).min(1.0)
-    };
+    // Apply min_co_change_count directly on the raw observation count carried by
+    // each entry (default 2) to suppress one-off coincidental pairs — the
+    // coupling strength itself is a smoothed-Jaccard association now, not a
+    // count proxy. Structural seeds (co_count == 0) never pass this filter,
+    // matching the old behavior where the floor sat above the 0.1 base.
+    let min_co_count = input.min_co_change_count.unwrap_or(2).max(1);
     let git_co_change_predictions: Vec<m1nd_core::temporal::CoChangeEntry> = {
         let git_preds = state
             .orchestrator
@@ -2105,7 +2103,7 @@ pub fn handle_predict(
             .predict(node, input.top_k);
         git_preds
             .into_iter()
-            .filter(|e| e.strength.get() >= min_strength)
+            .filter(|e| e.co_count >= min_co_count)
             .collect()
     };
 
@@ -2155,6 +2153,7 @@ pub fn handle_predict(
                 structural_predictions.push(m1nd_core::temporal::CoChangeEntry {
                     target,
                     strength: weight,
+                    co_count: 0,
                 });
                 seen.insert(target);
             }
@@ -2175,6 +2174,7 @@ pub fn handle_predict(
                 structural_predictions.push(m1nd_core::temporal::CoChangeEntry {
                     target: source,
                     strength: weight,
+                    co_count: 0,
                 });
                 seen.insert(source);
             }
@@ -2875,6 +2875,11 @@ pub fn handle_learn(state: &mut SessionState, input: LearnInput) -> M1ndResult<s
     drop(graph);
 
     // Record co-change for all pairs of input nodes (feeds the predict tool).
+    // The learned node set is one co-change event: note each node's appearance
+    // once (the smoothed-Jaccard marginal count), then record the pairs.
+    for &node in &nodes {
+        state.temporal.co_change.note_node_appearance(node);
+    }
     for i in 0..nodes.len() {
         for j in (i + 1)..nodes.len() {
             let _ = state


### PR DESCRIPTION
## What

`CoChangeMatrix` coupling strength was a naive count (`0.1·N`, capped at 1.0): promiscuous files looked coupled to everything and the confidence scale carried no marginal-frequency information. `predict`'s `coupling_strength` is now a smoothed-Jaccard association computed on read:

```
strength(A,B) = co(A,B) / (count(A) + count(B) − co(A,B) + 2)
```

- `record_co_change` accumulates raw pair co-counts; `populate_from_commit_groups` registers one appearance per node per commit (the marginals). Strengths are computed at `predict` time, so they never go stale as counts grow.
- Structural bootstrap seeds (`co_count = 0`) pass their BFS strength through; real observations supersede the structural prior.
- Output contract preserved: `coupling_strength ∈ [0,1]` + the calibration verdict.
- `handle_predict`'s `min_co_change_count` now filters on the raw co-count carried by each entry (it was a `count·0.1` strength proxy — broken under any non-count confidence scale).
- `calibrate_predict` additionally reports a `precision_coverage_curve` (held-out tradeoff at ~5% coverage steps) — the instrument that made this A/B provable and makes the next signal experiment cheap.

## The proof

m1nd's own git history, identical date-split (median ts 1775173333), α=0.10, top_k=10, n=9269 held-out predictions from 207 commits — all four variants measured with the same probe protocol (fresh temp graph, full ingest, `calibrate_predict`):

| signal | τ | act precision | act coverage |
|---|---|---|---|
| raw counts `0.1·N` (baseline) | 0.600 | 29.1% | 15.4% |
| unsmoothed Jaccard (k=0) | 1.000 | 20.6% | 10.8% |
| smoothed k=1 | 0.556 | 32.1% | 13.4% |
| **smoothed k=2 (shipped)** | **0.500** | **32.1%** | **13.5%** |

Matched-coverage curve comparison: in the 10–15% coverage band where the conformal gate actually operates, baseline is ~29.2% precise vs k=2's 32.1% (**+3.0 pts**). k=2's top confidence band is also its most precise (39.3% @ 6.5% cov vs baseline's 36.0% @ 5.7%) — precision is monotone in confidence again. The rejected variants are part of the evidence: k=0 saturates one-off pairs at 1.0 and collapses the act band (20.6%); k=1 leaves the top band (27.1%) less precise than the middle (34.5%).

Post-rebase confirmation on the grown corpus (578 commits): 32.4% @ 13.7%, τ=0.500, n=9249 — stable.

## Notes

- Existing `calibration_state.json` rows were measured on the old confidence scale → stale-scaled. Safe and honest: the verdict gate abstains-by-default on mismatch; re-running `calibrate_predict` refreshes the row.
- Recency weighting (exp-decay on commit age) was designed but deliberately not shipped: it needs timestamp plumbing through `populate_from_commit_groups` plus weighted (float) counts, and the corpus is small for the 720 h half-life. The new curve output makes it a cheap follow-up experiment.
- Direct `record_co_change` callers without appearance bookkeeping stay bounded: the union saturates to the co-count (strength = `co/(co+2)`), locked by test.

## Gate

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace`: 1149 passed, 0 failed (50 suites) — includes new exact-value oracles for the smoothed-Jaccard semantics and the direct-record denominator guard
- battery (m1nd suite, incl. #204's calibration/envelope cases): **36/36**
