### PR TITLE
release: v1.2.1 — compounding live (north×L1GHT), cry-wolf killed, field-triage fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "clap",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Plus an **attention runtime** — `focus` hands the agent the minimal, budget-bo
 
 1.2.0 turns the loop from "retrieve, then hope" into **pre-orient → act on calibrated verdicts → capture what you learned**. The theme is the same as the trust layer: an honest *no* beats a confident guess.
 
-- **`north(task)` — pre-orient in one call.** The new front door composes trust, task context (focus nodes + PageRank anchors), prior cross-session memory, a sufficiency signal, one `next_move`, and `honest_gaps` (what m1nd does *not* yet know). `needs_ingest` is a real answer for an empty graph. (The L1GHT-recall composition that folds prior memory into the packet landed on `main` just after the 1.2.0 tag — it is not in the 1.2.0 binary.)
+- **`north(task)` — pre-orient in one call.** The new front door composes trust, task context (focus nodes + PageRank anchors), prior cross-session memory, a sufficiency signal, one `next_move`, and `honest_gaps` (what m1nd does *not* yet know). `needs_ingest` is a real answer for an empty graph. (The L1GHT-recall composition that folds prior memory into the packet shipped in **1.2.1** — it landed on `main` just after the 1.2.0 tag, so it is not in the 1.2.0 binary.)
 - **Conformal calibration on prediction.** `calibrate_predict` arms a per-repo gate; verdicts then read `act` / `reverify` / `abstain`, where `abstain` means *uncalibrated or insufficient* — a signal to stop, not a weak yes. Ships dark: until you calibrate, verdicts cap at `reverify`.
 - **`trust_envelope` on `seek`** (ships dark) and a **`closure` verdict on `why`** — `blocked` means the path rests on an unresolved/guessed edge. **`trust_band: insufficient_evidence`** is now distinct from a risk band: it means *no evidence*, the honest cold-start answer, not "medium risk".
 - **Memory grew a provenance spine** — claims carry real age + author, supersede older claims, age out, and respect a recency cap, so remembered knowledge states its own freshness instead of quietly going stale.
@@ -117,7 +117,7 @@ The response is one oriented packet — trust verdict, memory the last session l
 }
 ```
 
-If `north` reports `needs: "needs_ingest"` (empty graph), or you are on an older binary without the L1GHT-recall composition, fall back to the explicit trust loop — establish trust *before* believing any retrieval:
+If `north` reports `needs: "needs_ingest"` (empty graph), or you are on a pre-1.2.1 binary without the L1GHT-recall composition, fall back to the explicit trust loop — establish trust *before* believing any retrieval:
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -283,7 +283,7 @@ The same honesty rides on retrieval. A `seek` hit carries a `sufficiency` readou
 
 The proof of the commitment is what was killed for it: `savings` and `resonate` were pulled from the advertised surface in beta.7 because a tool that always claims to win is not credible. No competitor — not mem0, Zep, Letta, Sourcegraph, or any code-graph MCP — ships a layer that tells the agent what *not* to trust and how to recover.
 
-**The field-triage loop closes on itself.** The session telemetry agents leave in `~/.m1nd/field-reports.jsonl` (local-only — m1nd never phones home) is not a passive log: reports get triaged, and a *confirmed* field bug becomes a red battery case **before** the fix, so the regression is proven, not just described. That loop has already run once end-to-end: two field-reported bugs turned into failing battery cases and then merged fixes — `north` now composes L1GHT recall into its memory packet, and the `temp` graph sentinel resolves to a real tempdir instead of littering the working directory.
+**The field-triage loop closes on itself.** The session telemetry agents leave in `~/.m1nd/field-reports.jsonl` (local-only — m1nd never phones home) is not a passive log: reports get triaged, and a *confirmed* field bug becomes a red battery case **before** the fix, so the regression is proven, not just described. That loop has already run end-to-end through a full field-triage sweep: four field-reported bugs turned into failing battery cases and then merged fixes, all shipped in **1.2.1** — `north` now composes L1GHT recall into its memory packet, the `temp` graph sentinel resolves to a real tempdir instead of littering the working directory, `memorize` accepts a numeric `confidence`, and the closure ambiguity tag now fires only on genuine ties (the cry-wolf: ambiguous-blocked fell 9/11 → 0/11).
 
 ## Language Coverage
 

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -2,6 +2,13 @@
 
 > Read this first. Single source of truth for any chat / subagent / parallel
 > session working on m1nd, so we don't re-derive state or contradict each other.
+> Last checkpoint: 2026-07-03 (**checkpoint 8.1 — v1.2.1 CUT: compounding live in the runtime**).
+> v1.2.1 tagged on the merge commit, published to crates.io + npm, GitHub Release cut, and
+> Max's live `:1338` owner rebuilt on the 1.2.1 binary — carrying the four field-triage fixes
+> (#211 `north`×L1GHT recall = THE compounding fix; #212 temp-graph tempdir; #218 numeric
+> `confidence`; #219 closure cry-wolf killed, ambiguous-blocked 9/11 → 0/11). The field-report
+> mailbox now stands at **5 reports / 4 resolved / 1 residue** (the unresolved-tag granularity
+> follow-up remains open). Prior checkpoint 8 below.
 > Last checkpoint: 2026-07-02 (**checkpoint 8 — v1.2.0 CUT: the first OMEGA-era release**).
 > Tagged `v1.2.0`, published to crates.io + npm, GitHub Release cut, and Max's live
 > `:1338` owner upgraded to the 1.2.0 binary. The era content shipped since v1.1.0:
@@ -22,7 +29,24 @@ m1nd = operational intelligence for coding agents. The bar: genuinely BEAT plain
 Run a continuous, chained improvement engine: measure (battery) → fix+test the
 real defect → checkpoint → seed the next cycle. Never sugarcoat results.
 
-## Current State (2026-07-02, checkpoint 8 — v1.2.0 CUT, the first OMEGA-era release)
+## Current State (2026-07-03, checkpoint 8.1 — v1.2.1 CUT, compounding live)
+
+**v1.2.1 IS RELEASED — and the compounding is now live in Max's runtime.** Tag `v1.2.1` on
+the merge commit, `release.yml` published `m1nd-core` / `m1nd-ingest` / `m1nd-mcp` to crates.io
++ `@maxkle1nz/m1nd` to npm, a GitHub Release was cut, and Max's live `:1338` owner was rebuilt
+on the tagged binary (`--version` → `1.2.1 (<sha>)`). The patch carries the four field-triage
+fixes merged since the 1.2.0 tag: **#211 `north` composes L1GHT agent-memory recall — THE
+compounding fix** (memorize once, recall through the front door thereafter); #212 temp-graph
+sentinel → real tempdir; #218 numeric `confidence` coerced instead of rejected; **#219 closure
+ambiguity tag fires only on genuine ties — the cry-wolf killed** (ambiguous-blocked 9/11 → 0/11,
+honesty guard proven). Battery grew to **37/37**. `m1nd-openclaw` stays `0.1.0`.
+**Field-report mailbox: 5 reports / 4 resolved / 1 residue** — the four fixes above closed their
+reports; the residue is a follow-up on unresolved-tag granularity (still open). The live north
+memory-recall proof (agent-memory surfacing through `north` on the running :1338 binary) was
+captured at cut time — this checkpoint is where compounding stopped being an A/B hypothesis and
+became a live runtime property.
+
+---
 
 **v1.2.0 IS RELEASED.** Tag `v1.2.0` on the merge commit, `release.yml` published
 `m1nd-core` / `m1nd-ingest` / `m1nd-mcp` to crates.io + `@maxkle1nz/m1nd` to npm (the

--- a/docs/wiki/src/changelog.md
+++ b/docs/wiki/src/changelog.md
@@ -10,6 +10,31 @@ No unreleased changes.
 
 ---
 
+## [1.2.1] — 2026-07-03
+
+The first field-triage patch. Four bugs reported through the local field-report
+mailbox (`~/.m1nd/field-reports.jsonl`) were each turned into a red battery case and
+then fixed — the telemetry loop closing on itself. This is the release that turns the
+**compounding on**: `north` now folds prior L1GHT agent-memory into its packet, so what
+one agent memorizes the next agent reads back through the front door.
+
+### Fixed
+
+- **`north` composes L1GHT agent-memory recall (#211).** The pre-orient packet now folds
+  prior cross-session memory (each claim with its real age + source agent) into `north`
+  itself — the composition landed on `main` just after the 1.2.0 tag, so it ships here in
+  the binary for the first time. This is the compounding beat: memorize once, recall through
+  `north` thereafter.
+- **`temp` graph sentinel resolves to a real tempdir (#212).** The `temp` graph target now
+  resolves under the OS tempdir instead of littering the working directory.
+- **`memorize` accepts a numeric `confidence` (#218).** A numeric confidence is coerced to
+  string instead of being rejected — agents that pass `0.9` no longer fail the call.
+- **Closure ambiguity tag fires only on genuine ties (#219).** `ingest` closure now tags
+  ambiguity only when candidates are actually tied, killing the cry-wolf: on the battery,
+  ambiguous-blocked cases fell **9/11 → 0/11** — the honesty guard proven, not just claimed.
+
+---
+
 ## [1.2.0] — 2026-07-02
 
 The first OMEGA-era release. The loop shifts from "retrieve, then hope" to

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -41,7 +41,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.2.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.2.1" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -18,8 +18,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.2.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.2.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.2.1" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.2.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## v1.2.1 — the first field-triage patch

Four bugs reported through the local field-report mailbox (\`~/.m1nd/field-reports.jsonl\`) were each turned into a **red battery case** and then fixed — the telemetry loop closing on itself. This is the release that turns the **compounding on**: \`north\` now folds prior L1GHT agent-memory into its packet, so what one agent memorizes the next agent reads back through the front door.

### Fixes (all merged to main since the v1.2.0 tag)
- **#211 \`fix(north)\`** — north composes L1GHT agent-memory recall into the pre-orient packet (each claim with real age + source agent). Landed on \`main\` just after the 1.2.0 tag, so it ships **in the binary** here for the first time. **THE compounding fix.**
- **#212 \`fix(mcp)\`** — the \`temp\` graph sentinel resolves to a real tempdir instead of littering CWD.
- **#218 \`fix(memorize)\`** — a numeric \`confidence\` is coerced to string instead of rejected.
- **#219 \`fix(ingest)\`** — closure ambiguity tag fires only on genuine ties. Cry-wolf killed: ambiguous-blocked **9/11 → 0/11** on the battery — the honesty guard proven, not just claimed.

### Bumps
\`m1nd-core\` / \`m1nd-ingest\` / \`m1nd-mcp\` 1.2.0 → 1.2.1 (+ inter-dep refs + Cargo.lock); npm root 1.2.0 → 1.2.1. \`m1nd-openclaw\` stays 0.1.0.

### Docs
README honest footnote updated (the north L1GHT-composition now ships in 1.2.1), changelog \`[1.2.1]\` entry, PATHOS checkpoint 8.1 (compounding live; mailbox 5/4/1).

### Gate (green)
- \`cargo fmt --check\` — clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` — 0
- \`cargo test --workspace\` — 0 failed
- battery (\`--suite m1nd\`) — **37/37** (20 wins / 17 ties / 0 grep-wins)