### PR TITLE
test(memory): de-flake supersession concurrency test (race the memorize, not session init)

### DIFF
--- a/m1nd-mcp/src/light_author_handlers.rs
+++ b/m1nd-mcp/src/light_author_handlers.rs
@@ -1097,13 +1097,21 @@ mod tests {
             handle_light_author(&mut state, super_input("Race", "authored", "0.5")).expect("seed");
         }
 
+        // Build BOTH sessions SEQUENTIALLY, before spawning any thread. Each is an
+        // independent SessionState pointing at the SAME runtime_root — the real
+        // multi-session-drift shape — but session INITIALIZATION is not what this
+        // test proves and is not concurrent-safe (two same-pid ReadWrite acquirers
+        // race the shared instance-lease write in instance_registry). Initializing
+        // here, off the hot path, isolates the property under test: the per-slug
+        // flock in handle_light_author is the ONLY serializer of the concurrent
+        // read-modify-write, exactly as it is across two live sibling processes.
+        let sessions: Vec<SessionState> =
+            (0..2u32).map(|_| build_session(root.as_path())).collect();
+
         let mut handles = Vec::new();
-        for i in 0..2u32 {
-            let root = Arc::clone(&root);
+        for (i, mut state) in sessions.into_iter().enumerate() {
             handles.push(thread::spawn(move || {
-                // Each thread builds its own SessionState pointing at the SAME
-                // runtime_root, so the per-slug flock is the only serializer.
-                let mut state = build_session(root.as_path());
+                // Race ONLY the memorize RMW; the flock must serialize it.
                 let conf = if i == 0 { "0.9" } else { "0.8" };
                 let _ = handle_light_author(&mut state, super_input("Race", "verified", conf));
             }));


### PR DESCRIPTION
## Problem
`light_author_handlers::tests::supersession_concurrent_same_slug_is_serialized` failed ~2/5 runs even in isolation, taxing CI. Reproduced on `origin/main` (9c96d75): **2/15 failures**, always the same signature:

```
thread '<unnamed>' panicked at m1nd-mcp/src/light_author_handlers.rs:628:79:
init session: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
thread 'supersession_concurrent_same_slug_is_serialized' panicked at ...:1112:22:
```

## Root cause (file:line)
The panic was at **`light_author_handlers.rs:628`** — `SessionState::initialize(...).expect("init session")` inside `build_session`, called **from inside each spawned thread**. The test raced TWO session inits on ONE `runtime_root`; the flock under test only guards the memorize read-modify-write, not init.

The ENOENT traces to `instance_registry::acquire_with_mode` (`instance_registry.rs:134`), which every `SessionState::initialize` calls at `session.rs:1252` to take the ReadWrite instance lease. Two threads share one process, so `std::process::id()` is identical → the owner-conflict guard at `instance_registry.rs:164` (`existing.pid != std::process::id()`) is false and both proceed to write the **shared** lease file `leases/<fingerprint(runtime_root)>.json` via `save_json_atomic` (`instance_registry.rs:624`). That helper writes `path.with_extension("tmp")` then renames — and **the temp path is NOT unique per writer**. For the shared lease both threads compute the identical `<fingerprint>.tmp`: writer A renames it into place, writer B's `fs::rename` then hits ENOENT. (The concurrent boot-GC sweep spawned at `session.rs:1272` widens the window.) The per-instance discovery entry does not collide — it's disambiguated by the `INSTANCE_SEQ` nonce — the collision is specifically the shared lease temp file.

## Is this a production bug? (honest finding)
**Not in the normal multi-process path — but there is a real latent robustness gap.** Two *separate* m1nd processes on one `runtime_root` do NOT both write the lease: the second sees a live lease owned by a different PID and is cleanly rejected with `AlreadyExists` at `instance_registry.rs:164-174`. The ENOENT race requires two **same-PID** ReadWrite acquirers on the same `runtime_root` concurrently — i.e. two in-process threads (this test), which the real stdio/attach model does not do.

The latent gap: `save_json_atomic` (`instance_registry.rs:624`) uses a non-unique temp name (`path.with_extension("tmp")`), so ANY two concurrent writers of the same target file (lease or discovery entry) can lose one write to an ENOENT rename. Today only the test triggers it, but a future in-process caller that concurrently reacquires/refreshes the same registry file would too. **Recommended follow-up (separate PR, out of scope here): give `save_json_atomic` a unique temp suffix (pid+nonce, mirroring `write_atomic` in `light_author_handlers.rs:585`).** Not fixed here to keep this PR minimal and focused on de-flaking.

## The fix (test-only, minimal)
Build both independent `SessionState`s **sequentially before spawning threads**, then race ONLY the two `handle_light_author` calls. Each session is still an independent instance pointing at the SAME `runtime_root` (the real multi-session-drift shape); only their construction moved off the raced hot path. The per-slug flock (`LockGuard`, keyed on `runtime_root/agent-memory/.locks/<slug>.lock`, per-open-fd, `light_author_handlers.rs:117`+`374`) remains the sole serializer of the concurrent RMW — which is exactly what the test exists to prove. **All assertions unchanged** (exactly one live file, complete non-torn `Protocol: L1GHT/1.0` doc ending in `]`, no stray `.tmp`).

Diff is 13 insertions / 5 deletions, confined to `m1nd-mcp/src/light_author_handlers.rs`.

## Proof
- Target test in a loop: **15/15 green** (was ~2/15 failing on the same commit).
- `cargo fmt --check` → exit 0.
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0 (0 warnings).
- `cargo test --workspace` run **twice** → **1147 passed / 0 failed** each time.