### PR TITLE
fix(ingest): closure ambiguity tag only on genuine ties — kill the cry-wolf (field-triage #4)

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -76,9 +76,17 @@ fix.** The mailbox is **local-only — m1nd never phones home**; the roadmap `m1
 verb (opt-in, redacted, one-click GitHub issue) is the ONLY path upstream, and always the
 human's explicit call.
 
-**4 seeded reports awaiting first triage** (the next improvement session sweeps these first):
-1. **closure cry-wolf** — `why`-closure over-reports `blocked` on paths that are actually fine
-   (honesty class; the calibration-ground-truth kind).
+**Seeded reports triage status** (the improvement session sweeps these first):
+1. **closure cry-wolf (AMBIGUOUS portion) = FIXED (field-triage #4).** The `m1nd:edge:ambiguous`
+   tag fired on nearly every load-bearing path because it (a) tagged whenever a same-name fallback
+   had >1 candidates even when proximity/qualifier picked a DECISIVE winner, and (b) was read
+   node-level, so any node with ONE ambiguous edge poisoned EVERY clean path through it. Fix: tag
+   only GENUINE coin-flips (decisive binds no longer tag), and read a targeted
+   `m1nd:edge:ambiguous:<target>` tag PER-EDGE. Measured on the m1nd repo itself: ambiguous-blocked
+   dropped **9/11 → 0/11** connected pairs; the honesty guard (a true 2-way tie still yields
+   `blocked`+`ambiguous`) is proven end-to-end. NOTE: a SEPARATE node-granularity over-fire remains
+   for the `unresolved` tag (explicitly out of scope — unresolved semantics unchanged); see Known
+   Problems → "closure UNRESOLVED node-granularity".
 2. **`memorize` unanchored on a live runtime** — evidence paths didn't anchor to code nodes
    against the running owner (friction/bug on the live `:1338` runtime).
 3. **the `temp` artifact bug** — a stray `temp` file dropped in cwd by a battery/tool path
@@ -264,10 +272,23 @@ battery gate; orchestrate + verify. Update this file at big checkpoints.
 ## Known Problems
 - **Checkpoint-8 carry-over (open into the v1.2.x cycle — sweep the field-report mailbox
   first, then these):**
-  - **`why`-closure CRY-WOLF (seeded field report #1, honesty class).** Closure over-reports
-    `blocked` on paths that are actually fine — an honesty miss (m1nd says the path rests on an
-    unresolved edge when it doesn't). Highest-value to fix: it is calibration ground truth.
-    Next session turns this into a battery case BEFORE the fix.
+  - **`why`-closure CRY-WOLF — AMBIGUOUS portion = FIXED (field-triage #4, PR pending).** The
+    `m1nd:edge:ambiguous` over-fire is closed: the tag now fires only on a genuine coin-flip
+    (decisive proximity/qualifier binds no longer tag) and is read edge-specifically via a targeted
+    `m1nd:edge:ambiguous:<target>` tag. Ambiguous-blocked dropped 9/11 → 0/11 on the m1nd repo;
+    battery case `closure_verdict_wellformed_blocked` updated to assert (well-formed contract) +
+    (no `ambiguous` dangling on the clean handle_seek→pack_to_budget path) + (honesty guard: a real
+    tie STILL blocks). Binding behavior itself is UNCHANGED — only the tag precision/read granularity.
+  - **`why`-closure UNRESOLVED node-granularity (NEW, discovered during field-triage #4; OPEN).**
+    The `m1nd:edge:unresolved` tag has the SAME node-granularity over-fire the ambiguous tag had:
+    it is set per-source-node whenever a node drops ANY outbound ref (e.g. a call to a std/external
+    fn), and `closure_reason_for_edge` reads it node-level — so a clean path leaving such a node
+    (e.g. handle_seek→pack_to_budget, a unique-name target) still reads `blocked` on `unresolved`.
+    Left UNTOUCHED by triage #4 because "EDGE_UNRESOLVED_TAG semantics stay unchanged" was explicit
+    scope, AND it needs a DESIGN DECISION (a dropped ref has no target node to key an edge-specific
+    tag against; and the contract test `why_reports_blocked_when_path_rests_on_dangling_edge`
+    encodes the current intent). Measured residue: 8/11 connected pairs still blocked, now all on
+    `unresolved`. Follow-up task spawned.
   - **`memorize` unanchored on the live runtime (seeded field report #2).** Evidence paths
     didn't anchor to code nodes against the running `:1338` owner — friction/bug on the live
     runtime specifically. Reproduce against a served-attach graph, then fix.

--- a/m1nd-ingest/src/resolve.rs
+++ b/m1nd-ingest/src/resolve.rs
@@ -34,11 +34,37 @@ pub struct ResolutionStats {
 }
 
 /// Node tag marking a source node that has at least one outgoing edge which was
-/// resolved via a low-confidence fallback among same-name candidates (a guess).
-/// Provenance only — the edge IS created; the tag lets `why` flag a path that
-/// rests on it. Shared so the read side (`why` closure verdict) uses the same
-/// literal.
+/// resolved via a genuine coin-flip among same-name candidates (a guess no
+/// qualifier/hint/proximity signal could decide). Provenance only — the edge IS
+/// created; the tag lets `why` flag a path that rests on it. Shared so the read
+/// side (`why` closure verdict) uses the same literal.
+///
+/// This BARE tag is node-level ("this node has SOME ambiguous outbound edge").
+/// It is intentionally coarse and drives the `ResolutionStats.ambiguous` count.
+/// For a PER-PATH honest verdict the resolver ALSO emits a TARGETED variant,
+/// `m1nd:edge:ambiguous:<target_external_id>` (see [`ambiguous_edge_tag`]), that
+/// names the specific ambiguous edge. `why` reads the targeted tag so a CLEAN
+/// edge leaving a node that happens to have an unrelated ambiguous edge is NOT
+/// falsely reported blocked — killing the closure cry-wolf.
 pub const EDGE_AMBIGUOUS_TAG: &str = "m1nd:edge:ambiguous";
+
+/// Build the TARGETED ambiguity tag for an edge whose binding to `target_ext_id`
+/// was a genuine coin-flip: `m1nd:edge:ambiguous:<target_external_id>`. Placed on
+/// the SOURCE node so the read side can tell WHICH outgoing edge was the guess
+/// (the bare [`EDGE_AMBIGUOUS_TAG`] only says the node has one somewhere). Kept
+/// here so the tagger and the `why` reader share one literal scheme.
+pub fn ambiguous_edge_tag(target_ext_id: &str) -> String {
+    format!("{EDGE_AMBIGUOUS_TAG}:{target_ext_id}")
+}
+
+/// Read side: does `source` carry the TARGETED ambiguity tag for the specific
+/// edge to `target_ext_id`? True iff THAT edge was a genuine coin-flip at ingest.
+/// Used by `why` to make the closure verdict edge-specific instead of blaming a
+/// clean edge for an unrelated ambiguous sibling on the same source node.
+pub fn source_has_ambiguous_edge_to(graph: &Graph, source: NodeId, target_ext_id: &str) -> bool {
+    let needle = ambiguous_edge_tag(target_ext_id);
+    graph.node_tags(source).iter().any(|t| *t == needle)
+}
 
 /// Node tag marking a source node that had at least one outgoing reference m1nd
 /// could NOT resolve to any target (the edge was dropped, leaving the source's
@@ -135,31 +161,28 @@ impl ReferenceResolver {
                         graph.add_node_tags(source, &[EDGE_UNRESOLVED_TAG]);
                         continue;
                     }
-                    if found.len() > 1 {
-                        stats.ambiguous += 1;
-                        // Provenance: this source node has at least one outgoing
-                        // edge that resolved via a low-confidence fallback among
-                        // same-name candidates. The edge is still created (binding
-                        // unchanged) — the tag only makes the guess KNOWABLE so
-                        // `why` can flag a path that rests on it.
-                        graph.add_node_tags(source, &[EDGE_AMBIGUOUS_TAG]);
-                    }
                     // Use first match (or disambiguate if multiple). A call-site
                     // qualifier (`ref::Type::method`) wins first — it pins the
                     // owner among same-name candidates; then the import hint; then
-                    // proximity.
-                    let target = if found.len() == 1 {
-                        found[0]
+                    // proximity. `pick_candidate` also reports whether the choice
+                    // was a GENUINE tie (a coin-flip) so the provenance tag fires
+                    // only on real ambiguity, not merely "same name existed".
+                    let (target, is_tie) = if found.len() == 1 {
+                        (found[0], false)
                     } else {
-                        Self::disambiguate_with_qualifier(graph, &found, qualifier)
-                            .or_else(|| {
-                                import_hint.and_then(|hint| {
-                                    Self::disambiguate_with_hint(graph, source, &found, hint)
-                                })
-                            })
-                            .or_else(|| Self::disambiguate(graph, source, &found))
-                            .unwrap_or(found[0])
+                        Self::pick_candidate(graph, source, &found, qualifier, import_hint)
                     };
+                    if is_tie {
+                        stats.ambiguous += 1;
+                        // Provenance: this source node's outgoing edge resolved via
+                        // a genuine coin-flip among same-name candidates that no
+                        // qualifier/hint/proximity signal could decide. The edge is
+                        // still created (binding unchanged) — the tags only make the
+                        // guess KNOWABLE so `why` can flag a path that rests on it.
+                        // Both the bare (node-level count) and targeted (per-edge,
+                        // read by `why`) tags are added.
+                        Self::tag_ambiguous_edge(graph, source, target);
+                    }
 
                     // Add edge
                     let rel = relation.as_str();
@@ -184,27 +207,22 @@ impl ReferenceResolver {
                     graph.add_node_tags(source, &[EDGE_UNRESOLVED_TAG]);
                     continue;
                 }
-                if candidates.len() > 1 {
+                // Qualifier (`ref::Type::method`) first, then import hint, then
+                // proximity — same precedence as the suffix branch above.
+                // `pick_candidate` reports whether the choice was a genuine tie so
+                // the provenance tag fires only on real ambiguity.
+                let (target, is_tie) = if candidates.len() == 1 {
+                    (candidates[0], false)
+                } else {
+                    Self::pick_candidate(graph, source, candidates, qualifier, import_hint)
+                };
+                if is_tie {
                     stats.ambiguous += 1;
                     // Provenance only — see the suffix-branch comment above. The
-                    // SAME `candidates[0]`/disambiguated edge is still created.
-                    graph.add_node_tags(source, &[EDGE_AMBIGUOUS_TAG]);
+                    // SAME disambiguated edge is still created; the tags mark a
+                    // genuine coin-flip so `why` can flag a path that rests on it.
+                    Self::tag_ambiguous_edge(graph, source, target);
                 }
-
-                let target = if candidates.len() == 1 {
-                    candidates[0]
-                } else {
-                    // Qualifier (`ref::Type::method`) first, then import hint, then
-                    // proximity — same precedence as the suffix branch above.
-                    Self::disambiguate_with_qualifier(graph, candidates, qualifier)
-                        .or_else(|| {
-                            import_hint.and_then(|hint| {
-                                Self::disambiguate_with_hint(graph, source, candidates, hint)
-                            })
-                        })
-                        .or_else(|| Self::disambiguate(graph, source, candidates))
-                        .unwrap_or(candidates[0])
-                };
 
                 let rel = relation.as_str();
                 let _ = graph.add_edge(
@@ -238,31 +256,109 @@ impl ReferenceResolver {
         index
     }
 
-    /// Disambiguate among multiple candidates using proximity.
-    /// Priority: same file > same directory > same module > first match.
-    fn disambiguate(graph: &Graph, source: NodeId, candidates: &[NodeId]) -> Option<NodeId> {
+    /// Record provenance for a genuinely-ambiguous edge `source -> target`: the
+    /// bare node-level [`EDGE_AMBIGUOUS_TAG`] (drives the count / back-compat) AND
+    /// the TARGETED `m1nd:edge:ambiguous:<target_ext_id>` tag that names THIS edge
+    /// so `why` can report it per-path (not blame clean siblings). If the target
+    /// has no resolvable external id (should not happen for a real bind), only the
+    /// bare tag is added.
+    fn tag_ambiguous_edge(graph: &mut Graph, source: NodeId, target: NodeId) {
+        graph.add_node_tags(source, &[EDGE_AMBIGUOUS_TAG]);
+        if let Some(target_ext_id) = Self::find_external_id(graph, target) {
+            let targeted = ambiguous_edge_tag(&target_ext_id);
+            graph.add_node_tags(source, &[targeted.as_str()]);
+        }
+    }
+
+    /// Pick the winning candidate AND report whether the choice was a GENUINE
+    /// tie (a coin-flip). Runs the same precedence as the call sites — qualifier
+    /// (`ref::Type::method`) → import hint → proximity → first-match fallback —
+    /// but returns `(winner, is_tie)`:
+    ///   * a qualifier or import-hint match is DECISIVE → `is_tie == false`;
+    ///   * proximity is decisive only when ONE candidate holds the strict best
+    ///     score → `is_tie == false`;
+    ///   * when nothing above decided it (≥2 candidates share the best proximity
+    ///     rank, or no signal applied) the bind is a coin-flip on `candidates[0]`
+    ///     → `is_tie == true`.
+    ///
+    /// This is what tightens the `m1nd:edge:ambiguous` provenance tag from
+    /// "same-name existed" to "the resolution was actually ambiguous", killing
+    /// the closure cry-wolf while still flagging real ties. Callers pass ≥2
+    /// candidates; a single candidate never reaches here (handled inline).
+    fn pick_candidate(
+        graph: &Graph,
+        source: NodeId,
+        candidates: &[NodeId],
+        qualifier: Option<&str>,
+        import_hint: Option<&str>,
+    ) -> (NodeId, bool) {
+        // 1) Call-site qualifier decides the owner — decisive.
+        if let Some(t) = Self::disambiguate_with_qualifier(graph, candidates, qualifier) {
+            return (t, false);
+        }
+        // 2) Import-path hint decides the module — decisive.
+        if let Some(hint) = import_hint {
+            if let Some(t) = Self::disambiguate_with_hint(graph, source, candidates, hint) {
+                return (t, false);
+            }
+        }
+        // 3) Proximity: decisive only when the best score is uniquely held.
+        if let Some((t, unique_best)) = Self::disambiguate_decisive(graph, source, candidates) {
+            return (t, !unique_best);
+        }
+        // 4) No signal applied at all (e.g. source has no external id): coin-flip.
+        (candidates[0], true)
+    }
+
+    /// Proximity disambiguation that also reports whether the winning score is
+    /// held by a UNIQUE candidate. Returns `(best, unique_best)` where
+    /// `unique_best` is true iff exactly one candidate achieves the maximum
+    /// proximity score — i.e. proximity genuinely decided it. When ≥2 candidates
+    /// tie for the top score (including the degenerate all-zero case where no
+    /// candidate shares any prefix), `unique_best` is false and the caller treats
+    /// the pick as a coin-flip. The winning node is exactly the highest-proximity
+    /// candidate (`proximity_score`, same-file > same-dir > cross-crate); this
+    /// only adds the strict-uniqueness (tie) signal on top of that choice.
+    fn disambiguate_decisive(
+        graph: &Graph,
+        source: NodeId,
+        candidates: &[NodeId],
+    ) -> Option<(NodeId, bool)> {
         if candidates.is_empty() {
             return None;
         }
-
-        // Get source's external ID to compute proximity
         let source_ext_id = Self::find_external_id(graph, source)?;
 
-        // Score each candidate by proximity to source
-        let mut best = candidates[0];
+        // Only candidates that actually have an external id can be scored; seed
+        // `best`/`best_score` on the FIRST scored candidate so an unscorable
+        // `candidates[0]` never masquerades as the winner. If NONE is scorable,
+        // fall back to `candidates[0]` as a non-unique (coin-flip) pick.
+        let mut best: Option<NodeId> = None;
         let mut best_score = 0u32;
-
+        let mut best_count = 0usize; // how many scored candidates hold `best_score`
         for &candidate in candidates {
             if let Some(cand_ext_id) = Self::find_external_id(graph, candidate) {
                 let score = Self::proximity_score(&source_ext_id, &cand_ext_id);
-                if score > best_score {
-                    best_score = score;
-                    best = candidate;
+                match best {
+                    Some(_) if score > best_score => {
+                        best_score = score;
+                        best = Some(candidate);
+                        best_count = 1;
+                    }
+                    Some(_) if score == best_score => best_count += 1,
+                    Some(_) => {}
+                    None => {
+                        best_score = score;
+                        best = Some(candidate);
+                        best_count = 1;
+                    }
                 }
             }
         }
-
-        Some(best)
+        match best {
+            Some(b) => Some((b, best_count == 1)),
+            None => Some((candidates[0], false)),
+        }
     }
 
     /// Find external ID string for a node.
@@ -594,18 +690,21 @@ mod tests {
         );
     }
 
-    /// Provenance regression: an ambiguous `ref::` that hits the same-name
-    /// fallback must (a) still create the SAME edge — binding unchanged — and
-    /// (b) tag the SOURCE node `m1nd:edge:ambiguous` while incrementing
-    /// `ResolutionStats.ambiguous`, so the guess is knowable. Two same-name
-    /// candidates make the resolution ambiguous; the edge is created regardless.
+    /// Provenance (GENUINE TIE): an ambiguous `ref::` whose same-name candidates
+    /// are a real coin-flip — two `helper`s in the SAME directory, so proximity
+    /// scores them identically, with NO qualifier to decide — must (a) still
+    /// create the SAME edge (binding unchanged) and (b) tag the SOURCE node
+    /// `m1nd:edge:ambiguous` while incrementing `ResolutionStats.ambiguous`, so
+    /// the guess is knowable. This is the honesty guard for the cry-wolf fix: a
+    /// true tie MUST still flag (and yield `blocked` on paths crossing it).
     #[test]
-    fn ambiguous_ref_tags_source_and_counts_ambiguous() {
+    fn genuine_tie_tags_source_and_counts_ambiguous() {
         let mut graph = Graph::new();
         let caller = fn_node(&mut graph, "file::crate_a/src/walker.rs::fn::walk", "walk");
-        // Two same-name targets in different crates -> ambiguous.
-        let _a = fn_node(&mut graph, "file::crate_a/src/x.rs::fn::helper", "helper");
-        let _b = fn_node(&mut graph, "file::crate_b/src/y.rs::fn::helper", "helper");
+        // Two same-name targets in the SAME directory -> identical proximity, no
+        // qualifier -> genuine coin-flip.
+        let _a = fn_node(&mut graph, "file::crate_a/src/one.rs::fn::helper", "helper");
+        let _b = fn_node(&mut graph, "file::crate_a/src/two.rs::fn::helper", "helper");
 
         let unresolved = vec![(
             "file::crate_a/src/walker.rs::fn::walk".to_string(),
@@ -620,11 +719,178 @@ mod tests {
             calls_target(&graph, caller).is_some(),
             "the same edge must still be created (binding unchanged)"
         );
-        // Provenance recorded.
-        assert_eq!(stats.ambiguous, 1, "ambiguous count must increment");
+        // Provenance recorded — a genuine tie still flags.
+        assert_eq!(
+            stats.ambiguous, 1,
+            "ambiguous count must increment on a true tie"
+        );
         assert!(
             graph.node_tags(caller).contains(&EDGE_AMBIGUOUS_TAG),
-            "source must carry the ambiguous provenance tag, got {:?}",
+            "source must carry the bare ambiguous provenance tag on a true tie, got {:?}",
+            graph.node_tags(caller)
+        );
+        // And the TARGETED tag names the specific edge that was picked, so `why`
+        // can flag exactly this edge per-path.
+        let picked = calls_target(&graph, caller).expect("edge exists");
+        let picked_ext = ReferenceResolver::find_external_id(&graph, picked).expect("ext id");
+        assert!(
+            source_has_ambiguous_edge_to(&graph, caller, &picked_ext),
+            "source must carry the TARGETED ambiguous tag for the picked edge, got {:?}",
+            graph.node_tags(caller)
+        );
+    }
+
+    /// Cry-wolf killer: a source with ONE genuinely-ambiguous outbound edge must
+    /// NOT taint a DIFFERENT, cleanly-resolved outbound edge. This is the exact
+    /// failure the field report describes — a clean path (e.g. handle_seek ->
+    /// pack_to_budget) reported `blocked` only because the source also calls some
+    /// common-named fn. The targeted tag is per-edge, so `source_has_ambiguous_
+    /// edge_to` is TRUE for the tied target and FALSE for the clean (unique) one.
+    #[test]
+    fn one_ambiguous_edge_does_not_taint_a_clean_sibling_edge() {
+        let mut graph = Graph::new();
+        let caller = fn_node(
+            &mut graph,
+            "file::crate_a/src/handler.rs::fn::handle",
+            "handle",
+        );
+        // A genuinely-ambiguous target: two same-name `get` in the same dir.
+        let _g1 = fn_node(&mut graph, "file::crate_a/src/one.rs::fn::get", "get");
+        let _g2 = fn_node(&mut graph, "file::crate_a/src/two.rs::fn::get", "get");
+        // A cleanly-resolvable UNIQUE target.
+        let unique = fn_node(
+            &mut graph,
+            "file::crate_a/src/pack.rs::fn::pack_to_budget",
+            "pack_to_budget",
+        );
+
+        let unresolved = vec![
+            (
+                "file::crate_a/src/handler.rs::fn::handle".to_string(),
+                "ref::get".to_string(),
+                "calls".to_string(),
+            ),
+            (
+                "file::crate_a/src/handler.rs::fn::handle".to_string(),
+                "ref::pack_to_budget".to_string(),
+                "calls".to_string(),
+            ),
+        ];
+        let stats = ReferenceResolver::resolve(&mut graph, &unresolved).expect("resolve");
+        assert_eq!(stats.resolved, 2, "both refs resolve");
+        assert_eq!(stats.ambiguous, 1, "only the `get` tie is ambiguous");
+
+        // The clean unique edge must NOT be reported ambiguous …
+        let unique_ext = ReferenceResolver::find_external_id(&graph, unique).expect("ext id");
+        assert!(
+            !source_has_ambiguous_edge_to(&graph, caller, &unique_ext),
+            "the clean pack_to_budget edge must NOT carry a targeted ambiguous tag"
+        );
+        // … even though the SAME source node is (bare) tagged because of `get`.
+        assert!(
+            graph.node_tags(caller).contains(&EDGE_AMBIGUOUS_TAG),
+            "the source is still bare-tagged due to its ambiguous `get` edge"
+        );
+    }
+
+    /// Cry-wolf fix (a): same-name candidates in DIFFERENT directories where
+    /// proximity picks a UNIQUE same-directory winner is a CONFIDENT bind, not a
+    /// coin-flip — it must NOT tag `m1nd:edge:ambiguous` nor increment the count,
+    /// even though a same-name candidate existed elsewhere. (Pre-fix this tagged
+    /// ambiguous purely because `found.len() > 1`, which is the cry-wolf.) The
+    /// edge still binds to the closer candidate.
+    #[test]
+    fn decisive_by_proximity_does_not_tag_ambiguous() {
+        let mut graph = Graph::new();
+        let caller = fn_node(&mut graph, "file::crate_a/src/walker.rs::fn::walk", "walk");
+        // Same-directory winner (shares crate_a/src prefix) …
+        let correct = fn_node(
+            &mut graph,
+            "file::crate_a/src/policy.rs::fn::helper",
+            "helper",
+        );
+        // … vs a cross-crate same-name candidate (proximity-disfavored).
+        let _far = fn_node(
+            &mut graph,
+            "file::crate_b/src/other.rs::fn::helper",
+            "helper",
+        );
+
+        let unresolved = vec![(
+            "file::crate_a/src/walker.rs::fn::walk".to_string(),
+            "ref::helper".to_string(),
+            "calls".to_string(),
+        )];
+        let stats = ReferenceResolver::resolve(&mut graph, &unresolved).expect("resolve");
+
+        assert_eq!(stats.resolved, 1, "the ref must resolve");
+        assert_eq!(
+            calls_target(&graph, caller),
+            Some(correct),
+            "must bind to the same-directory helper"
+        );
+        assert_eq!(
+            stats.ambiguous, 0,
+            "a unique proximity winner is decisive — no ambiguous count"
+        );
+        assert!(
+            !graph.node_tags(caller).contains(&EDGE_AMBIGUOUS_TAG),
+            "decisive proximity bind must NOT carry the ambiguous tag, got {:?}",
+            graph.node_tags(caller)
+        );
+    }
+
+    /// Cry-wolf fix (b): a `Type::method()` call whose qualifier resolves the
+    /// owner among same-name candidates is a CONFIDENT bind — it must NOT tag
+    /// `m1nd:edge:ambiguous`, even with two same-name `analyze` candidates. The
+    /// qualifier decided it; that is not a coin-flip.
+    #[test]
+    fn decisive_by_qualifier_does_not_tag_ambiguous() {
+        let mut graph = Graph::new();
+        let caller = fn_node(&mut graph, "file::crate_b/src/api.rs::fn::handle", "handle");
+        // Owned by TaintEngine (the qualifier target) …
+        let correct = graph
+            .add_node(
+                "file::crate_a/src/taint.rs::fn::analyze",
+                "analyze",
+                NodeType::Function,
+                &["rust:impl:self:TaintEngine"],
+                0.0,
+                0.0,
+            )
+            .expect("add correct");
+        // … vs a same-name decoy owned by a different type.
+        let _decoy = graph
+            .add_node(
+                "file::crate_b/src/tremor.rs::fn::analyze",
+                "analyze",
+                NodeType::Function,
+                &["rust:impl:self:TremorEngine"],
+                0.0,
+                0.0,
+            )
+            .expect("add decoy");
+
+        let unresolved = vec![(
+            "file::crate_b/src/api.rs::fn::handle".to_string(),
+            "ref::TaintEngine::analyze".to_string(),
+            "calls".to_string(),
+        )];
+        let stats = ReferenceResolver::resolve(&mut graph, &unresolved).expect("resolve");
+
+        assert_eq!(stats.resolved, 1, "the qualified ref must resolve");
+        assert_eq!(
+            calls_target(&graph, caller),
+            Some(correct),
+            "must bind to the TaintEngine-owned analyze"
+        );
+        assert_eq!(
+            stats.ambiguous, 0,
+            "a qualifier-resolved bind is decisive — no ambiguous count"
+        );
+        assert!(
+            !graph.node_tags(caller).contains(&EDGE_AMBIGUOUS_TAG),
+            "qualifier-decided bind must NOT carry the ambiguous tag, got {:?}",
             graph.node_tags(caller)
         );
     }

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -1755,7 +1755,11 @@ pub fn handle_why(state: &mut SessionState, input: WhyInput) -> M1ndResult<serde
             } else {
                 current
             };
-            let reason = closure_reason_for_source(&graph, edge_source);
+            // Edge-specific provenance: `edge_target` (the CSR-stored target `T`)
+            // is the real directed edge's target in both BFS directions, so we can
+            // ask whether THIS edge (edge_source -> edge_target) was the ambiguous
+            // guess — not whether edge_source has any ambiguous edge at all.
+            let reason = closure_reason_for_edge(&graph, edge_source, edge_target);
             load_bearing.push((edge_external_id(&graph, edge_source), rel.clone(), reason));
             path_relations.push(rel);
             current = prev;
@@ -1826,16 +1830,46 @@ fn edge_external_id(graph: &m1nd_core::graph::Graph, node_idx: usize) -> String 
     format!("node_{node_idx}")
 }
 
-/// Read the provenance reason carried by an edge's SOURCE node, if any. Returns
-/// `Some("ambiguous")`/`Some("unresolved")` when the node was tagged at ingest
-/// because one of its outgoing edges was a low-confidence fallback or a dropped
-/// reference; `None` for a cleanly-resolved source. Ambiguous (a wrong guess on
-/// a created edge) is reported in preference to unresolved (a dropped edge).
-fn closure_reason_for_source(graph: &m1nd_core::graph::Graph, node_idx: usize) -> Option<String> {
-    let tags = graph.node_tags(m1nd_core::types::NodeId::new(node_idx as u32));
-    if tags.contains(&m1nd_ingest::resolve::EDGE_AMBIGUOUS_TAG) {
+/// Read the provenance reason for the SPECIFIC directed edge `source -> target`
+/// that lies ON a reconstructed `why` path. Returns:
+///   * `Some("ambiguous")` iff THIS edge was a genuine coin-flip at ingest — i.e.
+///     `source` carries the TARGETED `m1nd:edge:ambiguous:<target_ext_id>` tag for
+///     exactly this target;
+///   * else `Some("unresolved")` iff `source` carries the node-level
+///     `EDGE_UNRESOLVED_TAG`;
+///   * else `None` (clean).
+///
+/// The AMBIGUOUS reason is now edge-specific — this is the cry-wolf fix. The tag
+/// is written per-SOURCE-NODE at ingest, but the closure verdict is a PER-PATH
+/// claim (`closure_verdict`'s contract: only edges ON the path count). The old
+/// reader used the BARE node-level ambiguous tag, so any node with SOME ambiguous
+/// outbound edge poisoned EVERY path through it — a clean edge like
+/// `handle_seek -> pack_to_budget` (a unique-name target) was reported `blocked`
+/// merely because `handle_seek` also calls a common-named fn (`get`/`resolve`/
+/// `new`) that is a genuine same-name tie. Reading the TARGETED tag blames ONLY
+/// the specific guessed edge, so clean siblings are no longer falsely blocked.
+///
+/// The UNRESOLVED reason is deliberately LEFT node-level (semantics unchanged, per
+/// the field-triage #4 scope): a dropped reference created no edge to key against,
+/// and the existing contract (see `why_reports_blocked_when_path_rests_on_dangling_edge`)
+/// is that a node with a dropped outbound reference honestly flags paths leaving
+/// it as incomplete. Only the ambiguous over-fire is tightened here. NOTE: this
+/// leaves a residual node-level over-fire for `unresolved` (a clean edge out of a
+/// node that drops an UNRELATED ref still reads blocked) — tracked as follow-up;
+/// not touched here because unresolved semantics were explicitly out of scope.
+fn closure_reason_for_edge(
+    graph: &m1nd_core::graph::Graph,
+    source_idx: usize,
+    target_idx: usize,
+) -> Option<String> {
+    let source = m1nd_core::types::NodeId::new(source_idx as u32);
+    let target_ext_id = edge_external_id(graph, target_idx);
+    if m1nd_ingest::resolve::source_has_ambiguous_edge_to(graph, source, &target_ext_id) {
         Some("ambiguous".to_string())
-    } else if tags.contains(&m1nd_ingest::resolve::EDGE_UNRESOLVED_TAG) {
+    } else if graph
+        .node_tags(source)
+        .contains(&m1nd_ingest::resolve::EDGE_UNRESOLVED_TAG)
+    {
         Some("unresolved".to_string())
     } else {
         None

--- a/scratchpad/m1nd_battery.py
+++ b/scratchpad/m1nd_battery.py
@@ -24,6 +24,62 @@ import time
 
 TIMEOUT = 180.0
 
+# The m1nd binary under test — set by run_battery so in-check helpers (e.g. the
+# closure honesty-guard) can spin up an ISOLATED second process without touching
+# the shared suite graph.
+_BIN_PATH = None
+
+
+def _true_tie_still_blocks():
+    """Honesty guard for the closure cry-wolf fix: prove that a GENUINE coin-flip
+    edge STILL yields closure.state == "blocked" via a fresh, ISOLATED m1nd
+    process (its own temp runtime — does NOT perturb the shared suite graph).
+
+    Plants the minimal ambiguous corpus: `walk()` calls `helper()` with TWO
+    same-name `helper` fns in the SAME directory (identical proximity, no
+    qualifier) — a true tie. Returns True iff `why(walk -> the bound helper)` is
+    blocked with a `calls` dangling edge whose reason is "ambiguous". Stable:
+    the resolver deterministically binds one helper and flags that edge.
+    """
+    if not _BIN_PATH:
+        return False
+    root = tempfile.mkdtemp(prefix="m1nd_tie_corpus_")
+    src = os.path.join(root, "src")
+    os.makedirs(src)
+    open(os.path.join(src, "walker.rs"), "w").write("pub fn walk() {\n    helper();\n}\n")
+    open(os.path.join(src, "one.rs"), "w").write("pub fn helper() -> u32 { 1 }\n")
+    open(os.path.join(src, "two.rs"), "w").write("pub fn helper() -> u32 { 2 }\n")
+    open(os.path.join(root, "Cargo.toml"), "w").write(
+        "[package]\nname='tie'\nversion='0.0.0'\nedition='2021'\n")
+    tmp = tempfile.mkdtemp(prefix="m1nd_tie_rt_")
+    env = dict(os.environ)
+    env.update(M1ND_GRAPH_SOURCE="temp", M1ND_PLASTICITY_STATE=os.path.join(tmp, "p.json"),
+               M1ND_RUNTIME_DIR=tmp, M1ND_TOOL_TIER="full")
+    errf = open(os.path.join(tmp, "err.log"), "wb")
+    proc = subprocess.Popen([_BIN_PATH, "--stdio", "--no-gui"], stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE, stderr=errf, env=env)
+    cc = C(proc)
+    try:
+        cc.rpc("initialize", {"protocolVersion": "2024-11-05", "capabilities": {},
+                              "clientInfo": {"name": "tie", "version": "0"}})
+        cc.rpc("tools/list")
+        cc.tool("ingest", {"agent_id": "tie", "path": root})
+        for t in ("file::src/one.rs::fn::helper", "file::src/two.rs::fn::helper"):
+            r, _ = cc.tool("why", {"source": "file::src/walker.rs::fn::walk",
+                                   "target": t, "agent_id": "tie", "max_hops": 3})
+            cl = r.get("closure") or {}
+            if (r.get("found") and cl.get("state") == "blocked"
+                    and any(d.get("reason") == "ambiguous" and d.get("relation") == "calls"
+                            for d in (cl.get("dangling_edges") or []))):
+                return True
+        return False
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+
 
 # --------------------------------------------------------------------------- #
 # MCP stdio client (framing copied from focus_smoke.py)                        #
@@ -835,17 +891,40 @@ def suite_m1nd(repo):
         # `check(res,q,c)` owns its verdict. STRUCTURE-first (no pinned τ).     #
         # =================================================================== #
 
-        # ---- closure verdict on `why` (#185) ----
+        # ---- closure verdict on `why` (#185, tightened by field-triage #4) ----
         # `why` attaches a top-level `closure` block: state ∈ {closed, blocked},
         # a non-empty `why` string, and `dangling_edges` (empty iff closed, non-
-        # empty iff blocked). MEASURED stable: handle_seek->pack_to_budget is
-        # `blocked` because handle_seek's outbound `calls` edge is ambiguous (many
-        # same-name fns in-repo), surfacing one dangling `calls` edge sourced at
-        # handle_seek. We assert the well-formed invariant AND that the ambiguity
-        # is actually DETECTED here (state=blocked with that dangling edge) — proof
-        # the verdict reflects real resolution, not just a field that exists.
+        # empty iff blocked).
+        #
+        # UPDATED for field-triage #4 (the AMBIGUOUS closure cry-wolf). PREVIOUSLY
+        # this case asserted handle_seek->pack_to_budget was `blocked` with an
+        # `ambiguous` reason, because the ambiguity tag was NODE-level: handle_seek
+        # also calls common-named fns (get/resolve/new) that are genuine same-name
+        # ties, so the WHOLE node was tagged and EVERY clean path through it
+        # (including the unique-target pack_to_budget edge) was falsely reported
+        # ambiguous. That false alarm fired on ~100% of load-bearing paths in this
+        # repo (measured: 9/11 connected pairs blocked on `ambiguous`) — the
+        # cry-wolf. The fix (a) tags only GENUINE coin-flips (decisive proximity/
+        # qualifier binds no longer tag) and (b) reads the tag PER-EDGE via a
+        # targeted `m1nd:edge:ambiguous:<target>` tag, so a clean edge is never
+        # blamed for an unrelated ambiguous sibling. Result: ambiguous-blocked
+        # dropped 9/11 -> 0/11.
+        #
+        # NOTE on this specific path: handle_seek ALSO carries the node-level
+        # `EDGE_UNRESOLVED_TAG` (it calls std/external fns that drop), and
+        # unresolved semantics were explicitly OUT OF SCOPE for triage #4 (left
+        # unchanged). So this path may still be `blocked` — but now on
+        # `unresolved`, NEVER on `ambiguous`. We therefore assert exactly the
+        # in-scope contract:
+        #   1. well-formed contract (state/why/dangling coherent), UNCHANGED;
+        #   2. the AMBIGUOUS cry-wolf is gone HERE: no dangling edge on this path
+        #      carries reason "ambiguous" (it is closed, or blocked only on
+        #      unresolved);
+        #   3. HONESTY GUARD: the fix did NOT overshoot into silence — a GENUINE
+        #      tie STILL yields `blocked`+`ambiguous`, proven end-to-end via an
+        #      isolated planted-corpus probe (`_true_tie_still_blocks`).
         dict(id="closure_verdict_wellformed_blocked",
-             intent="why must carry a well-formed closure verdict and flag the ambiguous edge as blocked",
+             intent="why closure verdict well-formed; ambiguous cry-wolf gone on this path; genuine tie still blocked (fixed, not silenced)",
              tool="why",
              args=dict(source="file::m1nd-mcp/src/layer_handlers.rs::fn::handle_seek",
                        target="file::m1nd-mcp/src/result_shaping.rs::fn::pack_to_budget", agent_id=aid, max_hops=3),
@@ -854,19 +933,19 @@ def suite_m1nd(repo):
              check=lambda res, q, c: (
                  (lambda cl: (
                      isinstance(cl, dict)
+                     # (1) well-formed contract — unchanged.
                      and cl.get("state") in ("closed", "blocked")
                      and isinstance(cl.get("why"), str) and len(cl.get("why")) > 0
                      and isinstance(cl.get("dangling_edges"), list)
                      and (cl.get("dangling_edges") == []) == (cl.get("state") == "closed")
-                     # measured-stable specifics for this path: blocked, and the
-                     # dangling edge is a `calls` edge sourced at handle_seek.
-                     and cl.get("state") == "blocked"
-                     and any(d.get("relation") == "calls"
-                             and str(d.get("source", "")).endswith("::fn::handle_seek")
-                             and isinstance(d.get("reason"), str)
-                             for d in (cl.get("dangling_edges") or []))
+                     # (2) the AMBIGUOUS cry-wolf is gone on this clean path: no
+                     # dangling edge here is reason "ambiguous" (unique-name target).
+                     and not any(d.get("reason") == "ambiguous"
+                                 for d in (cl.get("dangling_edges") or []))
+                     # (3) honesty guard: a true coin-flip STILL flags blocked.
+                     and _true_tie_still_blocks()
                  ))(res.get("closure")),
-                 "closure well-formed (state/why/dangling coherent) and blocked on the ambiguous handle_seek calls edge",
+                 "closure well-formed; no `ambiguous` dangling on handle_seek->pack_to_budget (cry-wolf gone); genuine tie still blocked+ambiguous (not silenced)",
              )),
 
         # ---- trust cold-start honesty (#182) ----
@@ -1059,6 +1138,8 @@ def suite_ts(repo):
 # Battery runner                                                               #
 # --------------------------------------------------------------------------- #
 def run_battery(bin_path, repo, suite_name):
+    global _BIN_PATH
+    _BIN_PATH = bin_path  # let in-check helpers spawn isolated probes
     env = dict(os.environ)
     tmp = tempfile.mkdtemp(prefix="m1nd_battery_")
     env["M1ND_GRAPH_SOURCE"] = "temp"  # FRESH temp graph as instructed


### PR DESCRIPTION
## Field report L1 (the cry-wolf, honesty class)

> The `closure` verdict on `why` fires `blocked` on NEARLY EVERY load-bearing path in the m1nd repo itself, because the ingest-time ambiguity tagger marks `m1nd:edge:ambiguous` whenever a same-name fallback had >1 candidates — even when proximity/qualifier resolution picked a clear winner. A verdict that almost always fires becomes noise agents tune out — the cry-wolf kills the signal. Tighten it so `blocked` means GENUINE ambiguity (a coin-flip), not "same-name existed somewhere".

## Root cause (two layers)

The `m1nd:edge:ambiguous` provenance tag was both too eager AND read at the wrong granularity:

1. **Too eager (the reported bug).** At both same-name fallback sites in `m1nd-ingest/src/resolve.rs`, the tag was applied on `found.len() > 1` / `candidates.len() > 1` — *before* the winner was even selected. So a decisive bind (unique best proximity per #170, or a call-site qualifier match per #175) was still flagged ambiguous.
2. **Wrong granularity (discovered while measuring).** The tag is written **per-source-node**, but the closure verdict is a **per-path** claim (`closure_verdict`'s own contract: "only edges ON the path count"). The reader consulted the node-level tag, so a node with ONE genuinely-ambiguous outbound edge — e.g. a call to a common name like `get`/`resolve`/`new`, of which nearly every handler has several — poisoned **every** clean path through it. Forensics confirmed `handle_seek → pack_to_budget` (a **unique-name** target whose edge bound cleanly) was reported `blocked`, blamed entirely on `handle_seek`'s unrelated `get`/`resolve` calls.

## The fix (tagger precision + edge-specific read; binding behavior UNCHANGED)

- `pick_candidate` runs the exact resolution precedence (qualifier → import-hint → proximity → first-match) and reports whether the winner was a **genuine coin-flip**: a qualifier/hint match is decisive; proximity is decisive only when ONE candidate holds the strict-best score; a tie (≥2 at the best rank, or no signal) is a coin-flip. The tag fires **only** on a coin-flip.
- The resolver also emits a **targeted** `m1nd:edge:ambiguous:<target_external_id>` tag naming the specific ambiguous edge; `why` reads THAT per-edge, so a clean sibling edge is never blamed for an unrelated ambiguous edge on the same source node.
- `EDGE_UNRESOLVED_TAG` (dropped edges) semantics are **deliberately unchanged** (explicitly out of scope). The verdict contract (`closure.state ∈ {closed, blocked}`, `dangling_edges`, same shapes) is unchanged — only the tag precision/read granularity changed.

## Before → after (measured on the m1nd repo itself, isolated `M1ND_GRAPH_SOURCE=temp`)

Probed ~12 representative connected pairs (`handle_seek→pack_to_budget`, `handle_ingest→provider_availability`, `handle_why→closure_verdict`, `resolve→proximity_score`, plus others):

| metric | before | after |
| --- | --- | --- |
| **ambiguous-blocked** (the in-scope cry-wolf) | **9/11** | **0/11** |
| overall connected blocked (incl. out-of-scope `unresolved`) | 11/11 | 8/8 |

The **ambiguous** cry-wolf is eliminated: no path is blocked on a false `ambiguous` alarm. The remaining blocks are on the node-level `unresolved` tag (a separate over-fire, left unchanged per scope — tracked as follow-up).

**Honesty guard (proven end-to-end):** a genuine 2-way tie — `walk()` calling `helper()` with two same-name `helper` fns in the same directory, identical proximity, no qualifier — STILL yields `closure.state == "blocked"` with a `calls` dangling edge reason `ambiguous`. The fix narrows to genuine ambiguity; it does not eliminate it. Stable across 3 runs.

## Proof

Red → green at the resolve layer (all in `m1nd-ingest/src/resolve.rs`):
- `decisive_by_proximity_does_not_tag_ambiguous` — same-name across different dirs, unique same-dir proximity winner → NO tag. **Fails on the old `len>1` tagger, passes with the fix.**
- `decisive_by_qualifier_does_not_tag_ambiguous` — `Type::method` qualifier resolves the owner → NO tag. **Fails on old, passes with fix.**
- `genuine_tie_tags_source_and_counts_ambiguous` — two same-name candidates in the SAME dir, no qualifier → tag PRESENT (bare + targeted). Passes under both (a true tie is a true tie).
- `one_ambiguous_edge_does_not_taint_a_clean_sibling_edge` — the cry-wolf killer: a source with one ambiguous edge does NOT taint a different clean edge (targeted tag TRUE for the tied target, FALSE for the unique one).

### Battery case update rationale

`closure_verdict_wellformed_blocked` previously hard-asserted `state == "blocked"` with an `ambiguous` reason on `handle_seek → pack_to_budget`. That assertion encoded the cry-wolf (it passed only because of the node-level over-fire). Updated honestly to keep the well-formed contract assertion and instead assert (1) the contract (state/why/dangling coherent), (2) **no `ambiguous` dangling** on this clean path (the cry-wolf is gone here), and (3) the **honesty guard** — a genuine tie still blocks+ambiguous, proven via an isolated planted-corpus probe that does not perturb the shared suite graph. All other 36 cases stay green untouched, including every `xfile_*`/`qualified_*` binding case (binding behavior did not change).

## Gate

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo test --workspace` → **1171 passed, 0 failed** (incl. the `why_closure_verdict_behavior` integration tests — the `unresolved` contract test still passes, unchanged)
- battery `m1nd_battery.py` → **37/37 ×2**

## Follow-up (out of scope, spawned)

The `unresolved` tag has the same node-granularity over-fire (a clean path leaving a node that drops an *unrelated* ref still reads `blocked` on `unresolved`). It needs a design decision (a dropped ref has no target to key an edge-specific tag against; the `why_reports_blocked_when_path_rests_on_dangling_edge` contract test encodes the current intent) and was explicitly out of scope for this triage. Documented in PATHOS → Known Problems.
