### PR TITLE
release: v1.2.0 — the first OMEGA-era release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "axum",
  "clap",

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Plus an **attention runtime** — `focus` hands the agent the minimal, budget-bo
   <img src=".github/m1nd-agent-first-map-v2.jpeg" alt="Traditional agent loop vs m1nd-grounded loop" width="960" />
 </p>
 
+## New in 1.2.0 — the first OMEGA-era release
+
+1.2.0 turns the loop from "retrieve, then hope" into **pre-orient → act on calibrated verdicts → capture what you learned**. The theme is the same as the trust layer: an honest *no* beats a confident guess.
+
+- **`north(task)` — pre-orient in one call.** The new front door composes trust, task context (focus nodes + PageRank anchors), prior cross-session memory, a sufficiency signal, one `next_move`, and `honest_gaps` (what m1nd does *not* yet know). `needs_ingest` is a real answer for an empty graph.
+- **Conformal calibration on prediction.** `calibrate_predict` arms a per-repo gate; verdicts then read `act` / `reverify` / `abstain`, where `abstain` means *uncalibrated or insufficient* — a signal to stop, not a weak yes. Ships dark: until you calibrate, verdicts cap at `reverify`.
+- **`trust_envelope` on `seek`** (ships dark) and a **`closure` verdict on `why`** — `blocked` means the path rests on an unresolved/guessed edge. **`trust_band: insufficient_evidence`** is now distinct from a risk band: it means *no evidence*, the honest cold-start answer, not "medium risk".
+- **Memory grew a provenance spine** — claims carry real age + author, supersede older claims, age out, and respect a recency cap, so remembered knowledge states its own freshness instead of quietly going stale.
+- **Smoothed-Jaccard co-change** — `ghost_edges` / `predict` now normalize coupling instead of counting raw co-commits (calibration-proven +3 points over raw counts).
+- **Binary version + sha fingerprint** — `--version` prints `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) let a host detect and refuse a drifted binary.
+- **Agent-native MCP instructions + local-only field reports.** The `initialize` instructions every host receives now *are* the operating loop above. Agents can leave one telemetry signal per session — `learn` on a retrieval verdict, or a line in `~/.m1nd/field-reports.jsonl` when m1nd itself misbehaves. That file is local-only; **m1nd never phones home.**
+
 ## Quick Start
 
 The minimal happy path — install from source (always current), check health, wire your host:
@@ -240,7 +252,7 @@ Three core Rust crates plus one auxiliary bridge:
 - **`m1nd-ingest`** — extraction, routing, and graph construction adapters (code, universal docs, L1GHT).
 - **`m1nd-openclaw`** — auxiliary OpenClaw bridge (Unix-socket lane, independently versioned).
 
-Current crate versions: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` all `1.0.0`.
+Current crate versions: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` all `1.2.0` (`m1nd-openclaw` is versioned independently at `0.1.0`).
 
 <p align="center">
   <img src=".github/m1nd-architecture-overview-v2.jpeg" alt="m1nd architecture overview" width="960" />

--- a/docs/NEXTGEN-AGENT-PRD.md
+++ b/docs/NEXTGEN-AGENT-PRD.md
@@ -230,6 +230,7 @@ The durable-moats recipe is not "be best" — it is **format + narrow interface 
 - **Move 6 — Negative-Space Bug Localizer (`negative_space`).** Cross-rank `missing` ∩ `ghost_edges` ∩ `taint_trace` boundary_misses ∩ `antibody_scan` negative-edges, weighted by `tremor`.
 - **Move 7 — Reality-Weighted Blast Radius (`hot_blast`).** Re-rank `impact`/`epidemic` by `runtime_overlay` heat × `taint_trace` × `trust`. Ship the structural-only fallback first; light up runtime weighting when a span batch arrives (highest external dependency).
 - **Move 8 — Swarm Collision Forecast (`swarm_collision`).** Intersect `ghost_edges`/`predict` coupling with `perspective_list`/`trail_list` live footprints. Lands once Subsystem A's parallel-agent usage is real.
+- **`m1nd feedback` — opt-in, redacted, one-click field-report submission.** The local field-report mailbox (`~/.m1nd/field-reports.jsonl`, shipped in 1.2.0) stays local by default. This roadmap verb lets a user *choose* to file the local reports upstream as a redacted GitHub issue in one command — **never automatic, never a phone-home.** Local-first is the trust brand: the reports exist to make m1nd honest with itself first; sharing them is always the human's explicit call.
 - **Then — durability hardening (the §O.9 bets):** freeze the receipt/graph format + back-compat pledge; cut over to file-incremental re-index. At ~**v2.0** the era graduates into a separately-named product.
 
 ## O.11 Manifesto

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -2,25 +2,95 @@
 
 > Read this first. Single source of truth for any chat / subagent / parallel
 > session working on m1nd, so we don't re-derive state or contradict each other.
-> Last checkpoint: 2026-07-01 (checkpoint 7 — the MEMORY roadmap (PRD Subsystem D)
-> moves **#3-#6 all SHIPPED + orchestrator-verified** (age-staleness #198, the
-> `activate_temporal` per-type decay fix #199, supersession-on-rewrite with a per-slug
-> flock #200, recency-capped auto-load #201) — so memory moves #1-#6 are DONE; and the
-> **pre-flight A/B experiment** returned its first REAL verdict — the `north` pre-flight
-> packet (injected via a Claude Code hook into a real headless `claude -p` agent) HELPS
-> orientation (correct-file-first 3/3 vs 0/3 control) and does NOT confuse or hinder, BUT
-> compounding memory is an HONEST NULL, architecturally BLOCKED by the process-per-hook +
-> in-process-graph setup → the ambient loop's real prerequisite is `--serve`/`--attach`
-> (m1nd already has it, #157/#158), which becomes the FIRST ambient milestone before any
-> hook install (§Ω+1.3b). 11 PRs merged this session (#191-#201). Prior: checkpoint 6 —
-> OMEGA Move 1 (Trust-Gated Envelope #195) SHIPPED + verified; cross-repo stress test
-> (TS/Py/Rust) + gitignore fix #194; Ω+1 ambient-loop direction folded into the PRD.
+> Last checkpoint: 2026-07-02 (**checkpoint 8 — v1.2.0 CUT: the first OMEGA-era release**).
+> Tagged `v1.2.0`, published to crates.io + npm, GitHub Release cut, and Max's live
+> `:1338` owner upgraded to the 1.2.0 binary. The era content shipped since v1.1.0:
+> OMEGA Moves 0 (calibration) + 1 (Envelope) + the Move-2 honest reframe; `north`
+> pre-orient; memory moves #1-#6; the root-`.gitignore` fix (#194); smoothed-Jaccard
+> co-change (#206, calibration-proven **+3pts** over raw counts); binary version+sha
+> honesty (#205, `M1ND_EXPECTED_*`/`M1ND_STRICT_VERSION`); battery grown to **36/36**
+> (#204); and the **agent-native MCP `initialize` instructions** (#208) — the loop now
+> ships in the wire every host reads. This checkpoint also establishes the **UNIVERSAL
+> FIELD-TELEMETRY DOCTRINE** (see below) with **4 seeded reports awaiting first triage**.
+> Prior: checkpoint 7 — memory moves #3-#6 SHIPPED + the pre-flight A/B returned its
+> first REAL verdict (north HELPS orientation 3/3 vs 0/3; compounding memory an HONEST
+> NULL, blocked by process-per-hook → prerequisite is `--serve`/`--attach`, §Ω+1.3b).
 
 ## North Star
 m1nd = operational intelligence for coding agents. The bar: genuinely BEAT plain
 `rg`/Read in the inner loop, measured honestly — not tie, not "feels useful".
 Run a continuous, chained improvement engine: measure (battery) → fix+test the
 real defect → checkpoint → seed the next cycle. Never sugarcoat results.
+
+## Current State (2026-07-02, checkpoint 8 — v1.2.0 CUT, the first OMEGA-era release)
+
+**v1.2.0 IS RELEASED.** Tag `v1.2.0` on the merge commit, `release.yml` published
+`m1nd-core` / `m1nd-ingest` / `m1nd-mcp` to crates.io + `@maxkle1nz/m1nd` to npm (the
+v1.1.0 precedent), a GitHub Release was cut with real era notes, and Max's live `:1338`
+owner was rebuilt on the tagged binary (`--version` → `1.2.0 (<sha>)`). `m1nd-openclaw`
+stays `0.1.0` (versioned independently).
+
+**What the era shipped (v1.1.0 → v1.2.0), the honest ledger:**
+- **OMEGA Move 0 — the calibration harness (keystone).** Conformal precision-at-coverage
+  calibrator; `calibrate_predict` date-splits the repo's OWN git history; `predict` emits
+  `act | reverify | abstain`, uncalibrated ⇒ honestly `abstain`. First real number on m1nd's
+  own history: τ=0.60, coverage 14.6%, act-band precision 28.3% — the calibrator's JOB was to
+  surface that the strength model is coarse, and it did.
+- **OMEGA Move 1 — the Trust-Gated Envelope (#195).** Answer + map + trust verdict composed
+  from `trust_selftest` × `cross_verify` × `am_i_stale` × `why`-closure × `mission_verify`.
+- **OMEGA Move 2 — the HONEST REFRAME (#203).** The token-economics claim was DROPPED (m1nd
+  has no token ledger and cannot source consumption); `stop_gate` stays **roadmap-only** — it
+  is NOT referenced by the shipped instructions.
+- **`north` pre-orient.** The composing front door (trust + focus/anchors + prior memory +
+  sufficiency + one `next_move` + `honest_gaps`; `needs_ingest` is a real answer).
+- **Memory moves #1-#6 DONE** — `Created`/`Source-Agent` provenance, authored-age + source on
+  recall, `aged_out` age-staleness (#198), `activate_temporal` per-type decay fix (#199),
+  supersession-on-rewrite + per-slug flock (#200), recency-capped auto-load (#201).
+- **Root-`.gitignore` directory-entry fix (#194)** — ingest now honours root `.gitignore`
+  directory entries (folded in with the cross-repo stress test).
+- **Smoothed-Jaccard co-change (#206)** — `ghost_edges`/`predict` normalize coupling instead
+  of raw co-commit counts; **calibration-proven +3 points** over raw.
+- **Binary version-honesty (#205)** — `--version` = `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION`/
+  `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) detect and (strict) refuse a drifted binary.
+- **Battery grown to 36/36 (#204)** — the OMEGA/memory surface (closure, trust_band,
+  calibration, envelope, north, provenance/supersession/aged_out) is now covered; the m1nd
+  suite passes 36/36 on the release binary.
+- **Agent-native MCP `initialize` instructions (#208)** — the `M1ND_INSTRUCTIONS` string every
+  host receives is now the operating loop itself: **pre-orient (`north`-first) → act on
+  calibrated verdicts → post-capture (`memorize` + one field-telemetry signal)**. Every
+  referenced verb was verified against the live dispatcher; roadmap-only `stop_gate` is NOT
+  referenced. Replaces the old flat WORKFLOWS catalogue.
+
+### THE UNIVERSAL FIELD-TELEMETRY DOCTRINE (new this checkpoint)
+**Every agent, every repo, is a sensor.** When m1nd misbehaves during ANY mission — even on
+another repo — the agent REPORTS, it does not fix: append **one JSON line** to the single
+machine-global mailbox `~/.m1nd/field-reports.jsonl`
+(`{ts,agent,repo,tool,class:"bug|honesty|friction|win",what,expected,snippet}`) and keep
+working. **Report-never-fix mid-mission** is the rule — never detour into m1nd surgery while
+on task; note the workaround, report, move on. The **`honesty` class is the most valuable**:
+it is calibration ground truth (m1nd overclaimed — said fresh/closed/act and was wrong). When
+retrieval was simply right/wrong, prefer the built-in `learn` verb (correct/wrong/partial).
+**Triage closes the loop: every m1nd improvement session STARTS by sweeping the mailbox
+(+ `seek` for field memories); a confirmed field bug becomes a battery case/test BEFORE the
+fix.** The mailbox is **local-only — m1nd never phones home**; the roadmap `m1nd feedback`
+verb (opt-in, redacted, one-click GitHub issue) is the ONLY path upstream, and always the
+human's explicit call.
+
+**4 seeded reports awaiting first triage** (the next improvement session sweeps these first):
+1. **closure cry-wolf** — `why`-closure over-reports `blocked` on paths that are actually fine
+   (honesty class; the calibration-ground-truth kind).
+2. **`memorize` unanchored on a live runtime** — evidence paths didn't anchor to code nodes
+   against the running owner (friction/bug on the live `:1338` runtime).
+3. **the `temp` artifact bug** — a stray `temp` file dropped in cwd by a battery/tool path
+   (bug; the battery already `rm -f temp`s around it, but the source drop is unfixed).
+4. **stale instructions = FIXED** — the old flat WORKFLOWS instructions string; closed by #208
+   this checkpoint (kept as a `win`/closed marker for the triage sweep).
+
+### Runtime carry-over (post-upgrade honesty)
+Max's live owner was upgraded to the 1.2.0 binary, so **any calibration rows scaled against the
+OLD binary are now stale — re-run `calibrate_predict` once per ingested repo** on the live
+runtime to refresh them (done at upgrade if the graph had an ingested repo; noted honestly if
+the graph was empty).
 
 ## Current State (2026-07-01, checkpoint 7 — memory roadmap #3-#6 shipped + the pre-flight A/B returned its first real verdict)
 - **MEMORY roadmap (PRD Subsystem D) — moves #3-#6 ALL SHIPPED + orchestrator-verified;
@@ -93,11 +163,11 @@ real defect → checkpoint → seed the next cycle. Never sugarcoat results.
   meaning "lose a feature" and starts meaning **"lose institutional memory."** Four critic
   corrections are BAKED IN (see Known Problems) — the doc models the honesty moat, does not
   present the design as flawless.
-- **v1.1.0 is the released base.** main carries 1.1.0 (core/ingest/mcp + npm;
-  openclaw stays 0.1.0); the tag + crates.io/npm publish landed at checkpoint 3.
-  Everything below this is on top of v1.1.0 on main, UNRELEASED on crates/npm
-  (no new tag — these merges are docs/feat, no version bump). **v1.2.0 = Move 0
-  (calibration) + Move 1 (Envelope) — BOTH DONE as of checkpoint 6.**
+- **v1.1.0 WAS the released base (superseded by checkpoint 8 → v1.2.0 is now
+  released).** At checkpoint 7 main carried 1.1.0 (core/ingest/mcp + npm; openclaw
+  0.1.0), with the OMEGA/memory era UNRELEASED on top. **Checkpoint 8 cut v1.2.0** —
+  the tag + crates.io/npm publish + GitHub Release landed; see the checkpoint-8 Current
+  State above. **v1.2.0 = Move 0 (calibration) + Move 1 (Envelope) + the era ledger.**
 - **m1nd-OMEGA is now the BANNER for the v1.2 → v2.0 era (PR #191, `docs`).**
   `docs/NEXTGEN-AGENT-PRD.md` §O.1–O.11 frames the vision: a **verifiable trust
   substrate** where every answer ships as a triple — **answer + map + trust verdict**
@@ -177,8 +247,9 @@ battery gate; orchestrate + verify. Update this file at big checkpoints.
 - Battery harness: `scratchpad/m1nd_battery.py` — **now TRACKED in-repo** (#183;
   protected by the `.gitignore` negation `!scratchpad/m1nd_battery.py` at line 52, so
   it survives scratchpad clears). Fresh ingest + ground-truth PASS/FAIL + `rg`
-  head-to-head; 34 cases (28 m1nd + 6 ts), m1nd suite green at 28/28. Probes:
-  `impact_probe.py`, `edge_proof.py`. Reports: `M1ND_BATTERY_REPORT.md`, `battery_FINAL.txt`.
+  head-to-head; the m1nd suite is now **36 cases, green at 36/36** on the release binary
+  (grown to cover the OMEGA/memory surface, #204). Probes: `impact_probe.py`, `edge_proof.py`.
+  Reports: `M1ND_BATTERY_REPORT.md`, `battery_FINAL.txt`.
 - MCP stdio client pattern: `scratchpad/focus_smoke.py` (Content-Length JSON-RPC).
 - Build: `cargo build -p m1nd-mcp --bin m1nd-mcp` → `./target/debug/m1nd-mcp`.
 - 360 vision: `docs/X360-RUNTIME-PRD.md`. Focus runtime: `docs/FOCUS-RUNTIME-PRD.md`.
@@ -186,11 +257,27 @@ battery gate; orchestrate + verify. Update this file at big checkpoints.
   account silently flips to `velvetside` mid-session → `gh pr create` fails with
   "must be a collaborator". Run `gh auth switch --user maxkle1nz` before EVERY
   push/PR.**
-- Battery is now 28 cases (JSON key `records`, each row has `m1nd_pass`); per-case
-  `check=lambda res,q,c:` hook + `has_direct_calls_edge` helper enable structural
-  cross-file assertions via the live client.
+- Battery is now 36 cases (JSON key `records`, each row has `m1nd_pass`; summary carries
+  `m1nd_pass`/`m1nd_pass_rate`); per-case `check=lambda res,q,c:` hook + `has_direct_calls_edge`
+  helper enable structural cross-file assertions via the live client.
 
 ## Known Problems
+- **Checkpoint-8 carry-over (open into the v1.2.x cycle — sweep the field-report mailbox
+  first, then these):**
+  - **`why`-closure CRY-WOLF (seeded field report #1, honesty class).** Closure over-reports
+    `blocked` on paths that are actually fine — an honesty miss (m1nd says the path rests on an
+    unresolved edge when it doesn't). Highest-value to fix: it is calibration ground truth.
+    Next session turns this into a battery case BEFORE the fix.
+  - **`memorize` unanchored on the live runtime (seeded field report #2).** Evidence paths
+    didn't anchor to code nodes against the running `:1338` owner — friction/bug on the live
+    runtime specifically. Reproduce against a served-attach graph, then fix.
+  - **the `temp` artifact drop (seeded field report #3).** A stray `temp` file lands in cwd via
+    a battery/tool path; the battery works around it (`rm -f temp`) but the SOURCE drop is
+    unfixed. Trace which tool writes `temp` and stop it at source.
+  - **Memory roadmap remainder: #7 reinforce-on-use BLOCKED, #8 daemon reflect/consolidate
+    PENDING.** #7 needs a `last_used`/`memory_used` signal that does not yet exist (a design
+    decision — feedback verb on recall? auto-stamp on `activate` touch?); #8 is the largest and
+    leans on #7. Both carry forward unchanged.
 - **Ω+1 ambient-loop OPEN RISKS (the four critic corrections, baked into the PRD § Ω+1.3
   — this design is NOT shipped, it is a direction awaiting Max's green-light on hook
   install).**

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -41,7 +41,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.1.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.2.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -18,8 +18,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.1.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.1.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.2.0" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.2.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts **v1.2.0**, the first release of the OMEGA era. Bumps `m1nd-core` / `m1nd-ingest` / `m1nd-mcp` 1.1.0 → 1.2.0 (inter-crate refs + `Cargo.lock`) and the `@maxkle1nz/m1nd` npm package. `m1nd-openclaw` stays `0.1.0` (independent).

## The era since v1.1.0
- **OMEGA Move 0** — conformal calibration harness; `predict` verdicts read `act`/`reverify`/`abstain` (uncalibrated ⇒ honest `abstain`). **Move 1** — the Trust-Gated Envelope (answer + map + trust). **Move 2** — honest reframe (token-economics lie dropped; `stop_gate` stays roadmap-only, unreferenced by the shipped instructions).
- **`north` pre-orient** — trust + focus/anchors + prior memory + sufficiency + one `next_move` + `honest_gaps`.
- **Memory moves #1-#6** — `Created`/`Source-Agent` provenance, `aged_out` age-staleness, supersession-on-rewrite + per-slug flock, recency-capped auto-load.
- **Root `.gitignore` directory-entry fix** (#194).
- **Smoothed-Jaccard co-change** (#206) — calibration-proven **+3pts** over raw counts.
- **Binary version+sha fingerprint** (#205) — `M1ND_EXPECTED_*` / `M1ND_STRICT_VERSION`.
- **Battery grown to 36/36** over the OMEGA/memory surface (#204).
- **Agent-native MCP `initialize` instructions** (#208) — the operating loop ships in the wire every host reads.

## Docs (doc gate)
- **README** — "New in 1.2.0" section + version corrected to 1.2.0 (was stale at 1.0.0).
- **NEXTGEN-AGENT-PRD** — one roadmap bullet: `m1nd feedback` (opt-in, redacted, one-click GitHub issue; **never automatic** — local-first is the trust brand).
- **PATHOS checkpoint 8** — the era ledger, the **universal field-telemetry doctrine** (every agent a sensor; report-never-fix mid-mission; single machine-global mailbox `~/.m1nd/field-reports.jsonl`; honesty-class = calibration ground truth; every m1nd session STARTS by sweeping the mailbox → confirmed field bug becomes a battery case BEFORE the fix), 4 seeded reports awaiting first triage, runtime-upgrade carry-over, and the carried-over Known Problems.

## Gate (local, this branch)
`cargo fmt --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` = **0** · `cargo test --workspace` = **0 failed** · battery m1nd suite **36/36** on the release binary (`--version` → `1.2.0`).

After merge: tag `v1.2.0` on the merge commit → `release.yml` publishes crates.io + npm (the v1.1.0 precedent).