### PR TITLE
feat(mcp): agent-native server instructions — the OMEGA doctrine

### DIFF
--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -31,88 +31,61 @@ use std::time::Duration;
 // automatically understand how to use m1nd effectively.
 // ---------------------------------------------------------------------------
 const M1ND_INSTRUCTIONS: &str = "\
-m1nd is a neuro-symbolic code graph engine. It ingests codebases into a weighted \
-graph and provides spreading-activation queries, impact analysis, prediction, and \
-stateful perspective navigation. All tool calls require an `agent_id` parameter.
+m1nd is a neuro-symbolic code graph over this repo. It answers with calibrated \
+trust, not vibes: absent / null / abstain / insufficient_evidence are REAL answers — \
+prefer them over guessing. Every tool call needs an `agent_id`. Knowledge is shared: \
+what one agent proves and memorizes, the next agent reads. Operate in a loop.
 
-## WORKFLOWS
+## 1. PRE-ORIENT — never start cold
 
-**Session Start**: `trust_selftest` → `recovery_playbook` if trust is not full \
-or retrieval looks blocked → `ingest` if needed → `seek`/`audit`. Use `session_handshake` \
-for cheaper host-surface classification and `doctor` when the playbook asks for \
-deeper diagnosis of a degraded host surface, empty graph, or stale-looking binding. \
-This gives you codebase-aware context.
+Call `north(task)` FIRST, before reading or editing anything. One round-trip returns: \
+binding trust (`trust_mode`; the repair travels with it when degraded), task context \
+(focus nodes + PageRank anchors), prior cross-session memory (each claim with its real \
+age + author — absent, never faked, when unknown), a sufficiency signal, one \
+`next_move`, and `honest_gaps` (what m1nd does NOT yet know). If it returns \
+`needs_ingest` (empty/unbound graph), `ingest` the repo, then `north` again. `north` \
+composes trust_selftest + orient + boot_memory + focus — reach for the pieces directly \
+only when you need just one.
 
-**Research**: `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → \
-`learn(feedback)` → `memorize` any durable finding. Use `seek` for keyword search, \
-`scan` for broad discovery, `trace` for dependency chains, `timeline` for temporal ordering.
+## 2. ACT ON VERDICTS — trust the calibration, don't override it
 
-**Code Change**: `impact(node)` (blast radius) → `predict(node)` (co-change likelihood; \
-run `ghost_edges` first to load the git co-change matrix, else predict has only \
-structural fallback) → `counterfactual(nodes)` (simulate removal) → \
-`warmup(task_description)` (prime graph) → `memorize` the decision and why (with \
-`evidence` paths). Use `differential` to compare two subgraphs. `hypothesize` to test what-ifs.
+Retrieval and prediction return a calibrated verdict; obey it:
+- **`act` / `reverify` / `abstain`** — `abstain` means uncalibrated or insufficient \
+evidence: do NOT guess past it. The gate is armed per-repo by running \
+`calibrate_predict` ONCE; until then verdicts cap at `reverify`, never `act`.
+- **`why` answers carry a `closure` verdict** — `blocked` means the path rests on an \
+unresolved (guessed/dropped) edge: verify that edge before you rely on the path.
+- **`seek` carries a `trust_envelope` + a sufficiency stop-signal** — `sufficient` \
+means stop gathering; `gathering`/`saturated` mean widen or refine.
+- **`trust_band: insufficient_evidence` means NO evidence — not medium risk.** \
+It is the honest cold-start answer, distinct from low/medium/high risk.
 
-**Deep Analysis**: `fingerprint(nodes)` for duplicate/equivalence detection. \
-`diverge(baseline)` detects structural drift between a baseline (ISO date, git ref, or \
-last_session) and the current graph. `federate` to query across graph namespaces.
+## 3. POST-CAPTURE — leave the graph warmer than you found it
 
-**Memory (compounding, cross-session)**: when you conclude something durable — a \
-decision, a verified finding, an undecided design point, why code is the way it is — \
-persist it with `memorize`. Pass structured claims with `confidence` and, crucially, \
-`evidence` paths to the code that backs each claim. `memorize` writes a graph-native \
-`.light.md`, ingests it, and anchors every evidence path to the real code node, so the \
-knowledge lives in the same activation space as code and surfaces in `seek`/`activate`. \
-It auto-loads on every future session start (reported in `session_handshake.agent_memory`). \
-Later, `cross_verify(check:[\"evidence_freshness\"])` flags any claim whose cited code has \
-changed — so the memory tells you when it has gone stale instead of misleading you. \
-Closing a mission? Pass `write_light_memory:true` to `mission_close` to persist its \
-verified claims the same way in one step.
+Before ending, `memorize` every durable finding (a decision, a verified fact, why code \
+is the way it is, an open design point). Pass structured claims with `confidence` and — \
+crucially — repo-relative `evidence` paths to the code that backs each claim. `memorize` \
+anchors each path to the real code node, so the knowledge lives in the same activation \
+space as code, surfaces in later `seek`/`north`, and self-flags as stale via \
+`cross_verify(check:[\"evidence_freshness\"])` when that code changes. Closing a mission? \
+Pass `write_light_memory:true` to `mission_close` to persist its verified claims in one \
+step. This is how knowledge compounds instead of being lost between sessions.
 
-## PERSPECTIVE SYSTEM (stateful navigation)
+Then leave ONE field-telemetry signal and keep working (report, never detour): when a \
+retrieval was right or wrong, `learn(correct|wrong|partial)`; when m1nd ITSELF misbehaves \
+(a bug, friction, or an honesty miss — it claimed fresh/closed/act and was wrong), append \
+one JSON line to `~/.m1nd/field-reports.jsonl` \
+(`{ts,agent,repo,tool,class:\"bug|honesty|friction|win\",what,expected,snippet}`) — \
+local-only, it never phones home.
 
-Perspectives are named, agent-scoped navigation sessions through the graph. \
-Flow: `perspective_start(name, seed_nodes)` → `perspective_follow(node)` (move focus) → \
-`perspective_branch(name)` (fork exploration) → `perspective_back` (undo last move) → \
-`perspective_close`. Use `perspective_inspect` to see current state, `perspective_peek` \
-to look at a node without moving, `perspective_list` for all open perspectives, \
-`perspective_compare` to diff two perspectives, `perspective_suggest` for next-step \
-recommendations, `perspective_routes` for paths between nodes, `perspective_affinity` \
-for related-node scoring.
+## SECONDARY VERBS (one line each)
 
-## CONCURRENCY & STATE
-
-`lock_create` / `lock_release` — advisory locks for multi-agent coordination on graph \
-regions. `lock_watch` monitors lock state. `lock_diff` shows changes within a lock scope. \
-`lock_rebase` replays external changes into a locked region. \
-`trail_save` / `trail_list` / `trail_resume` / `trail_merge` — persist and restore \
-exploration trails across sessions. `validate_plan` checks a proposed multi-step plan \
-for structural soundness.
-
-## CRITICAL PATTERNS
-
-1. **Always call `learn` after using `activate` results.** Feedback (correct/wrong/partial) \
-trains the graph weights via Hebbian learning. Skipping this degrades future queries.
-2. **Use `ingest` at session start** if the graph has zero nodes or the codebase changed.
-3. **Use `drift` to recover context** between sessions — it shows weight changes since \
-a baseline timestamp.
-4. **`warmup` before focused work** — primes activation patterns for a specific task, \
-making subsequent queries faster and more relevant.
-5. **Never call `activate` without `agent_id`** — multi-agent isolation depends on it.
-6. **Prefer `impact` over `activate` for code changes** — impact gives directional \
-blast-radius analysis; activate gives associative exploration.
-7. **Graph persists automatically** every 50 queries and on shutdown. Use `trail_save` \
-for explicit exploration checkpoints.
-8. **Use `boot_memory` for small canonical doctrine/state** that should persist quickly \
-and stay hot in runtime memory without polluting trails or transcripts.
-9. **If `tools/list` is missing recovery tools such as `ingest`, call `doctor` with \
-`observed_tool=\"tools/list\"`, `observed_tool_count`, `available_tools`, and \
-`missing_tools`. Treat the host surface as degraded until it is rebound; use direct \
-repo reads for final truth when m1nd cannot re-ingest from the current session.**
-10. **Persist durable conclusions with `memorize`** (or `mission_close write_light_memory:true`) \
-before ending work or a mission. Knowledge with `evidence` paths anchors to code, auto-loads \
-next session, and self-flags as stale via `cross_verify(check:[\"evidence_freshness\"])` when \
-that code changes. This is how findings compound across sessions instead of being lost.
+- `seek(query)` / `focus(task)` — budgeted retrieval; carry the trust + sufficiency signals above.
+- `impact(node)` — directional blast radius before a change; `why(a,b)` — the load-bearing path between two nodes.
+- `trust_selftest` / `recovery_playbook` — run when trust looks off or retrieval is blocked; `doctor` for deeper host-surface/graph diagnosis.
+- `am_i_stale(claim)` — check BEFORE editing on the strength of remembered/cached knowledge.
+- `coverage_session` — surface the blind spots in what you have and haven't looked at this session.
+- `ingest` — (re)load the repo when the graph is empty or the code changed under you.
 ";
 
 /// Stdio MCP framing mode auto-detected on the inbound stream. The matching
@@ -5282,11 +5255,44 @@ mod tests {
     }
 
     #[test]
-    fn server_instructions_document_the_memory_habit() {
+    fn server_instructions_document_the_agent_native_loop() {
         // Host-agnostic contract: every MCP host injects M1ND_INSTRUCTIONS, so the
-        // memory-authoring habit must be documented here (not in a host-specific skill).
+        // OMEGA operating loop must be documented here (not in a host-specific skill).
+        // The doctrine is: pre-orient (north-first) -> act on calibrated verdicts ->
+        // post-capture (memorize with evidence). Guard every load-bearing beat.
         let s = super::M1ND_INSTRUCTIONS;
+        assert!(
+            s.contains("agent_id"),
+            "instructions must state the agent_id requirement"
+        );
+        // 1. PRE-ORIENT: north is called first and needs_ingest is the honest empty-graph answer.
+        assert!(
+            s.contains("north"),
+            "instructions must lead with north (pre-orient)"
+        );
+        assert!(
+            s.contains("needs_ingest"),
+            "instructions must document the needs_ingest -> ingest -> re-north path"
+        );
+        // 2. ACT ON VERDICTS: the calibrated gate and its honest answers.
+        assert!(
+            s.contains("abstain"),
+            "instructions must document the act/reverify/abstain verdict"
+        );
+        assert!(
+            s.contains("calibrate_predict"),
+            "instructions must document arming the gate with calibrate_predict"
+        );
+        assert!(
+            s.contains("insufficient_evidence"),
+            "instructions must distinguish insufficient_evidence from a risk band"
+        );
+        // 3. POST-CAPTURE: the compounding memory habit with staleness self-flagging.
         assert!(s.contains("memorize"), "instructions must mention memorize");
+        assert!(
+            s.contains("evidence"),
+            "instructions must require evidence paths on memorized claims"
+        );
         assert!(
             s.contains("evidence_freshness"),
             "instructions must mention the staleness check"
@@ -5294,6 +5300,12 @@ mod tests {
         assert!(
             s.contains("write_light_memory"),
             "instructions must mention the mission_close memory option"
+        );
+        // Field telemetry: every agent is a sensor — learn on retrieval verdicts,
+        // local-only field-reports.jsonl when m1nd itself misbehaves (report, never detour).
+        assert!(
+            s.contains("learn") && s.contains("field-reports.jsonl"),
+            "instructions must document the field-telemetry loop (learn + local field-reports)"
         );
     }
 


### PR DESCRIPTION
Rewrites the MCP `initialize` instructions string (returned to every host) from a flat tool catalogue into the **agent-native OMEGA operating loop**.

## The loop it now teaches
1. **PRE-ORIENT** — `north(task)` FIRST, never start cold. One round-trip: binding trust, task context (focus + PageRank anchors), prior cross-session memory (real age + author, absent-not-faked), sufficiency signal, one `next_move`, `honest_gaps`. `needs_ingest` → ingest → re-north. `north` composes trust_selftest + orient + boot_memory + focus.
2. **ACT ON VERDICTS** — obey the calibration: `act`/`reverify`/`abstain` (arm once with `calibrate_predict`; caps at reverify until then), `why`'s `closure` (`blocked` = unresolved edge), `seek`'s `trust_envelope` + sufficiency stop-signal, `trust_band: insufficient_evidence` = NO evidence (not medium risk).
3. **POST-CAPTURE** — `memorize` durable findings with repo-relative `evidence`; self-flags stale via `cross_verify(evidence_freshness)`. Then one field-telemetry signal: `learn` on retrieval verdicts; local-only `~/.m1nd/field-reports.jsonl` when m1nd itself misbehaves — report, never detour.

Leads with the loop, calibrated-trust framing up top, `agent_id` stated once, secondary verbs one line each, shorter than the original. Every referenced verb verified against the live dispatcher (no roadmap-only tools like `stop_gate`). The `M1ND_INSTRUCTIONS` test now asserts the agent-native beats.

**Gate (local, this branch):** fmt --check clean · clippy --workspace --all-targets -D warnings = 0 · cargo test --workspace = 0 failed · battery m1nd suite 36/36.