### PR TITLE
fix(mcp): remove the unmeasured savings envelope — an uncalibrated claim is the confident guess (brand gate G1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ No unreleased changes.
 
 ---
 
+## [1.2.2] — 2026-07-03
+
+Brand gate G1 — honesty is the product.
+
+### Removed
+
+- **The unmeasured `savings` envelope (brand gate G1).** Every response used to
+  carry `_m1nd.savings`, `_m1nd.tokens_saved`, and `_m1nd.gaia.global_tokens_never_burned`
+  — a confidently-stated "tokens saved" number with no measured basis. An uncalibrated
+  claim is the confident guess, and it has no place in a product whose whole promise is
+  calibrated trust. The envelope's honest neighbors (`suggest_next`, `read_only`,
+  `summary`) are kept; the standalone opt-in `savings`/`report` tools are unchanged.
+
+---
+
 ## [1.1.0] — 2026-06-28
 
 A code-intelligence correctness release: a new attention runtime (`focus`), the

--- a/docs/wiki/src/changelog.md
+++ b/docs/wiki/src/changelog.md
@@ -10,6 +10,21 @@ No unreleased changes.
 
 ---
 
+## [1.2.2] — 2026-07-03
+
+Brand gate G1 — honesty is the product.
+
+### Removed
+
+- **The unmeasured `savings` envelope (brand gate G1).** Every response used to
+  carry `_m1nd.savings`, `_m1nd.tokens_saved`, and `_m1nd.gaia.global_tokens_never_burned`
+  — a confidently-stated "tokens saved" number with no measured basis. An uncalibrated
+  claim is the confident guess, and it has no place in a product whose whole promise is
+  calibrated trust. The envelope's honest neighbors (`suggest_next`, `read_only`,
+  `summary`) are kept; the standalone opt-in `savings`/`report` tools are unchanged.
+
+---
+
 ## [1.2.1] — 2026-07-03
 
 The first field-triage patch. Four bugs reported through the local field-report

--- a/m1nd-mcp/src/personality.rs
+++ b/m1nd-mcp/src/personality.rs
@@ -289,24 +289,12 @@ pub fn personality_line(tool_name: &str, result: &Value) -> String {
 // ---------------------------------------------------------------------------
 
 /// Build the `_m1nd` metadata envelope to wrap every tool response.
-pub fn build_m1nd_meta(
-    tool_name: &str,
-    result: &Value,
-    session_tokens_saved: u64,
-    global_tokens_saved: u64,
-) -> Value {
+pub fn build_m1nd_meta(tool_name: &str, result: &Value) -> Value {
     let suggestions = suggest_next(tool_name);
     let personality = personality_line(tool_name, result);
 
     let mut meta = json!({
         "suggest_next": suggestions,
-        "savings": {
-            "query_tokens_saved": estimate_query_savings(tool_name),
-            "session_total": session_tokens_saved,
-        },
-        "gaia": {
-            "global_tokens_never_burned": global_tokens_saved,
-        },
     });
 
     if !personality.is_empty() {
@@ -314,20 +302,6 @@ pub fn build_m1nd_meta(
     }
 
     meta
-}
-
-/// Estimate tokens saved for a single query.
-fn estimate_query_savings(tool_name: &str) -> u64 {
-    match tool_name {
-        "activate" | "seek" | "search" => 750,
-        "impact" | "predict" | "counterfactual" => 1000,
-        "surgical_context" => 3200,
-        "surgical_context_v2" => 4800,
-        "hypothesize" | "missing" => 1000,
-        "apply" | "apply_batch" => 900,
-        "scan" => 1000,
-        _ => 500,
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -3519,7 +3519,7 @@ fn build_orient_coverage(state: &SessionState, agent_id: &str) -> serde_json::Va
 /// Dispatch a tool call by name. Normalizes underscores to dots.
 /// Used by both JSON-RPC stdio and HTTP API -- zero duplication.
 ///
-/// v0.4.0: wraps all responses with _m1nd metadata, tracks savings.
+/// v0.4.0: wraps all responses with _m1nd metadata.
 pub fn dispatch_tool(
     state: &mut SessionState,
     tool_name: &str,
@@ -3678,20 +3678,15 @@ Run surgical_context_v2 (agent_id='{agent}', path='{first}') for each unproven t
         // never removes or renames existing fields. Non-object results (rare)
         // are left untouched.
         if response_envelope_enabled() && value.is_object() {
-            let session_saved = state.savings_tracker.tokens_saved;
-            let global_saved = state.global_savings.total_tokens_saved + session_saved;
             // Builders read the result; snapshot it once to avoid a borrow
             // conflict with the mutable insert below.
             let snapshot = value.clone();
-            let mut meta =
-                personality::build_m1nd_meta(&normalized, &snapshot, session_saved, global_saved);
-            // Promote the headline fields the contract calls for so agents get
-            // them without reaching into nested `savings`.
+            let mut meta = personality::build_m1nd_meta(&normalized, &snapshot);
+            // Promote the headline summary so agents get it at the top level.
             let summary = personality::personality_line(&normalized, &snapshot);
             if !summary.is_empty() {
                 meta["summary"] = serde_json::Value::String(summary);
             }
-            meta["tokens_saved"] = serde_json::json!(session_saved);
             meta["read_only"] = serde_json::json!(state.read_only);
 
             // Tier 3: memory at point-of-relevance (additive, capped, best-effort).
@@ -5347,8 +5342,17 @@ mod tests {
         let obj = out.as_object().expect("object result");
         assert!(obj.contains_key("_m1nd"), "_m1nd envelope must be present");
         let meta = &obj["_m1nd"];
-        assert!(meta.get("suggest_next").is_some(), "suggest_next present");
-        assert!(meta.get("tokens_saved").is_some(), "tokens_saved present");
+        assert!(meta.get("suggest_next").is_some(), "suggest_next kept");
+        assert!(meta.get("read_only").is_some(), "read_only kept");
+        // Brand gate G1: the unmeasured savings envelope is removed. An
+        // uncalibrated `tokens_saved` guessed on every response is the
+        // confident guess — honesty is the product.
+        assert!(
+            meta.get("tokens_saved").is_none(),
+            "tokens_saved must be gone (unmeasured claim)"
+        );
+        assert!(meta.get("savings").is_none(), "savings block must be gone");
+        assert!(meta.get("gaia").is_none(), "gaia block must be gone");
         // Additive: the original results field is still there.
         assert!(obj.contains_key("results"), "results field preserved");
     }


### PR DESCRIPTION
## Brand gate G1 — kill the unmeasured `savings` envelope

### The problem (honesty-class field report + brand-critic finding)
Every m1nd response shipped an uncalibrated "savings" claim:
```
"_m1nd": {
  "gaia": { "global_tokens_never_burned": N },
  "savings": { "query_tokens_saved": N, "session_total": N },
  "tokens_saved": N,          // e.g. 7500
  "read_only": bool,
  "suggest_next": [...]
}
```
`tokens_saved: 7500` was a **confidently-stated number with no measured basis** — a fixed per-tool guess (`estimate_query_savings`) plus a persisted running total. In the flagship *honesty* product, that is the confident guess: the 0.5 all over again. beta.7 already removed `savings`/`resonate` from the **advertised** surface; the **envelope** survived. This finishes the job.

### Founder decision
> KILL the `savings` envelope upstream (remove it from the product). An uncalibrated claim has no place in the product; honesty is the product.

### Removed vs kept
**Removed** from the per-response `_m1nd` envelope:
- `_m1nd.savings` (`query_tokens_saved`, `session_total`)
- `_m1nd.gaia.global_tokens_never_burned` (the whole `gaia` block — it carried only this one unmeasured field)
- top-level `_m1nd.tokens_saved`
- the now-dead `estimate_query_savings` helper (`personality.rs`) and the unused `session_saved`/`global_saved` envelope locals (`server.rs`) — dead code would fail `clippy -D warnings`.

**Kept** (honest neighbors, factual/useful — not entangled):
- `_m1nd.suggest_next`, `_m1nd.read_only`, `_m1nd.summary`, `_m1nd.personality`, `_m1nd.memory_nearby`
- the separate **opt-in** `savings`/`report` tools + their `SavingsTracker`/`GlobalSavings` accounting and golden tests (`test_v04.rs`). These are a distinct advertised surface an agent must explicitly call — not shipped on every response — so they were left intact and their `record()` accounting still feeds them (not dead).

### Red → green
The existing `response_envelope_attaches_additively` test asserted `meta.get("tokens_saved").is_some()` (green on main because the field was there). It now asserts the killed fields are **absent** and the kept neighbors **present**:
```rust
assert!(meta.get("suggest_next").is_some(), "suggest_next kept");
assert!(meta.get("read_only").is_some(), "read_only kept");
assert!(meta.get("tokens_saved").is_none(), "tokens_saved must be gone (unmeasured claim)");
assert!(meta.get("savings").is_none(), "savings block must be gone");
assert!(meta.get("gaia").is_none(), "gaia block must be gone");
```
The killed fields provably existed on `origin/main` (`build_m1nd_meta`'s 4-param signature, `query_tokens_saved`, `global_tokens_never_burned`, the `estimate_query_savings` fn), so this assertion fails on main and passes here.

### Gate (all green)
- `cargo fmt --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: **0 warnings** (dead `estimate_query_savings` + unused locals removed)
- `cargo test --workspace`: **0 failed** (m1nd-mcp 523, test_v04 26, m1nd-core 233)
- battery `--suite m1nd`: **37/37** (20 wins / 17 ties / 0 losses to grep); no battery case reads `tokens_saved`

### Honest residue
- `m1nd-ui`: zero savings references — nothing to remove.
- No persisted counter had to be wiped: `GlobalSavings` (`global_savings.json`) still backs the kept opt-in `savings`/`report` tools, so its accounting stays live rather than becoming orphaned. The envelope simply no longer reads it.
- Pre-existing changelog drift (root `CHANGELOG.md` stops at 1.1.0; wiki `changelog.md` carries 1.2.1/1.2.0) is out of G1 scope; the identical `1.2.2` block was inserted cleanly into both.
