### PR TITLE
docs(i18n): regenerate all 7 READMEs from the 1.2.0-era English

### DIFF
--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">Eine Lokale Mission Runtime für Coding-Agenten</h1>
+<h1 align="center">Operational Intelligence für Coding-Agenten</h1>
 
 <p align="center">
   <strong>Dein Coding-Agent hört auf, blind zu starten.</strong><br/>
@@ -36,7 +36,7 @@
 
 ---
 
-**m1nd ist eine lokale Mission Runtime für Coding-Agenten — sie steuert die Betriebsschleife, nicht nur den Retrieval.**
+**m1nd ist Operational Intelligence für Coding-Agenten — es steuert die Betriebsschleife, nicht nur den Retrieval.**
 
 > grep findet Text. Vektorsuche findet ähnliche Chunks. `m1nd` gibt Agenten einen lokalen Graphen davon, was verbunden ist, was sich geändert hat, was bricht, was gedriftet ist, und wo weiterzumachen ist.
 
@@ -46,9 +46,23 @@ Drei Dinge koexistieren hier, die kein anderes Tool vereint:
 - **Selbstverifizierendes Gedächtnis** — `memorize` verankert Erkenntnisse an echten Code-Knoten; `cross_verify` markiert sie als veraltet, wenn dieser Code sich ändert.
 - **Ein Trust- / Recovery-Layer** — jedes Ergebnis trägt einen Trust-Mode; `trust_selftest` und `recovery_playbook` teilen dem Agenten mit, wann das Workspace-Binding falsch ist und wie er es repariert.
 
+Dazu eine **Attention-Runtime** — `focus` reicht dem Agenten das minimale, budget-begrenzte Working Set für ein Ziel, mit einem ehrlichen Rest dessen, was es weggelassen hat, und einem Signal dafür, ob das *genug* Kontext ist.
+
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Traditionelle Agentenschleife vs. m1nd-grounded-Schleife" width="960" />
 </p>
+
+## Neu in 1.2.0 — das erste Release der OMEGA-Ära
+
+1.2.0 verwandelt die Schleife von „abrufen, dann hoffen" in **vor-orientieren → auf kalibrierte Urteile handeln → festhalten, was du gelernt hast**. Das Motto ist dasselbe wie beim Trust-Layer: ein ehrliches *Nein* schlägt eine selbstbewusste Vermutung.
+
+- **`north(task)` — Vor-Orientierung in einem Aufruf.** Die neue Eingangstür komponiert Trust, Task-Kontext (Focus-Knoten + PageRank-Anker), vorheriges Cross-Session-Gedächtnis, ein Suffizienz-Signal, einen `next_move` und `honest_gaps` (was m1nd noch *nicht* weiß). `needs_ingest` ist eine echte Antwort für einen leeren Graphen. (Die L1GHT-Recall-Komposition, die vorheriges Gedächtnis in das Paket einfaltet, landete auf `main` kurz nach dem 1.2.0-Tag — sie ist nicht im 1.2.0-Binary.)
+- **Konforme Kalibrierung bei der Prädiktion.** `calibrate_predict` scharft ein Pro-Repo-Gate; Urteile lesen sich dann als `act` / `reverify` / `abstain`, wobei `abstain` *unkalibriert oder unzureichend* bedeutet — ein Signal zum Anhalten, kein schwaches Ja. Wird dunkel ausgeliefert: bis du kalibrierst, deckeln Urteile bei `reverify`.
+- **`trust_envelope` bei `seek`** (wird dunkel ausgeliefert) und ein **`closure`-Urteil bei `why`** — `blocked` bedeutet, der Pfad ruht auf einer unaufgelösten/geratenen Kante. **`trust_band: insufficient_evidence`** ist jetzt von einem Risiko-Band verschieden: es bedeutet *keine Evidenz*, die ehrliche Cold-Start-Antwort, nicht „mittleres Risiko".
+- **Das Gedächtnis bekam ein Provenienz-Rückgrat** — Behauptungen tragen echtes Alter + Autor, lösen ältere Behauptungen ab, altern aus und respektieren einen Recency-Cap, sodass erinnertes Wissen seine eigene Frische angibt, anstatt still zu veralten.
+- **Geglättetes-Jaccard-Co-Change** — `ghost_edges` / `predict` normalisieren jetzt die Kopplung, anstatt rohe Co-Commits zu zählen (kalibrierungsbewiesen +3 Punkte gegenüber rohen Zählungen).
+- **Binary-Version + SHA-Fingerprint** — `--version` gibt `1.2.0 (<sha>)` aus; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) lassen einen Host ein gedriftetes Binary erkennen und ablehnen.
+- **Agent-native MCP-Instructions + rein lokale Field-Reports.** Die `initialize`-Instructions, die jeder Host erhält, *sind* jetzt die obige Betriebsschleife. Agenten können ein Telemetrie-Signal pro Session hinterlassen — `learn` auf einem Retrieval-Urteil, oder eine Zeile in `~/.m1nd/field-reports.jsonl`, wenn m1nd sich selbst fehlverhält. Diese Datei ist rein lokal; **m1nd telefoniert niemals nach Hause.**
 
 ## Schnellstart
 
@@ -58,11 +72,11 @@ Der minimale Happy-Path — aus den Quellen installieren (immer aktuell), Gesund
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # oder: claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-Oder aus dem npm-Beta-Kanal: `npm install -g @maxkle1nz/m1nd@beta`.
+Oder aus npm: `npm install -g @maxkle1nz/m1nd`.
 
 Vollständige Installationskarte, Host-Packs, nativer Runtime-Build und Update-Flags: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · Client-für-Client-Einrichtung: [Integrationsmatrix](../docs/IDE-INTEGRATIONS.md).
 
@@ -79,20 +93,36 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 Innerhalb einer MCP-Session ist die Doktrin diese Trust-Schleife — Trust *vor* dem Vertrauen in irgendwelchen Retrieval herstellen:
 
 ```jsonc
-// 0. Binding in einem Aufruf prüfen (Urteil vor dem Retrieval)
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. Wenn das Urteil nicht full_trust ist, den deterministischen Recovery-Pfad anfordern
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. Graph-Wahrheit aufbauen
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. Eine strukturelle Frage stellen — leere Ergebnisse sagen *warum*, niemals nur "keine Ergebnisse"
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **Erste-Session-Schleife, in vier Zügen:** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` das dauerhafte Ergebnis, damit die nächste Session voraus startet.
+
+### Einen Graphen servieren, viele Agenten attachen
+
+Der Schnellstart oben verdrahtet einen stdio-Server pro Host — in Ordnung für einen Agenten, aber jeder Prozess lädt seinen eigenen Graphen und hält seinen eigenen Lease. Das Deployment, für das m1nd gebaut ist, ist ein Eigentümer, viele attachte Agenten. Ein Eigentümer-Prozess hält den Live-Graphen:
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+Jeder Agent attacht dann als dünne stdio↔HTTP-Bridge — er lädt **keinen** Graphen, baut keine Engines und nimmt **keinen** Lease:
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+Beliebig viele Bridges zeigen auf den einen Eigentümer und teilen sich seinen einzigen Live-Graphen, sodass das, was ein Agent `memorize`t, ein anderer sofort abruft — kein Reingest, keine Pro-Agent-Kopie. Queries laufen über localhost, sodass es local-first bleibt (`bind` bleibt `127.0.0.1`, außer du entscheidest dich für `--bind 0.0.0.0`). Ein warmes `seek` über die Bridge maß ≈0.7ms auf einem kleinen Graphen auf einer Maschine — Größenordnung, keine Garantie: Attach fügt einen localhost-Roundtrip hinzu, und die Latenz skaliert mit Graphgröße und Last.
 
 ## Was m1nd Nicht Ist
 
@@ -108,7 +138,7 @@ Es ist der Layer, der diese Oberflächen in ein operatives System verwandelt, ü
 
 ## Warum Agenten es Brauchen
 
-Ohne m1nd beginnt jede Session mit grep-Schleifen und manuelle Reorientierung; die Erkenntnisse der letzten Woche sind weg, und ein leeres Suchergebnis ist nicht von einem falschen Workspace-Binding zu unterscheiden. Mit m1nd beginnt die Session mit einem Trust-Urteil, vergangene Erkenntnisse laden automatisch bereits verankert an dem Code, der sie unterstützt, und leere Ergebnisse sagen *warum*.
+Ohne m1nd beginnt jede Session mit grep-Schleifen und manueller Reorientierung; die Erkenntnisse der letzten Woche sind weg, und ein leeres Suchergebnis ist nicht von einem falschen Workspace-Binding zu unterscheiden. Mit m1nd beginnt die Session mit einem Trust-Urteil, vergangene Erkenntnisse laden automatisch bereits verankert an dem Code, der sie unterstützt, und leere Ergebnisse sagen *warum*.
 
 Agenten auf echten Codebasen scheitern nicht, weil sie nicht suchen können. Sie scheitern, weil sie kein operatives Modell haben. Sie bauen Kontext jede Session von Grund auf neu auf, editieren ohne den Blast Radius zu kennen, und können ein leeres Ergebnis, das „nichts existiert" bedeutet, nicht von einem unterscheiden, das „falsches Repo" bedeutet.
 
@@ -144,12 +174,14 @@ Diese Schleife wurde live von Ende zu Ende bewiesen: `memorize` → `grounded_in
 Das ist das Verteidigungswürdigste, was m1nd tut, und kein Konkurrent liefert es. Die Doktrin: **Glaubwürdigkeit kommt von Ehrlichkeit, nicht davon, immer zu gewinnen.**
 
 - **`trust_selftest`** gibt ein Urteil *vor* jedem Retrieval zurück: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected`, oder `degraded_host_tool_surface`. Der Agent weiß, ob er fortfahren, ingestieren, rebinden oder zurückfallen soll.
-- **`agent_runtime_contract`** begleitet jede Retrieve-Antwort und trägt einen `trust_mode`. Ein leeres Ergebnis wird disambiguiert — an falsches Repo gebunden vs. genuinement nichts vorhanden — niemals still als „keine Ergebnisse" gemeldet.
+- **`agent_runtime_contract`** begleitet jede Retrieve-Antwort und trägt einen `trust_mode`. Ein leeres Ergebnis wird disambiguiert — an falsches Repo gebunden vs. tatsächlich nichts vorhanden — niemals still als „keine Ergebnisse" gemeldet.
 - **`non_claims`-Arrays** werden bei jedem Mission-Tool geliefert. m1nd teilt dem Agenten mit, was es *nicht* bewiesen hat.
 - **`mission_verify` kann Nein sagen — und tut es, in getestetem Code.** Es lehnt Graph-only-Beweise ab: eine Behauptung kann sich nicht schließen ohne einen Dateilesevorgang, einen Testlauf oder eine Runtime-Probe. Der Test heißt buchstäblich `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** gibt eine deterministische, geordnete Schritt-Liste zurück, um das Binding zu reparieren.
 
 Der Beweis für das Engagement ist das, was dafür gestrichen wurde: `savings` und `resonate` wurden in beta.7 aus der beworbenen Oberfläche entfernt, weil ein Tool, das immer behauptet zu gewinnen, nicht glaubwürdig ist. Kein Konkurrent — weder mem0, Zep, Letta, Sourcegraph, noch irgendein Code-Graph-MCP — liefert einen Layer, der dem Agenten sagt, was er *nicht* vertrauen soll und wie er sich erholt.
+
+**Die Field-Triage-Schleife schließt sich auf sich selbst.** Die Session-Telemetrie, die Agenten in `~/.m1nd/field-reports.jsonl` hinterlassen (rein lokal — m1nd telefoniert niemals nach Hause), ist kein passives Log: Reports werden triagiert, und ein *bestätigter* Field-Bug wird zu einem roten Battery-Case **vor** dem Fix, sodass die Regression bewiesen und nicht nur beschrieben ist. Diese Schleife ist bereits einmal von Ende zu Ende gelaufen: zwei im Feld gemeldete Bugs wurden zu fehlschlagenden Battery-Cases und dann gemergten Fixes — `north` komponiert jetzt L1GHT-Recall in sein Gedächtnis-Paket, und der `temp`-Graph-Sentinel löst zu einem echten Tempdir auf, anstatt das Arbeitsverzeichnis zu vermüllen.
 
 ## Sprachabdeckung
 
@@ -201,7 +233,7 @@ Das Agent-Pack ist Teil des Produkts, keine dekorative Dokumentation. m1nd ist a
 - **Tiefenanalyse** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (die RETROBUILDER-Linse) für versteckte Kopplung, Sicherheitspfade, strukturelle Duplikate und Runtime-Wärme.
 - **Gedächtnis** — dauerhafte Schlussfolgerungen mit `memorize` persistieren, mit `confidence` und `evidence`-Pfaden.
 
-Mission Control ist Beweisdisziplin, keine Feature-Liste. `mission_next` gibt genau einen Zug plus `do_not`-Guardrails zurück; `mission_verify` lehnt Graph-only-Behauptungen ab; `mission_close` drängt den Agenten immer, verifizietes Wissen zu persistieren, und zeichnet Lücken und Non-Claims auf. Im `bug_hunt`-Modus erfordert MC0 einen abschließenden `direct_sweep` nach verifizierten Erkenntnissen vor dem Schließen, damit Agenten den Negativraum prüfen.
+Mission Control ist Beweisdisziplin, keine Feature-Liste. `mission_next` gibt genau einen Zug plus `do_not`-Guardrails zurück; `mission_verify` lehnt Graph-only-Behauptungen ab; `mission_close` drängt den Agenten immer, verifiziertes Wissen zu persistieren, und zeichnet Lücken und Non-Claims auf. Im `bug_hunt`-Modus erfordert MC0 einen abschließenden direkten `direct_sweep` nach verifizierten Erkenntnissen vor dem Schließen, damit Agenten den Negativraum prüfen.
 
 **Vorbehalt:** `predict` hat **nur strukturellen Fallback** bis `ghost_edges` die Git-Co-Change-Matrix lädt — führe `ghost_edges` zuerst aus, wenn du echte Co-Change-Wahrscheinlichkeit brauchst.
 
@@ -211,11 +243,13 @@ Jede Zeile ist genau auf das kalibriert, was gemessen wurde. m1nd führt keine E
 
 | Behauptung | Ergebnis | Quelle / Einschränkung |
 |---|---|---|
-| `activate` / `impact`-Latenz | sub-µs `activate`, sub-ms `impact` | Criterion-Benchmarks in `m1nd-core/benches/` auf einem synthetischen 1K-Knoten-Graph — [Methodik](https://m1nd.world/wiki/benchmarks.html); als Größenordnung behandeln. |
+| `activate` / `impact`-Latenz | ~1µs `activate`, sub-µs `impact` auf einem synthetischen 1K-Knoten-Graph | Criterion-Benchmarks — **reproduziere es selbst: `cargo bench -p m1nd-core`** (gemessen `activate_1k_nodes` ≈1.4µs, `impact_depth3` ≈0.5µs auf einem Apple-Silicon-Mac); [Methodik](https://m1nd.world/wiki/benchmarks.html); Größenordnung, hardware-abhängig. |
 | Sprachmatrix | Calls + Cross-File-Imports für 10 Sprachen (+ Ruby Cross-File) | Von Ende zu Ende in einem einzelnen polyglottes Ingest verifiziert; sprachspezifische Tests in `m1nd-ingest`. Siehe [Sprachabdeckung](#sprachabdeckung). |
 | Post-Write-Validierungsstichprobe | 12/12 korrekt klassifiziert | Interner Runtime-Check. |
 | Geseedeter Bug-Hunt | 16/20 in der ersten akzeptierten `humanize`-Seed-Defekt-Runde (m1nd-trained); `m1nd-basic` und direkt je 8/15 | Interne Produktnachweise, `public_claim_worthy=false` — kein universeller Benchmark. |
 | Gedächtnis-Selbstverifizierung | live von Ende zu Ende bewiesen | `memorize` → `grounded_in` → Freshness-Flag auf bearbeiteter Datei → überlebt replace → Boot-Auto-Load. |
+| Fähigkeiten-Battery vs. grep | 37/37 bestanden; head-to-head 16 m1nd-Siege / 12 Unentschieden / **0 grep-Siege** | In-Repo-Harness `scratchpad/m1nd_battery.py` (37 Fälle, frischer Ingest + Ground-Truth-PASS/FAIL + `rg`-head-to-head). **Reproduziere: `python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`.** Einschränkung: ein Repo (m1nd selbst), selbst verfasste Fälle; ~5 der Unentschieden sind strukturelle Tools, gewertet gegen einen Literal-grep-Proxy, der nicht ausdrücken kann, was sie beantworten. |
+| Konforme Kalibrierung (`predict`) | act-Band ≈32% Präzision @ ≈13.5% Coverage (α=0.10) | Auf m1nds eigener Git-Historie (n≈9.2k held-out Prädiktionen), +3pts gegenüber rohen Zählungen nach der Geglättetes-Jaccard-Änderung. Einschränkung: ein Repo, ein grobes zählbasiertes Signal — das Gate abstiniert heute meist, **by design**: Abstinenz ist die ehrliche Ausgabe eines schwachen Signals, kein Fehler. |
 
 ## Einschränkungen
 
@@ -238,7 +272,7 @@ Drei Kern-Rust-Crates plus eine auxiliäre Bridge:
 - **`m1nd-ingest`** — Extraktions-, Routing- und Graph-Konstruktions-Adapter (Code, universelle Docs, L1GHT).
 - **`m1nd-openclaw`** — auxiliäre OpenClaw-Bridge (Unix-Socket-Lane, unabhängig versioniert).
 
-Aktuelle Crate-Versionen: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` alle `0.9.0-beta.8`.
+Aktuelle Crate-Versionen: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` alle `1.2.0` (`m1nd-openclaw` ist unabhängig bei `0.1.0` versioniert).
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="m1nd Architektur-Übersicht" width="960" />

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">Un Runtime de Misión Local para Agentes de Código</h1>
+<h1 align="center">Inteligencia Operacional para Agentes de Código</h1>
 
 <p align="center">
   <strong>Tu agente de código deja de empezar a ciegas.</strong><br/>
@@ -36,7 +36,7 @@
 
 ---
 
-**m1nd es un runtime de misión local para agentes de código — gobierna el loop operacional, no solo la recuperación de datos.**
+**m1nd es inteligencia operacional para agentes de código — gobierna el loop operacional, no solo la recuperación de datos.**
 
 > `grep` encuentra texto. La búsqueda vectorial encuentra chunks similares. `m1nd` da a los agentes un grafo local de qué se conecta, qué cambió, qué se rompe, qué ha derivado y dónde retomar.
 
@@ -46,9 +46,23 @@ Tres cosas coexisten aquí en ninguna otra herramienta:
 - **Memoria auto-verificable** — `memorize` ancla hallazgos a nodos reales del código; `cross_verify` los marca como obsoletos cuando ese código cambia.
 - **Una capa de confianza y recuperación** — cada resultado lleva un modo de confianza; `trust_selftest` y `recovery_playbook` le dicen al agente cuándo el binding del workspace está mal y cómo recuperarse.
 
+Además, un **runtime de atención** — `focus` le entrega al agente el conjunto de trabajo mínimo y acotado por presupuesto para un objetivo, con una cola honesta de lo que dejó fuera y una señal de si eso ya es contexto *suficiente*.
+
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Loop tradicional de agente vs loop anclado en m1nd" width="960" />
 </p>
+
+## Novedades en 1.2.0 — el primer release de la era OMEGA
+
+1.2.0 transforma el loop de "recuperar y luego esperar" en **pre-orientar → actuar sobre veredictos calibrados → capturar lo que aprendiste**. El tema es el mismo que el de la capa de confianza: un *no* honesto vence a una conjetura confiada.
+
+- **`north(task)` — pre-orienta en una sola llamada.** La nueva puerta de entrada compone confianza, contexto de tarea (nodos de focus + anclas de PageRank), memoria previa entre sesiones, una señal de suficiencia, un `next_move` y `honest_gaps` (lo que m1nd *todavía* no sabe). `needs_ingest` es una respuesta real para un grafo vacío. (La composición de L1GHT-recall que pliega la memoria previa dentro del paquete llegó a `main` justo después del tag 1.2.0 — no está en el binario 1.2.0.)
+- **Calibración conformal en la predicción.** `calibrate_predict` arma una compuerta por repositorio; los veredictos luego leen `act` / `reverify` / `abstain`, donde `abstain` significa *no calibrado o insuficiente* — una señal para detenerse, no un sí débil. Se entrega en modo oscuro: hasta que calibres, los veredictos se topan en `reverify`.
+- **`trust_envelope` en `seek`** (se entrega en modo oscuro) y un **veredicto `closure` en `why`** — `blocked` significa que la ruta descansa sobre una arista no resuelta/adivinada. **`trust_band: insufficient_evidence`** ahora es distinto de una banda de riesgo: significa *sin evidencia*, la respuesta honesta de arranque en frío, no "riesgo medio".
+- **La memoria ganó una columna vertebral de procedencia** — las afirmaciones llevan edad + autor reales, reemplazan afirmaciones más antiguas, expiran con el tiempo y respetan un tope de recencia, de modo que el conocimiento recordado declara su propia frescura en lugar de volverse obsoleto en silencio.
+- **Co-cambio con Jaccard suavizado** — `ghost_edges` / `predict` ahora normalizan el acoplamiento en lugar de contar co-commits crudos (calibración probada: +3 puntos sobre los conteos crudos).
+- **Versión binaria + fingerprint sha** — `--version` imprime `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permiten que un host detecte y rechace un binario que ha derivado.
+- **Instrucciones MCP nativas de agente + reportes de campo solo locales.** Las instrucciones de `initialize` que cada host recibe ahora *son* el loop operacional de arriba. Los agentes pueden dejar una única señal de telemetría por sesión — `learn` sobre un veredicto de recuperación, o una línea en `~/.m1nd/field-reports.jsonl` cuando el propio m1nd se comporta mal. Ese archivo es solo local; **m1nd nunca llama a casa.**
 
 ## Inicio Rápido
 
@@ -58,11 +72,11 @@ El camino mínimo feliz — instala desde el fuente (siempre actualizado), verif
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # o: claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-O desde el canal beta de npm: `npm install -g @maxkle1nz/m1nd@beta`.
+O desde npm: `npm install -g @maxkle1nz/m1nd`.
 
 Mapa completo de instalación, paquetes de host, build nativo del runtime y flags de actualización: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuración por cliente: [matriz de integración](../docs/IDE-INTEGRATIONS.md).
 
@@ -79,20 +93,36 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 Dentro de una sesión MCP, la doctrina es este loop de confianza — establece confianza *antes* de creer cualquier recuperación:
 
 ```jsonc
-// 0. Confía en el binding en una llamada (veredicto antes de la recuperación)
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. Si el veredicto no es full_trust, pide el camino de recuperación determinístico
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. Construye la verdad del grafo
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. Haz una pregunta estructural — los resultados vacíos dicen *por qué*, nunca solo "sin resultados"
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **Loop de primera sesión, en cuatro movimientos:** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` el hallazgo duradero para que la próxima sesión empiece adelantada.
+
+### Sirve un grafo, adjunta muchos agentes
+
+El Inicio Rápido de arriba conecta un servidor stdio por host — está bien para un agente, pero cada proceso carga su propio grafo y retiene su propia lease. El despliegue para el que m1nd fue construido es un dueño, muchos agentes adjuntos. Un proceso dueño retiene el grafo vivo:
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+Cada agente luego se adjunta como un puente delgado stdio↔HTTP — **no** carga grafo, no construye motores y **no** toma lease:
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+Cualquier número de puentes apunta al único dueño y comparte su único grafo vivo, así que lo que un agente hace `memorize` otro lo recupera de inmediato — sin reingestión, sin copia por agente. Las consultas van por localhost, así que se mantiene local-first (el bind se queda en `127.0.0.1` a menos que optes por `--bind 0.0.0.0`). Un `seek` en caliente sobre el puente midió ≈0.7ms en un grafo pequeño en una sola máquina — orden de magnitud, no una garantía: adjuntar añade un round-trip por localhost, y la latencia escala con el tamaño del grafo y la carga.
 
 ## Lo Que m1nd No Es
 
@@ -150,6 +180,8 @@ Esta es la cosa más defendible que hace m1nd, y ningún competidor la entrega. 
 - **`recovery_playbook`** devuelve una lista de pasos determinística y ordenada para reparar el binding.
 
 La prueba del compromiso está en lo que se sacrificó por él: `savings` y `resonate` fueron retirados de la superficie anunciada en beta.7 porque una herramienta que siempre afirma ganar no es creíble. Ningún competidor — ni mem0, Zep, Letta, Sourcegraph ni ningún MCP de grafo de código — entrega una capa que le dice al agente en qué *no* confiar y cómo recuperarse.
+
+**El loop de triaje de campo se cierra sobre sí mismo.** La telemetría de sesión que los agentes dejan en `~/.m1nd/field-reports.jsonl` (solo local — m1nd nunca llama a casa) no es un log pasivo: los reportes se triajean, y un bug de campo *confirmado* se convierte en un caso rojo de batería **antes** del arreglo, de modo que la regresión queda probada, no solo descrita. Ese loop ya corrió una vez de extremo a extremo: dos bugs reportados en campo se convirtieron en casos de batería fallidos y luego en arreglos mergeados — `north` ahora compone el recall de L1GHT dentro de su paquete de memoria, y el sentinela de grafo `temp` resuelve a un tempdir real en lugar de ensuciar el directorio de trabajo.
 
 ## Cobertura de Lenguajes
 
@@ -211,11 +243,13 @@ Cada fila está calibrada exactamente a lo que se midió. m1nd no lidera con nú
 
 | Afirmación | Resultado | Fuente / advertencia |
 |---|---|---|
-| Latencia de `activate` / `impact` | sub-µs `activate`, sub-ms `impact` | Benchmarks Criterion en `m1nd-core/benches/` en un grafo sintético de 1K nodos — [metodología](https://m1nd.world/wiki/benchmarks.html); trátalo como orden de magnitud. |
+| Latencia de `activate` / `impact` | ~1µs `activate`, sub-µs `impact` en un grafo sintético de 1K nodos | Benchmarks Criterion — **reprodúcelo tú mismo: `cargo bench -p m1nd-core`** (medido `activate_1k_nodes` ≈1.4µs, `impact_depth3` ≈0.5µs en un Mac con Apple silicon); [metodología](https://m1nd.world/wiki/benchmarks.html); orden de magnitud, dependiente del hardware. |
 | Matriz de lenguajes | calls + imports entre archivos para 10 lenguajes (+ Ruby entre archivos) | Verificado de extremo a extremo en una única ingestión políglota; tests por lenguaje en `m1nd-ingest`. Ver [Cobertura de Lenguajes](#cobertura-de-lenguajes). |
 | Muestra de validación post-escritura | 12/12 clasificados correctamente | Verificación de runtime interna. |
 | Caza de bugs con seeds | 16/20 en la primera ronda aceptada de defectos con seed `humanize` (entrenado con m1nd); `m1nd-basic` y directo cada uno 8/15 | Evidencia interna de producto, `public_claim_worthy=false` — no es un benchmark universal. |
 | Auto-verificación de memoria | probado en vivo de extremo a extremo | `memorize` → `grounded_in` → flag de frescura en archivo editado → sobrevive a replace → carga automática en el boot. |
+| Batería de capacidades vs grep | 37/37 pasan; mano a mano 16 victorias-m1nd / 12 empates / **0 victorias-grep** | Harness en el repo `scratchpad/m1nd_battery.py` (37 casos, ingestión fresca + PASS/FAIL contra ground-truth + mano a mano con `rg`). **Reprodúcelo: `python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`.** Advertencia: un solo repo (el propio m1nd), casos escritos por nosotros; ~5 de los empates son herramientas estructurales puntuadas contra un proxy de grep literal que no puede expresar lo que ellas responden. |
+| Calibración conformal (`predict`) | banda act ≈32% de precisión @ ≈13.5% de cobertura (α=0.10) | Sobre el propio historial git de m1nd (n≈9.2k predicciones held-out), +3pts sobre los conteos crudos tras el cambio a Jaccard suavizado. Advertencia: un solo repo, una señal gruesa basada en conteos — la compuerta hoy mayormente se abstiene, **por diseño**: la abstención es la salida honesta de una señal débil, no un fallo. |
 
 ## Límites
 
@@ -238,7 +272,7 @@ Tres crates core en Rust más un bridge auxiliar:
 - **`m1nd-ingest`** — extracción, enrutamiento y adapters de construcción de grafo (código, docs universales, L1GHT).
 - **`m1nd-openclaw`** — bridge auxiliar OpenClaw (canal Unix socket, versionado independientemente).
 
-Versiones actuales de los crates: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` todos en `0.9.0-beta.8`.
+Versiones actuales de los crates: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` todos en `1.2.0` (`m1nd-openclaw` está versionado de forma independiente en `0.1.0`).
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Resumen de la arquitectura de m1nd" width="960" />

--- a/i18n/README.fr.md
+++ b/i18n/README.fr.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">Un Runtime de Mission Local pour Agents de Coding</h1>
+<h1 align="center">Intelligence Opérationnelle pour Agents de Coding</h1>
 
 <p align="center">
   <strong>Votre agent de coding arrête de démarrer à l'aveugle.</strong><br/>
@@ -36,7 +36,7 @@
 
 ---
 
-**m1nd est un runtime de mission local pour agents de coding — il gouverne la boucle opérationnelle, pas seulement le retrieval.**
+**m1nd est une intelligence opérationnelle pour agents de coding — il gouverne la boucle opérationnelle, pas seulement le retrieval.**
 
 > grep trouve du texte. La recherche vectorielle trouve des chunks similaires. `m1nd` donne aux agents un graphe local de ce qui est connecté, ce qui a changé, ce qui casse, ce qui a dérivé, et où reprendre.
 
@@ -46,9 +46,23 @@ Trois choses coexistent ici qu'aucun autre outil ne réunit :
 - **Mémoire auto-vérifiante** — `memorize` ancre les résultats à de vrais nœuds de code ; `cross_verify` les signale comme obsolètes quand ce code change.
 - **Un layer de trust / recovery** — chaque résultat porte un trust mode ; `trust_selftest` et `recovery_playbook` indiquent à l'agent quand le binding du workspace est incorrect et comment récupérer.
 
+Plus un **runtime d'attention** — `focus` remet à l'agent le working set minimal et borné en budget pour un objectif, avec une queue honnête de ce qu'il a laissé de côté et un signal indiquant si c'est *assez* de contexte pour l'instant.
+
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Boucle agent traditionnelle vs boucle m1nd-grounded" width="960" />
 </p>
+
+## Nouveautés de la 1.2.0 — la première release de l'ère OMEGA
+
+La 1.2.0 fait passer la boucle de « récupérer, puis espérer » à **pré-orienter → agir sur des verdicts calibrés → capturer ce que vous avez appris**. Le thème est le même que celui du layer de trust : un *non* honnête vaut mieux qu'une supposition confiante.
+
+- **`north(task)` — pré-orienter en un seul appel.** La nouvelle porte d'entrée compose le trust, le contexte de la tâche (focus nodes + ancres PageRank), la mémoire inter-sessions antérieure, un signal de suffisance, un `next_move`, et `honest_gaps` (ce que m1nd ne sait *pas* encore). `needs_ingest` est une vraie réponse pour un graphe vide. (La composition L1GHT-recall qui replie la mémoire antérieure dans le paquet a atterri sur `main` juste après le tag 1.2.0 — elle n'est pas dans le binaire 1.2.0.)
+- **Calibration conforme sur la prédiction.** `calibrate_predict` arme une gate par dépôt ; les verdicts lisent ensuite `act` / `reverify` / `abstain`, où `abstain` signifie *non calibré ou insuffisant* — un signal pour s'arrêter, pas un oui faible. Livré dark : tant que vous ne calibrez pas, les verdicts plafonnent à `reverify`.
+- **`trust_envelope` sur `seek`** (livré dark) et un **verdict `closure` sur `why`** — `blocked` signifie que le chemin repose sur un edge non résolu/deviné. **`trust_band: insufficient_evidence`** est désormais distinct d'un risk band : il signifie *aucune preuve*, la réponse honnête de démarrage à froid, pas « risque moyen ».
+- **La mémoire a gagné une colonne vertébrale de provenance** — les affirmations portent un âge + un auteur réels, supplantent les affirmations plus anciennes, expirent avec le temps, et respectent un plafond de récence, si bien que la connaissance mémorisée déclare sa propre fraîcheur au lieu de se périmer en silence.
+- **Co-change en Jaccard lissé** — `ghost_edges` / `predict` normalisent désormais le couplage au lieu de compter les co-commits bruts (+3 points prouvés par calibration face aux comptes bruts).
+- **Version du binaire + empreinte sha** — `--version` affiche `1.2.0 (<sha>)` ; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permettent à un hôte de détecter et de refuser un binaire qui a dérivé.
+- **Instructions MCP agent-natives + field reports local-only.** Les instructions d'`initialize` que chaque hôte reçoit *sont* désormais la boucle opérationnelle ci-dessus. Les agents peuvent laisser un signal de télémétrie par session — `learn` sur un verdict de retrieval, ou une ligne dans `~/.m1nd/field-reports.jsonl` quand m1nd lui-même se comporte mal. Ce fichier est local-only ; **m1nd ne téléphone jamais à la maison.**
 
 ## Démarrage Rapide
 
@@ -58,11 +72,11 @@ Le chemin minimal fonctionnel — installer depuis les sources (toujours à jour
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # ou : claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-Ou depuis le canal npm beta : `npm install -g @maxkle1nz/m1nd@beta`.
+Ou depuis npm : `npm install -g @maxkle1nz/m1nd`.
 
 Carte d'installation complète, packs d'hôtes, build du runtime natif et flags de mise à jour : [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuration client par client : [matrice d'intégration](../docs/IDE-INTEGRATIONS.md).
 
@@ -79,20 +93,36 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 Dans une session MCP, la doctrine est cette boucle de trust — établir le trust *avant* de faire confiance à tout retrieval :
 
 ```jsonc
-// 0. Vérifier le binding en un seul appel (verdict avant le retrieval)
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. Si le verdict n'est pas full_trust, demander le chemin de recovery déterministe
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. Construire la vérité du graphe
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. Poser une question structurelle — les résultats vides disent *pourquoi*, jamais juste "aucun résultat"
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **Boucle première session, en quatre mouvements :** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` le résultat durable pour que la prochaine session parte en avance.
+
+### Servir un seul graphe, attacher plusieurs agents
+
+Le Démarrage Rapide ci-dessus câble un serveur stdio par hôte — parfait pour un seul agent, mais chaque processus charge son propre graphe et détient sa propre lease. Le déploiement pour lequel m1nd est conçu, c'est un seul propriétaire, plusieurs agents attachés. Un seul processus propriétaire détient le graphe vivant :
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+Chaque agent s'attache ensuite comme un fin pont stdio↔HTTP — il ne charge **aucun** graphe, ne construit aucun moteur, et ne prend **aucune** lease :
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+N'importe quel nombre de ponts pointent vers l'unique propriétaire et partagent son unique graphe vivant, si bien que ce qu'un agent `memorize` est immédiatement rappelé par un autre — pas de réingest, pas de copie par agent. Les requêtes passent par localhost, donc ça reste local-first (le bind reste `127.0.0.1` sauf si vous optez pour `--bind 0.0.0.0`). Un `seek` à chaud via le pont a mesuré ≈0.7ms sur un petit graphe sur une seule machine — ordre de grandeur, pas une garantie : l'attach ajoute un aller-retour localhost, et la latence croît avec la taille du graphe et la charge.
 
 ## Ce que m1nd N'Est Pas
 
@@ -150,6 +180,8 @@ C'est la chose la plus défendable que m1nd fait, et aucun concurrent ne la prop
 - **`recovery_playbook`** retourne une liste d'étapes déterministe et ordonnée pour réparer le binding.
 
 La preuve de l'engagement est ce qui a été supprimé pour lui : `savings` et `resonate` ont été retirés de la surface annoncée en beta.7 parce qu'un outil qui prétend toujours gagner n'est pas crédible. Aucun concurrent — ni mem0, Zep, Letta, Sourcegraph, ni aucun MCP code-graph — ne propose un layer qui dit à l'agent ce à quoi il ne faut *pas* faire confiance et comment récupérer.
+
+**La boucle de field-triage se referme sur elle-même.** La télémétrie de session que les agents laissent dans `~/.m1nd/field-reports.jsonl` (local-only — m1nd ne téléphone jamais à la maison) n'est pas un log passif : les reports sont triés, et un bug de terrain *confirmé* devient un cas de batterie rouge **avant** le fix, si bien que la régression est prouvée, pas seulement décrite. Cette boucle a déjà tourné une fois de bout en bout : deux bugs remontés du terrain sont devenus des cas de batterie en échec puis des fixes mergés — `north` compose désormais le L1GHT recall dans son paquet de mémoire, et le sentinel de graphe `temp` se résout vers un vrai tempdir au lieu de joncher le répertoire de travail.
 
 ## Couverture Linguistique
 
@@ -211,11 +243,13 @@ Chaque ligne est calibrée exactement à ce qui a été mesuré. m1nd ne met pas
 
 | Affirmation | Résultat | Source / calibration |
 |---|---|---|
-| Latence `activate` / `impact` | `activate` sub-µs, `impact` sub-ms | Benchmarks Criterion dans `m1nd-core/benches/` sur un graphe synthétique de 1K nœuds — [méthodologie](https://m1nd.world/wiki/benchmarks.html) ; traiter comme ordre de grandeur. |
+| Latence `activate` / `impact` | `activate` ~1µs, `impact` sub-µs sur un graphe synthétique de 1K nœuds | Benchmarks Criterion — **reproduisez-le vous-même : `cargo bench -p m1nd-core`** (mesuré `activate_1k_nodes` ≈1.4µs, `impact_depth3` ≈0.5µs sur un Mac Apple-silicon) ; [méthodologie](https://m1nd.world/wiki/benchmarks.html) ; ordre de grandeur, dépendant du matériel. |
 | Matrice linguistique | appels + imports cross-fichier pour 10 langages (+ Ruby cross-fichier) | Vérifié de bout en bout dans un seul ingest polyglotte ; tests par langage dans `m1nd-ingest`. Voir [Couverture Linguistique](#couverture-linguistique). |
 | Échantillon de validation post-écriture | 12/12 classifiés correctement | Vérification runtime interne. |
 | Bug-hunt avec graines | 16/20 au premier round accepté de défauts semés `humanize` (m1nd-trained) ; `m1nd-basic` et direct chacun 8/15 | Preuve produit interne, `public_claim_worthy=false` — pas un benchmark universel. |
 | Auto-vérification de la mémoire | prouvée en direct de bout en bout | `memorize` → `grounded_in` → signal de freshness sur fichier modifié → survit à replace → boot auto-load. |
+| Batterie de capacités vs grep | 37/37 passent ; en face-à-face 16 victoires m1nd / 12 égalités / **0 victoire grep** | Harness in-repo `scratchpad/m1nd_battery.py` (37 cas, ingest frais + vérité-terrain PASS/FAIL + face-à-face `rg`). **Reproduire : `python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`.** Calibration : un seul dépôt (m1nd lui-même), cas auto-rédigés ; ~5 des égalités sont des outils structurels notés face à un proxy grep littéral qui ne peut pas exprimer ce à quoi ils répondent. |
+| Calibration conforme (`predict`) | act-band ≈32% de précision @ ≈13.5% de couverture (α=0.10) | Sur l'historique git propre de m1nd (n≈9.2k prédictions held-out), +3pts face aux comptes bruts après le passage au Jaccard lissé. Calibration : un seul dépôt, un signal grossier basé sur des comptes — la gate s'abstient surtout aujourd'hui, **par design** : l'abstention est la sortie honnête d'un signal faible, pas un échec. |
 
 ## Limites
 
@@ -238,7 +272,7 @@ Trois crates Rust core plus un bridge auxiliaire :
 - **`m1nd-ingest`** — adapters d'extraction, de routage et de construction de graphe (code, docs universels, L1GHT).
 - **`m1nd-openclaw`** — bridge auxiliaire OpenClaw (lane Unix-socket, versioning indépendant).
 
-Versions actuelles des crates : `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` tous `0.9.0-beta.8`.
+Versions actuelles des crates : `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` tous en `1.2.0` (`m1nd-openclaw` est versionné indépendamment en `0.1.0`).
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Aperçu de l'architecture m1nd" width="960" />

--- a/i18n/README.it.md
+++ b/i18n/README.it.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">Un Runtime di Missione Locale per Agenti di Coding</h1>
+<h1 align="center">Intelligenza Operativa per Agenti di Coding</h1>
 
 <p align="center">
   <strong>Il tuo agente di coding smette di partire alla cieca.</strong><br/>
@@ -36,7 +36,7 @@
 
 ---
 
-**m1nd è un runtime di missione locale per agenti di coding — governa il ciclo operativo, non solo il retrieval.**
+**m1nd è intelligenza operativa per agenti di coding — governa il ciclo operativo, non solo il retrieval.**
 
 > grep trova testo. La ricerca vettoriale trova chunk simili. `m1nd` dà agli agenti un grafo locale di cosa è connesso, cosa è cambiato, cosa si rompe, cosa è andato in drift, e dove riprendere.
 
@@ -46,9 +46,23 @@ Tre cose che qui coesistono e non si trovano in nessun altro strumento:
 - **Memoria auto-verificante** — `memorize` ancora i risultati a nodi reali del codice; `cross_verify` li segnala come obsoleti quando quel codice cambia.
 - **Un layer di trust / recovery** — ogni risultato porta un trust mode; `trust_selftest` e `recovery_playbook` dicono all'agente quando il binding del workspace è sbagliato e come recuperare.
 
+Più un **runtime di attenzione** — `focus` consegna all'agente il working set minimo e delimitato dal budget per un obiettivo, con una coda onesta di ciò che ha lasciato fuori e un segnale che indica se quel contesto è già *sufficiente*.
+
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Ciclo agente tradizionale vs ciclo m1nd-grounded" width="960" />
 </p>
+
+## Novità nella 1.2.0 — il primo rilascio dell'era OMEGA
+
+La 1.2.0 trasforma il ciclo da "recupera, poi spera" in **pre-orientarsi → agire su verdetti calibrati → catturare ciò che hai imparato**. Il tema è lo stesso del layer di trust: un *no* onesto batte una supposizione sicura.
+
+- **`north(task)` — pre-orientamento in una sola chiamata.** La nuova porta d'ingresso compone trust, contesto del task (nodi di focus + anchor PageRank), memoria pregressa cross-sessione, un segnale di sufficienza, un `next_move`, e `honest_gaps` (ciò che m1nd *non* sa ancora). `needs_ingest` è una risposta reale per un grafo vuoto. (La composizione L1GHT-recall che integra la memoria pregressa nel packet è arrivata su `main` subito dopo il tag 1.2.0 — non è presente nel binario 1.2.0.)
+- **Calibrazione conforme sulla predizione.** `calibrate_predict` arma un gate per-repo; i verdetti leggono poi `act` / `reverify` / `abstain`, dove `abstain` significa *non calibrato o insufficiente* — un segnale per fermarsi, non un sì debole. Rilasciato dark: finché non calibri, i verdetti si fermano a `reverify`.
+- **`trust_envelope` su `seek`** (rilasciato dark) e un **verdetto `closure` su `why`** — `blocked` significa che il percorso poggia su un edge irrisolto/supposto. **`trust_band: insufficient_evidence`** è ora distinto da una banda di rischio: significa *nessuna evidenza*, la risposta onesta a freddo, non "rischio medio".
+- **La memoria ha acquisito una spina dorsale di provenienza** — le affermazioni portano età + autore reali, soppiantano affermazioni più vecchie, decadono nel tempo, e rispettano un limite di recency, così la conoscenza ricordata dichiara la propria freschezza invece di andare silenziosamente obsoleta.
+- **Co-change con Jaccard smussato** — `ghost_edges` / `predict` ora normalizzano l'accoppiamento invece di contare i co-commit grezzi (calibrazione-provata: +3 punti rispetto ai conteggi grezzi).
+- **Versione del binario + fingerprint sha** — `--version` stampa `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permettono a un host di rilevare e rifiutare un binario andato in drift.
+- **Istruzioni MCP agent-native + field report solo-locali.** Le istruzioni di `initialize` che ogni host riceve *sono* ora il ciclo operativo qui sopra. Gli agenti possono lasciare un solo segnale di telemetria per sessione — `learn` su un verdetto di retrieval, o una riga in `~/.m1nd/field-reports.jsonl` quando m1nd stesso si comporta male. Quel file è solo-locale; **m1nd non telefona mai a casa.**
 
 ## Avvio Rapido
 
@@ -58,11 +72,11 @@ Il percorso minimo funzionante — installa dai sorgenti (sempre aggiornato), ve
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # oppure: claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-Oppure dal canale npm beta: `npm install -g @maxkle1nz/m1nd@beta`.
+Oppure dal canale npm: `npm install -g @maxkle1nz/m1nd`.
 
 Mappa di installazione completa, pack per host, build del runtime nativo e flag di aggiornamento: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configurazione client per client: [matrice di integrazione](../docs/IDE-INTEGRATIONS.md).
 
@@ -79,20 +93,36 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 All'interno di una sessione MCP, la dottrina è questo ciclo di trust — stabilisci il trust *prima* di fidarti di qualsiasi retrieval:
 
 ```jsonc
-// 0. Verifica il binding in una sola chiamata (verdetto prima del retrieval)
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. Se il verdetto non è full_trust, chiedi il percorso di recovery deterministico
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. Costruisci la verità del grafo
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. Poni una domanda strutturale — risultati vuoti dicono *perché*, mai solo "nessun risultato"
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **Ciclo prima sessione, in quattro mosse:** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` il risultato duraturo così la sessione successiva parte avvantaggiata.
+
+### Servi un grafo, collega molti agenti
+
+L'Avvio Rapido qui sopra collega un server stdio per host — va bene per un solo agente, ma ogni processo carica il proprio grafo e detiene il proprio lease. Il deployment per cui m1nd è costruito è un proprietario, molti agenti collegati. Un unico processo proprietario detiene il grafo live:
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+Ogni agente si collega poi come un sottile bridge stdio↔HTTP — **non** carica alcun grafo, non costruisce engine, e **non** prende alcun lease:
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+Un numero qualsiasi di bridge punta all'unico proprietario e ne condivide il singolo grafo live, così ciò che un agente `memorize` un altro lo richiama immediatamente — nessun reingest, nessuna copia per-agente. Le query passano su localhost, quindi resta local-first (il bind resta `127.0.0.1` a meno che tu non scelga `--bind 0.0.0.0`). Un `seek` a caldo sul bridge ha misurato ≈0.7ms su un grafo piccolo su una singola macchina — ordine di grandezza, non una garanzia: il collegamento aggiunge un round-trip su localhost, e la latenza scala con la dimensione del grafo e il carico.
 
 ## Cosa m1nd Non È
 
@@ -150,6 +180,8 @@ Questa è la cosa più difendibile che m1nd fa, e nessun concorrente la offre. L
 - **`recovery_playbook`** restituisce un elenco di passi deterministico e ordinato per riparare il binding.
 
 La prova dell'impegno è ciò che è stato eliminato per esso: `savings` e `resonate` sono stati rimossi dalla superficie pubblicizzata nella beta.7 perché uno strumento che afferma sempre di vincere non è credibile. Nessun concorrente — né mem0, Zep, Letta, Sourcegraph, né alcun MCP code-graph — offre un layer che dice all'agente cosa *non* fidarsi e come recuperare.
+
+**Il ciclo di field-triage si chiude su sé stesso.** La telemetria di sessione che gli agenti lasciano in `~/.m1nd/field-reports.jsonl` (solo-locale — m1nd non telefona mai a casa) non è un log passivo: i report vengono sottoposti a triage, e un bug sul campo *confermato* diventa un caso rosso della battery **prima** della fix, così la regressione è provata, non solo descritta. Quel ciclo è già stato eseguito una volta end-to-end: due bug segnalati sul campo sono diventati casi della battery falliti e poi fix merge — `north` ora compone il recall L1GHT nel suo packet di memoria, e la sentinella del grafo `temp` si risolve in una vera tempdir invece di sporcare la directory di lavoro.
 
 ## Copertura Linguistica
 
@@ -211,11 +243,13 @@ Ogni riga è calibrata esattamente a ciò che è stato misurato. m1nd non guida 
 
 | Affermazione | Risultato | Fonte / calibrazione |
 |---|---|---|
-| Latenza `activate` / `impact` | `activate` sub-µs, `impact` sub-ms | Benchmark Criterion in `m1nd-core/benches/` su un grafo sintetico da 1K nodi — [metodologia](https://m1nd.world/wiki/benchmarks.html); trattare come ordine di grandezza. |
+| Latenza `activate` / `impact` | ~1µs `activate`, `impact` sub-µs su un grafo sintetico da 1K nodi | Benchmark Criterion — **riproducilo tu stesso: `cargo bench -p m1nd-core`** (misurati `activate_1k_nodes` ≈1.4µs, `impact_depth3` ≈0.5µs su un Mac Apple-silicon); [metodologia](https://m1nd.world/wiki/benchmarks.html); ordine di grandezza, dipendente dall'hardware. |
 | Matrice linguistica | chiamate + import cross-file per 10 linguaggi (+ Ruby cross-file) | Verificato end-to-end in un singolo ingest poliglotta; test per linguaggio in `m1nd-ingest`. Vedi [Copertura Linguistica](#copertura-linguistica). |
 | Campione di validazione post-scrittura | 12/12 classificati correttamente | Controllo di runtime interno. |
 | Bug-hunt con semi | 16/20 al primo round accettato di difetti seminati `humanize` (m1nd-trained); `m1nd-basic` e diretto ciascuno 8/15 | Evidenza di prodotto interno, `public_claim_worthy=false` — non un benchmark universale. |
 | Auto-verifica della memoria | provata live end-to-end | `memorize` → `grounded_in` → segnale di freshness su file modificato → sopravvive a replace → boot auto-load. |
+| Capability battery vs grep | 37/37 superati; testa a testa 16 vittorie-m1nd / 12 pari / **0 vittorie-grep** | Harness in-repo `scratchpad/m1nd_battery.py` (37 casi, ingest fresco + PASS/FAIL su ground-truth + testa a testa con `rg`). **Riproduci: `python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`.** Calibrazione: un solo repo (m1nd stesso), casi auto-scritti; ~5 dei pari sono strumenti strutturali valutati contro un proxy grep-letterale che non riesce a esprimere ciò a cui rispondono. |
+| Calibrazione conforme (`predict`) | banda-act ≈32% di precisione @ ≈13.5% di copertura (α=0.10) | Sulla cronologia git di m1nd stesso (n≈9.2k predizioni held-out), +3pts rispetto ai conteggi grezzi dopo il cambiamento a Jaccard smussato. Calibrazione: un solo repo, un segnale grezzo basato su conteggi — il gate oggi si astiene per lo più, **by design**: l'astensione è l'output onesto di un segnale debole, non un fallimento. |
 
 ## Limiti
 
@@ -238,7 +272,7 @@ Tre crate Rust core più un bridge ausiliario:
 - **`m1nd-ingest`** — adapter di estrazione, routing e costruzione del grafo (codice, doc universali, L1GHT).
 - **`m1nd-openclaw`** — bridge ausiliario OpenClaw (lane Unix-socket, versioning indipendente).
 
-Versioni correnti dei crate: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` tutti `0.9.0-beta.8`.
+Versioni correnti dei crate: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` tutti `1.2.0` (`m1nd-openclaw` è versionato indipendentemente a `0.1.0`).
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Panoramica architettura m1nd" width="960" />

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">コーディングエージェントのためのローカルミッションランタイム</h1>
+<h1 align="center">コーディングエージェントのためのオペレーショナルインテリジェンス</h1>
 
 <p align="center">
   <strong>あなたのコーディングエージェントは盲目でのスタートを卒業する。</strong><br/>
@@ -36,19 +36,33 @@
 
 ---
 
-**m1nd はコーディングエージェントのためのローカルミッションランタイムであり、単なる検索ではなく操作ループ全体を統括する。**
+**m1nd はコーディングエージェントのためのオペレーショナルインテリジェンスであり、単なる検索ではなく操作ループを統括する。**
 
 > `grep` はテキストを見つける。ベクトル検索は類似チャンクを見つける。`m1nd` はエージェントに、何が繋がっていて、何が変わって、何が壊れて、何がドリフトして、どこから再開すべきかを示すローカルグラフを与える。
 
 以下の三つは他のどのツールにも同時には存在しない：
 
-- **因果コードグラフ** — 編集前に `impact` を呼ぶと、見落としていた爆発半径が分かる；`ghost_edges` は import 関係がないのに常に一緒に変更されるファイルを浮かび上がらせる。
+- **因果コードグラフ** — 編集前に `impact` を呼ぶと、読んでいなかった爆発半径が分かる；`ghost_edges` は import 関係がないのに常に一緒に変更されるファイルを浮かび上がらせる。
 - **自己検証メモリ** — `memorize` は発見を実際のコードノードに固定する；コードが変更されると `cross_verify` がそれを古いものとして警告する。
 - **トラスト／リカバリレイヤー** — すべての結果はトラストモードを持つ；`trust_selftest` と `recovery_playbook` は、ワークスペースバインディングが間違っているときとその回復方法をエージェントに伝える。
+
+加えて**アテンションランタイム** — `focus` はゴールに対する最小限で予算に制限された作業セットをエージェントに渡し、切り捨てたものの誠実なテールと、それが*十分な*コンテキストかどうかのシグナルを添える。
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="従来のエージェントループ vs m1ndグラウンドループ" width="960" />
 </p>
+
+## 1.2.0 の新機能 — 最初の OMEGA 期リリース
+
+1.2.0 はループを「取得して、あとは祈る」から**事前定向 → キャリブレーション済みの判定に基づいて行動する → 学んだことを取り込む**へと変える。テーマはトラストレイヤーと同じ：誠実な*ノー*は自信ありげな推測に勝る。
+
+- **`north(task)` — 一回の呼び出しで事前定向。** 新しいフロントドアは、トラスト、タスクコンテキスト（focus ノード + PageRank アンカー）、以前のクロスセッションメモリ、十分性シグナル、一つの `next_move`、そして `honest_gaps`（m1nd が*まだ*知らないこと）を合成する。`needs_ingest` は空のグラフに対する本物の答えだ。（以前のメモリをパケットに畳み込む L1GHT リコール合成は 1.2.0 タグの直後に `main` に着地した——1.2.0 のバイナリには含まれていない。）
+- **予測に対するコンフォーマルキャリブレーション。** `calibrate_predict` はリポジトリごとのゲートを起動する；その後、判定は `act` / `reverify` / `abstain` を読み、`abstain` は*キャリブレーションされていないか不十分*を意味する——弱い「イエス」ではなく、止まれというシグナルだ。ダークで出荷される：キャリブレーションするまで、判定は `reverify` で頭打ちになる。
+- **`seek` の `trust_envelope`**（ダークで出荷）と **`why` の `closure` 判定** — `blocked` は、パスが未解決／推測されたエッジに依存していることを意味する。**`trust_band: insufficient_evidence`** はいまやリスクバンドとは別物だ：それは*証拠なし*、誠実なコールドスタートの答えを意味し、「中リスク」ではない。
+- **メモリはプロヴェナンスの背骨を得た** — 主張は本物の経過時間 + 著者を持ち、古い主張を上書きし、時とともに失効し、リーセンシー上限を尊重する——だから記憶された知識は、静かに古びていくのではなく、自分自身のフレッシュネスを表明する。
+- **平滑化 Jaccard 共変更** — `ghost_edges` / `predict` はいまや生の共コミット数を数えるのではなく、結合を正規化する（キャリブレーションで生の数え上げに対して +3 ポイントが実証された）。
+- **バイナリバージョン + sha フィンガープリント** — `--version` は `1.2.0 (<sha>)` を印字する；`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`（+ `M1ND_STRICT_VERSION`）により、ホストはドリフトしたバイナリを検出して拒否できる。
+- **エージェントネイティブな MCP instructions + ローカル限定のフィールドレポート。** すべてのホストが受け取る `initialize` instructions は、いまや上記の操作ループそのものだ。エージェントはセッションごとに一つのテレメトリシグナルを残せる——検索判定に対する `learn`、または m1nd 自身が誤動作したときの `~/.m1nd/field-reports.jsonl` への一行。そのファイルはローカル限定だ；**m1nd は決して外部に通信しない。**
 
 ## クイックスタート
 
@@ -58,11 +72,11 @@
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # または: claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-npm ベータチャンネルからのインストール：`npm install -g @maxkle1nz/m1nd@beta`。
+または npm から：`npm install -g @maxkle1nz/m1nd`。
 
 完全なインストールマップ、ホストパック、ネイティブランタイムビルド、更新フラグ：[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · クライアント別セットアップ：[統合マトリクス](../docs/IDE-INTEGRATIONS.md)。
 
@@ -79,20 +93,36 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 MCP セッション内での教義はこのトラストループ——検索結果を信じる*前に*トラストを確立する：
 
 ```jsonc
-// 0. 一回の呼び出しでバインディングを信頼（検索前に判定を得る）
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. 判定が full_trust でない場合、決定論的リカバリパスを要求する
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. グラフの真実を構築する
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. 構造的な質問をする——空の結果は「なぜ」を言う、決して「結果なし」とだけ言わない
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **初回セッションループ、四ステップで：** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` で永続的な発見を残し、次のセッションを先行スタートさせる。
+
+### 一つのグラフをサーブし、多数のエージェントをアタッチする
+
+上記のクイックスタートはホストごとに stdio サーバーを接続する——一つのエージェントには十分だが、各プロセスは自身のグラフをロードし、自身のリースを保持する。m1nd が本来向けて作られているデプロイは、一人のオーナーと多数のアタッチされたエージェントだ。一つのオーナープロセスがライブグラフを保持する：
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+その後、各エージェントは薄い stdio↔HTTP ブリッジとしてアタッチする——グラフを**一切**ロードせず、エンジンを構築せず、リースを**一切**取らない：
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+任意の数のブリッジが一つのオーナーを指し、その単一のライブグラフを共有する。だから、あるエージェントが `memorize` したものを別のエージェントが即座にリコールする——再インジェストなし、エージェントごとのコピーなし。クエリは localhost を経由するので、ローカルファーストを保つ（`--bind 0.0.0.0` をオプトインしない限り、bind は `127.0.0.1` のままだ）。ブリッジ越しのウォームな `seek` は、一台のマシンの小さなグラフで ≈0.7ms を計測した——桁のオーダーであり、保証ではない：アタッチは localhost のラウンドトリップを加え、レイテンシはグラフサイズと負荷に応じてスケールする。
 
 ## m1nd ではないもの
 
@@ -134,10 +164,10 @@ memorize({
 ```
 
 2. **固定する** — m1nd は `<runtime>/agent-memory/` 下にグラフネイティブな `.light.md` を書き、インジェストし（`adapter=light mode=merge`）、`grounded_in` エッジで各 `evidence` パスを実際のコードノードに解決する——知識がコードと同じ活性化空間に存在し、`seek` / `activate` / `impact` でサーフェスされるようになる。
-3. **自動ロード** — すべての将来のセッション開始時に、`m1nd` は `agent-memory/` を自動的にインジェストし、`session_handshake.agent_memory` で報告する。過去の発見は `mode=replace` インジェストを生き延び、そこに*存在する*。
-4. **古さの自己フラグ立て** — `cross_verify(check: ["evidence_freshness"])` はすべての引用ファイルを再ハッシュし、コードが変更されたために古くなった主張を名指しする——メモリが嘘をつくときに教えてくれる、誤解させるのではなく。
+3. **自動ロード** — すべての将来のセッション開始時に、`m1nd` は `agent-memory/` を自動的にインジェストし、`session_handshake.agent_memory` で報告する。過去の発見は `mode=replace` インジェストを生き延び、ただそこに*存在する*。
+4. **古さの自己フラグ立て** — `cross_verify(check: ["evidence_freshness"])` はすべての引用ファイルを再ハッシュし、コードが変更されたために古くなった主張を名指しする——だからメモリは、誤解させるのではなく、嘘をつくときに教えてくれる。
 
-このループはエンドツーエンドで実証されている：`memorize` → `grounded_in` エッジ → 編集されたファイルのフレッシュネスフラグ → `mode=replace` を生き延びる → 起動時の自動ロード。有界ミッションを閉じるとき？`write_light_memory: true` を `mission_close` に渡すと、その検証済みの主張を同じ方法で永続化できる。この習慣は、すべての MCP クライアントが `initialize` 時に受け取るサーバーの `instructions` に文書化されている——ホスト非依存、クライアント固有のプラグイン不要。
+このループはエンドツーエンドでライブ実証されている：`memorize` → `grounded_in` エッジ → 編集されたファイルのフレッシュネスフラグ → `mode=replace` を生き延びる → 起動時の自動ロード。有界ミッションを閉じるとき？`write_light_memory: true` を `mission_close` に渡すと、その検証済みの主張を同じ方法で永続化できる。この習慣は、すべての MCP クライアントが `initialize` 時に受け取るサーバーの `instructions` に文書化されている——ホスト非依存、クライアント固有のプラグイン不要。
 
 ## トラスト／誠実性レイヤー
 
@@ -151,9 +181,11 @@ memorize({
 
 この約束の証明は、そのために犠牲にしたもの：`savings` と `resonate` は beta.7 で公告サーフェスから削除された、なぜなら常に勝つと主張するツールは信頼できないからだ。競合他社——mem0、Zep、Letta、Sourcegraph、またはいかなるコードグラフ MCP も——エージェントに何を*信頼しないべきか*そして回復方法を伝えるレイヤーを提供していない。
 
+**フィールドトリアージのループはそれ自身の上で閉じる。** エージェントが `~/.m1nd/field-reports.jsonl` に残すセッションテレメトリ（ローカル限定——m1nd は決して外部に通信しない）は受動的なログではない：レポートはトリアージされ、*確認された*フィールドバグは修正の**前に**赤いバッテリーケースになる——だからリグレッションは記述されるだけでなく、証明される。そのループはすでにエンドツーエンドで一度回った：二つのフィールド報告バグが失敗するバッテリーケースになり、その後マージされた修正になった——`north` はいまや L1GHT リコールをそのメモリパケットに合成し、`temp` グラフのセンチネルは作業ディレクトリを散らかす代わりに本物の tempdir に解決される。
+
 ## 言語カバレッジ
 
-グラフ推論（`impact`、`why`、`predict`、`trace`、`taint_trace`）はエクストラクターの品質に依存する。m1nd は言語ごとに **`calls` エッジ**（コールグラフ）と**クロスファイル `imports`**（ファイル→ファイルの依存解決）を解決する。以下のマトリクスは単一のポリグロットインジェストで実証された：
+グラフ推論（`impact`、`why`、`predict`、`trace`、`taint_trace`）はエクストラクターの品質に依存する。m1nd は言語ごとに **`calls` エッジ**（コールグラフ）と**クロスファイル `imports`**（ファイル→ファイルの依存解決）の両方を解決する。以下のマトリクスは単一のポリグロットインジェストでライブ実証された：
 
 | 言語 | `calls` | クロスファイル imports |
 |---|:---:|:---:|
@@ -180,16 +212,16 @@ memorize({
 |---|---|---|
 | グラフ基盤 | コードのインジェスト、グラフ状態の維持、セッション継続性の診断、有用なパスの強化、クロスセッションの重みドリフト検出 | `trust_selftest`、`session_handshake`、`recovery_playbook`、`ingest`、`health`、`doctor`、`learn`、`warmup`、`drift` |
 | 検索と定向 | 手動ファイル読み取りの前にテキスト、パス、意図、構造、または関係で検索 | `audit`、`search`、`glob`、`seek`、`activate`、`why`、`trace` |
-| ドキュメントと知識バインディング | ユニバーサルドキュメントまたはグラフネイティブ `L1GHT` をインジェストし、コンセプトをコードにリンクする | `ingest(adapter="universal"\|"light")`、`document_resolve`、`document_provider_health`、`document_bindings`、`document_drift`、`auto_ingest_*` |
+| ドキュメントと知識バインディング | ユニバーサルドキュメントまたはグラフネイティブ `L1GHT` をインジェストし、コンセプトをコードにリンクバックする | `ingest(adapter="universal"\|"light")`、`document_resolve`、`document_provider_health`、`document_bindings`、`document_drift`、`auto_ingest_*` |
 | ナビゲーションと継続性 | セッションをまたいでステートフルなルート、引き継ぎ、ベースライン、調査メモリを維持する | `perspective_*`、`trail_*`、`coverage_session`、`boot_memory`、`persist` |
-| Mission Control と証明の規律 | 有界ルートを維持し、イベントを記録し、グラフ定向から直接証明に切り替え、明示的なギャップでクローズする | `mission_start`、`mission_event`、`mission_next`、`mission_verify`、`mission_handoff`、`mission_close` |
+| Mission Control と証明の規律 | 有界ルートを維持し、イベントを記録し、グラフ定向から直接証明に切り替え、引き継ぎ、明示的なギャップでクローズする | `mission_start`、`mission_event`、`mission_next`、`mission_verify`、`mission_handoff`、`mission_close` |
 | 変更計画と証明 | 影響、共変更、欠落ステップ、失敗パス、構造的主張について推論する | `impact`、`predict`、`validate_plan`、`missing`、`hypothesize`、`counterfactual`、`differential` |
 | 品質、セキュリティ、アーキテクチャ | パターン、汚染パス、トラスト境界、重複、レイヤー違反、型フロー、リファクタリング対象を検出する | `scan`、`scan_all`、`heuristics_surface`、`antibody_*`、`taint_trace`、`type_trace`、`trust`、`layers`、`layer_inspect`、`twins`、`fingerprint`、`flow_simulate`、`epidemic`、`tremor`、`refactor_plan` |
 | 時間、ランタイム、マルチリポジトリ作業 | git 履歴、ドリフト、隠れた共変更エッジ、ランタイムオーバーレイ、クロスリポジトリ参照を検査する | `timeline`、`diverge`、`ghost_edges`、`runtime_overlay`、`external_references`、`federate`、`federate_auto` |
 | 運用と監視 | リポジトリの状態を監査し、グラフとディスクの真実を検証し、デーモン監視を実行し、状態を永続化し、永続アラートを浮かび上がらせる | `audit`、`cross_verify`、`daemon_*`、`alerts_*`、`panoramic`、`metrics`、`report`、`persist`、`diagram`、`help` |
 | サージカル編集の準備と実行 | コンパクトな接続済みコンテキストを取得し、書き込みをプレビューし、グラフ対応編集を適用する | `surgical_context`、`surgical_context_v2`、`view`、`batch_view`、`edit_preview`、`edit_commit`、`apply`、`apply_batch` |
 
-**ティアリング：** デフォルトでは 27 のエッセンシャルツールが公告され、ツール選択コストを削減する；`M1ND_TOOL_TIER=full` を設定するとフルサーフェス（100 以上のツール：RETROBUILDER、perspectives、federation、daemon）が公告される。いくつかのツール（`resonate`、`savings`、`lock_*`）は名前で呼び出せるが公告サーフェスには載っていない。隠されたツールは常に `tools/call` で呼び出せる——ティアリングは `tools/list` がサーフェスするものだけを制御する。
+**ティアリング：** ツール選択コストを削減するため、デフォルトでは 27 のエッセンシャルツールが公告される；`M1ND_TOOL_TIER=full` を設定するとフルサーフェス（100 以上のツール：RETROBUILDER、perspectives、federation、daemon）が公告される。いくつかのツール（`resonate`、`savings`、`lock_*`）は名前で呼び出せるが公告サーフェスには載っていない。隠されたツールは常に `tools/call` で呼び出せる——ティアリングは `tools/list` がサーフェスするものだけを制御する。
 
 ## 操作ループ
 
@@ -201,7 +233,7 @@ memorize({
 - **深い分析** — `fingerprint`、`diverge`、`ghost_edges`、`taint_trace`、`twins`、`refactor_plan`、`runtime_overlay`（RETROBUILDER レンズ）、隠れた結合、セキュリティパス、構造的重複、ランタイムヒートのために。
 - **メモリ** — `confidence` と `evidence` パスを持って `memorize` で永続的な結論を残す。
 
-Mission Control は証明の規律であり、機能リストではない。`mission_next` はちょうど一つのアクションと `do_not` ガードレールを返す；`mission_verify` はグラフのみの主張を拒否する；`mission_close` は常にエージェントが検証済みの知識を永続化し、ギャップと非主張を記録するよう促す。`bug_hunt` モードでは、MC0 は検証済みの発見の後にクローズ前の最終 `direct_sweep` を要求し、エージェントが負の空間を確認するようにする。
+Mission Control は証明の規律であり、機能リストではない。`mission_next` はちょうど一つのアクションと `do_not` ガードレールを返す；`mission_verify` はグラフのみの主張を拒否する；`mission_close` は常にエージェントが検証済みの知識を永続化するよう促し、ギャップと非主張を記録する。`bug_hunt` モードでは、MC0 は検証済みの発見の後にクローズ前の最終 `direct_sweep` を要求し、エージェントが負の空間を確認するようにする。
 
 **注意：** `predict` は `ghost_edges` が git 共変更マトリクスをロードするまで**構造的フォールバックのみ**——本当の共変更可能性が必要なときは先に `ghost_edges` を実行すること。
 
@@ -211,11 +243,13 @@ Mission Control は証明の規律であり、機能リストではない。`mis
 
 | 主張 | 結果 | ソース／ヘッジ |
 |---|---|---|
-| `activate` / `impact` レイテンシ | `activate` サブマイクロ秒、`impact` サブミリ秒 | `m1nd-core/benches/` の 1K ノード合成グラフでの Criterion ベンチマーク——[方法論](https://m1nd.world/wiki/benchmarks.html)；桁の参考として扱うこと。 |
+| `activate` / `impact` レイテンシ | 1K ノード合成グラフで `activate` ~1µs、`impact` サブマイクロ秒 | Criterion ベンチマーク——**自分で再現せよ：`cargo bench -p m1nd-core`**（Apple シリコン Mac で `activate_1k_nodes` ≈1.4µs、`impact_depth3` ≈0.5µs を計測）；[方法論](https://m1nd.world/wiki/benchmarks.html)；桁のオーダー、ハードウェア依存。 |
 | 言語マトリクス | 10 言語の calls + クロスファイル imports（+ Ruby クロスファイル） | 単一のポリグロットインジェストでエンドツーエンド検証；言語ごとのテストは `m1nd-ingest` にある。[言語カバレッジ](#言語カバレッジ)参照。 |
 | 書き込み後検証サンプル | 12/12 を正しく分類 | 内部ランタイムチェック。 |
 | シードされたバグハント | 最初に受け入れられた `humanize` シード欠陥ラウンドで 16/20（m1nd 訓練済み）；`m1nd-basic` と直接はそれぞれ 8/15 | 内部製品証拠、`public_claim_worthy=false`——ユニバーサルベンチマークではない。 |
-| メモリの自己検証 | エンドツーエンドで実証済み | `memorize` → `grounded_in` → 編集されたファイルのフレッシュネスフラグ → replace を生き延びる → 起動時の自動ロード。 |
+| メモリの自己検証 | エンドツーエンドでライブ実証済み | `memorize` → `grounded_in` → 編集されたファイルのフレッシュネスフラグ → replace を生き延びる → 起動時の自動ロード。 |
+| ケイパビリティバッテリー vs grep | 37/37 パス；直接対決 16 m1nd 勝ち / 12 引き分け / **0 grep 勝ち** | リポジトリ内ハーネス `scratchpad/m1nd_battery.py`（37 ケース、フレッシュインジェスト + グラウンドトゥルース PASS/FAIL + `rg` 直接対決）。**再現：`python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`。** ヘッジ：一つのリポジトリ（m1nd 自身）、自己著述のケース；引き分けのうち約 5 件は、答えを表現できないリテラル grep プロキシに対してスコアされた構造ツールだ。 |
+| コンフォーマルキャリブレーション（`predict`） | act バンド ≈32% 精度 @ ≈13.5% カバレッジ（α=0.10） | m1nd 自身の git 履歴上（n≈9.2k のホールドアウト予測）、平滑化 Jaccard 変更後に生の数え上げに対して +3pts。ヘッジ：一つのリポジトリ、粗い数え上げベースのシグナル——ゲートは今日ほとんど棄権する、**設計どおりに**：棄権は弱いシグナルの誠実な出力であって、失敗ではない。 |
 
 ## 制限事項
 
@@ -227,7 +261,7 @@ Mission Control は証明の規律であり、機能リストではない。`mis
 - コンパイラまたはランタイムの真実だけが必要な場合
 - 構造的な不確実性のない単純なローカルファイル操作の場合
 
-**フィーディングが必要：** `trust` と `tremor` は `learn` フィードバック / `ghost_edges` データが蓄積されるまで中立的な事前分布から始まり、`predict` は共変更シグナルが意味を持つ前に `ghost_edges` のロードが必要だ。これらは使うほど改善する；起動時に情報がないことについて誠実だ。
+**フィーディングが必要：** `trust` と `tremor` は `learn` フィードバック / `ghost_edges` データが蓄積されるまで中立的な事前分布から始まり、`predict` はその共変更シグナルが意味を持つ前にまず `ghost_edges` のロードが必要だ。これらは使うほど改善する；起動時に情報がないことについて誠実だ。
 
 ## アーキテクチャ概観
 
@@ -238,7 +272,7 @@ Mission Control は証明の規律であり、機能リストではない。`mis
 - **`m1nd-ingest`** — 抽出、ルーティング、グラフ構築アダプター（コード、ユニバーサルドキュメント、L1GHT）。
 - **`m1nd-openclaw`** — 補助 OpenClaw ブリッジ（Unix ソケットレーン、独立バージョニング）。
 
-現在のクレートバージョン：`m1nd-core`、`m1nd-ingest`、`m1nd-mcp` はすべて `0.9.0-beta.8`。
+現在のクレートバージョン：`m1nd-core`、`m1nd-ingest`、`m1nd-mcp` はすべて `1.2.0`（`m1nd-openclaw` は `0.1.0` で独立にバージョニングされている）。
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="m1nd アーキテクチャ概観" width="960" />

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">Um Runtime de Missão Local para Agentes de Código</h1>
+<h1 align="center">Inteligência Operacional para Agentes de Código</h1>
 
 <p align="center">
   <strong>Seu agente de código para de começar às cegas.</strong><br/>
@@ -36,7 +36,7 @@
 
 ---
 
-**m1nd é um runtime de missão local para agentes de código — ele governa o loop operacional, não apenas a recuperação de dados.**
+**m1nd é inteligência operacional para agentes de código — ele governa o loop operacional, não apenas a recuperação de dados.**
 
 > `grep` encontra texto. Busca vetorial encontra chunks similares. `m1nd` dá aos agentes um grafo local do que se conecta, o que mudou, o que quebra, o que derivou e onde retomar.
 
@@ -46,9 +46,23 @@ Três coisas aqui coexistem em nenhuma outra ferramenta:
 - **Memória auto-verificável** — `memorize` ancora descobertas a nós reais do código; `cross_verify` os marca como obsoletos quando esse código muda.
 - **Uma camada de confiança e recuperação** — cada resultado carrega um modo de confiança; `trust_selftest` e `recovery_playbook` avisam o agente quando o binding de workspace está errado e como se recuperar.
 
+Além de um **runtime de atenção** — `focus` entrega ao agente o conjunto de trabalho mínimo e delimitado por orçamento para um objetivo, com uma cauda honesta do que deixou de fora e um sinal de se aquilo já é contexto *suficiente*.
+
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Loop tradicional de agente vs loop ancorado no m1nd" width="960" />
 </p>
+
+## Novidades na 1.2.0 — o primeiro release da era OMEGA
+
+A 1.2.0 transforma o loop de "recupere, depois torça" em **pré-orientar → agir sobre veredictos calibrados → capturar o que você aprendeu**. O tema é o mesmo da camada de confiança: um *não* honesto vence um palpite confiante.
+
+- **`north(task)` — pré-orientação em uma chamada.** A nova porta de entrada compõe confiança, contexto da tarefa (nós de foco + âncoras de PageRank), memória prévia entre sessões, um sinal de suficiência, um `next_move` e `honest_gaps` (o que o m1nd ainda *não* sabe). `needs_ingest` é uma resposta real para um grafo vazio. (A composição de recall L1GHT que dobra a memória prévia dentro do pacote entrou na `main` logo após a tag 1.2.0 — ela não está no binário 1.2.0.)
+- **Calibração conformal na predição.** `calibrate_predict` arma um gate por repositório; os veredictos passam então a ler `act` / `reverify` / `abstain`, onde `abstain` significa *não calibrado ou insuficiente* — um sinal para parar, não um sim fraco. Vem desativado: até você calibrar, os veredictos ficam limitados a `reverify`.
+- **`trust_envelope` no `seek`** (vem desativado) e um **veredicto `closure` no `why`** — `blocked` significa que o caminho se apoia em uma aresta não resolvida/adivinhada. **`trust_band: insufficient_evidence`** agora é distinto de uma banda de risco: significa *sem evidência*, a resposta honesta de partida a frio, não "risco médio".
+- **A memória ganhou uma espinha de proveniência** — afirmações carregam idade + autor reais, substituem afirmações mais antigas, expiram e respeitam um teto de recência, de modo que o conhecimento lembrado declara seu próprio frescor em vez de silenciosamente ficar obsoleto.
+- **Co-mudança com Jaccard suavizado** — `ghost_edges` / `predict` agora normalizam o acoplamento em vez de contar co-commits brutos (comprovado em calibração como +3 pontos sobre contagens brutas).
+- **Versão do binário + fingerprint sha** — `--version` imprime `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permitem que um host detecte e recuse um binário que derivou.
+- **Instruções MCP nativas de agente + relatórios de campo apenas locais.** As instruções de `initialize` que todo host recebe agora *são* o loop operacional acima. Agentes podem deixar um sinal de telemetria por sessão — `learn` sobre um veredicto de recuperação, ou uma linha em `~/.m1nd/field-reports.jsonl` quando o próprio m1nd se comporta mal. Esse arquivo é apenas local; **o m1nd nunca liga para casa.**
 
 ## Início Rápido
 
@@ -58,11 +72,11 @@ O caminho mínimo feliz — instale a partir do fonte (sempre atualizado), verif
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # ou: claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-Ou pelo canal beta do npm: `npm install -g @maxkle1nz/m1nd@beta`.
+Ou pelo npm: `npm install -g @maxkle1nz/m1nd`.
 
 Mapa completo de instalação, pacotes de host, build nativo do runtime e flags de atualização: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuração por cliente: [matriz de integração](../docs/IDE-INTEGRATIONS.md).
 
@@ -79,20 +93,36 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 Dentro de uma sessão MCP, a doutrina é este loop de confiança — estabeleça confiança *antes* de acreditar em qualquer recuperação:
 
 ```jsonc
-// 0. Confie no binding em uma chamada (veredicto antes da recuperação)
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. Se o veredicto não for full_trust, peça o caminho de recuperação determinístico
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. Construa a verdade do grafo
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. Faça uma pergunta estrutural — resultados vazios dizem *por que*, nunca só "sem resultados"
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **Loop de primeira sessão, em quatro movimentos:** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` a descoberta durável para que a próxima sessão comece à frente.
+
+### Sirva um grafo, conecte muitos agentes
+
+O Início Rápido acima conecta um servidor stdio por host — ótimo para um agente, mas cada processo carrega seu próprio grafo e mantém seu próprio lease. O deployment para o qual o m1nd foi construído é um dono, muitos agentes conectados. Um processo dono mantém o grafo vivo:
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+Cada agente então se conecta como uma ponte fina stdio↔HTTP — ele não carrega **nenhum** grafo, não constrói nenhum motor e não toma **nenhum** lease:
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+Qualquer número de pontes aponta para o único dono e compartilha seu único grafo vivo, de modo que o que um agente `memorize` outro recupera imediatamente — sem reingestão, sem cópia por agente. As consultas passam por localhost, então continua local-first (o bind permanece `127.0.0.1` a menos que você opte por `--bind 0.0.0.0`). Um `seek` quente sobre a ponte mediu ≈0.7ms em um grafo pequeno em uma máquina — ordem de grandeza, não uma garantia: o attach adiciona um round-trip de localhost, e a latência escala com o tamanho e a carga do grafo.
 
 ## O Que o m1nd Não É
 
@@ -150,6 +180,8 @@ Esta é a coisa mais defensável que o m1nd faz, e nenhum concorrente a entrega.
 - **`recovery_playbook`** retorna uma lista de passos determinística e ordenada para reparar o binding.
 
 A prova do compromisso está no que foi sacrificado por ele: `savings` e `resonate` foram removidos da superfície anunciada no beta.7 porque uma ferramenta que sempre afirma vencer não é crível. Nenhum concorrente — nem mem0, Zep, Letta, Sourcegraph ou qualquer MCP de grafo de código — entrega uma camada que diz ao agente no que *não* confiar e como se recuperar.
+
+**O loop de triagem de campo se fecha sobre si mesmo.** A telemetria de sessão que os agentes deixam em `~/.m1nd/field-reports.jsonl` (apenas local — o m1nd nunca liga para casa) não é um log passivo: os relatórios são triados, e um bug de campo *confirmado* vira um caso de bateria vermelho **antes** da correção, de modo que a regressão é provada, não apenas descrita. Esse loop já rodou uma vez de ponta a ponta: dois bugs reportados em campo viraram casos de bateria que falhavam e depois correções mergeadas — o `north` agora compõe recall L1GHT em seu pacote de memória, e a sentinela de grafo `temp` resolve para um tempdir real em vez de sujar o diretório de trabalho.
 
 ## Cobertura de Linguagens
 
@@ -211,11 +243,13 @@ Cada linha é calibrada exatamente ao que foi medido. O m1nd não lidera com nú
 
 | Afirmação | Resultado | Fonte / ressalva |
 |---|---|---|
-| Latência de `activate` / `impact` | sub-µs `activate`, sub-ms `impact` | Benchmarks Criterion em `m1nd-core/benches/` em um grafo sintético de 1K nós — [metodologia](https://m1nd.world/wiki/benchmarks.html); trate como ordem de grandeza. |
+| Latência de `activate` / `impact` | ~1µs `activate`, sub-µs `impact` em um grafo sintético de 1K nós | Benchmarks Criterion — **reproduza você mesmo: `cargo bench -p m1nd-core`** (medido `activate_1k_nodes` ≈1.4µs, `impact_depth3` ≈0.5µs em um Mac com Apple silicon); [metodologia](https://m1nd.world/wiki/benchmarks.html); ordem de grandeza, dependente de hardware. |
 | Matriz de linguagens | calls + imports entre arquivos para 10 linguagens (+ Ruby entre arquivos) | Verificado de ponta a ponta em uma única ingestão poliglota; testes por linguagem em `m1nd-ingest`. Veja [Cobertura de Linguagens](#cobertura-de-linguagens). |
 | Amostra de validação pós-escrita | 12/12 classificados corretamente | Verificação de runtime interna. |
 | Caça a bugs com seeds | 16/20 na primeira rodada aceita de defeitos com seed `humanize` (treinado com m1nd); `m1nd-basic` e direto cada um 8/15 | Evidência interna de produto, `public_claim_worthy=false` — não é um benchmark universal. |
 | Auto-verificação de memória | provado ao vivo de ponta a ponta | `memorize` → `grounded_in` → flag de frescor em arquivo editado → sobrevive a replace → carga automática no boot. |
+| Bateria de capacidades vs grep | 37/37 passam; frente a frente 16 vitórias do m1nd / 12 empates / **0 vitórias do grep** | Harness in-repo `scratchpad/m1nd_battery.py` (37 casos, ingestão nova + PASS/FAIL de ground-truth + confronto direto com `rg`). **Reproduza: `python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`.** Ressalva: um repo (o próprio m1nd), casos escritos por nós mesmos; ~5 dos empates são ferramentas estruturais pontuadas contra um proxy de grep literal que não consegue expressar o que elas respondem. |
+| Calibração conformal (`predict`) | banda act ≈32% de precisão @ ≈13.5% de cobertura (α=0.10) | Sobre o próprio histórico git do m1nd (n≈9.2k predições held-out), +3pts sobre contagens brutas após a mudança para Jaccard suavizado. Ressalva: um repo, um sinal grosseiro baseado em contagem — o gate hoje majoritariamente se abstém, **por design**: a abstenção é a saída honesta de um sinal fraco, não uma falha. |
 
 ## Limites
 
@@ -238,7 +272,7 @@ Três crates core em Rust mais uma bridge auxiliar:
 - **`m1nd-ingest`** — extração, roteamento e adapters de construção de grafo (código, docs universais, L1GHT).
 - **`m1nd-openclaw`** — bridge auxiliar OpenClaw (lane de Unix socket, versionado independentemente).
 
-Versões atuais dos crates: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` todos em `0.9.0-beta.8`.
+Versões atuais dos crates: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` todos em `1.2.0` (`m1nd-openclaw` é versionado independentemente em `0.1.0`).
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Visão geral da arquitetura do m1nd" width="960" />

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -4,7 +4,7 @@
   <img src="../.github/m1nd-logo.svg" alt="m1nd" width="400" />
 </p>
 
-<h1 align="center">面向代码智能体的本地任务运行时</h1>
+<h1 align="center">面向代码智能体的操作智能</h1>
 
 <p align="center">
   <strong>你的代码智能体不再盲目启动。</strong><br/>
@@ -36,19 +36,33 @@
 
 ---
 
-**m1nd 是面向代码智能体的本地任务运行时——它掌管的是操作循环，而不仅仅是检索。**
+**m1nd 是面向代码智能体的操作智能——它掌管的是操作循环，而不仅仅是检索。**
 
-> `grep` 能找到文本。向量搜索能找到相似片段。`m1nd` 给智能体一张本地图，显示什么与什么相连、什么发生了变化、什么会崩溃、什么产生了漂移，以及从哪里恢复。
+> grep 能找到文本。向量搜索能找到相似片段。`m1nd` 给智能体一张本地图，显示什么与什么相连、什么发生了变化、什么会崩溃、什么产生了漂移，以及从哪里恢复。
 
 以下三点在任何其他工具中都不同时存在：
 
 - **因果代码图** — 编辑前调用 `impact` 可看清你没读到的爆炸半径；`ghost_edges` 会找出那些总是一起变动但没有任何 import 关系的文件。
 - **自我验证记忆** — `memorize` 将发现锚定到真实代码节点；当代码变更时，`cross_verify` 会将其标记为过期。
-- **信任与恢复层** — 每个结果都附带信任模式；`trust_selftest` 和 `recovery_playbook` 会告知智能体工作区绑定何时出错以及如何恢复。
+- **信任 / 恢复层** — 每个结果都附带信任模式；`trust_selftest` 和 `recovery_playbook` 会告知智能体工作区绑定何时出错以及如何恢复。
+
+此外还有一个**注意力运行时**——`focus` 为一个目标向智能体交付最小的、受预算约束的工作集，附带一条诚实的尾部列出它遗漏了什么，以及一个信号来判断上下文*是否已足够*。
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="传统智能体循环 vs m1nd 接地循环" width="960" />
 </p>
+
+## 1.2.0 新特性——首个 OMEGA 时代版本
+
+1.2.0 将循环从"检索，然后寄希望"转变为**预定向 → 依据校准过的裁决行动 → 捕获所学**。主题与信任层一致：诚实的"不"胜过自信的猜测。
+
+- **`north(task)` — 一次调用即可预定向。** 这个新的前门整合了信任、任务上下文（focus 节点 + PageRank 锚点）、先前的跨会话记忆、一个充分性信号、一个 `next_move`，以及 `honest_gaps`（m1nd *尚不*知道的内容）。对于空图，`needs_ingest` 是一个真实的答案。（将先前记忆折叠进数据包的 L1GHT-recall 整合是在 1.2.0 标签之后才落到 `main` 上的——它不在 1.2.0 二进制文件中。）
+- **预测上的保形校准。** `calibrate_predict` 为每个仓库装配一道闸门；此后裁决读作 `act` / `reverify` / `abstain`，其中 `abstain` 意味着*未校准或不充分*——一个停止信号，而不是弱肯定。默认隐藏出厂：在你校准之前，裁决最高只到 `reverify`。
+- **`seek` 上的 `trust_envelope`**（隐藏出厂）以及 **`why` 上的 `closure` 裁决**——`blocked` 意味着该路径依赖于一条未解析/猜测的边。**`trust_band: insufficient_evidence`** 现在与风险等级截然不同：它意味着*没有证据*，是诚实的冷启动答案，而非"中等风险"。
+- **记忆长出了一条溯源脊柱**——声明携带真实的年龄 + 作者、取代更旧的声明、随时间老化，并遵守一个新近度上限，因此被记住的知识会陈述自己的新鲜度，而不是悄然过期。
+- **平滑化 Jaccard 共变更**——`ghost_edges` / `predict` 现在对耦合进行归一化，而不是统计原始的共提交次数（经校准证明，比原始计数高出 +3 个点）。
+- **二进制版本 + sha 指纹**——`--version` 打印 `1.2.0 (<sha>)`；`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`（+ `M1ND_STRICT_VERSION`）让宿主能够检测并拒绝一个漂移的二进制文件。
+- **智能体原生的 MCP 指令 + 仅本地的现场报告。** 每个宿主收到的 `initialize` 指令现在*就是*上述操作循环。智能体每个会话可以留下一个遥测信号——对某个检索裁决执行 `learn`，或在 m1nd 自身行为异常时在 `~/.m1nd/field-reports.jsonl` 中写一行。该文件仅在本地；**m1nd 从不回传数据。**
 
 ## 快速开始
 
@@ -58,11 +72,11 @@
 git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
 npm install -g .
 m1nd doctor
-m1nd install-skills codex          # 或: claude / gemini / antigravity / generic
+m1nd install-skills codex          # or: claude / gemini / antigravity / generic
 m1nd mcp-config codex --project /your/project
 ```
 
-或通过 npm 测试通道安装：`npm install -g @maxkle1nz/m1nd@beta`。
+或通过 npm：`npm install -g @maxkle1nz/m1nd`。
 
 完整安装指南、宿主包、原生运行时构建和更新标志：[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · 逐客户端配置：[集成矩阵](../docs/IDE-INTEGRATIONS.md)。
 
@@ -76,23 +90,39 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 
 `m1nd agent first-minute` 是接触新仓库最安全的第一步。它会界定仓库范围、建立信任、按需摄入、运行一次有界的定向扫描、返回候选锚点，然后告知智能体直接从源码、测试、编译器/运行时输出、日志或探针来验证。
 
-在 MCP 会话内，教义是如下信任循环——在相信任何检索结果之前，先*建立信任*：
+在 MCP 会话内，教义是如下信任循环——在相信任何检索结果*之前*先建立信任：
 
 ```jsonc
-// 0. 一次调用即可信任绑定（检索前先得出裁决）
+// 0. Trust the binding in one call (verdict before retrieval)
 {"method":"tools/call","params":{"name":"trust_selftest","arguments":{"agent_id":"dev"}}}
 
-// 1. 若裁决不是 full_trust，请求确定性恢复路径
+// 1. If the verdict is not full_trust, ask for the deterministic recovery path
 {"method":"tools/call","params":{"name":"recovery_playbook","arguments":{"agent_id":"dev"}}}
 
-// 2. 构建图真相
+// 2. Build graph truth
 {"method":"tools/call","params":{"name":"ingest","arguments":{"path":"/your/project","agent_id":"dev"}}}
 
-// 3. 提问结构性问题——空结果会说明*原因*，而不只是"无结果"
+// 3. Ask a structural question — empty results say *why*, never just "no results"
 {"method":"tools/call","params":{"name":"activate","arguments":{"query":"authentication flow","agent_id":"dev"}}}
 ```
 
 **首次会话循环，四步完成：** `trust_selftest` → `ingest` → `seek`/`audit` → `memorize` 持久化发现，让下次会话提前起跑。
+
+### 服务一张图，附着多个智能体
+
+上面的快速开始为每个宿主连接了一个 stdio 服务器——对单个智能体来说没问题，但每个进程都加载自己的图并持有自己的租约。m1nd 为之而生的部署形态是一个所有者、多个附着的智能体。一个所有者进程持有活图：
+
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
+
+随后每个智能体都作为一个轻量的 stdio↔HTTP 桥接附着——它**不**加载图、不构建引擎、也**不**持有租约：
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+任意数量的桥接都指向那一个所有者并共享其单一的活图，因此一个智能体 `memorize` 的内容，另一个能立即调回——无需重新摄入，无需每个智能体各存一份。查询走 localhost，因此它保持本地优先（除非你选择加入 `--bind 0.0.0.0`，否则 bind 保持 `127.0.0.1`）。在单台机器上的一张小图上，经桥接的热 `seek` 测得 ≈0.7ms——这是数量级参考，而非保证：附着会增加一次 localhost 往返，延迟随图规模和负载而变化。
 
 ## m1nd 不是什么
 
@@ -104,21 +134,21 @@ m1nd agent first-minute --repo /your/project --query "understand this system" --
 - 一个替代编译器、测试或安全工具的静态分析工具
 - 一个无关工具的 MCP 捆绑包
 
-它是将这些界面转化为智能体可以推理和行动的操作系统的那一层。不适用于单文件查找、简单 grep 或编译器真相——那些情况请用普通工具。
+它是将这些界面转化为智能体可以推理并据以行动的操作系统的那一层。不适用于单文件查找、简单 grep 或编译器真相——那些情况请用普通工具。
 
 ## 为什么智能体需要它
 
 没有 m1nd，每次会话都从 grep 循环和手动重新定向开始；上周的发现已消失，空搜索结果与错误工作区绑定无从区分。有了 m1nd，会话以信任裁决开始，过去的发现已自动加载并锚定到支撑它们的代码，空结果会说明*原因*。
 
-在真实代码库上工作的智能体失败，不是因为无法搜索，而是因为没有操作模型。它们每次会话都从头重建上下文，在不知道爆炸半径的情况下编辑，无法区分"什么都没有"和"仓库绑定错误"这两种空结果。
+在真实代码库上工作的智能体失败，不是因为无法搜索，而是因为没有操作模型。它们每次会话都从头重建上下文，在不知道爆炸半径的情况下编辑，无法区分意味着"什么都不存在"的空结果和意味着"仓库错误"的空结果。
 
-对于小型代码库，这还行得通。当项目有生成产物、规格文档、隐藏的共变更历史、多个智能体和漫长的交接时，就会崩溃。问题不仅在于智能体的推理——智能体根本没有代码库结构的持久模型。`m1nd` 给了它这个模型：一个跨结构、语义、时间和因果维度进行扩散激活的因果代码图，加上每个智能体跨会话复利的 Hebbian 可塑性。
+对于小型代码库，这还行得通。当项目有生成产物、规格、文档、隐藏的共变更历史、多个智能体和漫长的交接时，就会崩溃。问题不仅在于智能体的推理——智能体根本没有代码库结构的持久模型。`m1nd` 给了它这个模型：一个跨结构、语义、时间和因果维度进行扩散激活的因果代码图，加上每个智能体跨会话复利的 Hebbian 可塑性。
 
 ## 复利记忆（L1GHT）
 
-大多数工具给智能体更好的*检索*。`m1nd` 还让智能体能够**撰写持久的、机器可读的知识**，这些知识跨会话复利，并对代码保持诚实。L1GHT 将撰写的知识转化为图原生结构，当所引用代码发生变化时自动标记——高置信度的声明会传播更多激活。
+大多数工具给智能体更好的*检索*。`m1nd` 还让智能体能够**撰写持久的、机器可读的知识**，这些知识跨会话复利，并对代码保持诚实。L1GHT 将撰写的知识转化为图原生结构，当其所引用的代码发生变化时自动标记——高置信度的声明比不确定的声明传播更多激活。
 
-端到端循环：
+端到端的完整循环：
 
 1. **得出结论** — 智能体得到持久性结论（一个决策、一个经过验证的发现、代码为何如此设计），并用结构化声明和 `evidence` 路径调用 `memorize`。
 
@@ -134,26 +164,28 @@ memorize({
 ```
 
 2. **锚定** — m1nd 在 `<runtime>/agent-memory/` 下写入图原生 `.light.md`，摄入它（`adapter=light mode=merge`），并通过 `grounded_in` 边将每条 `evidence` 路径解析到真实代码节点——让知识与代码处于同一激活空间，并在 `seek` / `activate` / `impact` 中浮现。
-3. **自动加载** — 在每次未来会话开始时，`m1nd` 自动摄入 `agent-memory/` 并在 `session_handshake.agent_memory` 中报告。过去的发现在 `mode=replace` 摄入后依然存在，随时可用。
-4. **自动标记过期** — `cross_verify(check: ["evidence_freshness"])` 对每个引用文件重新哈希，并指出哪些声明因代码变更而过期——让记忆在撒谎时告诉你，而不是误导你。
+3. **自动加载** — 在每次未来会话开始时，`m1nd` 自动摄入 `agent-memory/` 并在 `session_handshake.agent_memory` 中报告。过去的发现在 `mode=replace` 摄入后依然存活，随时*就在那里*。
+4. **自动标记过期** — `cross_verify(check: ["evidence_freshness"])` 对每个引用文件重新哈希，并指出哪些声明因其代码变更而过期——这样记忆会在它撒谎时告诉你，而不是误导你。
 
-这个循环已被端到端验证：`memorize` → `grounded_in` 边 → 编辑文件上的新鲜度标志 → 在 `mode=replace` 后存活 → 启动自动加载。关闭一个有界任务？向 `mission_close` 传入 `write_light_memory: true` 以同样方式持久化其经过验证的声明。该习惯记录在每个 MCP 客户端在 `initialize` 时收到的服务器 `instructions` 中——与宿主无关，无需特定客户端插件。
+这个循环已被端到端实时验证：`memorize` → `grounded_in` 边 → 编辑文件上的新鲜度标志 → 在 `mode=replace` 后存活 → 启动自动加载。关闭一个有界任务？向 `mission_close` 传入 `write_light_memory: true`，以同样方式持久化其经过验证的声明。该习惯记录在每个 MCP 客户端在 `initialize` 时收到的服务器 `instructions` 中——与宿主无关，无需特定客户端插件。
 
-## 信任与诚实层
+## 信任 / 诚实层
 
-这是 m1nd 最无可替代的事情，没有竞争对手提供它。教义：**可信度来自诚实，而非永远正确。**
+这是 m1nd 最无可替代的事情，没有竞争对手提供它。教义：**可信度来自诚实，而非永远获胜。**
 
-- **`trust_selftest`** 在任何检索*之前*返回裁决：`full_trust`、`needs_ingest`、`wrong_workspace_binding`、`stale_binding_suspected` 或 `degraded_host_tool_surface`。智能体知道是继续、摄入、重新绑定还是降级。
-- **`agent_runtime_contract`** 附在每个检索响应上，携带 `trust_mode`。空结果有明确区分——绑定到错误仓库还是真的什么都没有——而不是静默报告"无结果"。
+- **`trust_selftest`** 在任何检索*之前*返回裁决：`full_trust`、`needs_ingest`、`wrong_workspace_binding`、`stale_binding_suspected` 或 `degraded_host_tool_surface`。智能体由此知道是继续、摄入、重新绑定还是降级。
+- **`agent_runtime_contract`** 附在每个检索响应上，携带一个 `trust_mode`。空结果得到明确区分——绑定到错误仓库还是真的什么都没有——绝不会静默报告为"无结果"。
 - **`non_claims` 数组** 附在每个任务工具上。m1nd 告诉智能体它*没有*证明什么。
-- **`mission_verify` 可以说不——并且在测试代码中确实如此。** 它拒绝纯图证据：声明在没有文件读取、测试运行或运行时探针的情况下无法关闭。该测试的名称字面上就是 `graph_only_evidence_is_not_enough`。
-- **`recovery_playbook`** 返回修复绑定的确定性、有序步骤列表。
+- **`mission_verify` 可以说不——并且在经过测试的代码中确实如此。** 它拒绝纯图证据：一个声明在没有文件读取、测试运行或运行时探针的情况下无法关闭。该测试的名称字面上就是 `graph_only_evidence_is_not_enough`。
+- **`recovery_playbook`** 返回一份修复绑定的确定性、有序步骤列表。
 
-对这一承诺的证明是为此牺牲的东西：`savings` 和 `resonate` 在 beta.7 中从公告的界面中移除，因为一个总声称获胜的工具不可信。没有竞争对手——不是 mem0、Zep、Letta、Sourcegraph，也不是任何代码图 MCP——提供一个告诉智能体*不该信任什么*以及如何恢复的层。
+对这一承诺的证明是为此牺牲的东西：`savings` 和 `resonate` 在 beta.7 中从公告的界面中撤下，因为一个总声称获胜的工具不可信。没有竞争对手——不是 mem0、Zep、Letta、Sourcegraph，也不是任何代码图 MCP——提供一个告诉智能体*不该信任什么*以及如何恢复的层。
+
+**现场分诊循环闭合于自身。** 智能体留在 `~/.m1nd/field-reports.jsonl` 中的会话遥测（仅本地——m1nd 从不回传数据）并不是被动日志：报告会被分诊，一个*已确认*的现场 bug 会在修复**之前**变成一个红色的电池用例，因此该回归是被证明的，而非仅仅被描述。那个循环已经端到端运行过一次：两个现场上报的 bug 变成了失败的电池用例，随后是合并的修复——`north` 现在将 L1GHT recall 整合进其记忆数据包，而 `temp` 图哨兵会解析到一个真实的临时目录，而不是把工作目录弄乱。
 
 ## 语言覆盖
 
-图推理（`impact`、`why`、`predict`、`trace`、`taint_trace`）取决于提取器的质量。m1nd 为每种语言解析 **`calls` 边**（调用图）和**跨文件 `imports`**（文件→文件依赖解析）。下表在单次多语言摄入中得到验证：
+图推理（`impact`、`why`、`predict`、`trace`、`taint_trace`）的好坏取决于提取器。m1nd 为每种语言解析 **`calls` 边**（调用图）和**跨文件 `imports`**（文件→文件依赖解析）。下表在单次多语言摄入中得到实时验证：
 
 | 语言 | `calls` | 跨文件 imports |
 |---|:---:|:---:|
@@ -170,11 +202,11 @@ memorize({
 | C# | ✅ | —（命名空间不能 1:1 映射到文件） |
 | Swift | ✅ | — |
 
-所有 ✅ 行均经过端到端验证（`caller`→`callee` import 可解析且调用者生成 call 边）。其他语言回退到通用提取器（仅 `contains`）。无法解析的 import（外部包、gem、标准库、系统头文件）会如实留作未解析，而不是猜测。
+所有 ✅ 行均经过端到端验证（一条 `caller`→`callee` import 可解析且调用者生成 call 边）。其他语言回退到通用提取器（仅 `contains`）。无法解析的 import（外部包、gem、标准库、系统头文件）会如实留作未解析，而不是猜测。
 
 ## 能力图
 
-Live MCP 界面随版本更新。使用 `tools/list` 获取当前构建中的确切工具数量和名称。
+Live MCP 界面随版本更新。使用 `tools/list` 获取当前构建中确切的工具数量和名称。
 
 | 领域 | 功能 | 代表性工具 |
 |---|---|---|
@@ -182,7 +214,7 @@ Live MCP 界面随版本更新。使用 `tools/list` 获取当前构建中的确
 | 检索与定向 | 在手动读取文件之前按文本、路径、意图、结构或关系搜索 | `audit`、`search`、`glob`、`seek`、`activate`、`why`、`trace` |
 | 文档与知识绑定 | 摄入通用文档或图原生 `L1GHT`，然后将概念链接回代码 | `ingest(adapter="universal"\|"light")`、`document_resolve`、`document_provider_health`、`document_bindings`、`document_drift`、`auto_ingest_*` |
 | 导航与连续性 | 跨会话维护有状态路由、交接、基线和调查记忆 | `perspective_*`、`trail_*`、`coverage_session`、`boot_memory`、`persist` |
-| Mission Control 与证明纪律 | 维护有界路由、记录事件、从图定向切换到直接证明、交接并带明确缺口关闭 | `mission_start`、`mission_event`、`mission_next`、`mission_verify`、`mission_handoff`、`mission_close` |
+| Mission Control 与证明纪律 | 维护有界路由、记录事件、从图定向切换到直接证明、交接，并带明确缺口关闭 | `mission_start`、`mission_event`、`mission_next`、`mission_verify`、`mission_handoff`、`mission_close` |
 | 变更规划与证明 | 推理影响、共变更、缺失步骤、失败路径和结构声明 | `impact`、`predict`、`validate_plan`、`missing`、`hypothesize`、`counterfactual`、`differential` |
 | 质量、安全与架构 | 检测模式、污点路径、信任边界、重复、层违规、类型流和重构目标 | `scan`、`scan_all`、`heuristics_surface`、`antibody_*`、`taint_trace`、`type_trace`、`trust`、`layers`、`layer_inspect`、`twins`、`fingerprint`、`flow_simulate`、`epidemic`、`tremor`、`refactor_plan` |
 | 时间、运行时与多仓库工作 | 检查 git 历史、漂移、隐藏共变更边、运行时叠加和跨仓库引用 | `timeline`、`diverge`、`ghost_edges`、`runtime_overlay`、`external_references`、`federate`、`federate_auto` |
@@ -201,44 +233,46 @@ Live MCP 界面随版本更新。使用 `tools/list` 获取当前构建中的确
 - **深度分析** — `fingerprint`、`diverge`、`ghost_edges`、`taint_trace`、`twins`、`refactor_plan`、`runtime_overlay`（RETROBUILDER 镜头），用于隐藏耦合、安全路径、结构重复和运行时热点。
 - **记忆** — 用 `memorize` 持久化持久性结论，携带 `confidence` 和 `evidence` 路径。
 
-Mission Control 是证明纪律，而不是功能列表。`mission_next` 恰好返回一个动作加 `do_not` 护栏；`mission_verify` 拒绝纯图声明；`mission_close` 始终推动智能体持久化经过验证的知识并记录缺口和非声明。在 `bug_hunt` 模式下，MC0 在关闭前要求在验证发现之后进行最终的直接 `direct_sweep`，以便智能体检查负空间。
+Mission Control 是证明纪律，而不是功能列表。`mission_next` 恰好返回一个动作加 `do_not` 护栏；`mission_verify` 拒绝纯图声明；`mission_close` 始终推动智能体持久化经过验证的知识并记录缺口和非声明。在 `bug_hunt` 模式下，MC0 要求在关闭前、在验证发现之后进行一次最终的直接 `direct_sweep`，以便智能体检查负空间。
 
-**注意：** `predict` 在 `ghost_edges` 加载 git 共变更矩阵之前**仅有结构回退**——当你需要真实的共变更可能性时，请先运行 `ghost_edges`。
+**注意：** 在 `ghost_edges` 加载 git 共变更矩阵之前，`predict` **仅有结构回退**——当你需要真实的共变更可能性时，请先运行 `ghost_edges`。
 
 ## 证据
 
-每行的对冲范围恰好是所测量的内容。m1nd 不以节省或 ROI 数字作为引导——这正是要点所在。
+每一行的对冲范围恰好是所测量的内容。m1nd 不以节省或 ROI 数字作为引导——这正是要点所在。
 
-| 声明 | 结果 | 来源与对冲 |
+| 声明 | 结果 | 来源 / 对冲 |
 |---|---|---|
-| `activate` / `impact` 延迟 | `activate` 亚微秒，`impact` 亚毫秒 | `m1nd-core/benches/` 中基于 1K 节点合成图的 Criterion 基准——[方法论](https://m1nd.world/wiki/benchmarks.html)；视为数量级参考。 |
+| `activate` / `impact` 延迟 | 在 1K 节点合成图上 `activate` ~1µs，`impact` 亚微秒 | Criterion 基准——**自己复现它：`cargo bench -p m1nd-core`**（在一台 Apple 芯片 Mac 上测得 `activate_1k_nodes` ≈1.4µs，`impact_depth3` ≈0.5µs）；[方法论](https://m1nd.world/wiki/benchmarks.html)；数量级参考，取决于硬件。 |
 | 语言矩阵 | 10 种语言的 calls + 跨文件 imports（+ Ruby 跨文件） | 在单次多语言摄入中端到端验证；每种语言的测试在 `m1nd-ingest` 中。见[语言覆盖](#语言覆盖)。 |
 | 写后验证样本 | 12/12 分类正确 | 内部运行时检查。 |
 | 种子 bug 搜寻 | 在第一轮被接受的 `humanize` 种子缺陷测试中 16/20（m1nd 训练）；`m1nd-basic` 和直接模式各 8/15 | 内部产品证据，`public_claim_worthy=false`——非通用基准。 |
-| 记忆自我验证 | 端到端验证 | `memorize` → `grounded_in` → 编辑文件上的新鲜度标志 → 在 replace 后存活 → 启动自动加载。 |
+| 记忆自我验证 | 端到端实时验证 | `memorize` → `grounded_in` → 编辑文件上的新鲜度标志 → 在 replace 后存活 → 启动自动加载。 |
+| 能力电池 vs grep | 37/37 通过；正面交锋 16 个 m1nd 胜 / 12 个平局 / **0 个 grep 胜** | 仓库内测试框架 `scratchpad/m1nd_battery.py`（37 个用例，全新摄入 + 真值 PASS/FAIL + 与 `rg` 正面交锋）。**复现：`python3 scratchpad/m1nd_battery.py ./target/release/m1nd-mcp . --suite m1nd`。** 对冲：单个仓库（m1nd 自身）、自撰用例；约 5 个平局是结构性工具，被拿来与一个无法表达它们所回答内容的字面 grep 代理评分。 |
+| 保形校准（`predict`） | act 等级 ≈32% 精确率 @ ≈13.5% 覆盖率（α=0.10） | 在 m1nd 自己的 git 历史上（n≈9.2k 个留出预测），在平滑化 Jaccard 变更后比原始计数高出 +3pts。对冲：单个仓库、一个粗糙的基于计数的信号——这道闸门如今大多选择弃权，**这是有意为之**：弃权是弱信号的诚实输出，而非失败。 |
 
 ## 局限性
 
-`m1nd` 是对 LSP、编译器、测试运行器、安全扫描器和可观测性栈的补充，而非替代。在搜索、审查或变更之前，以及在文档、影响或连续性重要时，它最为有用。
+`m1nd` 是对你的 LSP、编译器、测试运行器、安全扫描器和可观测性栈的补充，而非替代。它在搜索、审查或变更之前，以及在文档、影响或连续性重要时，最为有用。
 
 在以下情况**用处较小**：
 
 - 精确文本搜索已能回答问题
-- 编译器或运行时真相是唯一需要的
+- 编译器或运行时真相是你唯一需要的
 - 任务是无结构不确定性的简单本地文件操作
 
-**需要喂数据：** `trust` 和 `tremor` 在 `learn` 反馈 / `ghost_edges` 数据积累之前从中性先验开始，`predict` 在 `ghost_edges` 加载之前需要其共变更信号才有意义。这些会随使用而改善；它们对启动时的无信息状态保持诚实。
+**需要喂数据：** `trust` 和 `tremor` 从中性先验开始，直到 `learn` 反馈 / `ghost_edges` 数据积累起来，而 `predict` 需要先加载 `ghost_edges`，其共变更信号才有意义。这些会随使用而改善；它们对启动时的无信息状态保持诚实。
 
 ## 架构概览
 
 三个核心 Rust crate 加一个辅助桥接：
 
 - **`m1nd-mcp`** — MCP 服务器和操作运行时界面。
-- **`m1nd-core`** — 图引擎：执行扩散激活、Hebbian 可塑性、CSR 邻接和 git 派生幽灵边的 `WavefrontEngine`。
+- **`m1nd-core`** — 图引擎：一个执行扩散激活、Hebbian 可塑性、CSR 邻接和 git 派生幽灵边的 `WavefrontEngine`。
 - **`m1nd-ingest`** — 提取、路由和图构建适配器（代码、通用文档、L1GHT）。
 - **`m1nd-openclaw`** — 辅助 OpenClaw 桥接（Unix socket 通道，独立版本）。
 
-当前 crate 版本：`m1nd-core`、`m1nd-ingest`、`m1nd-mcp` 均为 `0.9.0-beta.8`。
+当前 crate 版本：`m1nd-core`、`m1nd-ingest`、`m1nd-mcp` 均为 `1.2.0`（`m1nd-openclaw` 独立版本化，为 `0.1.0`）。
 
 <p align="center">
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="m1nd 架构概览" width="960" />


### PR DESCRIPTION
The 7 translated READMEs under `i18n/` were two eras stale (pre-1.2.0, 13 sections vs the English's 14 — missing the entire "New in 1.2.0" section, the serve/attach subsection, the two new Evidence rows, and the field-triage paragraph). Each is regenerated as a complete, faithful translation of the final English README (post-#213).

## Verified per language (pt-BR, es, it, fr, de, zh, ja)
- Section parity with EN: 14 `## ` + 2 `### ` headings, same order ("New in 1.2.0" lands on the same line 55 in every file).
- All fenced code blocks **byte-identical** to the English source (commands, JSON-RPC, comments untranslated).
- Language-switcher first line correct and uniform in all 7 (`../README.md` for EN, sibling `README.xx.md`).
- Repo-relative links/images carry the `../` prefix; in-page anchors localized to the translated headings (stale files' proven slugs reused).
- Tool names, verbs, env vars, CLI flags, verdict values kept in English verbatim.
- Every hedge preserved at the same force; all measured numbers verbatim (37/37, 16/12/0, ≈0.7ms, ≈32% @ ≈13.5%, α=0.10, n≈9.2k, +3pts).
- Table parity: Language matrix 12 rows, Evidence 7 rows, Capability Map 10 rows in every language.
- pt-BR is Brazilian Portuguese; zh is Simplified.

Docs-only: diff touches exactly the 7 `i18n/README.*.md` files (+353/−115; net +238 = the EN's 34-line growth × 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)