### PR TITLE
fix(mcp): temp graph sentinel resolves to a real tempdir (never litters CWD) (field-triage #2)

### DIFF
--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -92,6 +92,22 @@ fn resolve_attach_auto(cli: &Cli) -> Result<String, String> {
     Ok(url)
 }
 
+/// Resolve the graph-source path, honoring the `temp` sentinel.
+///
+/// The bare value `temp` means "ephemeral graph, I never read the snapshot
+/// back" — it is NOT a relative path. Treating it literally made
+/// `save_graph` write a multi-MB file named `temp` into the current
+/// directory (see field-triage #2). We resolve it to a per-process file
+/// under the OS temp dir so persistence keeps working without ever
+/// littering the CWD / repo root.
+fn resolve_graph_source(path: PathBuf) -> PathBuf {
+    if path.as_os_str() == "temp" {
+        std::env::temp_dir().join(format!("m1nd-graph-{}.snapshot", std::process::id()))
+    } else {
+        path
+    }
+}
+
 fn load_config_from_cli(cli: &Cli) -> McpConfig {
     // Priority: --config file > --graph/--plasticity/--domain flags > env vars > defaults
 
@@ -121,6 +137,7 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
         .map(PathBuf::from)
         .or_else(|| std::env::var("M1ND_GRAPH_SOURCE").ok().map(PathBuf::from))
         .or_else(|| std::env::var("GRAPH_SNAPSHOT_PATH").ok().map(PathBuf::from))
+        .map(resolve_graph_source)
         .unwrap_or_else(|| PathBuf::from("./graph_snapshot.json"));
 
     let plasticity_state = cli
@@ -389,7 +406,54 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::strict_version_verdict;
+    use super::{resolve_graph_source, strict_version_verdict};
+    use std::path::PathBuf;
+
+    // --- field-triage #2: the `temp` graph-source sentinel must not litter CWD ---
+
+    #[test]
+    fn temp_sentinel_never_resolves_to_a_cwd_relative_temp_path() {
+        // BUG (field report): `M1ND_GRAPH_SOURCE=temp` was taken literally, so
+        // save_graph wrote an ~8.5MB file named `temp` into the CWD/repo root.
+        let resolved = resolve_graph_source(PathBuf::from("temp"));
+
+        // Must NOT be the bare relative `temp` (which lands in the CWD).
+        assert_ne!(
+            resolved,
+            PathBuf::from("temp"),
+            "temp sentinel still resolves to CWD `temp`"
+        );
+        assert!(
+            resolved.is_absolute(),
+            "resolved temp graph path must be absolute, got {resolved:?}"
+        );
+
+        // It must live under the OS temp dir, not the working directory.
+        assert!(
+            resolved.starts_with(std::env::temp_dir()),
+            "temp graph snapshot must live under the OS temp dir, got {resolved:?}"
+        );
+        // Sanity: it keeps a snapshot-ish name so persistence still works.
+        assert!(
+            resolved
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("m1nd-graph-")),
+            "temp graph snapshot filename should be process-scoped, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn non_sentinel_graph_source_passes_through_unchanged() {
+        // Any other value is a real path and must be left exactly as given.
+        let explicit = PathBuf::from("/some/where/graph_snapshot.json");
+        assert_eq!(resolve_graph_source(explicit.clone()), explicit);
+        // A literal relative path that merely contains "temp" is NOT the sentinel.
+        let looks_like = PathBuf::from("temp.json");
+        assert_eq!(resolve_graph_source(looks_like.clone()), looks_like);
+        let nested = PathBuf::from("./temp/graph.json");
+        assert_eq!(resolve_graph_source(nested.clone()), nested);
+    }
 
     #[test]
     fn strict_off_never_refuses_even_on_mismatch() {


### PR DESCRIPTION
## Field report (triage #2)

> Running with `M1ND_GRAPH_SOURCE=temp` writes an ~8.5MB graph-snapshot file literally named `temp` into the CWD/repo root — every battery/probe run has needed a manual `rm -f temp`. The `temp` sentinel is being treated as a real relative path.

## Root cause

`m1nd-mcp/src/main.rs` read `M1ND_GRAPH_SOURCE=temp` via `PathBuf::from("temp")` — a bare relative path. That flowed to `session.rs` (`graph_path = config.graph_source`) and then to `snapshot::save_graph(&graph, &self.graph_path)`, which wrote `./temp` (~8.5MB) into the working directory. There was no sentinel handling anywhere.

The bare value `temp` is meant to signal an **ephemeral graph** — the battery sets it for a FRESH graph and never reads the snapshot back — not a literal `./temp` path.

## Fix

A small pure helper `resolve_graph_source(PathBuf) -> PathBuf` in `main.rs`:
- if the value is exactly `temp` → resolve to `std::env::temp_dir().join("m1nd-graph-<pid>.snapshot")` (process-scoped);
- any other value passes through unchanged.

Persistence still works (the graph is saved, `graph_path.exists()` checks still hold) — it just lands in the OS temp dir instead of littering the CWD. Chosen tempdir over disabling persistence because it's the smaller, lower-risk change: only *where* the sentinel resolves changes, not the save path itself.

## Proof

**Red → green** (unit tests in `main.rs`):
- With current-main pass-through behavior, `temp_sentinel_never_resolves_to_a_cwd_relative_temp_path` **FAILS**: `assertion left != right failed: temp sentinel still resolves to CWD `temp`` (left `"temp"`, right `"temp"`).
- With the fix, both tests **PASS** (`temp_sentinel_…` + `non_sentinel_graph_source_passes_through_unchanged`).

**Battery — the no-`./temp` proof:**
- `python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd` → **36/36** (`m1nd_pass_rate: 1.0`).
- After the run: `ls temp` → `No such file or directory`. The ~8.5MB snapshot now lands at `/var/…/T/m1nd-graph-<pid>.snapshot` (8938768 bytes) instead. **Its absence in the CWD is the fix.**

## Gate
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo test --workspace` → 0 failed (all suites `ok`; includes the 2 new tests)
- battery 36/36, no `./temp` artifact

## Scope
Single file: `m1nd-mcp/src/main.rs` (+65/-1). Does NOT touch the `server.rs` north handler or `scratchpad/m1nd_battery.py` (concurrent sibling work).