### PR TITLE
fix(north): compose L1GHT agent-memory recall into the north packet (field-triage #1)

### DIFF
--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -2945,13 +2945,17 @@ fn handle_north(
         .cloned()
         .filter(|v| !v.is_null());
 
-    // 2. MEMORY — durable KV recall via boot_memory (action=list). Each entry
-    //    carries a REAL age (now − updated_at_ms) and its authoring agent. If a
-    //    timestamp is ever absent, the age is ABSENT (honest "unknown"), never
-    //    faked to "now" — the same rule seek's recall provenance follows.
+    // 2. MEMORY — durable cross-session recall from BOTH memory systems, merged:
+    //    (a) boot_memory KV (action=list), and (b) L1GHT agent-memory written by
+    //    `memorize` (the primary memory system). Each entry carries a REAL age and
+    //    its authoring agent when known. If a timestamp is ever absent, the age is
+    //    ABSENT (honest "unknown"), never faked to "now" — the same rule seek's
+    //    recall provenance follows. The two feeds are concatenated so a cold agent
+    //    sees the durable KV facts AND the memorized L1GHT claims for its task.
     let now = now_ms();
     let stale_after_ms: u64 = 30 * 24 * 60 * 60 * 1000; // 30 days
-    let memory: Vec<serde_json::Value> = {
+                                                        // (a) boot_memory KV entries.
+    let boot_entries: Vec<serde_json::Value> = {
         let list = crate::boot_memory_handlers::handle_boot_memory(
             state,
             crate::boot_memory_handlers::BootMemoryInput {
@@ -2977,6 +2981,7 @@ fn handle_north(
                             .map(|ts| now.saturating_sub(ts));
                         let stale = age_ms.map(|age| age > stale_after_ms);
                         let mut obj = serde_json::Map::new();
+                        obj.insert("kind".into(), serde_json::json!("boot_memory"));
                         obj.insert(
                             "claim".into(),
                             entry.get("key").cloned().unwrap_or(serde_json::Value::Null),
@@ -3011,6 +3016,94 @@ fn handle_north(
             })
             .unwrap_or_default()
     };
+
+    // (b) L1GHT agent-memory recall — the fix. `memorize` (the primary memory
+    //     system) writes graph-native `.light.md` claims that the runtime auto-loads
+    //     and that `seek` already surfaces WITH provenance (`source_agent`,
+    //     `authored_ms_ago` — stamped only on `.light.md` hits, never on code nodes).
+    //     Compose that recall INTO the packet so a memorized-at-close claim compounds
+    //     into the next agent's north. We reuse `seek` wholesale (no new retrieval),
+    //     scoped to the task, and keep only the memory hits — a seek result is a
+    //     L1GHT memory iff it carries light provenance (source_agent or authored age).
+    //     Judgment call (stated in the PR): when the task-scoped seek surfaces no
+    //     memory hit, we fall back to a broad recall so a cold agent still sees that
+    //     institutional memory EXISTS, rather than implying there is none.
+    let light_limit = 5usize;
+    let is_light_hit = |r: &layers::SeekResultEntry| -> bool {
+        r.source_agent.is_some() || r.authored_ms_ago.is_some()
+    };
+    let map_light = |r: &layers::SeekResultEntry| -> serde_json::Value {
+        // age_ms is the authored age seek already computed (now − Created); absent
+        // stays absent — never fabricated. staleness uses the same 30-day rule.
+        let age_ms = r.authored_ms_ago;
+        let stale = age_ms.map(|age| age > stale_after_ms);
+        let mut obj = serde_json::Map::new();
+        obj.insert("kind".into(), serde_json::json!("light"));
+        obj.insert("claim".into(), serde_json::json!(r.label));
+        if let Some(age) = age_ms {
+            obj.insert("age_ms".into(), serde_json::json!(age));
+        }
+        obj.insert(
+            "source_agent".into(),
+            r.source_agent
+                .clone()
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+        );
+        if let Some(stale) = stale {
+            obj.insert("stale".into(), serde_json::json!(stale));
+        }
+        obj.insert("node_id".into(), serde_json::json!(r.node_id));
+        serde_json::Value::Object(obj)
+    };
+    let light_entries: Vec<serde_json::Value> = if graph_populated {
+        let mut seek_light = |query: &str, k: usize| -> Vec<layers::SeekResultEntry> {
+            layer_handlers::handle_seek(
+                state,
+                layers::SeekInput {
+                    query: query.to_string(),
+                    agent_id: agent_id.clone(),
+                    top_k: k,
+                    scope: scope.clone(),
+                    node_types: Vec::new(),
+                    min_score: 0.1,
+                    graph_rerank: true,
+                    conformance_aware: true,
+                    token_budget: None,
+                },
+            )
+            .map(|o| o.results.into_iter().filter(|r| is_light_hit(r)).collect())
+            .unwrap_or_default()
+        };
+        // Task-scoped recall first: the memories most relevant to what the agent is
+        // about to do. Ask for a wider top_k since light nodes compete with code.
+        let mut hits = seek_light(&task, 24);
+        if hits.is_empty() {
+            // No task-relevant memory surfaced — fall back to a broad memory recall so
+            // a cold agent still sees that institutional memory EXISTS (honest: this is
+            // "memory exists, not necessarily about your task", surfaced most-recent).
+            hits = seek_light("memory decision finding note claim", 24);
+            // Prefer the freshest few when the recall is not task-scoped.
+            hits.sort_by_key(|r| r.authored_ms_ago);
+        }
+        // De-dup by node_id (a memory can surface under both label and evidence path)
+        // and cap at light_limit.
+        let mut seen = std::collections::HashSet::new();
+        hits.into_iter()
+            .filter(|r| seen.insert(r.node_id.clone()))
+            .take(light_limit)
+            .map(|r| map_light(&r))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // Merge both feeds: durable KV facts first, then the memorized L1GHT claims.
+    let memory: Vec<serde_json::Value> = boot_entries
+        .iter()
+        .cloned()
+        .chain(light_entries.iter().cloned())
+        .collect();
 
     // Honest gaps — what m1nd does NOT yet know for this task. A pre-orient MUST
     // say what it can't see rather than imply omniscience.
@@ -3105,7 +3198,13 @@ fn handle_north(
     }
     if memory.is_empty() {
         honest_gaps.push(
-            "No durable boot memory yet — there are no prior cross-session claims to carry.".into(),
+            "No durable memory yet — neither boot_memory nor L1GHT agent-memory holds a prior cross-session claim to carry.".into(),
+        );
+    } else if light_entries.is_empty() && graph_populated {
+        // Boot KV facts exist but no memorized L1GHT claim surfaced — say so, so the
+        // agent knows the primary (memorize) memory had nothing to add for this task.
+        honest_gaps.push(
+            "No L1GHT agent-memory claim surfaced for this task — only durable boot_memory facts are carried; `memorize` findings, if any, did not match.".into(),
         );
     }
 
@@ -7276,6 +7375,92 @@ mod tests {
             "a fresh memory must not be flagged stale"
         );
         assert_eq!(entry["tags"], serde_json::json!(["lease", "doctrine"]));
+    }
+
+    /// Field-triage #1: north must COMPOSE L1GHT agent-memory (written by
+    /// `memorize`, the primary memory system) into its `memory` block — not only
+    /// boot_memory. We plant a `.light.md` with the exact frontmatter the memorize
+    /// writer stamps, ingest it (light adapter) into the same graph, then call north
+    /// with a task matching that memory. The memorized claim must surface in
+    /// `packet.memory` tagged `kind:"light"`, carrying its `source_agent` and a
+    /// concrete authored `age_ms` (both lifted from seek's light provenance).
+    #[test]
+    fn north_composes_light_memory_recall() {
+        let (temp, mut state) = build_state_populated(false);
+
+        // A memorized claim about lease leadership, authored just now by agent-mem,
+        // with the frontmatter shape `memorize` renders (Created + Source-Agent).
+        let now_ms = super::now_ms();
+        let mem_dir = temp.path().join("light-mem");
+        std::fs::create_dir_all(&mem_dir).expect("light mem dir");
+        let md = format!(
+            "---\nProtocol: L1GHT/1.0\nNode: LeaseLeadership\nState: verified\n\
+             Created: {now_ms}\nSource-Agent: agent-mem\n---\n\n\
+             # LeaseLeadership\n\n## LeaseLeadership\n\n\
+             The lease leadership handoff must renew the registry lease before takeover.\n\n\
+             [⍂ entity: lease enforcement leadership handoff]\n[𝔻 confidence: 0.9]\n"
+        );
+        std::fs::write(mem_dir.join("lease_leadership.light.md"), md).expect("write memory");
+
+        // Merge the light memory INTO the populated code graph (adapter=light).
+        super::dispatch_tool(
+            &mut state,
+            "ingest",
+            &serde_json::json!({
+                "agent_id": "agent-mem",
+                "path": mem_dir.to_string_lossy(),
+                "adapter": "light",
+                "mode": "merge",
+                "namespace": "light",
+            }),
+        )
+        .expect("ingest light memory");
+
+        let out = super::dispatch_tool(
+            &mut state,
+            "north",
+            &serde_json::json!({
+                "agent_id": "northerner",
+                "task": "lease enforcement leadership handoff",
+            }),
+        )
+        .expect("north with a memorized L1GHT claim present");
+
+        let memory = out["memory"].as_array().expect("memory array");
+        let light: Vec<&serde_json::Value> = memory
+            .iter()
+            .filter(|e| e.get("kind").and_then(|k| k.as_str()) == Some("light"))
+            .collect();
+        assert!(
+            !light.is_empty(),
+            "north.memory must compose at least one L1GHT claim, got {memory:?}"
+        );
+        // The memorized claim's provenance is carried honestly.
+        let hit = light
+            .iter()
+            .find(|e| {
+                e["source_agent"].as_str() == Some("agent-mem")
+                    || e["claim"]
+                        .as_str()
+                        .map(|c| c.to_lowercase().contains("lease"))
+                        .unwrap_or(false)
+            })
+            .unwrap_or(&light[0]);
+        assert_eq!(
+            hit["source_agent"], "agent-mem",
+            "the memorized claim carries its authoring agent as source_agent"
+        );
+        let age = hit["age_ms"]
+            .as_u64()
+            .expect("age_ms present — the light hit carries an authored age");
+        assert!(
+            age < 60_000,
+            "a just-authored memory should have a small age, got {age}ms"
+        );
+        assert_eq!(
+            hit["stale"], false,
+            "a fresh memory must not be flagged stale"
+        );
     }
 
     /// REAL PROBE: load the repo's actual graph_snapshot.json (~5540 nodes) and

--- a/scratchpad/m1nd_battery.py
+++ b/scratchpad/m1nd_battery.py
@@ -355,6 +355,62 @@ def aged_out_after_planting(c):
                   f"age_ms present; stale_evidence_count={cv.get('stale_evidence_count')}")
 
 
+def north_recalls_memorized_claim(c):
+    """north must COMPOSE prior L1GHT agent-memory (written by `memorize`, the PRIMARY
+    memory system) into its `memory` block — not just the boot_memory KV store.
+
+    Field-triage #1 (the reproduced bug): `north`'s memory beat read ONLY boot_memory,
+    so a memorized claim never surfaced in `packet.memory` — memorize-at-close did NOT
+    compound into the next agent's north. This drives the whole sequence via the live
+    client:
+
+    1. memorize a distinctive authored claim (node_label 'battery-north-recall',
+       claim label 'north-recall-canary', one evidence path).
+    2. north(agent_id, task) with a task querying that topic.
+    3. assert `packet.memory` contains the memorized claim (label/claim text present),
+       with provenance (`source_agent`) surfaced when available.
+
+    Structure-based, not exact-string-brittle: we match the canary slug/label as a
+    substring across the memory entry's fields. Returns (passed, detail).
+    """
+    import time as _t
+    slug = "battery-north-recall"
+    claim_label = "north-recall-canary"
+    claim_txt = ("The north-recall canary doctrine: north must compose L1GHT agent "
+                 "memory recall into its packet memory block.")
+    m1, _ = c.tool("memorize", dict(
+        agent_id="scout-north-recall", node_label=slug,
+        claims=[dict(label=claim_label, text=claim_txt,
+                     confidence="0.9", evidence=["m1nd-mcp/src/server.rs"])]))
+    if not m1.get("ok"):
+        return False, f"memorize of the north-recall canary did not succeed: ok={m1.get('ok')}"
+
+    _t.sleep(0.15)
+    nr, _ = c.tool("north", dict(agent_id="battery",
+                                 task="recall the north-recall canary doctrine before editing north"))
+    mem = nr.get("memory")
+    if not isinstance(mem, list):
+        return False, f"north packet memory is not a list: {type(mem).__name__}"
+    # Match the memorized claim in ANY memory entry by slug/label/claim text — a
+    # memorized L1GHT claim that surfaces proves north now composes L1GHT recall.
+    needles = (slug, claim_label, "north-recall canary", "north_recall_canary")
+    matches = []
+    for e in mem:
+        blob = json.dumps(e, default=str).lower()
+        if any(n.lower() in blob for n in needles):
+            matches.append(e)
+    if not matches:
+        labels = [str((e or {}).get("claim") or (e or {}).get("label") or "") for e in mem]
+        return False, (f"memorized L1GHT claim did NOT surface in north.memory "
+                       f"(len={len(mem)}); entries={labels}")
+    hit = matches[0]
+    prov = hit.get("source_agent")
+    prov_note = (f"source_agent={prov!r}" if prov else
+                 "source_agent absent (honest — provenance not stamped)")
+    return True, (f"north.memory carries the memorized L1GHT claim "
+                  f"({len(matches)}/{len(mem)} entr(y/ies)); {prov_note}")
+
+
 # --------------------------------------------------------------------------- #
 # Query suites (each: id, intent, tool, args, expect_symbol, rg_pattern, rg_extra) #
 # Cross-file / relationship-correctness cases also carry a `check` callable.     #
@@ -918,6 +974,20 @@ def suite_m1nd(repo):
                  and res.get("needs") is None,  # not needs_ingest — the graph is populated
                  "packet has binding.trust_mode (str), grounded context object with focus_nodes, and honest_gaps list",
              )),
+
+        # ---- north composes L1GHT agent-memory recall (field-triage #1) ----
+        # THE BUG: north's memory beat read ONLY boot_memory (KV), so a claim written
+        # by `memorize` (the PRIMARY memory system, a L1GHT node) never surfaced in
+        # packet.memory — memorize-at-close did NOT compound into the next north.
+        # The `check` memorizes a canary claim, calls north with a task querying that
+        # topic, and asserts the memorized L1GHT claim surfaces in packet.memory with
+        # provenance. RED on main (memory carried boot_memory only); GREEN after the fix.
+        dict(id="north_recalls_memorized_claim",
+             intent="north composes a memorized L1GHT claim into packet.memory (not just boot_memory KV)",
+             tool="session_handshake", args=dict(agent_id=aid),
+             expect=None, expect_file="server.rs",
+             rg_pat=r"fn handle_north", rg_extra=["-t", "rust"],
+             check=lambda res, q, c: north_recalls_memorized_claim(c)),
 
         # ---- memory provenance + supersession (#187/#189/#200) ----
         # memorize a claim -> seek returns the hit with source_agent + a fresh


### PR DESCRIPTION
## Field-triage #1 — the report (reproduced live)

> `north`'s memory beat reads ONLY `boot_memory` (KV) — an existing, ingested L1GHT memorized claim (written by `memorize`, the PRIMARY memory system) does NOT surface in `packet.memory`. The shipped doctrine/instructions promise "prior agent memory with age/author" in north — so memorize-at-close → next north currently does NOT compound.

## Root cause

`handle_north`'s memory block (server.rs) composed **only** `boot_memory` (action=list). The primary memory system — `memorize`, which writes graph-native `.light.md` claims the runtime auto-loads and `seek` already surfaces **with provenance** — was never read. So a memorized-at-close claim was invisible to the next agent's `north`.

## The fix (reuse-first, additive)

Inside `handle_north`, after the boot_memory list:
- Run a **task-scoped `seek`** (reused wholesale — no new retrieval path) and keep only the **L1GHT-memory hits**. Discriminator: a seek result is a memory iff it carries light provenance (`source_agent` or `authored_ms_ago`) — these are stamped **only** on `.light.md` hits, never on code nodes (confirmed via `impact`/`why` on `handle_north` + the seek provenance path in `layer_handlers`).
- Map the top 5 into `packet.memory` entries `{kind:"light", claim, age_ms?, source_agent?, stale?, node_id}` and **concatenate** with the boot_memory entries (now tagged `kind:"boot_memory"`). Existing fields unchanged.

### Honesty choices (stated)
- **Absent age stays absent** — `age_ms` is seek's `authored_ms_ago` verbatim; never faked to "now". `stale` uses the same 30-day rule as boot_memory and only when age is present.
- **No task-match** → a **broad fallback** recall surfaces the freshest few memories, so a cold agent still sees institutional memory **EXISTS** rather than implying there is none.
- **`honest_gaps`** now reflects BOTH systems: "No durable memory yet — neither boot_memory nor L1GHT…" when empty, and a distinct "No L1GHT agent-memory claim surfaced for this task…" when only boot facts matched.

## Red → green proof (battery, m1nd suite 36 → 37)

New case `north_recalls_memorized_claim`: `memorize` a canary claim → `north(task)` querying it → assert the claim surfaces in `packet.memory` with provenance.

- **RED on `main`:** `memorized L1GHT claim did NOT surface in north.memory (len=0); entries=[]`
- **GREEN after:** `north.memory carries the memorized L1GHT claim (3/3 entries); source_agent='scout-north-recall'`

## Gate (all green)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0
- `cargo test --workspace` — 0 failed (incl. new unit test `north_composes_light_memory_recall`; empty-graph honesty test still green)
- battery ×2 (stability): **37/37**, the prior 36 unchanged

## Grounding (m1nd-on-m1nd, isolated runtime)

`impact` on `handle_north` showed its blast radius reached `handle_boot_memory` but **not** `handle_seek` (the bug, structurally); `why handle_north → handle_seek` returned a 2-hop path via `handle_focus`, proving `seek` is already reachable — so calling it directly adds no new module dependency. Reuse-first confirmed by the graph, not just grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)