### PR TITLE
docs(readme): the shell is the product — README re-spined around the operating loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,72 +36,65 @@
 
 ---
 
-**m1nd is operational intelligence for coding agents — it governs the operating loop, not just retrieval.**
+**m1nd is the shell around your coding agent — the operating loop it lives inside: oriented before it acts, honest verdicts while it works, memory with evidence after it finishes, compounding across sessions.**
 
 <p align="center"><img src="docs/assets/visuals/01-code-to-graph.png" width="520" alt="A stack of loose files becomes a connected graph of what links to what" /></p>
 
 > grep finds text. Vector search finds similar chunks. `m1nd` gives agents a local graph of what connects, what changed, what breaks, what drifted, and where to resume.
 
-Three things here exist together in no other tool:
+## What m1nd is: the shell around your agent
 
-- **Causal code graph** — `impact` before you edit shows the blast radius you didn't read; `ghost_edges` surfaces files that always change together but share no import.
-- **Self-verifying memory** — `memorize` anchors findings to real code nodes; `cross_verify` flags them stale when that code changes.
-- **A trust / recovery layer** — every result carries a trust mode; `trust_selftest` and `recovery_playbook` tell the agent when the workspace binding is wrong and how to recover.
+*m1nd wraps your coding agent in a loop that briefs it before it acts, keeps it honest while it works, and remembers what it learned when it's done.*
 
-Plus an **attention runtime** — `focus` hands the agent the minimal, budget-bounded working set for a goal, with an honest tail of what it left out and a signal for whether that's *enough* context yet.
+- **If you build with agents** — nothing new to learn: install once, keep talking to your agent. It stops guessing, starts remembering, and says "I don't know" when that is the truth.
+- **If you're an engineer** — a local-first Rust graph engine behind an MCP server: a causal code graph (structural, semantic, temporal, and causal edges), conformally calibrated verdicts, and memory anchored to code nodes with provenance. Nothing leaves your machine.
+
+Agents on real codebases do not fail because they cannot search — they fail because they have no operating model. Each session rebuilds context from scratch, edits without knowing the blast radius, and cannot tell an empty result that means "nothing exists" from one that means "wrong repo". m1nd gives the agent a durable model of the codebase — a causal graph with spreading activation and Hebbian plasticity — and wraps the agent's whole loop around it. Features are not a catalog here; they are the stations of that shell:
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd is operated by your agent, not by you.** Every tool below is called by the agent itself — automatically, before and after it works. A human never runs them in normal use; you install once ([Quick Start](#quick-start)) and keep talking to your agent as always.
+
+**One shell, three readers.** The same oriented packet is rendered for whoever is about to act: the **main agent** reads it as `north` (shipped — the front door below); a **subagent** will receive it as the Delegation Packet, the retrieval half of its spawn spec (designed — [docs/NEXTGEN-AGENT-PRD.md](docs/NEXTGEN-AGENT-PRD.md), §O.12); the **human** will see it as the Pre-Flight Card on the Living Tree — your project as a navigable tree with memory post-its, showing what the agent verified vs. guessed before an edit lands (designed, in development — [docs/HUMAN-LAYER-PRD.md](docs/HUMAN-LAYER-PRD.md)). One truth, computed once.
+
+<p align="center"><img src="docs/assets/plates/p6.png" width="560" alt="One truth, two readers — the same packet rendered for the agent and for the human" /></p>
 
 <p align="center">
   <img src=".github/m1nd-agent-first-map-v2.jpeg" alt="Traditional agent loop vs m1nd-grounded loop" width="960" />
 </p>
 
-## New in 1.2.0 — the first OMEGA-era release
+### What happens when you send a message
 
-1.2.0 turns the loop from "retrieve, then hope" into **pre-orient → act on calibrated verdicts → capture what you learned**. The theme is the same as the trust layer: an honest *no* beats a confident guess.
+You ask your agent to fix something. Here is what the shell does around that message:
 
-- **`north(task)` — pre-orient in one call.** The new front door composes trust, task context (focus nodes + PageRank anchors), prior cross-session memory, a sufficiency signal, one `next_move`, and `honest_gaps` (what m1nd does *not* yet know). `needs_ingest` is a real answer for an empty graph. (The L1GHT-recall composition that folds prior memory into the packet shipped in **1.2.1** — it landed on `main` just after the 1.2.0 tag, so it is not in the 1.2.0 binary.)
-- **Conformal calibration on prediction.** `calibrate_predict` arms a per-repo gate; verdicts then read `act` / `reverify` / `abstain`, where `abstain` means *uncalibrated or insufficient* — a signal to stop, not a weak yes. Ships dark: until you calibrate, verdicts cap at `reverify`.
-- **`trust_envelope` on `seek`** (ships dark) and a **`closure` verdict on `why`** — `blocked` means the path rests on an unresolved/guessed edge. **`trust_band: insufficient_evidence`** is now distinct from a risk band: it means *no evidence*, the honest cold-start answer, not "medium risk".
-- **Memory grew a provenance spine** — claims carry real age + author, supersede older claims, age out, and respect a recency cap, so remembered knowledge states its own freshness instead of quietly going stale.
-- **Smoothed-Jaccard co-change** — `ghost_edges` / `predict` now normalize coupling instead of counting raw co-commits (calibration-proven +3 points over raw counts).
-- **Binary version + sha fingerprint** — `--version` prints `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) let a host detect and refuse a drifted binary.
-- **Agent-native MCP instructions + local-only field reports.** The `initialize` instructions every host receives now *are* the operating loop above. Agents can leave one telemetry signal per session — `learn` on a retrieval verdict, or a line in `~/.m1nd/field-reports.jsonl` when m1nd itself misbehaves. That file is local-only; **m1nd never phones home.**
+1. **Before your agent acts**, m1nd hands it the live map of your project, what past sessions learned, how much to trust each piece — and what it does *not* know (`north`).
+2. **While it works**, it wears verdicts: it checks what an edit would break *before* touching the code (`impact`), and where evidence is thin it gets an honest "I don't know" instead of a confident guess (`abstain`).
+3. It can ask why two pieces of code are connected and be told when the answer rests on a guess (`why`), and it is warned before crossing an architecture boundary (`xray_gate`).
+4. **When it finishes**, the decision is written down with the evidence that backs it (`memorize`).
+5. That memory is anchored to the real code — if the code later changes, the memory flags itself stale instead of quietly lying (`cross_verify`).
+6. **Your next session starts already knowing** — any agent, any tool: Claude Code, Codex, Cursor, Gemini. What one agent learns, the next inherits.
 
-## Quick Start
+## BEFORE — born oriented
 
-The minimal happy path — install from source (always current), check health, wire your host:
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-Then wire your host — the same two commands, one per host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
-
-| Host | Install the agent pack | Wire the MCP config |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-Or from npm: `npm install -g @maxkle1nz/m1nd`.
-
-Full install map, host packs, native runtime build, and update flags: [docs/AGENT-PACKS.md](docs/AGENT-PACKS.md) · client-by-client setup: [integration matrix](docs/IDE-INTEGRATIONS.md).
-
-### Agent Entry Point
+*Your agent starts every session already knowing your project — and knowing what it doesn't know.*
 
 <p align="center"><img src="docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task): one front-door call returns the whole oriented packet" /></p>
 
-Agents parse this README. Inside an MCP session, the front door is one call — `north(task)` composes trust, task context, prior cross-session memory, a sufficiency signal, one `next_move`, and `honest_gaps` (what m1nd does *not* yet know) into a single packet, before any query:
+Inside an MCP session, the front door is one call — `north(task)` composes trust, task context (focus nodes + PageRank anchors), prior cross-session memory, a sufficiency signal, one `next_move`, and `honest_gaps` (what m1nd does *not* yet know) into a single packet, before any query:
 
 ```jsonc
 {"method":"tools/call","params":{"name":"north",
   "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
 ```
 
-The response is one oriented packet — trust verdict, memory the last session left, and an honest gap list, before any query. A real capture from the `main` binary, lightly trimmed:
+The response is one oriented packet — trust verdict, memory the last session left, and an honest gap list. A real capture from the `main` binary, lightly trimmed:
 
 ```jsonc
 {
@@ -117,7 +110,9 @@ The response is one oriented packet — trust verdict, memory the last session l
 }
 ```
 
-If `north` reports `needs: "needs_ingest"` (empty graph), or you are on a pre-1.2.1 binary without the L1GHT-recall composition, fall back to the explicit trust loop — establish trust *before* believing any retrieval:
+`north` composes `trust_selftest` + `orient` + `boot_memory` + `focus` — the agent reaches for a piece directly only when it needs just one. `focus` is this station's attention runtime: the minimal, budget-bounded working set for a goal, with an honest tail of what it left out and a signal for whether that's *enough* context yet. `needs_ingest` is a real answer for an empty graph.
+
+If `north` reports `needs: "needs_ingest"`, or you are on a pre-1.2.1 binary without the L1GHT-recall composition, the agent falls back to the explicit trust loop — establish trust *before* believing any retrieval:
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -135,57 +130,47 @@ If `north` reports `needs: "needs_ingest"` (empty graph), or you are on a pre-1.
 
 **First-session loop, in four moves:** `north` (or `trust_selftest` → `ingest`) → `seek`/`audit` → `memorize` the durable finding so the next session starts ahead.
 
-When there is no live MCP session to call `north` in — it is stale, bound to the wrong repo, or not loaded yet — reach for the host-neutral CLI escape hatch instead. It launches an isolated runtime, binds it to the repo, and returns one machine-readable envelope that scopes, trusts, ingests if needed, returns anchors, and hands off to direct proof:
+## DURING — verdicts worn while working
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*While it works, every answer arrives with how much to trust it — and "I don't know" is a real answer.*
+
+<p align="center"><img src="docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Every result is a verdict — act, reverify, or abstain — like doors the agent must choose" /></p>
+
+The agent does not consult m1nd; it wears it. Every mid-work answer is a calibrated verdict, not a vibe:
+
+- **`impact` before touching** shows the blast radius you didn't read; `ghost_edges` surfaces files that always change together but share no import.
+- **`why` carries a `closure` verdict** — `blocked` means the path rests on an unresolved or guessed edge: verify that edge before relying on the path.
+- **`predict` is conformally calibrated** — `calibrate_predict` arms a per-repo gate; verdicts then read `act` / `reverify` / `abstain`, where `abstain` means *uncalibrated or insufficient* — a signal to stop, not a weak yes. Ships dark: until you calibrate, verdicts cap at `reverify`. Co-change coupling is smoothed-Jaccard normalized, not raw commit counts (calibration-proven +3 points). *Caveat:* `predict` has structural fallback only until `ghost_edges` loads the git co-change matrix — run it first for real co-change likelihood.
+- **`xray_gate` guards architecture boundaries** — called before an edit, it answers "does this change cross a forbidden module boundary?" with `clear` / `caution` / `blocked`; only a ratified manifest can block (anti-guardrail-fatigue).
+- **Mission Control is proof discipline** — `mission_next` returns exactly one move plus `do_not` guardrails; in `bug_hunt` mode a final direct sweep is required before close, so agents check negative space.
+
+The same honesty rides on retrieval. A `seek` hit carries a `sufficiency` readout and a `trust_envelope` — and when the envelope has no calibration row measured yet, it caps its own verdict instead of overclaiming. A real capture, trimmed (the top hit is a memory the last session authored):
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### Serve one graph, attach many agents
+<p align="center"><img src="docs/assets/visuals/04-impact-web.png" width="520" alt="impact traces the blast radius across the web of connected code before you edit" /></p>
 
-<p align="center"><img src="docs/assets/visuals/10-attach-core.png" width="520" alt="One owner process holds the live graph; many agents attach to the same core" /></p>
+## AFTER — the graph gets warmer
 
-Quick Start above wires a stdio server per host — fine for one agent, but each process loads its own graph and holds its own lease. The deployment m1nd is built for is one owner, many attached agents. One owner process holds the live graph:
-
-```bash
-m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
-```
-
-Every agent then attaches as a thin stdio↔HTTP bridge — it loads **no** graph, builds no engines, and takes **no** lease:
-
-```bash
-m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
-```
-
-Any number of bridges point at the one owner and share its single live graph, so what one agent `memorize`s another recalls immediately — no reingest, no per-agent copy. Queries go over localhost, so it stays local-first (bind stays `127.0.0.1` unless you opt into `--bind 0.0.0.0`). Warm `seek` over the bridge measured ≈0.7ms on a small graph on one machine — order-of-magnitude, not a guarantee: attach adds a localhost round-trip, and latency scales with graph size and load.
-
-## What m1nd Is Not
-
-`m1nd` is not just:
-
-- a code search tool with a larger index
-- a repo RAG layer that only retrieves files or chunks
-- a graph database that leaves workflow decisions to the client
-- a static analysis replacement for the compiler, tests, or security tooling
-- an MCP bundle of unrelated utilities
-
-It is the layer that turns those surfaces into an operational system an agent can reason over and act through. Not for one-file lookups, simple grep, or compiler truth — use plain tools there.
-
-## Why Agents Need It
-
-Without m1nd, every session starts with grep loops and manual re-orientation; last week's findings are gone, and an empty search result is indistinguishable from a wrong-workspace bind. With m1nd, the session starts with a trust verdict, past findings auto-load already anchored to the code that backs them, and empty results say *why*.
-
-Agents on real codebases do not fail because they cannot search. They fail because they have no operating model. They rebuild context from scratch every session, edit without knowing the blast radius, and cannot tell an empty result that means "nothing exists" from one that means "wrong repo."
-
-That works for small codebases. It falls apart when the project has generated artifacts, specs, docs, hidden co-change history, multiple agents, and long handoffs. The problem is not only the agent's reasoning — the agent has no durable model of the codebase's structure. `m1nd` gives it one: a causal code graph with spreading activation across structural, semantic, temporal, and causal dimensions, plus Hebbian plasticity that compounds per-agent across sessions.
-
-## Compounding Memory (L1GHT)
+*When the work lands, what was learned is written down with the evidence that backs it — and it stays honest when the code moves on.*
 
 <p align="center"><img src="docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="Memory is anchored to real code; when the code changes, the memory flags itself" /></p>
 
-Most tools give an agent better *retrieval*. `m1nd` also lets an agent **author durable, machine-legible knowledge** that compounds across sessions and stays honest against the code. L1GHT turns authored knowledge into graph-native structure that self-flags when the code it cites changes — confident claims spread more activation than uncertain ones.
-
-The loop, end to end:
+Most tools give an agent better *retrieval*. At this station the agent **authors durable, machine-legible knowledge** that compounds across sessions and stays honest against the code. L1GHT turns authored knowledge into graph-native structure that self-flags when the code it cites changes — confident claims spread more activation than uncertain ones.
 
 1. **Conclude** — the agent reaches something durable (a decision, a verified finding, why code is the way it is) and calls `memorize` with structured claims and `evidence` paths.
 
@@ -215,8 +200,11 @@ The call returns proof it landed — this is a real captured response, trimmed:
 
 2. **Anchor** — m1nd writes a graph-native `.light.md` under `<runtime>/agent-memory/`, ingests it (`adapter=light mode=merge`), and resolves each `evidence` path to the real code node via a `grounded_in` edge — so the knowledge lives in the same activation space as code and surfaces in `seek` / `activate` / `impact`.
 3. **Auto-load** — on every future session start, `m1nd` ingests `agent-memory/` automatically and reports it in `session_handshake.agent_memory`. Past findings survive a `mode=replace` ingest and are just *there*.
+4. **Self-flag staleness** — `cross_verify(check: ["evidence_freshness"])` re-hashes every cited file and names which claims have gone stale because their code changed — so memory tells you when it lies instead of misleading you. Memory carries a provenance spine: claims state real age + author, supersede older claims, age out, and respect a recency cap — remembered knowledge states its own freshness instead of quietly going stale.
 
-The compounding is the point: kill that process, start a **fresh** one against the same runtime, and its first `north(task)` already carries the earlier session's claim — this is a real captured exchange (the two calls above ran in separate processes), trimmed:
+This loop has been proven live end-to-end: `memorize` → `grounded_in` edge → freshness flag on an edited file → survives `mode=replace` → boot auto-load. Closing a bounded mission? Pass `write_light_memory: true` to `mission_close` to persist its verified claims the same way.
+
+**COMPOUND — the next session is born inside the warmed shell.** Kill that process, start a **fresh** one against the same runtime, and its first `north(task)` already carries the earlier session's claim — this is a real captured exchange (the two calls above ran in separate processes), trimmed:
 
 ```jsonc
 // north.memory, from a process that never called memorize itself:
@@ -231,18 +219,33 @@ The compounding is the point: kill that process, start a **fresh** one against t
 
 `source_agent` names who authored it and `stale` re-checks the cited code — the next session inherits the knowledge *and* its provenance, not a bare string.
 
-4. **Self-flag staleness** — `cross_verify(check: ["evidence_freshness"])` re-hashes every cited file and names which claims have gone stale because their code changed — so memory tells you when it lies instead of misleading you.
+### One graph, many agents
 
-This loop has been proven live end-to-end: `memorize` → `grounded_in` edge → freshness flag on an edited file → survives `mode=replace` → boot auto-load. Closing a bounded mission? Pass `write_light_memory: true` to `mission_close` to persist its verified claims the same way. The habit is documented in the server `instructions` every MCP client receives at `initialize` — host-agnostic, no client-specific plugin required.
+<p align="center"><img src="docs/assets/visuals/10-attach-core.png" width="520" alt="One owner process holds the live graph; many agents attach to the same core" /></p>
 
-## The Trust / Honesty Layer
+Quick Start below wires a stdio server per host — fine for one agent, but each process loads its own graph and holds its own lease. The deployment m1nd is built for is one owner, many attached agents. One owner process holds the live graph:
 
-<p align="center"><img src="docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Every result is a verdict — act, reverify, or abstain — like doors the agent must choose" /></p>
+```bash
+m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
+```
 
-This is the most defensible thing m1nd does, and no competitor ships it. The doctrine: **credibility comes from honesty, not from always winning.**
+Every agent then attaches as a thin stdio↔HTTP bridge — it loads **no** graph, builds no engines, and takes **no** lease:
+
+```bash
+m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and omit the flag
+```
+
+Any number of bridges point at the one owner and share its single live graph, so what one agent `memorize`s another recalls immediately — no reingest, no per-agent copy. Queries go over localhost, so it stays local-first (bind stays `127.0.0.1` unless you opt into `--bind 0.0.0.0`). Warm `seek` over the bridge measured ≈0.7ms on a small graph on one machine — order-of-magnitude, not a guarantee: attach adds a localhost round-trip, and latency scales with graph size and load.
+
+## The material: honesty
+
+*The whole shell is built from one material — m1nd would rather tell your agent "don't trust this" than let it guess.*
+
+This is the most defensible thing m1nd does, and no competitor ships it. The doctrine: **credibility comes from honesty, not from always winning.** An honest *no* beats a confident guess — every station above is made of that.
 
 - **`trust_selftest`** returns a verdict *before* any retrieval: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected`, or `degraded_host_tool_surface`. The agent knows whether to proceed, ingest, rebind, or fall back.
 - **`agent_runtime_contract`** rides on every retrieve response, carrying a `trust_mode`. An empty result is disambiguated — bound to the wrong repo vs. genuinely nothing there — never silently reported as "no results."
+- **`trust_band: insufficient_evidence` means NO evidence — not medium risk.** The honest cold-start answer, distinct from low/medium/high.
 - **`non_claims` arrays** ship on every mission tool. m1nd tells the agent what it did *not* prove.
 - **`mission_verify` can say no — and does, in tested code.** It rejects graph-only evidence: a claim cannot close without a file read, a test run, or a runtime probe. The test is literally named `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** returns a deterministic, ordered step list to repair the binding.
@@ -263,83 +266,43 @@ Shown, not told. Call `trust_selftest` on an unbound runtime and the verdict *is
 }
 ```
 
-The same honesty rides on retrieval. A `seek` hit carries a `sufficiency` readout and a `trust_envelope` — and when the envelope has no calibration row measured yet, it caps its own verdict instead of overclaiming. A real capture, trimmed (the top hit is a memory the last session authored):
-
-```jsonc
-{
-  "results": [
-    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
-    // …code-node hits, trimmed…
-  ],
-  "sufficiency": { "state": "gathering", "top_score": 0.48,
-    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
-  "trust_envelope": {
-    "calibrated": false,               // no calibration row measured
-    "verdict": "reverify",             // …so the verdict is capped below `act`
-    "next_repair_call": "trust_selftest"
-  }
-}
-```
-
 The proof of the commitment is what was killed for it: `savings` and `resonate` were pulled from the advertised surface in beta.7 because a tool that always claims to win is not credible. No competitor — not mem0, Zep, Letta, Sourcegraph, or any code-graph MCP — ships a layer that tells the agent what *not* to trust and how to recover.
+
+<p align="center"><img src="docs/assets/visuals/11-triage-loop.png" width="520" alt="Field reports feed a triage loop that turns misbehavior into a test before a fix" /></p>
 
 **The field-triage loop closes on itself.** The session telemetry agents leave in `~/.m1nd/field-reports.jsonl` (local-only — m1nd never phones home) is not a passive log: reports get triaged, and a *confirmed* field bug becomes a red battery case **before** the fix, so the regression is proven, not just described. That loop has already run end-to-end through a full field-triage sweep: four field-reported bugs turned into failing battery cases and then merged fixes, all shipped in **1.2.1** — `north` now composes L1GHT recall into its memory packet, the `temp` graph sentinel resolves to a real tempdir instead of littering the working directory, `memorize` accepts a numeric `confidence`, and the closure ambiguity tag now fires only on genuine ties (the cry-wolf: ambiguous-blocked fell 9/11 → 0/11).
 
-## Language Coverage
+## Quick Start
 
-Graph reasoning (`impact`, `why`, `predict`, `trace`, `taint_trace`) is only as good as the extractor. m1nd resolves both **`calls` edges** (call graph) and **cross-file `imports`** (file→file dependency resolution) per language. The matrix below was proven live in a single polyglot ingest:
+*Install once, wire your agent's host, and get out of the way — from here on, your agent does the driving.*
 
-| Language | `calls` | cross-file imports |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅ (package) |
-| Java | ✅ | ✅ (FQCN + wildcard) |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅ (package) |
-| PHP | ✅ | ✅ (PSR-4) |
-| Scala | ✅ | ✅ (package) |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | — (namespaces don't map 1:1 to files) |
-| Swift | ✅ | — |
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-All ✅ rows are verified end-to-end (a `caller`→`callee` import resolves and the caller emits call edges). Other languages fall back to the generic extractor (`contains` only). Unresolvable imports (external packages, gems, stdlib, system headers) are honestly left unresolved rather than guessed.
+Then wire your host — the same two commands, one per host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
 
-## Capability Map
-
-<p align="center"><img src="docs/assets/visuals/04-impact-web.png" width="520" alt="impact traces the blast radius across the web of connected code before you edit" /></p>
-
-The live MCP surface evolves with releases. Use `tools/list` for the exact tool count and names in your current build.
-
-| Area | What it enables | Representative tools |
+| Host | Install the agent pack | Wire the MCP config |
 |---|---|---|
-| Graph foundation | ingest code, maintain graph state, diagnose session continuity, reinforce useful paths, and detect cross-session weight drift | `trust_selftest`, `session_handshake`, `recovery_playbook`, `ingest`, `health`, `doctor`, `learn`, `warmup`, `drift` |
-| Retrieval and orientation | search by text, path, intent, structure, or relationship before manual file reads | `audit`, `search`, `glob`, `seek`, `activate`, `why`, `trace` |
-| Docs and knowledge binding | ingest universal docs or graph-native `L1GHT`, then link concepts back to code | `ingest(adapter="universal"\|"light")`, `document_resolve`, `document_provider_health`, `document_bindings`, `document_drift`, `auto_ingest_*` |
-| Navigation and continuity | keep stateful routes, handoffs, baselines, and investigation memory across sessions | `perspective_*`, `trail_*`, `coverage_session`, `boot_memory`, `persist` |
-| Mission control and proof discipline | keep a bounded route, record events, switch from graph orientation to direct proof, hand off, and close with explicit gaps | `mission_start`, `mission_event`, `mission_next`, `mission_verify`, `mission_handoff`, `mission_close` |
-| Change planning and proof | reason about impact, co-change, missing steps, failure paths, and structural claims | `impact`, `predict`, `validate_plan`, `missing`, `hypothesize`, `counterfactual`, `differential` |
-| Quality, security, and architecture | detect patterns, taint paths, trust boundaries, duplication, layer violations, type flows, and refactor targets | `scan`, `scan_all`, `heuristics_surface`, `antibody_*`, `taint_trace`, `type_trace`, `trust`, `layers`, `layer_inspect`, `twins`, `fingerprint`, `flow_simulate`, `epidemic`, `tremor`, `refactor_plan` |
-| Time, runtime, and multi-repo work | inspect git history, drift, hidden co-change edges, runtime overlays, and cross-repo references | `timeline`, `diverge`, `ghost_edges`, `runtime_overlay`, `external_references`, `federate`, `federate_auto` |
-| Operations and monitoring | audit repo state, verify graph-vs-disk truth, run daemon watches, persist state, and surface durable alerts | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `panoramic`, `metrics`, `report`, `persist`, `diagram`, `help` |
-| Surgical edit prep and execution | pull compact connected context, preview writes, and apply graph-aware edits | `surgical_context`, `surgical_context_v2`, `view`, `batch_view`, `edit_preview`, `edit_commit`, `apply`, `apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**Tiering:** 27 essential tools are advertised by default to reduce tool-selection cost; set `M1ND_TOOL_TIER=full` to advertise the full surface (100+ tools: RETROBUILDER, perspectives, federation, daemon). A few tools (`resonate`, `savings`, `lock_*`) remain callable by name but are not on the advertised surface. Hidden tools are always callable via `tools/call` — tiering only controls what `tools/list` surfaces.
+Or from npm: `npm install -g @maxkle1nz/m1nd`. `install-skills` ships the agent pack — the operating loop itself as five named protocols, not decorative documentation.
 
-## The Operating Loops
+**The operator surface is this CLI; the agent's surface is MCP.** A human occasionally runs `m1nd doctor`, `install-skills`, `mcp-config` — the agent runs everything else. One host-neutral escape hatch exists for when there is no live MCP session to call `north` in (stale, bound to the wrong repo, or not loaded yet): it launches an isolated runtime, binds it to the repo, and returns one machine-readable envelope that scopes, trusts, ingests if needed, returns anchors, and hands off to direct proof:
 
-The agent pack is part of the product, not decorative documentation. m1nd is strongest when the agent receives the *operating loop*, not merely a graph endpoint. Five named protocols ship in the pack:
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **Session Start** — `trust_selftest` → `recovery_playbook` if trust is not full → `ingest` if needed → `seek`/`audit`.
-- **Research** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` any durable finding.
-- **Code Change** — `impact(node)` for blast radius → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` the decision and why.
-- **Deep Analysis** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (the RETROBUILDER lens) for hidden coupling, security paths, structural duplicates, and runtime heat.
-- **Memory** — persist durable conclusions with `memorize`, carrying `confidence` and `evidence` paths.
+Pin the binary if you need to: `--version` prints `1.2.x (<sha>)`, and `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) let a host detect and refuse a drifted binary.
 
-Mission Control is proof discipline, not a feature list. `mission_next` returns exactly one move plus `do_not` guardrails; `mission_verify` rejects graph-only claims; `mission_close` always nudges the agent to persist verified knowledge and records gaps and non-claims. In `bug_hunt` mode, MC0 requires a final direct `direct_sweep` after verified findings before close, so agents check negative space.
-
-**Caveat:** `predict` has **structural fallback only** until `ghost_edges` loads the git co-change matrix — run `ghost_edges` first when you need real co-change likelihood.
+Full install map, host packs, native runtime build, and update flags: [docs/AGENT-PACKS.md](docs/AGENT-PACKS.md) · client-by-client setup: [integration matrix](docs/IDE-INTEGRATIONS.md).
 
 ## Evidence
 
@@ -368,9 +331,6 @@ Every row is hedged to exactly what was measured. m1nd does not lead with saving
   <img src="docs/assets/visuals/08-calibration-earned.png" width="380" alt="Calibration is earned per repo before verdicts can read act" />
   <img src="docs/assets/visuals/09-closure-bridge.png" width="380" alt="A claim only closes when evidence bridges the gap — a file read, test, or probe" />
 </p>
-<p align="center">
-  <img src="docs/assets/visuals/11-triage-loop.png" width="380" alt="Field reports feed a triage loop that turns misbehavior into a test before a fix" />
-</p>
 </details>
 
 ## Limits
@@ -384,6 +344,40 @@ It is **less useful** when:
 - the task is a trivial local file action with no structural uncertainty
 
 **Needs feeding:** `trust` and `tremor` start with neutral priors until `learn` feedback / `ghost_edges` data accumulates, and `predict` needs `ghost_edges` loaded first before its co-change signal is meaningful. These improve with use; they are honest about being uninformed at boot.
+
+## What m1nd Is Not
+
+`m1nd` is not just:
+
+- a code search tool with a larger index
+- a repo RAG layer that only retrieves files or chunks
+- a graph database that leaves workflow decisions to the client
+- a static analysis replacement for the compiler, tests, or security tooling
+- an MCP bundle of unrelated utilities
+- a tool surface the human must learn — the verbs are the agent's; yours is the small [setup CLI](#quick-start)
+
+It is the layer that turns those surfaces into an operational system an agent can reason over and act through. Not for one-file lookups, simple grep, or compiler truth — use plain tools there.
+
+## Language Coverage
+
+Graph reasoning (`impact`, `why`, `predict`, `trace`, `taint_trace`) is only as good as the extractor. m1nd resolves both **`calls` edges** (call graph) and **cross-file `imports`** (file→file dependency resolution) per language. The matrix below was proven live in a single polyglot ingest:
+
+| Language | `calls` | cross-file imports |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅ (package) |
+| Java | ✅ | ✅ (FQCN + wildcard) |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅ (package) |
+| PHP | ✅ | ✅ (PSR-4) |
+| Scala | ✅ | ✅ (package) |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | — (namespaces don't map 1:1 to files) |
+| Swift | ✅ | — |
+
+All ✅ rows are verified end-to-end (a `caller`→`callee` import resolves and the caller emits call edges). Other languages fall back to the generic extractor (`contains` only). Unresolvable imports (external packages, gems, stdlib, system headers) are honestly left unresolved rather than guessed.
 
 ## Architecture At A Glance
 
@@ -400,7 +394,7 @@ Current crate versions: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` all `1.2.0` (`m1n
   <img src=".github/m1nd-architecture-overview-v2.jpeg" alt="m1nd architecture overview" width="960" />
 </p>
 
-For federation, perspectives, RETROBUILDER, multi-agent coordination, and the full agent-pack and operator reference, see the [canonical wiki](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](docs/AGENT-PACKS.md), and [EXAMPLES.md](EXAMPLES.md).
+The live MCP surface evolves with releases — use `tools/list` for the exact tool count and names in your build. **Tiering:** 27 essential tools are advertised by default to reduce tool-selection cost; set `M1ND_TOOL_TIER=full` to advertise the full surface (100+ tools: RETROBUILDER, perspectives, federation, daemon). Hidden tools are always callable via `tools/call` — tiering only controls what `tools/list` surfaces. The tool-by-tool catalog does not live in this README: see the [canonical wiki](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](docs/AGENT-PACKS.md), and [EXAMPLES.md](EXAMPLES.md) for depth, and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Contributing
 

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -15,7 +15,7 @@
   <a href="https://www.npmjs.com/package/@maxkle1nz/m1nd"><img src="https://img.shields.io/npm/v/@maxkle1nz/m1nd.svg?color=00f5ff&label=npm" alt="npm" /></a>
   <a href="https://crates.io/crates/m1nd-core"><img src="https://img.shields.io/crates/v/m1nd-core.svg" alt="crates.io" /></a>
   <a href="https://github.com/maxkle1nz/m1nd/actions"><img src="https://github.com/maxkle1nz/m1nd/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Lizenz" /></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://docs.rs/m1nd-core"><img src="https://img.shields.io/docsrs/m1nd-core" alt="docs.rs" /></a>
 </p>
 
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd ist Operational Intelligence für Coding-Agenten — es steuert die Betriebsschleife, nicht nur den Retrieval.**
+**m1nd ist die Hülle um deinen Coding-Agenten — die Betriebsschleife, in der er lebt: orientiert, bevor er handelt, ehrliche Verdikte, während er arbeitet, Gedächtnis mit Evidenz, nachdem er fertig ist, aufbauend über Sessions hinweg.**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="Ein Stapel loser Dateien wird zu einem verbundenen Graphen dessen, was womit verknüpft ist" /></p>
 
 > grep findet Text. Vektorsuche findet ähnliche Chunks. `m1nd` gibt Agenten einen lokalen Graphen davon, was verbunden ist, was sich geändert hat, was bricht, was gedriftet ist, und wo weiterzumachen ist.
 
-Drei Dinge koexistieren hier, die kein anderes Tool vereint:
+## Was m1nd ist: die Hülle um deinen Agenten
 
-- **Kausaler Code-Graph** — `impact` vor einer Bearbeitung zeigt den Blast Radius, den du nicht gelesen hast; `ghost_edges` bringt Dateien ans Licht, die sich immer zusammen ändern, aber keinen Import teilen.
-- **Selbstverifizierendes Gedächtnis** — `memorize` verankert Erkenntnisse an echten Code-Knoten; `cross_verify` markiert sie als veraltet, wenn dieser Code sich ändert.
-- **Ein Trust- / Recovery-Layer** — jedes Ergebnis trägt einen Trust-Mode; `trust_selftest` und `recovery_playbook` teilen dem Agenten mit, wann das Workspace-Binding falsch ist und wie er es repariert.
+*m1nd umhüllt deinen Coding-Agenten mit einer Schleife, die ihn orientiert, bevor er handelt, ihn ehrlich hält, während er arbeitet, und sich merkt, was er gelernt hat, wenn er fertig ist.*
 
-Dazu eine **Attention-Runtime** — `focus` reicht dem Agenten das minimale, budget-begrenzte Working Set für ein Ziel, mit einem ehrlichen Rest dessen, was es weggelassen hat, und einem Signal dafür, ob das *genug* Kontext ist.
+- **Wenn du mit Agenten baust** — nichts Neues zu lernen: einmal installieren und weiter mit deinem Agenten reden. Er hört auf zu raten, fängt an, sich zu erinnern, und sagt „ich weiß es nicht", wenn das die Wahrheit ist.
+- **Wenn du Ingenieur bist** — eine local-first Rust-Graph-Engine hinter einem MCP-Server: ein kausaler Code-Graph (strukturelle, semantische, zeitliche und kausale Kanten), konform kalibrierte Verdikte, und Gedächtnis, das mit Provenienz an Code-Knoten verankert ist. Nichts verlässt deine Maschine.
+
+Agenten auf echten Codebasen scheitern nicht, weil sie nicht suchen können — sie scheitern, weil sie kein operatives Modell haben. Jede Session baut den Kontext von Grund auf neu auf, editiert ohne den Blast Radius zu kennen, und kann ein leeres Ergebnis, das „nichts existiert" bedeutet, nicht von einem unterscheiden, das „falsches Repo" bedeutet. m1nd gibt dem Agenten ein dauerhaftes Modell der Codebasis — einen kausalen Graphen mit Spreading Activation und Hebbianischer Plastizität — und legt die gesamte Schleife des Agenten darum. Die Features sind hier kein Katalog; sie sind die Stationen dieser Hülle:
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd wird von deinem Agenten bedient, nicht von dir.** Jedes Tool unten wird vom Agenten selbst aufgerufen — automatisch, vor und nach seiner Arbeit. Ein Mensch führt sie im normalen Gebrauch nie aus; du installierst einmal ([Schnellstart](#schnellstart)) und redest weiter mit deinem Agenten wie immer.
+
+**Eine Hülle, drei Leser.** Dasselbe orientierte Paket wird für den gerendert, der gleich handelt: der **Haupt-Agent** liest es als `north` (ausgeliefert — die Eingangstür unten); ein **Subagent** wird es als das Delegation Packet erhalten, die Retrieval-Hälfte seiner Spawn-Spec (entworfen — [docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md), §O.12); der **Mensch** wird es als die Pre-Flight Card auf dem Living Tree sehen — dein Projekt als navigierbarer Baum mit Gedächtnis-Post-its, der zeigt, was der Agent verifiziert vs. geraten hat, bevor eine Änderung landet (entworfen, in Entwicklung — [docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)). Eine Wahrheit, einmal berechnet.
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="Eine Wahrheit, zwei Leser — dasselbe Paket gerendert für den Agenten und für den Menschen" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Traditionelle Agentenschleife vs. m1nd-grounded-Schleife" width="960" />
 </p>
 
-## Neu in 1.2.0 — das erste Release der OMEGA-Ära
+### Was passiert, wenn du eine Nachricht schickst
 
-1.2.0 verwandelt die Schleife von „abrufen, dann hoffen" in **vor-orientieren → auf kalibrierte Urteile handeln → festhalten, was du gelernt hast**. Das Motto ist dasselbe wie beim Trust-Layer: ein ehrliches *Nein* schlägt eine selbstbewusste Vermutung.
+Du bittest deinen Agenten, etwas zu reparieren. Das macht die Hülle um diese Nachricht herum:
 
-- **`north(task)` — Vor-Orientierung in einem Aufruf.** Die neue Eingangstür komponiert Trust, Task-Kontext (Focus-Knoten + PageRank-Anker), vorheriges Cross-Session-Gedächtnis, ein Suffizienz-Signal, einen `next_move` und `honest_gaps` (was m1nd noch *nicht* weiß). `needs_ingest` ist eine echte Antwort für einen leeren Graphen. (Die L1GHT-Recall-Komposition, die vorheriges Gedächtnis in das Paket einfaltet, landete auf `main` kurz nach dem 1.2.0-Tag — sie ist nicht im 1.2.0-Binary.)
-- **Konforme Kalibrierung bei der Prädiktion.** `calibrate_predict` scharft ein Pro-Repo-Gate; Urteile lesen sich dann als `act` / `reverify` / `abstain`, wobei `abstain` *unkalibriert oder unzureichend* bedeutet — ein Signal zum Anhalten, kein schwaches Ja. Wird dunkel ausgeliefert: bis du kalibrierst, deckeln Urteile bei `reverify`.
-- **`trust_envelope` bei `seek`** (wird dunkel ausgeliefert) und ein **`closure`-Urteil bei `why`** — `blocked` bedeutet, der Pfad ruht auf einer unaufgelösten/geratenen Kante. **`trust_band: insufficient_evidence`** ist jetzt von einem Risiko-Band verschieden: es bedeutet *keine Evidenz*, die ehrliche Cold-Start-Antwort, nicht „mittleres Risiko".
-- **Das Gedächtnis bekam ein Provenienz-Rückgrat** — Behauptungen tragen echtes Alter + Autor, lösen ältere Behauptungen ab, altern aus und respektieren einen Recency-Cap, sodass erinnertes Wissen seine eigene Frische angibt, anstatt still zu veralten.
-- **Geglättetes-Jaccard-Co-Change** — `ghost_edges` / `predict` normalisieren jetzt die Kopplung, anstatt rohe Co-Commits zu zählen (kalibrierungsbewiesen +3 Punkte gegenüber rohen Zählungen).
-- **Binary-Version + SHA-Fingerprint** — `--version` gibt `1.2.0 (<sha>)` aus; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) lassen einen Host ein gedriftetes Binary erkennen und ablehnen.
-- **Agent-native MCP-Instructions + rein lokale Field-Reports.** Die `initialize`-Instructions, die jeder Host erhält, *sind* jetzt die obige Betriebsschleife. Agenten können ein Telemetrie-Signal pro Session hinterlassen — `learn` auf einem Retrieval-Urteil, oder eine Zeile in `~/.m1nd/field-reports.jsonl`, wenn m1nd sich selbst fehlverhält. Diese Datei ist rein lokal; **m1nd telefoniert niemals nach Hause.**
+1. **Bevor dein Agent handelt**, reicht m1nd ihm die lebende Karte deines Projekts, was vergangene Sessions gelernt haben, wie sehr jedem Teil zu vertrauen ist — und was es *nicht* weiß (`north`).
+2. **Während er arbeitet**, trägt er Verdikte: er prüft, was eine Änderung kaputt machen würde, *bevor* er den Code anfasst (`impact`), und wo die Evidenz dünn ist, bekommt er ein ehrliches „ich weiß es nicht" statt einer selbstbewussten Vermutung (`abstain`).
+3. Er kann fragen, warum zwei Code-Teile verbunden sind, und gewarnt werden, wenn die Antwort auf einer Vermutung ruht (`why`), und er wird alarmiert, bevor er eine Architekturgrenze überschreitet (`xray_gate`).
+4. **Wenn er fertig ist**, wird die Entscheidung zusammen mit der Evidenz, die sie stützt, festgehalten (`memorize`).
+5. Dieses Gedächtnis ist am echten Code verankert — ändert sich der Code später, markiert sich das Gedächtnis selbst als veraltet, anstatt still zu lügen (`cross_verify`).
+6. **Deine nächste Session startet bereits wissend** — jeder Agent, jedes Tool: Claude Code, Codex, Cursor, Gemini. Was ein Agent lernt, erbt der nächste.
 
-## Schnellstart
+## BEFORE — orientiert geboren
 
-Der minimale Happy-Path — aus den Quellen installieren (immer aktuell), Gesundheit prüfen, Host verbinden:
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-Dann verbinde deinen Host — dieselben zwei Befehle, einer pro Host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
-
-| Host | Agent-Pack installieren | MCP-Config verbinden |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-Oder aus npm: `npm install -g @maxkle1nz/m1nd`.
-
-Vollständige Installationskarte, Host-Packs, nativer Runtime-Build und Update-Flags: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · Client-für-Client-Einrichtung: [Integrationsmatrix](../docs/IDE-INTEGRATIONS.md).
-
-### Agent-Einstiegspunkt
+*Dein Agent beginnt jede Session, indem er dein Projekt bereits kennt — und weiß, was er nicht weiß.*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task): ein einziger Eingangsaufruf liefert das ganze orientierte Paket" /></p>
 
-Agenten parsen dieses README. Innerhalb einer MCP-Session ist die Eingangstür ein einziger Aufruf — `north(task)` komponiert Trust, Task-Kontext, vorheriges Cross-Session-Gedächtnis, ein Suffizienz-Signal, einen `next_move` und `honest_gaps` (was m1nd noch *nicht* weiß) zu einem einzigen Paket. Meldet es `needs_ingest` (leerer Graph), oder läufst du auf einem älteren Binary, greife auf die explizite Trust-Schleife zurück — Trust *vor* dem Vertrauen in irgendein Retrieval herstellen:
+Innerhalb einer MCP-Session ist die Eingangstür ein einziger Aufruf — `north(task)` komponiert Trust, Task-Kontext (Focus-Knoten + PageRank-Anker), vorheriges Cross-Session-Gedächtnis, ein Suffizienz-Signal, einen `next_move` und `honest_gaps` (was m1nd noch *nicht* weiß) zu einem einzigen Paket, vor jeder Query:
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+Die Antwort ist ein orientiertes Paket — Trust-Verdikt, das Gedächtnis, das die letzte Session hinterlassen hat, und eine ehrliche Lückenliste. Eine echte Aufnahme vom `main`-Binary, leicht gekürzt:
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` komponiert `trust_selftest` + `orient` + `boot_memory` + `focus` — der Agent greift nur dann direkt zu einem Einzelteil, wenn er genau eines braucht. `focus` ist die Attention-Runtime dieser Station: das minimale, budget-begrenzte Working Set für ein Ziel, mit einem ehrlichen Rest dessen, was es weggelassen hat, und einem Signal dafür, ob das schon *genug* Kontext ist. `needs_ingest` ist eine echte Antwort für einen leeren Graphen.
+
+Meldet `north` `needs: "needs_ingest"`, oder läufst du auf einem Binary vor 1.2.1 ohne die L1GHT-Recall-Komposition, fällt der Agent auf die explizite Trust-Schleife zurück — Trust *vor* dem Vertrauen in irgendein Retrieval herstellen:
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ Agenten parsen dieses README. Innerhalb einer MCP-Session ist die Eingangstür e
 
 **Erste-Session-Schleife, in vier Zügen:** `north` (oder `trust_selftest` → `ingest`) → `seek`/`audit` → `memorize` das dauerhafte Ergebnis, damit die nächste Session voraus startet.
 
-Wenn es keine lebende MCP-Session gibt, in der du `north` aufrufen kannst — sie ist veraltet, an das falsche Repository gebunden, oder noch nicht geladen — greife stattdessen zur host-neutralen CLI als Notausgang. Sie startet eine isolierte Runtime, bindet sie an das Repository, und gibt einen einzigen maschinenlesbaren Envelope zurück, der scoped, Trust herstellt, bei Bedarf ingested, Anker zurückgibt, und zum direkten Beweis übergibt:
+## DURING — Verdikte, getragen während der Arbeit
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*Während er arbeitet, kommt jede Antwort mit der Angabe, wie sehr ihr zu vertrauen ist — und „ich weiß es nicht" ist eine echte Antwort.*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Jedes Ergebnis ist ein Verdikt — act, reverify oder abstain — wie Türen, die der Agent wählt" /></p>
+
+Der Agent konsultiert m1nd nicht; er trägt es. Jede Antwort mitten in der Arbeit ist ein kalibriertes Verdikt, kein Bauchgefühl:
+
+- **`impact` vor dem Anfassen** zeigt den Blast Radius, den du nicht gelesen hast; `ghost_edges` bringt Dateien ans Licht, die sich immer zusammen ändern, aber keinen Import teilen.
+- **`why` trägt ein `closure`-Verdikt** — `blocked` bedeutet, der Pfad ruht auf einer unaufgelösten oder geratenen Kante: verifiziere diese Kante, bevor du dich auf den Pfad verlässt.
+- **`predict` ist konform kalibriert** — `calibrate_predict` schärft ein Pro-Repo-Gate; Verdikte lesen sich dann als `act` / `reverify` / `abstain`, wobei `abstain` *unkalibriert oder unzureichend* bedeutet — ein Signal zum Anhalten, kein schwaches Ja. Wird dunkel ausgeliefert: bis du kalibrierst, deckeln Verdikte bei `reverify`. Co-Change-Kopplung wird geglättet-Jaccard-normalisiert, keine rohen Commit-Zählungen (kalibrierungsbewiesen +3 Punkte). *Vorbehalt:* `predict` hat nur strukturellen Fallback, bis `ghost_edges` die Git-Co-Change-Matrix lädt — führe es zuerst aus für echte Co-Change-Wahrscheinlichkeit.
+- **`xray_gate` bewacht Architekturgrenzen** — vor einer Änderung aufgerufen, beantwortet es „überschreitet diese Änderung eine verbotene Modulgrenze?" mit `clear` / `caution` / `blocked`; nur ein ratifiziertes Manifest kann blockieren (Anti-Guardrail-Müdigkeit).
+- **Mission Control ist Beweisdisziplin** — `mission_next` gibt genau einen Zug plus `do_not`-Guardrails zurück; im `bug_hunt`-Modus ist ein abschließender direkter Sweep vor dem Schließen erforderlich, damit Agenten den Negativraum prüfen.
+
+Dieselbe Ehrlichkeit begleitet das Retrieval. Ein `seek`-Treffer trägt eine `sufficiency`-Anzeige und einen `trust_envelope` — und wenn der Envelope noch keine gemessene Kalibrierungszeile hat, deckelt er sein eigenes Verdikt, anstatt zu übertreiben. Eine echte Aufnahme, gekürzt (der Top-Treffer ist ein Gedächtnis, das die letzte Session verfasst hat):
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### Einen Graphen servieren, viele Agenten attachen
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact verfolgt den Wirkungsradius durch das Netz aus verbundenem Code, bevor du editierst" /></p>
+
+## AFTER — der Graph wird wärmer
+
+*Wenn die Arbeit landet, wird das Gelernte mit der Evidenz festgehalten, die es stützt — und es bleibt ehrlich, wenn der Code weiterzieht.*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="Das Gedächtnis ist an echten Code verankert; ändert sich der Code, meldet sich das Gedächtnis selbst" /></p>
+
+Die meisten Tools geben einem Agenten besseres *Retrieval*. An dieser Station **verfasst der Agent dauerhafte, maschinenlesbare Erkenntnisse**, die sich über Sessions hinweg aufbauen und gegenüber dem Code ehrlich bleiben. L1GHT verwandelt verfasstes Wissen in graph-native Struktur, die sich selbst markiert, wenn sich der Code ändert, den es zitiert — sichere Behauptungen verbreiten mehr Aktivierung als unsichere.
+
+1. **Schlussfolgern** — der Agent erreicht etwas Dauerhaftes (eine Entscheidung, ein verifiziertes Ergebnis, warum Code so ist wie er ist) und ruft `memorize` mit strukturierten Behauptungen und `evidence`-Pfaden auf.
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+Der Aufruf liefert den Beweis, dass es gelandet ist — dies ist eine echte aufgenommene Antwort, gekürzt:
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **Verankern** — m1nd schreibt eine graph-native `.light.md` unter `<runtime>/agent-memory/`, ingest sie (`adapter=light mode=merge`), und löst jeden `evidence`-Pfad zum echten Code-Knoten über eine `grounded_in`-Kante auf — so lebt das Wissen im selben Aktivierungsraum wie Code und taucht in `seek` / `activate` / `impact` auf.
+3. **Auto-Load** — bei jedem zukünftigen Session-Start ingest `m1nd` `agent-memory/` automatisch und meldet es in `session_handshake.agent_memory`. Vergangene Erkenntnisse überleben einen `mode=replace`-Ingest und sind einfach *da*.
+4. **Staleness selbst markieren** — `cross_verify(check: ["evidence_freshness"])` re-hasht jede zitierte Datei und benennt, welche Behauptungen veraltet sind, weil sich ihr Code geändert hat — so sagt das Gedächtnis, wann es lügt, anstatt dich irrezuführen. Das Gedächtnis trägt ein Provenienz-Rückgrat: Behauptungen geben echtes Alter + Autor an, lösen ältere Behauptungen ab, altern aus und respektieren einen Recency-Cap — erinnertes Wissen gibt seine eigene Frische an, anstatt still zu veralten.
+
+Diese Schleife wurde live von Ende zu Ende bewiesen: `memorize` → `grounded_in`-Kante → Freshness-Flag auf bearbeiteter Datei → überlebt `mode=replace` → Boot-Auto-Load. Schließt du eine begrenzte Mission? Übergib `write_light_memory: true` an `mission_close`, um seine verifizierten Behauptungen auf dieselbe Weise zu persistieren.
+
+**COMPOUND — die nächste Session wird in der aufgewärmten Hülle geboren.** Töte diesen Prozess, starte einen **frischen** gegen dieselbe Runtime, und sein erstes `north(task)` trägt bereits die Behauptung der früheren Session — dies ist ein echter aufgenommener Austausch (die beiden Aufrufe oben liefen in getrennten Prozessen), gekürzt:
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` benennt, wer es verfasst hat, und `stale` prüft den zitierten Code erneut — die nächste Session erbt das Wissen *und* seine Provenienz, keinen bloßen String.
+
+### Ein Graph, viele Agenten
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="Ein Owner-Prozess hält den lebenden Graphen; viele Agenten attachen an denselben Kern" /></p>
 
-Der Schnellstart oben verdrahtet einen stdio-Server pro Host — in Ordnung für einen Agenten, aber jeder Prozess lädt seinen eigenen Graphen und hält seinen eigenen Lease. Das Deployment, für das m1nd gebaut ist, ist ein Eigentümer, viele attachte Agenten. Ein Eigentümer-Prozess hält den Live-Graphen:
+Der Schnellstart unten verdrahtet einen stdio-Server pro Host — in Ordnung für einen Agenten, aber jeder Prozess lädt seinen eigenen Graphen und hält seinen eigenen Lease. Das Deployment, für das m1nd gebaut ist, ist ein Eigentümer, viele attachte Agenten. Ein Eigentümer-Prozess hält den Live-Graphen:
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 Beliebig viele Bridges zeigen auf den einen Eigentümer und teilen sich seinen einzigen Live-Graphen, sodass das, was ein Agent `memorize`t, ein anderer sofort abruft — kein Reingest, keine Pro-Agent-Kopie. Queries laufen über localhost, sodass es local-first bleibt (`bind` bleibt `127.0.0.1`, außer du entscheidest dich für `--bind 0.0.0.0`). Ein warmes `seek` über die Bridge maß ≈0.7ms auf einem kleinen Graphen auf einer Maschine — Größenordnung, keine Garantie: Attach fügt einen localhost-Roundtrip hinzu, und die Latenz skaliert mit Graphgröße und Last.
 
-## Was m1nd Nicht Ist
+## Das Material: Ehrlichkeit
 
-`m1nd` ist nicht nur:
+*Die ganze Hülle besteht aus einem einzigen Material — m1nd sagt deinem Agenten lieber „vertrau dem nicht", als ihn raten zu lassen.*
 
-- ein Code-Suchtool mit einem größeren Index
-- ein Repo-RAG-Layer, der nur Dateien oder Chunks abruft
-- eine Graphdatenbank, die Workflow-Entscheidungen dem Client überlässt
-- ein Ersatz für statische Analyse durch Compiler, Tests oder Sicherheits-Tools
-- ein MCP-Bundle unzusammenhängender Hilfsmittel
+Das ist das Verteidigungswürdigste, was m1nd tut, und kein Konkurrent liefert es. Die Doktrin: **Glaubwürdigkeit kommt von Ehrlichkeit, nicht davon, immer zu gewinnen.** Ein ehrliches *Nein* schlägt eine selbstbewusste Vermutung — jede Station oben besteht aus diesem Material.
 
-Es ist der Layer, der diese Oberflächen in ein operatives System verwandelt, über das ein Agent nachdenken und durch das er handeln kann. Nicht für Einzeldatei-Lookups, einfaches grep oder Compiler-Wahrheit — verwende dort einfache Tools.
-
-## Warum Agenten es Brauchen
-
-Ohne m1nd beginnt jede Session mit grep-Schleifen und manueller Reorientierung; die Erkenntnisse der letzten Woche sind weg, und ein leeres Suchergebnis ist nicht von einem falschen Workspace-Binding zu unterscheiden. Mit m1nd beginnt die Session mit einem Trust-Urteil, vergangene Erkenntnisse laden automatisch bereits verankert an dem Code, der sie unterstützt, und leere Ergebnisse sagen *warum*.
-
-Agenten auf echten Codebasen scheitern nicht, weil sie nicht suchen können. Sie scheitern, weil sie kein operatives Modell haben. Sie bauen Kontext jede Session von Grund auf neu auf, editieren ohne den Blast Radius zu kennen, und können ein leeres Ergebnis, das „nichts existiert" bedeutet, nicht von einem unterscheiden, das „falsches Repo" bedeutet.
-
-Das funktioniert für kleine Codebasen. Es bricht zusammen, wenn das Projekt generierte Artefakte, Specs, Docs, versteckte Co-Change-Historie, mehrere Agenten und lange Handoffs hat. Das Problem ist nicht nur das Reasoning des Agenten — der Agent hat kein dauerhaftes Modell der Codebasis-Struktur. `m1nd` gibt ihm eines: einen kausalen Code-Graphen mit Spreading Activation über strukturelle, semantische, zeitliche und kausale Dimensionen, plus Hebbianische Plastizität, die pro Agent über Sessions hinweg aufbaut.
-
-## Zusammengesetztes Gedächtnis (L1GHT)
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="Das Gedächtnis ist an echten Code verankert; ändert sich der Code, meldet sich das Gedächtnis selbst" /></p>
-
-Die meisten Tools geben einem Agenten besseres *Retrieval*. `m1nd` erlaubt einem Agenten auch, **dauerhafte, maschinenlesbare Erkenntnisse zu verfassen**, die sich über Sessions hinweg aufbauen und gegenüber dem Code ehrlich bleiben. L1GHT verwandelt verfasstes Wissen in graph-native Struktur, die sich selbst markiert, wenn sich der Code ändert, den es zitiert — sichere Behauptungen verbreiten mehr Aktivierung als unsichere.
-
-Die Schleife, von Anfang bis Ende:
-
-1. **Schlussfolgern** — der Agent erreicht etwas Dauerhaftes (eine Entscheidung, ein verifiziertes Ergebnis, warum Code so ist wie er ist) und ruft `memorize` mit strukturierten Behauptungen und `evidence`-Pfaden auf.
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **Verankern** — m1nd schreibt eine graph-native `.light.md` unter `<runtime>/agent-memory/`, ingest sie (`adapter=light mode=merge`), und löst jeden `evidence`-Pfad zum echten Code-Knoten über eine `grounded_in`-Kante auf — so lebt das Wissen im selben Aktivierungsraum wie Code und taucht in `seek` / `activate` / `impact` auf.
-3. **Auto-Load** — bei jedem zukünftigen Session-Start ingest `m1nd` `agent-memory/` automatisch und meldet es in `session_handshake.agent_memory`. Vergangene Erkenntnisse überleben einen `mode=replace`-Ingest und sind einfach *da*.
-4. **Staleness selbst markieren** — `cross_verify(check: ["evidence_freshness"])` re-hasht jede zitierte Datei und benennt, welche Behauptungen veraltet sind, weil sich ihr Code geändert hat — so sagt das Gedächtnis, wann es lügt, anstatt dich irrezuführen.
-
-Diese Schleife wurde live von Ende zu Ende bewiesen: `memorize` → `grounded_in`-Kante → Freshness-Flag auf bearbeiteter Datei → überlebt `mode=replace` → Boot-Auto-Load. Schließt du eine begrenzte Mission? Übergib `write_light_memory: true` an `mission_close`, um seine verifizierten Behauptungen auf dieselbe Weise zu persistieren. Die Gewohnheit ist in den Server-`instructions` dokumentiert, die jeder MCP-Client bei `initialize` erhält — host-agnostic, kein client-spezifisches Plugin erforderlich.
-
-## Der Trust- / Ehrlichkeits-Layer
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Jedes Ergebnis ist ein Verdikt — act, reverify oder abstain — wie Türen, die der Agent wählt" /></p>
-
-Das ist das Verteidigungswürdigste, was m1nd tut, und kein Konkurrent liefert es. Die Doktrin: **Glaubwürdigkeit kommt von Ehrlichkeit, nicht davon, immer zu gewinnen.**
-
-- **`trust_selftest`** gibt ein Urteil *vor* jedem Retrieval zurück: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected`, oder `degraded_host_tool_surface`. Der Agent weiß, ob er fortfahren, ingestieren, rebinden oder zurückfallen soll.
+- **`trust_selftest`** gibt ein Verdikt *vor* jedem Retrieval zurück: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected`, oder `degraded_host_tool_surface`. Der Agent weiß, ob er fortfahren, ingestieren, rebinden oder zurückfallen soll.
 - **`agent_runtime_contract`** begleitet jede Retrieve-Antwort und trägt einen `trust_mode`. Ein leeres Ergebnis wird disambiguiert — an falsches Repo gebunden vs. tatsächlich nichts vorhanden — niemals still als „keine Ergebnisse" gemeldet.
+- **`trust_band: insufficient_evidence` bedeutet KEINE Evidenz — nicht mittleres Risiko.** Die ehrliche Cold-Start-Antwort, verschieden von niedrig/mittel/hoch.
 - **`non_claims`-Arrays** werden bei jedem Mission-Tool geliefert. m1nd teilt dem Agenten mit, was es *nicht* bewiesen hat.
 - **`mission_verify` kann Nein sagen — und tut es, in getestetem Code.** Es lehnt Graph-only-Beweise ab: eine Behauptung kann sich nicht schließen ohne einen Dateilesevorgang, einen Testlauf oder eine Runtime-Probe. Der Test heißt buchstäblich `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** gibt eine deterministische, geordnete Schritt-Liste zurück, um das Binding zu reparieren.
 
+Gezeigt, nicht erzählt. Rufe `trust_selftest` auf einer ungebundenen Runtime auf und das Verdikt *ist* die Reparaturanweisung — eine echte Aufnahme, gekürzt:
+
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
+
 Der Beweis für das Engagement ist das, was dafür gestrichen wurde: `savings` und `resonate` wurden in beta.7 aus der beworbenen Oberfläche entfernt, weil ein Tool, das immer behauptet zu gewinnen, nicht glaubwürdig ist. Kein Konkurrent — weder mem0, Zep, Letta, Sourcegraph, noch irgendein Code-Graph-MCP — liefert einen Layer, der dem Agenten sagt, was er *nicht* vertrauen soll und wie er sich erholt.
 
-**Die Field-Triage-Schleife schließt sich auf sich selbst.** Die Session-Telemetrie, die Agenten in `~/.m1nd/field-reports.jsonl` hinterlassen (rein lokal — m1nd telefoniert niemals nach Hause), ist kein passives Log: Reports werden triagiert, und ein *bestätigter* Field-Bug wird zu einem roten Battery-Case **vor** dem Fix, sodass die Regression bewiesen und nicht nur beschrieben ist. Diese Schleife ist bereits einmal von Ende zu Ende gelaufen: zwei im Feld gemeldete Bugs wurden zu fehlschlagenden Battery-Cases und dann gemergten Fixes — `north` komponiert jetzt L1GHT-Recall in sein Gedächtnis-Paket, und der `temp`-Graph-Sentinel löst zu einem echten Tempdir auf, anstatt das Arbeitsverzeichnis zu vermüllen.
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="Feldberichte speisen eine Triage-Schleife, die Fehlverhalten vor dem Fix in einen Test verwandelt" /></p>
 
-## Sprachabdeckung
+**Die Field-Triage-Schleife schließt sich auf sich selbst.** Die Session-Telemetrie, die Agenten in `~/.m1nd/field-reports.jsonl` hinterlassen (rein lokal — m1nd telefoniert niemals nach Hause), ist kein passives Log: Reports werden triagiert, und ein *bestätigter* Field-Bug wird zu einem roten Battery-Case **vor** dem Fix, sodass die Regression bewiesen und nicht nur beschrieben ist. Diese Schleife ist bereits von Ende zu Ende durch einen vollständigen Field-Triage-Sweep gelaufen: vier im Feld gemeldete Bugs wurden zu fehlschlagenden Battery-Cases und dann gemergten Fixes, alle in **1.2.1** ausgeliefert — `north` komponiert jetzt L1GHT-Recall in sein Gedächtnis-Paket, der `temp`-Graph-Sentinel löst zu einem echten Tempdir auf, anstatt das Arbeitsverzeichnis zu vermüllen, `memorize` akzeptiert eine numerische `confidence`, und das Closure-Ambiguitäts-Tag feuert jetzt nur bei echten Gleichständen (der Wolfsschrei: ambiguous-blocked fiel von 9/11 → 0/11).
 
-Graph-Reasoning (`impact`, `why`, `predict`, `trace`, `taint_trace`) ist nur so gut wie der Extraktor. m1nd löst sowohl **`calls`-Kanten** (Call-Graph) als auch **Cross-File-`imports`** (Datei→Datei-Abhängigkeitsauflösung) pro Sprache auf. Die Matrix unten wurde live in einem einzelnen polyglottes Ingest bewiesen:
+## Schnellstart
 
-| Sprache | `calls` | Cross-File-Imports |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅ (package) |
-| Java | ✅ | ✅ (FQCN + wildcard) |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅ (package) |
-| PHP | ✅ | ✅ (PSR-4) |
-| Scala | ✅ | ✅ (package) |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | — (Namespaces bilden nicht 1:1 auf Dateien ab) |
-| Swift | ✅ | — |
+*Einmal installieren, den Host deines Agenten verdrahten und aus dem Weg gehen — ab hier fährt dein Agent.*
 
-Alle ✅-Zeilen sind von Ende zu Ende verifiziert (ein `caller`→`callee`-Import löst auf und der Caller emittiert Call-Kanten). Andere Sprachen fallen auf den generischen Extraktor zurück (nur `contains`). Nicht auflösbare Imports (externe Pakete, Gems, Stdlib, System-Header) werden ehrlich unaufgelöst gelassen, anstatt geraten zu werden.
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-## Fähigkeiten-Karte
+Dann verbinde deinen Host — dieselben zwei Befehle, einer pro Host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact verfolgt den Wirkungsradius durch das Netz aus verbundenem Code, bevor du editierst" /></p>
-
-Die Live-MCP-Oberfläche entwickelt sich mit den Releases. Verwende `tools/list` für die genaue Tool-Anzahl und Namen in deinem aktuellen Build.
-
-| Bereich | Was es ermöglicht | Repräsentative Tools |
+| Host | Agent-Pack installieren | MCP-Config verbinden |
 |---|---|---|
-| Graph-Fundament | Code ingestieren, Graph-Zustand pflegen, Session-Kontinuität diagnostizieren, nützliche Pfade stärken, und Cross-Session-Gewichtsdrift erkennen | `trust_selftest`, `session_handshake`, `recovery_playbook`, `ingest`, `health`, `doctor`, `learn`, `warmup`, `drift` |
-| Retrieval und Orientierung | nach Text, Pfad, Absicht, Struktur oder Beziehung suchen vor manuellen Datei-Lesevorgängen | `audit`, `search`, `glob`, `seek`, `activate`, `why`, `trace` |
-| Docs und Wissensbindung | universelle Docs oder graph-natives `L1GHT` ingestieren, dann Konzepte zurück an Code verknüpfen | `ingest(adapter="universal"\|"light")`, `document_resolve`, `document_provider_health`, `document_bindings`, `document_drift`, `auto_ingest_*` |
-| Navigation und Kontinuität | statusbehaftete Routen, Handoffs, Baselines und Untersuchungsgedächtnis über Sessions hinweg pflegen | `perspective_*`, `trail_*`, `coverage_session`, `boot_memory`, `persist` |
-| Mission Control und Beweisdisziplin | eine begrenzte Route pflegen, Ereignisse aufzeichnen, von Graph-Orientierung zu direktem Beweis wechseln, Handoff durchführen und mit expliziten Lücken schließen | `mission_start`, `mission_event`, `mission_next`, `mission_verify`, `mission_handoff`, `mission_close` |
-| Änderungsplanung und -beweis | über Impact, Co-Change, fehlende Schritte, Fehlerpfade und strukturelle Behauptungen nachdenken | `impact`, `predict`, `validate_plan`, `missing`, `hypothesize`, `counterfactual`, `differential` |
-| Qualität, Sicherheit und Architektur | Muster, Taint-Pfade, Trust-Grenzen, Duplikation, Layer-Verletzungen, Typ-Flows und Refactoring-Ziele erkennen | `scan`, `scan_all`, `heuristics_surface`, `antibody_*`, `taint_trace`, `type_trace`, `trust`, `layers`, `layer_inspect`, `twins`, `fingerprint`, `flow_simulate`, `epidemic`, `tremor`, `refactor_plan` |
-| Zeit, Runtime und Multi-Repo-Arbeit | Git-Historie, Drift, versteckte Co-Change-Kanten, Runtime-Overlays und Cross-Repo-Referenzen inspizieren | `timeline`, `diverge`, `ghost_edges`, `runtime_overlay`, `external_references`, `federate`, `federate_auto` |
-| Betrieb und Monitoring | Repo-Zustand prüfen, Graph-vs-Disk-Wahrheit verifizieren, Daemon-Watches ausführen, Zustand persistieren und dauerhafte Alerts fördern | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `panoramic`, `metrics`, `report`, `persist`, `diagram`, `help` |
-| Chirurgische Edit-Vorbereitung und -Ausführung | kompakten verbundenen Kontext ziehen, Schreibvorgänge voranschauen und graph-aware Edits anwenden | `surgical_context`, `surgical_context_v2`, `view`, `batch_view`, `edit_preview`, `edit_commit`, `apply`, `apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**Tiering:** 27 essentielle Tools werden standardmäßig beworben, um die Tool-Auswahlkosten zu reduzieren; setze `M1ND_TOOL_TIER=full`, um die vollständige Oberfläche zu bewerben (100+ Tools: RETROBUILDER, Perspectives, Federation, Daemon). Einige Tools (`resonate`, `savings`, `lock_*`) bleiben per Namen aufrufbar, sind aber nicht auf der beworbenen Oberfläche. Versteckte Tools sind immer über `tools/call` aufrufbar — Tiering kontrolliert nur, was `tools/list` exposes.
+Oder aus npm: `npm install -g @maxkle1nz/m1nd`. `install-skills` liefert das Agent-Pack — die Betriebsschleife selbst als fünf benannte Protokolle, keine dekorative Dokumentation.
 
-## Die Betriebsschleifen
+**Die Operator-Oberfläche ist diese CLI; die Oberfläche des Agenten ist MCP.** Ein Mensch führt gelegentlich `m1nd doctor`, `install-skills`, `mcp-config` aus — der Agent führt alles andere aus. Ein host-neutraler Notausgang existiert für den Fall, dass es keine lebende MCP-Session gibt, in der `north` aufgerufen werden kann (veraltet, an das falsche Repo gebunden, oder noch nicht geladen): er startet eine isolierte Runtime, bindet sie an das Repository, und gibt einen einzigen maschinenlesbaren Envelope zurück, der scoped, Trust herstellt, bei Bedarf ingested, Anker zurückgibt und zum direkten Beweis übergibt:
 
-Das Agent-Pack ist Teil des Produkts, keine dekorative Dokumentation. m1nd ist am stärksten, wenn der Agent die *Betriebsschleife* erhält, nicht nur einen Graph-Endpunkt. Fünf benannte Protokolle werden im Pack geliefert:
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **Session-Start** — `trust_selftest` → `recovery_playbook` wenn Trust nicht vollständig ist → `ingest` falls nötig → `seek`/`audit`.
-- **Recherche** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` jedes dauerhafte Ergebnis.
-- **Code-Änderung** — `impact(node)` für Blast Radius → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` die Entscheidung und das Warum.
-- **Tiefenanalyse** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (die RETROBUILDER-Linse) für versteckte Kopplung, Sicherheitspfade, strukturelle Duplikate und Runtime-Wärme.
-- **Gedächtnis** — dauerhafte Schlussfolgerungen mit `memorize` persistieren, mit `confidence` und `evidence`-Pfaden.
+Pinne das Binary bei Bedarf: `--version` gibt `1.2.x (<sha>)` aus, und `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) lassen einen Host ein gedriftetes Binary erkennen und ablehnen.
 
-Mission Control ist Beweisdisziplin, keine Feature-Liste. `mission_next` gibt genau einen Zug plus `do_not`-Guardrails zurück; `mission_verify` lehnt Graph-only-Behauptungen ab; `mission_close` drängt den Agenten immer, verifiziertes Wissen zu persistieren, und zeichnet Lücken und Non-Claims auf. Im `bug_hunt`-Modus erfordert MC0 einen abschließenden direkten `direct_sweep` nach verifizierten Erkenntnissen vor dem Schließen, damit Agenten den Negativraum prüfen.
-
-**Vorbehalt:** `predict` hat **nur strukturellen Fallback** bis `ghost_edges` die Git-Co-Change-Matrix lädt — führe `ghost_edges` zuerst aus, wenn du echte Co-Change-Wahrscheinlichkeit brauchst.
+Vollständige Installationskarte, Host-Packs, nativer Runtime-Build und Update-Flags: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · Client-für-Client-Einrichtung: [Integrationsmatrix](../docs/IDE-INTEGRATIONS.md).
 
 ## Nachweise
 
@@ -282,9 +331,6 @@ Jede Zeile ist genau auf das kalibriert, was gemessen wurde. m1nd führt keine E
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="Kalibrierung wird pro Repo verdient, bevor Verdikte act lesen können" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="Eine Behauptung schließt erst, wenn Evidenz die Lücke überbrückt — ein Datei-Read, Test oder Probe" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="Feldberichte speisen eine Triage-Schleife, die Fehlverhalten vor dem Fix in einen Test verwandelt" />
-</p>
 </details>
 
 ## Einschränkungen
@@ -298,6 +344,40 @@ Es ist **weniger nützlich** wenn:
 - die Aufgabe eine triviale lokale Datei-Aktion ohne strukturelle Unsicherheit ist
 
 **Braucht Fütterung:** `trust` und `tremor` starten mit neutralen Priors, bis `learn`-Feedback / `ghost_edges`-Daten sich ansammeln, und `predict` braucht `ghost_edges` geladen, bevor sein Co-Change-Signal bedeutsam ist. Diese verbessern sich mit der Nutzung; sie sind ehrlich darüber, beim Start uninformiert zu sein.
+
+## Was m1nd Nicht Ist
+
+`m1nd` ist nicht nur:
+
+- ein Code-Suchtool mit einem größeren Index
+- ein Repo-RAG-Layer, der nur Dateien oder Chunks abruft
+- eine Graphdatenbank, die Workflow-Entscheidungen dem Client überlässt
+- ein Ersatz für statische Analyse durch Compiler, Tests oder Sicherheits-Tools
+- ein MCP-Bundle unzusammenhängender Hilfsmittel
+- eine Tool-Oberfläche, die der Mensch lernen muss — die Verben gehören dem Agenten; deins ist die kleine [Setup-CLI](#schnellstart)
+
+Es ist der Layer, der diese Oberflächen in ein operatives System verwandelt, über das ein Agent nachdenken und durch das er handeln kann. Nicht für Einzeldatei-Lookups, einfaches grep oder Compiler-Wahrheit — verwende dort einfache Tools.
+
+## Sprachabdeckung
+
+Graph-Reasoning (`impact`, `why`, `predict`, `trace`, `taint_trace`) ist nur so gut wie der Extraktor. m1nd löst sowohl **`calls`-Kanten** (Call-Graph) als auch **Cross-File-`imports`** (Datei→Datei-Abhängigkeitsauflösung) pro Sprache auf. Die Matrix unten wurde live in einem einzelnen polyglottes Ingest bewiesen:
+
+| Sprache | `calls` | Cross-File-Imports |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅ (package) |
+| Java | ✅ | ✅ (FQCN + wildcard) |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅ (package) |
+| PHP | ✅ | ✅ (PSR-4) |
+| Scala | ✅ | ✅ (package) |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | — (Namespaces bilden nicht 1:1 auf Dateien ab) |
+| Swift | ✅ | — |
+
+Alle ✅-Zeilen sind von Ende zu Ende verifiziert (ein `caller`→`callee`-Import löst auf und der Caller emittiert Call-Kanten). Andere Sprachen fallen auf den generischen Extraktor zurück (nur `contains`). Nicht auflösbare Imports (externe Pakete, Gems, Stdlib, System-Header) werden ehrlich unaufgelöst gelassen, anstatt geraten zu werden.
 
 ## Architektur auf einen Blick
 
@@ -314,7 +394,7 @@ Aktuelle Crate-Versionen: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` alle `1.2.0` (`
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="m1nd Architektur-Übersicht" width="960" />
 </p>
 
-Für Federation, Perspectives, RETROBUILDER, Multi-Agent-Koordination und die vollständige Agent-Pack- und Operator-Referenz, siehe das [kanonische Wiki](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) und [EXAMPLES.md](../EXAMPLES.md).
+Die Live-MCP-Oberfläche entwickelt sich mit den Releases — verwende `tools/list` für die genaue Tool-Anzahl und Namen in deinem Build. **Tiering:** 27 essentielle Tools werden standardmäßig beworben, um die Tool-Auswahlkosten zu reduzieren; setze `M1ND_TOOL_TIER=full`, um die vollständige Oberfläche zu bewerben (100+ Tools: RETROBUILDER, Perspectives, Federation, Daemon). Versteckte Tools sind immer über `tools/call` aufrufbar — Tiering kontrolliert nur, was `tools/list` anzeigt. Der Tool-für-Tool-Katalog lebt nicht in diesem README: siehe das [kanonische Wiki](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) und [EXAMPLES.md](../EXAMPLES.md) für die Tiefe, und [CHANGELOG.md](../CHANGELOG.md) für die Release-Historie.
 
 ## Beitragen
 

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd es inteligencia operacional para agentes de código — gobierna el loop operacional, no solo la recuperación de datos.**
+**m1nd es la carcasa alrededor de tu agente de código — el loop operacional dentro del cual vive: orientado antes de actuar, veredictos honestos mientras trabaja, memoria con evidencia después de terminar, acumulándose entre sesiones.**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="Una pila de archivos sueltos se convierte en un grafo conectado de qué enlaza con qué" /></p>
 
 > `grep` encuentra texto. La búsqueda vectorial encuentra chunks similares. `m1nd` da a los agentes un grafo local de qué se conecta, qué cambió, qué se rompe, qué ha derivado y dónde retomar.
 
-Tres cosas coexisten aquí en ninguna otra herramienta:
+## Qué es m1nd: la carcasa alrededor de tu agente
 
-- **Grafo causal de código** — `impact` antes de editar muestra el blast radius que no leíste; `ghost_edges` revela archivos que siempre cambian juntos pero no comparten ningún import.
-- **Memoria auto-verificable** — `memorize` ancla hallazgos a nodos reales del código; `cross_verify` los marca como obsoletos cuando ese código cambia.
-- **Una capa de confianza y recuperación** — cada resultado lleva un modo de confianza; `trust_selftest` y `recovery_playbook` le dicen al agente cuándo el binding del workspace está mal y cómo recuperarse.
+*m1nd envuelve a tu agente de código en un loop que lo orienta antes de actuar, lo mantiene honesto mientras trabaja y recuerda lo que aprendió cuando termina.*
 
-Además, un **runtime de atención** — `focus` le entrega al agente el conjunto de trabajo mínimo y acotado por presupuesto para un objetivo, con una cola honesta de lo que dejó fuera y una señal de si eso ya es contexto *suficiente*.
+- **Si construyes con agentes** — nada nuevo que aprender: instala una vez y sigue hablando con tu agente. Deja de adivinar, empieza a recordar y dice "no sé" cuando esa es la verdad.
+- **Si eres ingeniero** — un motor de grafo en Rust, local-first, detrás de un servidor MCP: un grafo causal de código (aristas estructurales, semánticas, temporales y causales), veredictos con calibración conformal y memoria anclada a nodos de código con procedencia. Nada sale de tu máquina.
+
+Los agentes en codebases reales no fallan porque no puedan buscar — fallan porque no tienen un modelo operacional. Cada sesión reconstruye contexto desde cero, edita sin conocer el blast radius y no puede distinguir un resultado vacío que significa "no existe nada" de uno que significa "repositorio equivocado". m1nd le da al agente un modelo duradero del codebase — un grafo causal con spreading activation y plasticidad Hebbiana — y envuelve el loop entero del agente a su alrededor. Las funcionalidades aquí no son un catálogo; son las estaciones de esa carcasa:
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd es operado por tu agente, no por ti.** Cada herramienta de abajo la llama el propio agente — automáticamente, antes y después de trabajar. Un humano nunca las ejecuta en uso normal; instalas una vez ([Inicio Rápido](#inicio-rápido)) y sigues hablando con tu agente como siempre.
+
+**Una carcasa, tres lectores.** El mismo paquete orientado se renderiza para quien está a punto de actuar: el **agente principal** lo lee como `north` (entregado — la puerta de entrada de abajo); un **subagente** lo recibirá como el Delegation Packet, la mitad de recuperación de su spec de spawn (diseñado — [docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md), §O.12); el **humano** lo verá como la Pre-Flight Card sobre el Living Tree — tu proyecto como un árbol navegable con post-its de memoria, mostrando qué verificó el agente vs. qué adivinó antes de que una edición aterrice (diseñado, en desarrollo — [docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)). Una verdad, computada una sola vez.
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="Una verdad, dos lectores — el mismo paquete renderizado para el agente y para el humano" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Loop tradicional de agente vs loop anclado en m1nd" width="960" />
 </p>
 
-## Novedades en 1.2.0 — el primer release de la era OMEGA
+### Qué pasa cuando envías un mensaje
 
-1.2.0 transforma el loop de "recuperar y luego esperar" en **pre-orientar → actuar sobre veredictos calibrados → capturar lo que aprendiste**. El tema es el mismo que el de la capa de confianza: un *no* honesto vence a una conjetura confiada.
+Le pides a tu agente que arregle algo. Esto es lo que la carcasa hace alrededor de ese mensaje:
 
-- **`north(task)` — pre-orienta en una sola llamada.** La nueva puerta de entrada compone confianza, contexto de tarea (nodos de focus + anclas de PageRank), memoria previa entre sesiones, una señal de suficiencia, un `next_move` y `honest_gaps` (lo que m1nd *todavía* no sabe). `needs_ingest` es una respuesta real para un grafo vacío. (La composición de L1GHT-recall que pliega la memoria previa dentro del paquete llegó a `main` justo después del tag 1.2.0 — no está en el binario 1.2.0.)
-- **Calibración conformal en la predicción.** `calibrate_predict` arma una compuerta por repositorio; los veredictos luego leen `act` / `reverify` / `abstain`, donde `abstain` significa *no calibrado o insuficiente* — una señal para detenerse, no un sí débil. Se entrega en modo oscuro: hasta que calibres, los veredictos se topan en `reverify`.
-- **`trust_envelope` en `seek`** (se entrega en modo oscuro) y un **veredicto `closure` en `why`** — `blocked` significa que la ruta descansa sobre una arista no resuelta/adivinada. **`trust_band: insufficient_evidence`** ahora es distinto de una banda de riesgo: significa *sin evidencia*, la respuesta honesta de arranque en frío, no "riesgo medio".
-- **La memoria ganó una columna vertebral de procedencia** — las afirmaciones llevan edad + autor reales, reemplazan afirmaciones más antiguas, expiran con el tiempo y respetan un tope de recencia, de modo que el conocimiento recordado declara su propia frescura en lugar de volverse obsoleto en silencio.
-- **Co-cambio con Jaccard suavizado** — `ghost_edges` / `predict` ahora normalizan el acoplamiento en lugar de contar co-commits crudos (calibración probada: +3 puntos sobre los conteos crudos).
-- **Versión binaria + fingerprint sha** — `--version` imprime `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permiten que un host detecte y rechace un binario que ha derivado.
-- **Instrucciones MCP nativas de agente + reportes de campo solo locales.** Las instrucciones de `initialize` que cada host recibe ahora *son* el loop operacional de arriba. Los agentes pueden dejar una única señal de telemetría por sesión — `learn` sobre un veredicto de recuperación, o una línea en `~/.m1nd/field-reports.jsonl` cuando el propio m1nd se comporta mal. Ese archivo es solo local; **m1nd nunca llama a casa.**
+1. **Antes de que tu agente actúe**, m1nd le entrega el mapa vivo de tu proyecto, lo que sesiones pasadas aprendieron, cuánto confiar en cada pieza — y lo que *no* sabe (`north`).
+2. **Mientras trabaja**, lleva puestos veredictos: comprueba qué rompería una edición *antes* de tocar el código (`impact`), y donde la evidencia es delgada recibe un honesto "no sé" en lugar de una conjetura confiada (`abstain`).
+3. Puede preguntar por qué dos piezas de código están conectadas y ser avisado cuando la respuesta descansa sobre una suposición (`why`), y es alertado antes de cruzar una frontera de arquitectura (`xray_gate`).
+4. **Cuando termina**, la decisión queda anotada junto con la evidencia que la respalda (`memorize`).
+5. Esa memoria está anclada al código real — si el código cambia después, la memoria se marca sola como obsoleta en lugar de mentir en silencio (`cross_verify`).
+6. **Tu próxima sesión empieza ya sabiendo** — cualquier agente, cualquier herramienta: Claude Code, Codex, Cursor, Gemini. Lo que un agente aprende, el siguiente lo hereda.
 
-## Inicio Rápido
+## BEFORE — nace orientado
 
-El camino mínimo feliz — instala desde el fuente (siempre actualizado), verifica la salud, conecta tu host:
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-Luego conecta tu host — los mismos dos comandos, uno por host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
-
-| Host | Instalar el paquete de agente | Conectar la config MCP |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-O desde npm: `npm install -g @maxkle1nz/m1nd`.
-
-Mapa completo de instalación, paquetes de host, build nativo del runtime y flags de actualización: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuración por cliente: [matriz de integración](../docs/IDE-INTEGRATIONS.md).
-
-### Punto de Entrada del Agente
+*Tu agente empieza cada sesión conociendo ya tu proyecto — y sabiendo lo que no sabe.*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task): una sola llamada de entrada devuelve el paquete orientado completo" /></p>
 
-Los agentes analizan este README. Dentro de una sesión MCP, la puerta de entrada es una sola llamada — `north(task)` compone confianza, contexto de tarea, memoria previa entre sesiones, una señal de suficiencia, un `next_move` y `honest_gaps` (lo que m1nd *todavía* no sabe) en un único paquete. Si reporta `needs_ingest` (grafo vacío), o estás en un binario más antiguo, recurre al loop explícito de confianza — establece confianza *antes* de creer cualquier recuperación:
+Dentro de una sesión MCP, la puerta de entrada es una sola llamada — `north(task)` compone confianza, contexto de tarea (nodos de focus + anclas de PageRank), memoria previa entre sesiones, una señal de suficiencia, un `next_move` y `honest_gaps` (lo que m1nd *todavía* no sabe) en un único paquete, antes de cualquier consulta:
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+La respuesta es un paquete orientado — veredicto de confianza, la memoria que dejó la última sesión y una lista honesta de brechas. Una captura real del binario de `main`, ligeramente recortada:
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` compone `trust_selftest` + `orient` + `boot_memory` + `focus` — el agente solo recurre a una pieza aislada cuando necesita exactamente una. `focus` es el runtime de atención de esta estación: el conjunto de trabajo mínimo y acotado por presupuesto para un objetivo, con una cola honesta de lo que dejó fuera y una señal de si eso ya es contexto *suficiente*. `needs_ingest` es una respuesta real para un grafo vacío.
+
+Si `north` reporta `needs: "needs_ingest"`, o estás en un binario anterior a 1.2.1 sin la composición de L1GHT-recall, el agente recurre al loop explícito de confianza — establecer confianza *antes* de creer cualquier recuperación:
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ Los agentes analizan este README. Dentro de una sesión MCP, la puerta de entrad
 
 **Loop de primera sesión, en cuatro movimientos:** `north` (o `trust_selftest` → `ingest`) → `seek`/`audit` → `memorize` el hallazgo duradero para que la próxima sesión empiece adelantada.
 
-Cuando no hay una sesión MCP activa en la que llamar a `north` — está obsoleta, vinculada al repositorio equivocado, o aún no cargada — recurre en su lugar al CLI neutro de host como vía de escape. Lanza un runtime aislado, lo vincula al repositorio, y devuelve un único sobre legible por máquina que delimita el alcance, establece confianza, ingiere si es necesario, devuelve anclas, y hace el handoff a la prueba directa:
+## DURING — veredictos puestos mientras trabaja
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*Mientras trabaja, cada respuesta llega con cuánto se puede confiar en ella — y "no sé" es una respuesta real.*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Cada resultado es un veredicto — act, reverify o abstain — como puertas que el agente elige" /></p>
+
+El agente no consulta a m1nd; lo lleva puesto. Cada respuesta a mitad del trabajo es un veredicto calibrado, no una intuición:
+
+- **`impact` antes de tocar** muestra el blast radius que no leíste; `ghost_edges` revela archivos que siempre cambian juntos pero no comparten ningún import.
+- **`why` lleva un veredicto `closure`** — `blocked` significa que la ruta descansa sobre una arista no resuelta o adivinada: verifica esa arista antes de confiar en la ruta.
+- **`predict` tiene calibración conformal** — `calibrate_predict` arma una compuerta por repositorio; los veredictos pasan a leer `act` / `reverify` / `abstain`, donde `abstain` significa *no calibrado o insuficiente* — una señal para detenerse, no un sí débil. Se entrega en modo oscuro: hasta que calibres, los veredictos se topan en `reverify`. El acoplamiento de co-cambio se normaliza con Jaccard suavizado, no conteos crudos de commits (calibración probada: +3 puntos). *Advertencia:* `predict` tiene fallback solo estructural hasta que `ghost_edges` cargue la matriz de co-cambio de git — ejecútalo primero para probabilidad real de co-cambio.
+- **`xray_gate` guarda las fronteras de la arquitectura** — llamado antes de una edición, responde "¿este cambio cruza una frontera de módulo prohibida?" con `clear` / `caution` / `blocked`; solo un manifiesto ratificado puede bloquear (anti-fatiga de guardrail).
+- **Mission Control es disciplina de prueba** — `mission_next` devuelve exactamente un movimiento más guardrails `do_not`; en modo `bug_hunt` se exige un barrido directo final antes del cierre, para que los agentes revisen el espacio negativo.
+
+La misma honestidad acompaña la recuperación. Un hit de `seek` lleva una lectura de `sufficiency` y un `trust_envelope` — y cuando el sobre aún no tiene ninguna fila de calibración medida, limita su propio veredicto en lugar de exagerar. Una captura real, recortada (el primer hit es una memoria que escribió la última sesión):
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### Sirve un grafo, adjunta muchos agentes
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact traza el radio de impacto por la red de código conectado antes de que edites" /></p>
+
+## AFTER — el grafo se calienta
+
+*Cuando el trabajo aterriza, lo aprendido queda anotado con la evidencia que lo respalda — y se mantiene honesto cuando el código sigue adelante.*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="La memoria se ancla al código real; cuando el código cambia, la memoria se marca sola" /></p>
+
+La mayoría de las herramientas dan al agente mejor *recuperación*. En esta estación el agente **produce conocimiento duradero y legible por máquina** que se acumula entre sesiones y se mantiene honesto respecto al código. L1GHT convierte el conocimiento producido en estructura nativa de grafo que se auto-señaliza cuando el código que cita cambia — las afirmaciones confiadas propagan más activación que las inciertas.
+
+1. **Concluir** — el agente llega a algo duradero (una decisión, un hallazgo verificado, por qué el código es como es) y llama a `memorize` con afirmaciones estructuradas y rutas de `evidence`.
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+La llamada devuelve la prueba de que aterrizó — esta es una respuesta real capturada, recortada:
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **Anclar** — m1nd escribe un `.light.md` nativo de grafo bajo `<runtime>/agent-memory/`, lo ingiere (`adapter=light mode=merge`) y resuelve cada ruta de `evidence` al nodo de código real vía arista `grounded_in` — haciendo que el conocimiento viva en el mismo espacio de activación que el código y emerja en `seek` / `activate` / `impact`.
+3. **Carga automática** — en cada inicio de sesión futuro, `m1nd` ingiere `agent-memory/` automáticamente y lo reporta en `session_handshake.agent_memory`. Los hallazgos pasados sobreviven a una ingestión `mode=replace` y simplemente *están ahí*.
+4. **Auto-señalización de obsolescencia** — `cross_verify(check: ["evidence_freshness"])` re-hashea cada archivo citado y nombra qué afirmaciones se volvieron obsoletas porque su código cambió — así la memoria avisa cuando miente, en lugar de inducir a error. La memoria lleva una columna vertebral de procedencia: las afirmaciones declaran edad + autor reales, reemplazan afirmaciones más antiguas, expiran con el tiempo y respetan un tope de recencia — el conocimiento recordado declara su propia frescura en lugar de volverse obsoleto en silencio.
+
+Este loop ha sido probado en vivo de extremo a extremo: `memorize` → arista `grounded_in` → flag de frescura en archivo editado → sobrevive a `mode=replace` → carga automática en el boot. ¿Cerrando una misión acotada? Pasa `write_light_memory: true` a `mission_close` para persistir sus afirmaciones verificadas de la misma manera.
+
+**COMPOUND — la próxima sesión nace dentro de la carcasa caldeada.** Mata ese proceso, arranca uno **nuevo** contra el mismo runtime, y su primer `north(task)` ya lleva la afirmación de la sesión anterior — este es un intercambio real capturado (las dos llamadas de arriba corrieron en procesos separados), recortado:
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` nombra quién la escribió y `stale` re-verifica el código citado — la próxima sesión hereda el conocimiento *y* su procedencia, no una string suelta.
+
+### Un grafo, muchos agentes
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="Un proceso propietario mantiene el grafo vivo; muchos agentes se conectan al mismo núcleo" /></p>
 
-El Inicio Rápido de arriba conecta un servidor stdio por host — está bien para un agente, pero cada proceso carga su propio grafo y retiene su propia lease. El despliegue para el que m1nd fue construido es un dueño, muchos agentes adjuntos. Un proceso dueño retiene el grafo vivo:
+El Inicio Rápido de abajo conecta un servidor stdio por host — está bien para un agente, pero cada proceso carga su propio grafo y retiene su propia lease. El despliegue para el que m1nd fue construido es un dueño, muchos agentes adjuntos. Un proceso dueño retiene el grafo vivo:
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 Cualquier número de puentes apunta al único dueño y comparte su único grafo vivo, así que lo que un agente hace `memorize` otro lo recupera de inmediato — sin reingestión, sin copia por agente. Las consultas van por localhost, así que se mantiene local-first (el bind se queda en `127.0.0.1` a menos que optes por `--bind 0.0.0.0`). Un `seek` en caliente sobre el puente midió ≈0.7ms en un grafo pequeño en una sola máquina — orden de magnitud, no una garantía: adjuntar añade un round-trip por localhost, y la latencia escala con el tamaño del grafo y la carga.
 
-## Lo Que m1nd No Es
+## El material: honestidad
 
-`m1nd` no es solo:
+*La carcasa entera está hecha de un solo material — m1nd prefiere decirle a tu agente "no confíes en esto" antes que dejarlo adivinar.*
 
-- una herramienta de búsqueda de código con un índice más grande
-- una capa de RAG de repositorio que solo recupera archivos o chunks
-- una base de datos de grafo que deja las decisiones de workflow al cliente
-- un reemplazo de análisis estático para el compilador, tests o herramientas de seguridad
-- un bundle MCP de utilidades sin relación entre sí
-
-Es la capa que convierte esas superficies en un sistema operacional sobre el que un agente puede razonar y actuar. No sirve para lookups de un solo archivo, grep simple o verdad del compilador — usa herramientas simples en esos casos.
-
-## Por Qué los Agentes lo Necesitan
-
-Sin m1nd, cada sesión empieza con loops de grep y reorientación manual; los hallazgos de la semana pasada desaparecieron, y un resultado de búsqueda vacío es indistinguible de un binding de workspace incorrecto. Con m1nd, la sesión comienza con un veredicto de confianza, los hallazgos pasados se cargan automáticamente ya anclados al código que los respalda, y los resultados vacíos dicen *por qué*.
-
-Los agentes en codebases reales no fallan porque no puedan buscar. Fallan porque no tienen un modelo operacional. Reconstruyen contexto desde cero en cada sesión, editan sin conocer el blast radius, y no pueden distinguir un resultado vacío que significa "no existe nada" de uno que significa "repositorio equivocado."
-
-Eso funciona para codebases pequeñas. Se desmorona cuando el proyecto tiene artefactos generados, specs, docs, historial oculto de co-cambio, múltiples agentes y handoffs largos. El problema no es solo el razonamiento del agente — el agente no tiene un modelo duradero de la estructura del codebase. `m1nd` le da uno: un grafo causal de código con spreading activation por dimensiones estructurales, semánticas, temporales y causales, más plasticidad Hebbiana que se acumula por agente entre sesiones.
-
-## Memoria Compuesta (L1GHT)
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="La memoria se ancla al código real; cuando el código cambia, la memoria se marca sola" /></p>
-
-La mayoría de las herramientas dan al agente mejor *recuperación*. `m1nd` también permite que un agente **produzca conocimiento duradero y legible por máquina** que se acumula entre sesiones y se mantiene honesto respecto al código. L1GHT convierte el conocimiento producido en estructura nativa de grafo que se auto-señaliza cuando el código que cita cambia — las afirmaciones confiantes propagan más activación que las inciertas.
-
-El loop, de principio a fin:
-
-1. **Concluir** — el agente llega a algo duradero (una decisión, un hallazgo verificado, por qué el código es como es) y llama a `memorize` con afirmaciones estructuradas y rutas de `evidence`.
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **Anclar** — m1nd escribe un `.light.md` nativo de grafo bajo `<runtime>/agent-memory/`, lo ingiere (`adapter=light mode=merge`) y resuelve cada ruta de `evidence` al nodo de código real vía arista `grounded_in` — haciendo que el conocimiento viva en el mismo espacio de activación que el código y emerja en `seek` / `activate` / `impact`.
-3. **Carga automática** — en cada inicio de sesión futuro, `m1nd` ingiere `agent-memory/` automáticamente y lo reporta en `session_handshake.agent_memory`. Los hallazgos pasados sobreviven a una ingestión `mode=replace` y simplemente *están ahí*.
-4. **Auto-señalización de obsolescencia** — `cross_verify(check: ["evidence_freshness"])` re-hashea cada archivo citado y nombra qué afirmaciones se volvieron obsoletas porque su código cambió — así la memoria avisa cuando miente, en lugar de inducir a error.
-
-Este loop ha sido probado en vivo de extremo a extremo: `memorize` → arista `grounded_in` → flag de frescura en archivo editado → sobrevive a `mode=replace` → carga automática en el boot. ¿Cerrando una misión acotada? Pasa `write_light_memory: true` a `mission_close` para persistir sus afirmaciones verificadas de la misma manera. El hábito está documentado en las `instructions` del servidor que cada cliente MCP recibe en `initialize` — agnóstico de host, sin plugin específico de cliente requerido.
-
-## La Capa de Confianza y Honestidad
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Cada resultado es un veredicto — act, reverify o abstain — como puertas que el agente elige" /></p>
-
-Esta es la cosa más defendible que hace m1nd, y ningún competidor la entrega. La doctrina: **la credibilidad viene de la honestidad, no de siempre ganar.**
+Esta es la cosa más defendible que hace m1nd, y ningún competidor la entrega. La doctrina: **la credibilidad viene de la honestidad, no de siempre ganar.** Un *no* honesto vence a una conjetura confiada — cada estación de arriba está hecha de ese material.
 
 - **`trust_selftest`** devuelve un veredicto *antes* de cualquier recuperación: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected` o `degraded_host_tool_surface`. El agente sabe si debe proceder, ingerir, rebindear o retroceder.
 - **`agent_runtime_contract`** acompaña cada respuesta de recuperación, llevando un `trust_mode`. Un resultado vacío está desambiguado — vinculado al repositorio equivocado versus genuinamente nada ahí — nunca reportado silenciosamente como "sin resultados."
+- **`trust_band: insufficient_evidence` significa SIN evidencia — no riesgo medio.** La respuesta honesta de arranque en frío, distinta de bajo/medio/alto.
 - **Arrays `non_claims`** se envían en cada herramienta de misión. m1nd le dice al agente lo que *no* probó.
 - **`mission_verify` puede decir no — y lo hace, en código testado.** Rechaza evidencia solo de grafo: una afirmación no puede cerrarse sin una lectura de archivo, una ejecución de test o una sonda de runtime. El test se llama literalmente `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** devuelve una lista de pasos determinística y ordenada para reparar el binding.
 
+Mostrado, no contado. Llama a `trust_selftest` en un runtime sin binding y el veredicto *es* la instrucción de reparación — una captura real, recortada:
+
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
+
 La prueba del compromiso está en lo que se sacrificó por él: `savings` y `resonate` fueron retirados de la superficie anunciada en beta.7 porque una herramienta que siempre afirma ganar no es creíble. Ningún competidor — ni mem0, Zep, Letta, Sourcegraph ni ningún MCP de grafo de código — entrega una capa que le dice al agente en qué *no* confiar y cómo recuperarse.
 
-**El loop de triaje de campo se cierra sobre sí mismo.** La telemetría de sesión que los agentes dejan en `~/.m1nd/field-reports.jsonl` (solo local — m1nd nunca llama a casa) no es un log pasivo: los reportes se triajean, y un bug de campo *confirmado* se convierte en un caso rojo de batería **antes** del arreglo, de modo que la regresión queda probada, no solo descrita. Ese loop ya corrió una vez de extremo a extremo: dos bugs reportados en campo se convirtieron en casos de batería fallidos y luego en arreglos mergeados — `north` ahora compone el recall de L1GHT dentro de su paquete de memoria, y el sentinela de grafo `temp` resuelve a un tempdir real en lugar de ensuciar el directorio de trabajo.
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="Los reportes de campo alimentan un loop de triaje que convierte el fallo en prueba antes del arreglo" /></p>
 
-## Cobertura de Lenguajes
+**El loop de triaje de campo se cierra sobre sí mismo.** La telemetría de sesión que los agentes dejan en `~/.m1nd/field-reports.jsonl` (solo local — m1nd nunca llama a casa) no es un log pasivo: los reportes se triajean, y un bug de campo *confirmado* se convierte en un caso rojo de batería **antes** del arreglo, de modo que la regresión queda probada, no solo descrita. Ese loop ya corrió de extremo a extremo en un barrido completo de triaje de campo: cuatro bugs reportados en campo se convirtieron en casos de batería fallidos y luego en arreglos mergeados, todos entregados en **1.2.1** — `north` ahora compone el recall de L1GHT dentro de su paquete de memoria, el centinela de grafo `temp` resuelve a un tempdir real en lugar de ensuciar el directorio de trabajo, `memorize` acepta una `confidence` numérica, y la etiqueta de ambigüedad de closure ahora solo se dispara en empates genuinos (el falso-alarmista: ambiguous-blocked cayó de 9/11 → 0/11).
 
-El razonamiento de grafo (`impact`, `why`, `predict`, `trace`, `taint_trace`) es tan bueno como el extractor. m1nd resuelve tanto **aristas `calls`** (grafo de llamadas) como **`imports` entre archivos** (resolución de dependencia archivo→archivo) por lenguaje. La matriz a continuación fue probada en vivo en una única ingestión políglota:
+## Inicio Rápido
 
-| Lenguaje | `calls` | imports entre archivos |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅ (package) |
-| Java | ✅ | ✅ (FQCN + wildcard) |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅ (package) |
-| PHP | ✅ | ✅ (PSR-4) |
-| Scala | ✅ | ✅ (package) |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | — (los namespaces no mapean 1:1 a archivos) |
-| Swift | ✅ | — |
+*Instala una vez, conecta el host de tu agente y apártate — desde aquí, tu agente lleva el volante.*
 
-Todas las filas ✅ están verificadas de extremo a extremo (un import `caller`→`callee` resuelve y el caller emite aristas de llamada). Otros lenguajes caen de vuelta al extractor genérico (solo `contains`). Los imports no resolvibles (paquetes externos, gems, stdlib, cabeceras de sistema) se dejan honestamente sin resolver en lugar de adivinarlos.
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-## Mapa de Capacidades
+Luego conecta tu host — los mismos dos comandos, uno por host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact traza el radio de impacto por la red de código conectado antes de que edites" /></p>
-
-La superficie MCP activa evoluciona con los releases. Usa `tools/list` para la cuenta exacta de herramientas y nombres en tu build actual.
-
-| Área | Qué permite | Herramientas representativas |
+| Host | Instalar el paquete de agente | Conectar la config MCP |
 |---|---|---|
-| Fundación del grafo | ingerir código, mantener estado del grafo, diagnosticar continuidad de sesión, reforzar rutas útiles y detectar drift de peso entre sesiones | `trust_selftest`, `session_handshake`, `recovery_playbook`, `ingest`, `health`, `doctor`, `learn`, `warmup`, `drift` |
-| Recuperación y orientación | buscar por texto, ruta, intención, estructura o relación antes de lecturas manuales de archivo | `audit`, `search`, `glob`, `seek`, `activate`, `why`, `trace` |
-| Documentos y binding de conocimiento | ingerir docs universales o `L1GHT` nativo de grafo y vincular conceptos de vuelta al código | `ingest(adapter="universal"\|"light")`, `document_resolve`, `document_provider_health`, `document_bindings`, `document_drift`, `auto_ingest_*` |
-| Navegación y continuidad | mantener rutas con estado, handoffs, baselines y memoria de investigación entre sesiones | `perspective_*`, `trail_*`, `coverage_session`, `boot_memory`, `persist` |
-| Mission control y disciplina de prueba | mantener una ruta acotada, registrar eventos, pasar de orientación por grafo a prueba directa, hacer handoff y cerrar con brechas explícitas | `mission_start`, `mission_event`, `mission_next`, `mission_verify`, `mission_handoff`, `mission_close` |
-| Planificación y prueba de cambios | razonar sobre impacto, co-cambio, pasos faltantes, rutas de fallo y afirmaciones estructurales | `impact`, `predict`, `validate_plan`, `missing`, `hypothesize`, `counterfactual`, `differential` |
-| Calidad, seguridad y arquitectura | detectar patrones, rutas de taint, fronteras de confianza, duplicación, violaciones de capa, flujos de tipo y objetivos de refactorización | `scan`, `scan_all`, `heuristics_surface`, `antibody_*`, `taint_trace`, `type_trace`, `trust`, `layers`, `layer_inspect`, `twins`, `fingerprint`, `flow_simulate`, `epidemic`, `tremor`, `refactor_plan` |
-| Tiempo, runtime y trabajo multi-repo | inspeccionar historial git, drift, aristas ocultas de co-cambio, overlays de runtime y referencias entre repositorios | `timeline`, `diverge`, `ghost_edges`, `runtime_overlay`, `external_references`, `federate`, `federate_auto` |
-| Operaciones y monitoreo | auditar estado del repo, verificar verdad grafo-vs-disco, ejecutar watches de daemon, persistir estado y surfacear alertas duraderas | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `panoramic`, `metrics`, `report`, `persist`, `diagram`, `help` |
-| Preparación y ejecución de edición quirúrgica | extraer contexto conectado compacto, previsualizar escrituras y aplicar ediciones conscientes del grafo | `surgical_context`, `surgical_context_v2`, `view`, `batch_view`, `edit_preview`, `edit_commit`, `apply`, `apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**Niveles:** 27 herramientas esenciales se anuncian por defecto para reducir el costo de selección de herramientas; establece `M1ND_TOOL_TIER=full` para anunciar la superficie completa (100+ herramientas: RETROBUILDER, perspectives, federación, daemon). Algunas herramientas (`resonate`, `savings`, `lock_*`) siguen siendo llamables por nombre pero no están en la superficie anunciada. Las herramientas ocultas siempre son llamables vía `tools/call` — el tiering solo controla lo que `tools/list` surfacea.
+O desde npm: `npm install -g @maxkle1nz/m1nd`. `install-skills` entrega el paquete de agente — el propio loop operacional en cinco protocolos nombrados, no documentación decorativa.
 
-## Los Loops Operacionales
+**La superficie del operador es este CLI; la superficie del agente es MCP.** Un humano ocasionalmente ejecuta `m1nd doctor`, `install-skills`, `mcp-config` — el agente ejecuta todo lo demás. Existe una vía de escape neutra de host para cuando no hay una sesión MCP activa en la que llamar a `north` (obsoleta, vinculada al repositorio equivocado, o aún no cargada): lanza un runtime aislado, lo vincula al repositorio y devuelve un único sobre legible por máquina que delimita el alcance, establece confianza, ingiere si es necesario, devuelve anclas y hace el handoff a la prueba directa:
 
-El paquete de agente es parte del producto, no documentación decorativa. m1nd es más poderoso cuando el agente recibe el *loop operacional*, no solo un endpoint de grafo. Cinco protocolos nombrados se entregan en el paquete:
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **Inicio de Sesión** — `trust_selftest` → `recovery_playbook` si la confianza no es total → `ingest` si es necesario → `seek`/`audit`.
-- **Investigación** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` cualquier hallazgo duradero.
-- **Cambio de Código** — `impact(node)` para blast radius → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` la decisión y el porqué.
-- **Análisis Profundo** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (la lente RETROBUILDER) para acoplamiento oculto, rutas de seguridad, duplicados estructurales y calor de runtime.
-- **Memoria** — persiste conclusiones duraderas con `memorize`, llevando `confidence` y rutas de `evidence`.
+Fija el binario si lo necesitas: `--version` imprime `1.2.x (<sha>)`, y `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permiten que un host detecte y rechace un binario que ha derivado.
 
-Mission Control es disciplina de prueba, no una lista de funcionalidades. `mission_next` devuelve exactamente un movimiento más guardrails `do_not`; `mission_verify` rechaza afirmaciones solo de grafo; `mission_close` siempre insta al agente a persistir conocimiento verificado y registra brechas y non-claims. En modo `bug_hunt`, el MC0 requiere un `direct_sweep` final directo después de los hallazgos verificados antes del cierre, para que los agentes verifiquen el espacio negativo.
-
-**Advertencia:** `predict` tiene **fallback solo estructural** hasta que `ghost_edges` cargue la matriz de co-cambio de git — ejecuta `ghost_edges` primero cuando necesites probabilidad real de co-cambio.
+Mapa completo de instalación, paquetes de host, build nativo del runtime y flags de actualización: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuración por cliente: [matriz de integración](../docs/IDE-INTEGRATIONS.md).
 
 ## Evidencias
 
@@ -282,9 +331,6 @@ Cada fila está calibrada exactamente a lo que se midió. m1nd no lidera con nú
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="La calibración se gana por repo antes de que los veredictos puedan leer act" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="Una afirmación solo se cierra cuando la evidencia tiende el puente — una lectura de archivo, prueba o sonda" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="Los reportes de campo alimentan un loop de triaje que convierte el fallo en prueba antes del arreglo" />
-</p>
 </details>
 
 ## Límites
@@ -298,6 +344,40 @@ Es **menos útil** cuando:
 - la tarea es una acción local trivial en archivo sin incertidumbre estructural
 
 **Necesita alimentarse:** `trust` y `tremor` comienzan con priors neutros hasta que el feedback de `learn` / los datos de `ghost_edges` se acumulen, y `predict` necesita que `ghost_edges` esté cargado primero para que su señal de co-cambio sea significativa. Mejoran con el uso; son honestos sobre estar sin información al arrancar.
+
+## Lo Que m1nd No Es
+
+`m1nd` no es solo:
+
+- una herramienta de búsqueda de código con un índice más grande
+- una capa de RAG de repositorio que solo recupera archivos o chunks
+- una base de datos de grafo que deja las decisiones de workflow al cliente
+- un reemplazo de análisis estático para el compilador, tests o herramientas de seguridad
+- un bundle MCP de utilidades sin relación entre sí
+- una superficie de herramientas que el humano deba aprender — los verbos son del agente; el tuyo es el pequeño [CLI de setup](#inicio-rápido)
+
+Es la capa que convierte esas superficies en un sistema operacional sobre el que un agente puede razonar y actuar. No sirve para lookups de un solo archivo, grep simple o verdad del compilador — usa herramientas simples en esos casos.
+
+## Cobertura de Lenguajes
+
+El razonamiento de grafo (`impact`, `why`, `predict`, `trace`, `taint_trace`) es tan bueno como el extractor. m1nd resuelve tanto **aristas `calls`** (grafo de llamadas) como **`imports` entre archivos** (resolución de dependencia archivo→archivo) por lenguaje. La matriz a continuación fue probada en vivo en una única ingestión políglota:
+
+| Lenguaje | `calls` | imports entre archivos |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅ (package) |
+| Java | ✅ | ✅ (FQCN + wildcard) |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅ (package) |
+| PHP | ✅ | ✅ (PSR-4) |
+| Scala | ✅ | ✅ (package) |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | — (los namespaces no mapean 1:1 a archivos) |
+| Swift | ✅ | — |
+
+Todas las filas ✅ están verificadas de extremo a extremo (un import `caller`→`callee` resuelve y el caller emite aristas de llamada). Otros lenguajes caen de vuelta al extractor genérico (solo `contains`). Los imports no resolvibles (paquetes externos, gems, stdlib, cabeceras de sistema) se dejan honestamente sin resolver en lugar de adivinarlos.
 
 ## Arquitectura de un Vistazo
 
@@ -314,7 +394,7 @@ Versiones actuales de los crates: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` todos e
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Resumen de la arquitectura de m1nd" width="960" />
 </p>
 
-Para federación, perspectives, RETROBUILDER, coordinación multiagente y la referencia completa de paquete de agente y operador, consulta la [wiki canónica](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) y [EXAMPLES.md](../EXAMPLES.md).
+La superficie MCP activa evoluciona con los releases — usa `tools/list` para la cuenta exacta de herramientas y nombres en tu build. **Niveles:** 27 herramientas esenciales se anuncian por defecto para reducir el costo de selección de herramientas; establece `M1ND_TOOL_TIER=full` para anunciar la superficie completa (100+ herramientas: RETROBUILDER, perspectives, federación, daemon). Las herramientas ocultas siempre son llamables vía `tools/call` — el tiering solo controla lo que `tools/list` anuncia. El catálogo herramienta a herramienta no vive en este README: ver la [wiki canónica](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) y [EXAMPLES.md](../EXAMPLES.md) para profundidad, y [CHANGELOG.md](../CHANGELOG.md) para el historial de releases.
 
 ## Contribuir
 

--- a/i18n/README.fr.md
+++ b/i18n/README.fr.md
@@ -15,7 +15,7 @@
   <a href="https://www.npmjs.com/package/@maxkle1nz/m1nd"><img src="https://img.shields.io/npm/v/@maxkle1nz/m1nd.svg?color=00f5ff&label=npm" alt="npm" /></a>
   <a href="https://crates.io/crates/m1nd-core"><img src="https://img.shields.io/crates/v/m1nd-core.svg" alt="crates.io" /></a>
   <a href="https://github.com/maxkle1nz/m1nd/actions"><img src="https://github.com/maxkle1nz/m1nd/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Licence" /></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://docs.rs/m1nd-core"><img src="https://img.shields.io/docsrs/m1nd-core" alt="docs.rs" /></a>
 </p>
 
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd est une intelligence opérationnelle pour agents de coding — il gouverne la boucle opérationnelle, pas seulement le retrieval.**
+**m1nd est la coque autour de votre agent de coding — la boucle opérationnelle dans laquelle il vit : orienté avant d'agir, des verdicts honnêtes pendant qu'il travaille, une mémoire avec preuves après qu'il a fini, qui se compose de session en session.**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="Une pile de fichiers épars devient un graphe connecté de ce qui relie quoi" /></p>
 
 > grep trouve du texte. La recherche vectorielle trouve des chunks similaires. `m1nd` donne aux agents un graphe local de ce qui est connecté, ce qui a changé, ce qui casse, ce qui a dérivé, et où reprendre.
 
-Trois choses coexistent ici qu'aucun autre outil ne réunit :
+## Ce qu'est m1nd : la coque autour de votre agent
 
-- **Graphe causal du code** — `impact` avant une modification montre le blast radius que vous n'aviez pas lu ; `ghost_edges` fait remonter les fichiers qui changent toujours ensemble mais ne partagent aucun import.
-- **Mémoire auto-vérifiante** — `memorize` ancre les résultats à de vrais nœuds de code ; `cross_verify` les signale comme obsolètes quand ce code change.
-- **Un layer de trust / recovery** — chaque résultat porte un trust mode ; `trust_selftest` et `recovery_playbook` indiquent à l'agent quand le binding du workspace est incorrect et comment récupérer.
+*m1nd enveloppe votre agent de coding dans une boucle qui l'oriente avant d'agir, le garde honnête pendant qu'il travaille, et retient ce qu'il a appris quand il a terminé.*
 
-Plus un **runtime d'attention** — `focus` remet à l'agent le working set minimal et borné en budget pour un objectif, avec une queue honnête de ce qu'il a laissé de côté et un signal indiquant si c'est *assez* de contexte pour l'instant.
+- **Si vous construisez avec des agents** — rien de nouveau à apprendre : installez une fois et continuez à parler à votre agent. Il arrête de deviner, commence à se souvenir, et dit « je ne sais pas » quand c'est la vérité.
+- **Si vous êtes ingénieur** — un moteur de graphe en Rust, local-first, derrière un serveur MCP : un graphe causal du code (edges structurels, sémantiques, temporels et causaux), des verdicts à calibration conforme, et une mémoire ancrée à des nœuds de code avec provenance. Rien ne quitte votre machine.
+
+Les agents sur de vraies bases de code n'échouent pas parce qu'ils ne savent pas chercher — ils échouent parce qu'ils n'ont pas de modèle opérationnel. Chaque session reconstruit le contexte depuis zéro, modifie sans connaître le blast radius, et ne peut pas distinguer un résultat vide qui signifie « rien n'existe » d'un qui signifie « mauvais dépôt ». m1nd donne à l'agent un modèle durable de la base de code — un graphe causal avec spreading activation et plasticité Hebbienne — et enveloppe toute la boucle de l'agent autour de lui. Les fonctionnalités ici ne sont pas un catalogue ; ce sont les stations de cette coque :
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd est opéré par votre agent, pas par vous.** Chaque outil ci-dessous est appelé par l'agent lui-même — automatiquement, avant et après son travail. Un humain ne les exécute jamais en usage normal ; vous installez une fois ([Démarrage Rapide](#démarrage-rapide)) et continuez à parler à votre agent comme d'habitude.
+
+**Une coque, trois lecteurs.** Le même paquet orienté est rendu pour celui qui s'apprête à agir : l'**agent principal** le lit comme `north` (livré — la porte d'entrée ci-dessous) ; un **sous-agent** le recevra comme le Delegation Packet, la moitié retrieval de sa spec de spawn (conçu — [docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md), §O.12) ; l'**humain** le verra comme la Pre-Flight Card sur le Living Tree — votre projet en arbre navigable avec des post-its de mémoire, montrant ce que l'agent a vérifié vs. deviné avant qu'une modification n'atterrisse (conçu, en développement — [docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)). Une seule vérité, calculée une seule fois.
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="Une vérité, deux lecteurs — le même paquet rendu pour l'agent et pour l'humain" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Boucle agent traditionnelle vs boucle m1nd-grounded" width="960" />
 </p>
 
-## Nouveautés de la 1.2.0 — la première release de l'ère OMEGA
+### Ce qui se passe quand vous envoyez un message
 
-La 1.2.0 fait passer la boucle de « récupérer, puis espérer » à **pré-orienter → agir sur des verdicts calibrés → capturer ce que vous avez appris**. Le thème est le même que celui du layer de trust : un *non* honnête vaut mieux qu'une supposition confiante.
+Vous demandez à votre agent de réparer quelque chose. Voici ce que la coque fait autour de ce message :
 
-- **`north(task)` — pré-orienter en un seul appel.** La nouvelle porte d'entrée compose le trust, le contexte de la tâche (focus nodes + ancres PageRank), la mémoire inter-sessions antérieure, un signal de suffisance, un `next_move`, et `honest_gaps` (ce que m1nd ne sait *pas* encore). `needs_ingest` est une vraie réponse pour un graphe vide. (La composition L1GHT-recall qui replie la mémoire antérieure dans le paquet a atterri sur `main` juste après le tag 1.2.0 — elle n'est pas dans le binaire 1.2.0.)
-- **Calibration conforme sur la prédiction.** `calibrate_predict` arme une gate par dépôt ; les verdicts lisent ensuite `act` / `reverify` / `abstain`, où `abstain` signifie *non calibré ou insuffisant* — un signal pour s'arrêter, pas un oui faible. Livré dark : tant que vous ne calibrez pas, les verdicts plafonnent à `reverify`.
-- **`trust_envelope` sur `seek`** (livré dark) et un **verdict `closure` sur `why`** — `blocked` signifie que le chemin repose sur un edge non résolu/deviné. **`trust_band: insufficient_evidence`** est désormais distinct d'un risk band : il signifie *aucune preuve*, la réponse honnête de démarrage à froid, pas « risque moyen ».
-- **La mémoire a gagné une colonne vertébrale de provenance** — les affirmations portent un âge + un auteur réels, supplantent les affirmations plus anciennes, expirent avec le temps, et respectent un plafond de récence, si bien que la connaissance mémorisée déclare sa propre fraîcheur au lieu de se périmer en silence.
-- **Co-change en Jaccard lissé** — `ghost_edges` / `predict` normalisent désormais le couplage au lieu de compter les co-commits bruts (+3 points prouvés par calibration face aux comptes bruts).
-- **Version du binaire + empreinte sha** — `--version` affiche `1.2.0 (<sha>)` ; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permettent à un hôte de détecter et de refuser un binaire qui a dérivé.
-- **Instructions MCP agent-natives + field reports local-only.** Les instructions d'`initialize` que chaque hôte reçoit *sont* désormais la boucle opérationnelle ci-dessus. Les agents peuvent laisser un signal de télémétrie par session — `learn` sur un verdict de retrieval, ou une ligne dans `~/.m1nd/field-reports.jsonl` quand m1nd lui-même se comporte mal. Ce fichier est local-only ; **m1nd ne téléphone jamais à la maison.**
+1. **Avant que votre agent n'agisse**, m1nd lui remet la carte vivante de votre projet, ce que les sessions passées ont appris, à quel point faire confiance à chaque pièce — et ce qu'il ne sait *pas* (`north`).
+2. **Pendant qu'il travaille**, il porte des verdicts : il vérifie ce qu'une modification casserait *avant* de toucher au code (`impact`), et là où la preuve est mince, il reçoit un honnête « je ne sais pas » au lieu d'une supposition confiante (`abstain`).
+3. Il peut demander pourquoi deux morceaux de code sont connectés et être prévenu quand la réponse repose sur une supposition (`why`), et il est alerté avant de franchir une frontière d'architecture (`xray_gate`).
+4. **Quand il termine**, la décision est consignée avec la preuve qui la soutient (`memorize`).
+5. Cette mémoire est ancrée au code réel — si le code change plus tard, la mémoire se signale d'elle-même comme obsolète au lieu de mentir en silence (`cross_verify`).
+6. **Votre prochaine session démarre en sachant déjà** — n'importe quel agent, n'importe quel outil : Claude Code, Codex, Cursor, Gemini. Ce qu'un agent apprend, le suivant en hérite.
 
-## Démarrage Rapide
+## BEFORE — né orienté
 
-Le chemin minimal fonctionnel — installer depuis les sources (toujours à jour), vérifier la santé, connecter votre hôte :
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-Ensuite, câblez votre hôte — les deux mêmes commandes, une par hôte (`codex`, `claude`, `gemini`, `antigravity`, `generic`) :
-
-| Hôte | Installer le pack d'agent | Câbler la config MCP |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-Ou depuis npm : `npm install -g @maxkle1nz/m1nd`.
-
-Carte d'installation complète, packs d'hôtes, build du runtime natif et flags de mise à jour : [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuration client par client : [matrice d'intégration](../docs/IDE-INTEGRATIONS.md).
-
-### Point d'Entrée des Agents
+*Votre agent démarre chaque session en connaissant déjà votre projet — et en sachant ce qu'il ne sait pas.*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task) : un seul appel d'entrée renvoie tout le paquet orienté" /></p>
 
-Les agents analysent ce README. Dans une session MCP, la porte d'entrée est un seul appel — `north(task)` compose le trust, le contexte de tâche, la mémoire inter-sessions antérieure, un signal de suffisance, un `next_move`, et `honest_gaps` (ce que m1nd ne sait *pas* encore) en un seul paquet. S'il rapporte `needs_ingest` (graphe vide), ou si vous êtes sur un binaire plus ancien, repliez-vous sur la boucle de trust explicite — établir le trust *avant* de faire confiance à tout retrieval :
+Dans une session MCP, la porte d'entrée est un seul appel — `north(task)` compose le trust, le contexte de tâche (focus nodes + ancres PageRank), la mémoire inter-sessions antérieure, un signal de suffisance, un `next_move`, et `honest_gaps` (ce que m1nd ne sait *pas* encore) en un seul paquet, avant toute requête :
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+La réponse est un paquet orienté — verdict de trust, la mémoire laissée par la dernière session, et une liste honnête de lacunes. Une capture réelle du binaire de `main`, légèrement élaguée :
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` compose `trust_selftest` + `orient` + `boot_memory` + `focus` — l'agent ne va chercher une pièce isolée que lorsqu'il n'en a besoin que d'une. `focus` est le runtime d'attention de cette station : le working set minimal et borné en budget pour un objectif, avec une queue honnête de ce qu'il a laissé de côté et un signal indiquant si c'est *assez* de contexte pour l'instant. `needs_ingest` est une vraie réponse pour un graphe vide.
+
+Si `north` rapporte `needs: "needs_ingest"`, ou si vous êtes sur un binaire antérieur à la 1.2.1 sans la composition L1GHT-recall, l'agent se replie sur la boucle de trust explicite — établir le trust *avant* de faire confiance à tout retrieval :
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ Les agents analysent ce README. Dans une session MCP, la porte d'entrée est un 
 
 **Boucle première session, en quatre mouvements :** `north` (ou `trust_selftest` → `ingest`) → `seek`/`audit` → `memorize` le résultat durable pour que la prochaine session parte en avance.
 
-Quand il n'y a pas de session MCP vivante où appeler `north` — elle est obsolète, liée au mauvais dépôt, ou pas encore chargée — utilisez plutôt la CLI host-neutral comme échappatoire. Elle lance un runtime isolé, le lie au dépôt, et retourne une seule enveloppe lisible par machine qui délimite le périmètre, établit le trust, ingère si nécessaire, retourne des ancres, et fait le handoff vers la preuve directe :
+## DURING — des verdicts portés pendant le travail
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*Pendant qu'il travaille, chaque réponse arrive avec le degré de confiance à lui accorder — et « je ne sais pas » est une vraie réponse.*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Chaque résultat est un verdict — act, reverify ou abstain — comme des portes que l'agent choisit" /></p>
+
+L'agent ne consulte pas m1nd ; il le porte. Chaque réponse en cours de travail est un verdict calibré, pas une intuition :
+
+- **`impact` avant de toucher** montre le blast radius que vous n'aviez pas lu ; `ghost_edges` fait remonter les fichiers qui changent toujours ensemble mais ne partagent aucun import.
+- **`why` porte un verdict `closure`** — `blocked` signifie que le chemin repose sur un edge non résolu ou deviné : vérifiez cet edge avant de vous fier au chemin.
+- **`predict` est à calibration conforme** — `calibrate_predict` arme une gate par dépôt ; les verdicts lisent ensuite `act` / `reverify` / `abstain`, où `abstain` signifie *non calibré ou insuffisant* — un signal pour s'arrêter, pas un oui faible. Livré dark : tant que vous ne calibrez pas, les verdicts plafonnent à `reverify`. Le couplage de co-change est normalisé en Jaccard lissé, pas en comptes bruts de commits (+3 points prouvés par calibration). *Mise en garde :* `predict` n'a qu'un fallback structurel tant que `ghost_edges` n'a pas chargé la matrice de co-change git — exécutez-le d'abord pour la vraie probabilité de co-change.
+- **`xray_gate` garde les frontières de l'architecture** — appelé avant une modification, il répond « ce changement franchit-il une frontière de module interdite ? » avec `clear` / `caution` / `blocked` ; seul un manifest ratifié peut bloquer (anti-fatigue de guardrail).
+- **Mission Control est de la discipline de preuve** — `mission_next` retourne exactement un mouvement plus des guardrails `do_not` ; en mode `bug_hunt`, un balayage direct final est requis avant la fermeture, pour que les agents vérifient l'espace négatif.
+
+La même honnêteté accompagne le retrieval. Un hit de `seek` porte une lecture de `sufficiency` et un `trust_envelope` — et quand l'enveloppe n'a encore aucune ligne de calibration mesurée, elle plafonne son propre verdict au lieu d'exagérer. Une capture réelle, élaguée (le premier hit est une mémoire écrite par la dernière session) :
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### Servir un seul graphe, attacher plusieurs agents
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact trace le rayon d'impact à travers la toile de code connecté avant que vous n'éditiez" /></p>
+
+## AFTER — le graphe se réchauffe
+
+*Quand le travail atterrit, ce qui a été appris est consigné avec la preuve qui le soutient — et reste honnête quand le code continue d'évoluer.*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="La mémoire est ancrée au code réel ; quand le code change, la mémoire se signale d'elle-même" /></p>
+
+La plupart des outils donnent à l'agent un meilleur *retrieval*. À cette station, l'agent **crée des connaissances durables et lisibles par machine** qui se composent à travers les sessions et restent honnêtes par rapport au code. L1GHT transforme les connaissances créées en structure graph-native qui s'auto-signale quand le code qu'elle cite change — les affirmations confiantes diffusent plus d'activation que les incertaines.
+
+1. **Conclure** — l'agent atteint quelque chose de durable (une décision, un résultat vérifié, pourquoi le code est ainsi) et appelle `memorize` avec des affirmations structurées et des chemins `evidence`.
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+L'appel retourne la preuve qu'il a atterri — voici une réponse réelle capturée, élaguée :
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **Ancrer** — m1nd écrit un `.light.md` graph-native sous `<runtime>/agent-memory/`, l'ingère (`adapter=light mode=merge`), et résout chaque chemin `evidence` vers le vrai nœud de code via un edge `grounded_in` — ainsi la connaissance vit dans le même espace d'activation que le code et remonte dans `seek` / `activate` / `impact`.
+3. **Auto-chargement** — à chaque démarrage de session future, `m1nd` ingère `agent-memory/` automatiquement et le rapporte dans `session_handshake.agent_memory`. Les résultats passés survivent à un ingest `mode=replace` et sont simplement *là*.
+4. **Auto-signalement de la staleness** — `cross_verify(check: ["evidence_freshness"])` re-hash chaque fichier cité et nomme quelles affirmations sont devenues obsolètes parce que leur code a changé — ainsi la mémoire vous dit quand elle ment au lieu de vous tromper. La mémoire porte une colonne vertébrale de provenance : les affirmations déclarent un âge + un auteur réels, supplantent les affirmations plus anciennes, expirent avec le temps et respectent un plafond de récence — la connaissance mémorisée déclare sa propre fraîcheur au lieu de se périmer en silence.
+
+Cette boucle a été prouvée en direct de bout en bout : `memorize` → edge `grounded_in` → signal de freshness sur fichier modifié → survit à `mode=replace` → boot auto-load. Vous fermez une mission bornée ? Passez `write_light_memory: true` à `mission_close` pour persister ses affirmations vérifiées de la même façon.
+
+**COMPOUND — la session suivante naît dans la coque réchauffée.** Tuez ce processus, démarrez-en un **nouveau** contre le même runtime, et son premier `north(task)` porte déjà l'affirmation de la session précédente — voici un échange réel capturé (les deux appels ci-dessus ont tourné dans des processus séparés), élagué :
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` nomme qui l'a écrite et `stale` re-vérifie le code cité — la session suivante hérite de la connaissance *et* de sa provenance, pas d'une simple chaîne.
+
+### Un graphe, plusieurs agents
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="Un processus propriétaire détient le graphe vivant ; de nombreux agents s'attachent au même cœur" /></p>
 
-Le Démarrage Rapide ci-dessus câble un serveur stdio par hôte — parfait pour un seul agent, mais chaque processus charge son propre graphe et détient sa propre lease. Le déploiement pour lequel m1nd est conçu, c'est un seul propriétaire, plusieurs agents attachés. Un seul processus propriétaire détient le graphe vivant :
+Le Démarrage Rapide ci-dessous câble un serveur stdio par hôte — parfait pour un seul agent, mais chaque processus charge son propre graphe et détient sa propre lease. Le déploiement pour lequel m1nd est conçu, c'est un seul propriétaire, plusieurs agents attachés. Un seul processus propriétaire détient le graphe vivant :
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 N'importe quel nombre de ponts pointent vers l'unique propriétaire et partagent son unique graphe vivant, si bien que ce qu'un agent `memorize` est immédiatement rappelé par un autre — pas de réingest, pas de copie par agent. Les requêtes passent par localhost, donc ça reste local-first (le bind reste `127.0.0.1` sauf si vous optez pour `--bind 0.0.0.0`). Un `seek` à chaud via le pont a mesuré ≈0.7ms sur un petit graphe sur une seule machine — ordre de grandeur, pas une garantie : l'attach ajoute un aller-retour localhost, et la latence croît avec la taille du graphe et la charge.
 
-## Ce que m1nd N'Est Pas
+## Le matériau : l'honnêteté
 
-`m1nd` n'est pas seulement :
+*Toute la coque est faite d'un seul matériau — m1nd préfère dire à votre agent « ne fais pas confiance à ceci » plutôt que de le laisser deviner.*
 
-- un outil de recherche de code avec un index plus grand
-- un layer de RAG sur le dépôt qui ne récupère que des fichiers ou des chunks
-- une base de données en graphe qui laisse les décisions de workflow au client
-- un remplacement d'analyse statique pour le compilateur, les tests ou les outils de sécurité
-- un bundle MCP d'utilitaires sans rapport
-
-C'est le layer qui transforme ces surfaces en un système opérationnel sur lequel un agent peut raisonner et agir. Pas pour les recherches mono-fichier, les grep simples, ou la vérité compilateur — utilisez des outils simples dans ces cas.
-
-## Pourquoi les Agents en ont Besoin
-
-Sans m1nd, chaque session commence par des boucles de grep et une réorientation manuelle ; les résultats de la semaine passée sont perdus, et un résultat de recherche vide est indiscernable d'un mauvais binding de workspace. Avec m1nd, la session commence par un verdict de trust, les résultats passés se chargent automatiquement déjà ancrés au code qui les supporte, et les résultats vides disent *pourquoi*.
-
-Les agents sur de vraies bases de code n'échouent pas parce qu'ils ne savent pas chercher. Ils échouent parce qu'ils n'ont pas de modèle opérationnel. Ils reconstruisent le contexte depuis zéro à chaque session, modifient sans connaître le blast radius, et ne peuvent pas distinguer un résultat vide qui signifie « rien n'existe » d'un qui signifie « mauvais dépôt. »
-
-Ça fonctionne pour les petites bases de code. Ça s'effondre quand le projet comporte des artefacts générés, des specs, des docs, un historique de co-change caché, plusieurs agents, et de longs handoffs. Le problème n'est pas seulement le raisonnement de l'agent — l'agent n'a pas de modèle durable de la structure de la base de code. `m1nd` lui en donne un : un graphe causal du code avec spreading activation à travers des dimensions structurelles, sémantiques, temporelles et causales, plus une plasticité Hebbienne qui se compose par agent à travers les sessions.
-
-## Mémoire Composée (L1GHT)
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="La mémoire est ancrée au code réel ; quand le code change, la mémoire se signale d'elle-même" /></p>
-
-La plupart des outils donnent à l'agent un meilleur *retrieval*. `m1nd` permet aussi à un agent de **créer des connaissances durables et lisibles par machine** qui se composent à travers les sessions et restent honnêtes par rapport au code. L1GHT transforme les connaissances créées en structure graph-native qui s'auto-signale quand le code qu'elle cite change — les affirmations confiantes diffusent plus d'activation que les incertaines.
-
-La boucle, du début à la fin :
-
-1. **Conclure** — l'agent atteint quelque chose de durable (une décision, un résultat vérifié, pourquoi le code est ainsi) et appelle `memorize` avec des affirmations structurées et des chemins `evidence`.
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **Ancrer** — m1nd écrit un `.light.md` graph-native sous `<runtime>/agent-memory/`, l'ingère (`adapter=light mode=merge`), et résout chaque chemin `evidence` vers le vrai nœud de code via un edge `grounded_in` — ainsi la connaissance vit dans le même espace d'activation que le code et remonte dans `seek` / `activate` / `impact`.
-3. **Auto-chargement** — à chaque démarrage de session future, `m1nd` ingère `agent-memory/` automatiquement et le rapporte dans `session_handshake.agent_memory`. Les résultats passés survivent à un ingest `mode=replace` et sont simplement *là*.
-4. **Auto-signalement de la staleness** — `cross_verify(check: ["evidence_freshness"])` re-hash chaque fichier cité et nomme quelles affirmations sont devenues obsolètes parce que leur code a changé — ainsi la mémoire vous dit quand elle ment au lieu de vous tromper.
-
-Cette boucle a été prouvée en direct de bout en bout : `memorize` → edge `grounded_in` → signal de freshness sur fichier modifié → survit à `mode=replace` → boot auto-load. Vous fermez une mission bornée ? Passez `write_light_memory: true` à `mission_close` pour persister ses affirmations vérifiées de la même façon. L'habitude est documentée dans les `instructions` du serveur que chaque client MCP reçoit à l'`initialize` — host-agnostic, aucun plugin client-spécifique requis.
-
-## Le Layer de Trust / Honnêteté
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Chaque résultat est un verdict — act, reverify ou abstain — comme des portes que l'agent choisit" /></p>
-
-C'est la chose la plus défendable que m1nd fait, et aucun concurrent ne la propose. La doctrine : **la crédibilité vient de l'honnêteté, pas de toujours gagner.**
+C'est la chose la plus défendable que m1nd fait, et aucun concurrent ne la propose. La doctrine : **la crédibilité vient de l'honnêteté, pas de toujours gagner.** Un *non* honnête vaut mieux qu'une supposition confiante — chaque station ci-dessus est faite de ce matériau.
 
 - **`trust_selftest`** retourne un verdict *avant* tout retrieval : `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected`, ou `degraded_host_tool_surface`. L'agent sait s'il doit continuer, ingérer, rebinder, ou faire un fallback.
 - **`agent_runtime_contract`** est présent dans chaque réponse de retrieval, portant un `trust_mode`. Un résultat vide est désambiguïsé — lié au mauvais dépôt vs. genuinement rien là — jamais silencieusement rapporté comme « aucun résultat. »
+- **`trust_band: insufficient_evidence` signifie AUCUNE preuve — pas un risque moyen.** La réponse honnête de démarrage à froid, distincte de faible/moyen/élevé.
 - **Les tableaux `non_claims`** sont présents sur chaque outil de mission. m1nd dit à l'agent ce qu'il n'a *pas* prouvé.
 - **`mission_verify` peut dire non — et le fait, dans du code testé.** Il rejette les preuves uniquement issues du graphe : une affirmation ne peut pas se fermer sans une lecture de fichier, une exécution de test, ou une sonde runtime. Le test s'appelle littéralement `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** retourne une liste d'étapes déterministe et ordonnée pour réparer le binding.
 
+Montré, pas raconté. Appelez `trust_selftest` sur un runtime sans binding et le verdict *est* l'instruction de réparation — une capture réelle, élaguée :
+
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
+
 La preuve de l'engagement est ce qui a été supprimé pour lui : `savings` et `resonate` ont été retirés de la surface annoncée en beta.7 parce qu'un outil qui prétend toujours gagner n'est pas crédible. Aucun concurrent — ni mem0, Zep, Letta, Sourcegraph, ni aucun MCP code-graph — ne propose un layer qui dit à l'agent ce à quoi il ne faut *pas* faire confiance et comment récupérer.
 
-**La boucle de field-triage se referme sur elle-même.** La télémétrie de session que les agents laissent dans `~/.m1nd/field-reports.jsonl` (local-only — m1nd ne téléphone jamais à la maison) n'est pas un log passif : les reports sont triés, et un bug de terrain *confirmé* devient un cas de batterie rouge **avant** le fix, si bien que la régression est prouvée, pas seulement décrite. Cette boucle a déjà tourné une fois de bout en bout : deux bugs remontés du terrain sont devenus des cas de batterie en échec puis des fixes mergés — `north` compose désormais le L1GHT recall dans son paquet de mémoire, et le sentinel de graphe `temp` se résout vers un vrai tempdir au lieu de joncher le répertoire de travail.
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="Les rapports de terrain alimentent une boucle de triage qui transforme le défaut en test avant le correctif" /></p>
 
-## Couverture Linguistique
+**La boucle de field-triage se referme sur elle-même.** La télémétrie de session que les agents laissent dans `~/.m1nd/field-reports.jsonl` (local-only — m1nd ne téléphone jamais à la maison) n'est pas un log passif : les reports sont triés, et un bug de terrain *confirmé* devient un cas de batterie rouge **avant** le fix, si bien que la régression est prouvée, pas seulement décrite. Cette boucle a déjà tourné de bout en bout dans un balayage complet de field-triage : quatre bugs remontés du terrain sont devenus des cas de batterie en échec puis des fixes mergés, tous livrés dans la **1.2.1** — `north` compose désormais le L1GHT recall dans son paquet de mémoire, le sentinel de graphe `temp` se résout vers un vrai tempdir au lieu de joncher le répertoire de travail, `memorize` accepte une `confidence` numérique, et le tag d'ambiguïté de closure ne se déclenche plus que sur des égalités authentiques (le crieur au loup : ambiguous-blocked est tombé de 9/11 → 0/11).
 
-Le raisonnement sur le graphe (`impact`, `why`, `predict`, `trace`, `taint_trace`) vaut ce que vaut l'extracteur. m1nd résout à la fois les **edges `calls`** (call graph) et les **`imports` cross-fichier** (résolution de dépendances fichier→fichier) par langage. La matrice ci-dessous a été prouvée en direct dans un seul ingest polyglotte :
+## Démarrage Rapide
 
-| Langage | `calls` | imports cross-fichier |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅ (package) |
-| Java | ✅ | ✅ (FQCN + wildcard) |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅ (package) |
-| PHP | ✅ | ✅ (PSR-4) |
-| Scala | ✅ | ✅ (package) |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | — (les namespaces ne mappent pas 1:1 aux fichiers) |
-| Swift | ✅ | — |
+*Installez une fois, câblez l'hôte de votre agent et laissez la place — à partir d'ici, c'est votre agent qui conduit.*
 
-Toutes les lignes ✅ sont vérifiées de bout en bout (un import `caller`→`callee` se résout et le caller émet des edges d'appel). Les autres langages tombent sur l'extracteur générique (uniquement `contains`). Les imports non résolvables (paquets externes, gems, stdlib, en-têtes système) sont honnêtement laissés non résolus plutôt que devinés.
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-## Carte des Capacités
+Ensuite, câblez votre hôte — les deux mêmes commandes, une par hôte (`codex`, `claude`, `gemini`, `antigravity`, `generic`) :
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact trace le rayon d'impact à travers la toile de code connecté avant que vous n'éditiez" /></p>
-
-La surface MCP live évolue avec les versions. Utilisez `tools/list` pour le nombre exact d'outils et les noms dans votre build actuelle.
-
-| Domaine | Ce qu'il permet | Outils représentatifs |
+| Hôte | Installer le pack d'agent | Câbler la config MCP |
 |---|---|---|
-| Fondation du graphe | ingérer du code, maintenir l'état du graphe, diagnostiquer la continuité de session, renforcer les chemins utiles, et détecter la dérive des poids entre sessions | `trust_selftest`, `session_handshake`, `recovery_playbook`, `ingest`, `health`, `doctor`, `learn`, `warmup`, `drift` |
-| Retrieval et orientation | chercher par texte, chemin, intention, structure, ou relation avant les lectures manuelles de fichiers | `audit`, `search`, `glob`, `seek`, `activate`, `why`, `trace` |
-| Docs et binding de connaissance | ingérer des docs universels ou du `L1GHT` graph-native, puis lier les concepts au code | `ingest(adapter="universal"\|"light")`, `document_resolve`, `document_provider_health`, `document_bindings`, `document_drift`, `auto_ingest_*` |
-| Navigation et continuité | maintenir des routes stateful, des handoffs, des baselines, et la mémoire d'investigation à travers les sessions | `perspective_*`, `trail_*`, `coverage_session`, `boot_memory`, `persist` |
-| Mission control et discipline de preuve | maintenir une route bornée, enregistrer des événements, passer de l'orientation sur graphe à la preuve directe, faire un handoff, et fermer avec des gaps explicites | `mission_start`, `mission_event`, `mission_next`, `mission_verify`, `mission_handoff`, `mission_close` |
-| Planification et preuve des changements | raisonner sur l'impact, le co-change, les étapes manquantes, les chemins d'échec, et les affirmations structurelles | `impact`, `predict`, `validate_plan`, `missing`, `hypothesize`, `counterfactual`, `differential` |
-| Qualité, sécurité et architecture | détecter les patterns, les chemins de taint, les frontières de trust, la duplication, les violations de layer, les flux de types, et les cibles de refactoring | `scan`, `scan_all`, `heuristics_surface`, `antibody_*`, `taint_trace`, `type_trace`, `trust`, `layers`, `layer_inspect`, `twins`, `fingerprint`, `flow_simulate`, `epidemic`, `tremor`, `refactor_plan` |
-| Temps, runtime et travail multi-dépôt | inspecter l'historique git, la dérive, les edges de co-change cachés, les overlays runtime, et les références cross-dépôt | `timeline`, `diverge`, `ghost_edges`, `runtime_overlay`, `external_references`, `federate`, `federate_auto` |
-| Opérations et monitoring | vérifier l'état du dépôt, vérifier la vérité graphe-vs-disque, exécuter des watches daemon, persister l'état, et faire remonter des alertes durables | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `panoramic`, `metrics`, `report`, `persist`, `diagram`, `help` |
-| Préparation et exécution d'éditions chirurgicales | extraire un contexte connecté compact, prévisualiser les écritures, et appliquer des éditions graph-aware | `surgical_context`, `surgical_context_v2`, `view`, `batch_view`, `edit_preview`, `edit_commit`, `apply`, `apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**Niveaux :** 27 outils essentiels sont annoncés par défaut pour réduire le coût de sélection des outils ; définissez `M1ND_TOOL_TIER=full` pour annoncer la surface complète (100+ outils : RETROBUILDER, perspectives, federation, daemon). Quelques outils (`resonate`, `savings`, `lock_*`) restent appelables par nom mais ne sont pas sur la surface annoncée. Les outils cachés sont toujours appelables via `tools/call` — le niveau contrôle uniquement ce que `tools/list` expose.
+Ou depuis npm : `npm install -g @maxkle1nz/m1nd`. `install-skills` livre le pack d'agent — la boucle opérationnelle elle-même en cinq protocoles nommés, pas de la documentation décorative.
 
-## Les Boucles Opérationnelles
+**La surface de l'opérateur, c'est cette CLI ; la surface de l'agent, c'est MCP.** Un humain exécute occasionnellement `m1nd doctor`, `install-skills`, `mcp-config` — l'agent exécute tout le reste. Une échappatoire host-neutral existe pour quand il n'y a pas de session MCP vivante où appeler `north` (obsolète, liée au mauvais dépôt, ou pas encore chargée) : elle lance un runtime isolé, le lie au dépôt, et retourne une seule enveloppe lisible par machine qui délimite le périmètre, établit le trust, ingère si nécessaire, retourne des ancres, et fait le handoff vers la preuve directe :
 
-Le pack d'agent fait partie du produit, pas de la documentation décorative. m1nd est le plus puissant quand l'agent reçoit la *boucle opérationnelle*, pas seulement un endpoint de graphe. Cinq protocoles nommés sont fournis dans le pack :
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **Démarrage de Session** — `trust_selftest` → `recovery_playbook` si le trust n'est pas complet → `ingest` si nécessaire → `seek`/`audit`.
-- **Recherche** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` tout résultat durable.
-- **Modification de Code** — `impact(node)` pour le blast radius → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` la décision et le pourquoi.
-- **Analyse Approfondie** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (la lentille RETROBUILDER) pour le couplage caché, les chemins de sécurité, les doublons structurels, et la chaleur runtime.
-- **Mémoire** — persister les conclusions durables avec `memorize`, portant `confidence` et chemins `evidence`.
+Épinglez le binaire si besoin : `--version` affiche `1.2.x (<sha>)`, et `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permettent à un hôte de détecter et de refuser un binaire qui a dérivé.
 
-Mission Control est de la discipline de preuve, pas une liste de fonctionnalités. `mission_next` retourne exactement un mouvement plus des guardrails `do_not` ; `mission_verify` rejette les affirmations uniquement issues du graphe ; `mission_close` pousse toujours l'agent à persister les connaissances vérifiées et enregistre les gaps et non-claims. En mode `bug_hunt`, MC0 requiert un `direct_sweep` final après les résultats vérifiés avant la fermeture, pour que les agents vérifient l'espace négatif.
-
-**Mise en garde :** `predict` a **uniquement un fallback structurel** tant que `ghost_edges` n'a pas chargé la matrice de co-change git — exécutez `ghost_edges` en premier quand vous avez besoin de la vraie probabilité de co-change.
+Carte d'installation complète, packs d'hôtes, build du runtime natif et flags de mise à jour : [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuration client par client : [matrice d'intégration](../docs/IDE-INTEGRATIONS.md).
 
 ## Preuves
 
@@ -282,9 +331,6 @@ Chaque ligne est calibrée exactement à ce qui a été mesuré. m1nd ne met pas
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="La calibration se gagne par dépôt avant que les verdicts puissent lire act" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="Une affirmation ne se ferme que lorsque la preuve fait le pont — une lecture de fichier, un test ou une sonde" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="Les rapports de terrain alimentent une boucle de triage qui transforme le défaut en test avant le correctif" />
-</p>
 </details>
 
 ## Limites
@@ -298,6 +344,40 @@ Il est **moins utile** quand :
 - la tâche est une action locale banale sur fichier sans incertitude structurelle
 
 **A besoin d'alimentation :** `trust` et `tremor` démarrent avec des priors neutres jusqu'à ce que le feedback `learn` / les données `ghost_edges` s'accumulent, et `predict` a besoin que `ghost_edges` soit chargé avant que son signal de co-change soit significatif. Ils s'améliorent avec l'usage ; ils sont honnêtes sur le fait d'être non informés au démarrage.
+
+## Ce que m1nd N'Est Pas
+
+`m1nd` n'est pas seulement :
+
+- un outil de recherche de code avec un index plus grand
+- un layer de RAG sur le dépôt qui ne récupère que des fichiers ou des chunks
+- une base de données en graphe qui laisse les décisions de workflow au client
+- un remplacement d'analyse statique pour le compilateur, les tests ou les outils de sécurité
+- un bundle MCP d'utilitaires sans rapport
+- une surface d'outils que l'humain doit apprendre — les verbes appartiennent à l'agent ; le vôtre, c'est la petite [CLI de setup](#démarrage-rapide)
+
+C'est le layer qui transforme ces surfaces en un système opérationnel sur lequel un agent peut raisonner et agir. Pas pour les recherches mono-fichier, les grep simples, ou la vérité compilateur — utilisez des outils simples dans ces cas.
+
+## Couverture Linguistique
+
+Le raisonnement sur le graphe (`impact`, `why`, `predict`, `trace`, `taint_trace`) vaut ce que vaut l'extracteur. m1nd résout à la fois les **edges `calls`** (call graph) et les **`imports` cross-fichier** (résolution de dépendances fichier→fichier) par langage. La matrice ci-dessous a été prouvée en direct dans un seul ingest polyglotte :
+
+| Langage | `calls` | imports cross-fichier |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅ (package) |
+| Java | ✅ | ✅ (FQCN + wildcard) |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅ (package) |
+| PHP | ✅ | ✅ (PSR-4) |
+| Scala | ✅ | ✅ (package) |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | — (les namespaces ne mappent pas 1:1 aux fichiers) |
+| Swift | ✅ | — |
+
+Toutes les lignes ✅ sont vérifiées de bout en bout (un import `caller`→`callee` se résout et le caller émet des edges d'appel). Les autres langages tombent sur l'extracteur générique (uniquement `contains`). Les imports non résolvables (paquets externes, gems, stdlib, en-têtes système) sont honnêtement laissés non résolus plutôt que devinés.
 
 ## Architecture en Un Coup d'Œil
 
@@ -314,7 +394,7 @@ Versions actuelles des crates : `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` tous en `
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Aperçu de l'architecture m1nd" width="960" />
 </p>
 
-Pour la federation, les perspectives, RETROBUILDER, la coordination multi-agent, et la référence complète du pack agent et opérateur, voir le [wiki canonique](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md), et [EXAMPLES.md](../EXAMPLES.md).
+La surface MCP live évolue avec les versions — utilisez `tools/list` pour le nombre exact d'outils et les noms dans votre build. **Niveaux :** 27 outils essentiels sont annoncés par défaut pour réduire le coût de sélection des outils ; définissez `M1ND_TOOL_TIER=full` pour annoncer la surface complète (100+ outils : RETROBUILDER, perspectives, federation, daemon). Les outils cachés sont toujours appelables via `tools/call` — le niveau contrôle uniquement ce que `tools/list` expose. Le catalogue outil par outil ne vit pas dans ce README : voir le [wiki canonique](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) et [EXAMPLES.md](../EXAMPLES.md) pour la profondeur, et [CHANGELOG.md](../CHANGELOG.md) pour l'historique des versions.
 
 ## Contribuer
 

--- a/i18n/README.it.md
+++ b/i18n/README.it.md
@@ -15,7 +15,7 @@
   <a href="https://www.npmjs.com/package/@maxkle1nz/m1nd"><img src="https://img.shields.io/npm/v/@maxkle1nz/m1nd.svg?color=00f5ff&label=npm" alt="npm" /></a>
   <a href="https://crates.io/crates/m1nd-core"><img src="https://img.shields.io/crates/v/m1nd-core.svg" alt="crates.io" /></a>
   <a href="https://github.com/maxkle1nz/m1nd/actions"><img src="https://github.com/maxkle1nz/m1nd/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Licenza" /></a>
+  <a href="../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://docs.rs/m1nd-core"><img src="https://img.shields.io/docsrs/m1nd-core" alt="docs.rs" /></a>
 </p>
 
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd è intelligenza operativa per agenti di coding — governa il ciclo operativo, non solo il retrieval.**
+**m1nd è il guscio attorno al tuo agente di coding — il ciclo operativo dentro cui vive: orientato prima di agire, verdetti onesti mentre lavora, memoria con evidenza dopo che ha finito, che si accumula tra le sessioni.**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="Una pila di file sparsi diventa un grafo connesso di cosa si collega a cosa" /></p>
 
 > grep trova testo. La ricerca vettoriale trova chunk simili. `m1nd` dà agli agenti un grafo locale di cosa è connesso, cosa è cambiato, cosa si rompe, cosa è andato in drift, e dove riprendere.
 
-Tre cose che qui coesistono e non si trovano in nessun altro strumento:
+## Cos'è m1nd: il guscio attorno al tuo agente
 
-- **Grafo causale del codice** — `impact` prima di modificare mostra il blast radius che non avevi letto; `ghost_edges` fa emergere i file che cambiano sempre insieme ma non condividono alcun import.
-- **Memoria auto-verificante** — `memorize` ancora i risultati a nodi reali del codice; `cross_verify` li segnala come obsoleti quando quel codice cambia.
-- **Un layer di trust / recovery** — ogni risultato porta un trust mode; `trust_selftest` e `recovery_playbook` dicono all'agente quando il binding del workspace è sbagliato e come recuperare.
+*m1nd avvolge il tuo agente di coding in un ciclo che lo orienta prima di agire, lo tiene onesto mentre lavora, e ricorda ciò che ha imparato quando ha finito.*
 
-Più un **runtime di attenzione** — `focus` consegna all'agente il working set minimo e delimitato dal budget per un obiettivo, con una coda onesta di ciò che ha lasciato fuori e un segnale che indica se quel contesto è già *sufficiente*.
+- **Se costruisci con gli agenti** — niente di nuovo da imparare: installi una volta e continui a parlare col tuo agente. Smette di tirare a indovinare, comincia a ricordare, e dice "non lo so" quando quella è la verità.
+- **Se sei un ingegnere** — un motore a grafo in Rust, local-first, dietro un server MCP: un grafo causale del codice (edge strutturali, semantici, temporali e causali), verdetti con calibrazione conforme, e memoria ancorata a nodi di codice con provenienza. Nulla lascia la tua macchina.
+
+Gli agenti su codebase reali non falliscono perché non sanno cercare — falliscono perché non hanno un modello operativo. Ogni sessione ricostruisce il contesto da zero, modifica senza conoscere il blast radius, e non distingue un risultato vuoto che significa "non esiste nulla" da uno che significa "repository sbagliato". m1nd dà all'agente un modello duraturo del codebase — un grafo causale con spreading activation e plasticità Hebbiana — e avvolge l'intero ciclo dell'agente attorno ad esso. Le funzionalità qui non sono un catalogo; sono le stazioni di quel guscio:
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd è operato dal tuo agente, non da te.** Ogni strumento qui sotto è chiamato dall'agente stesso — automaticamente, prima e dopo il lavoro. Un umano non li esegue mai nell'uso normale; installi una volta ([Avvio Rapido](#avvio-rapido)) e continui a parlare col tuo agente come sempre.
+
+**Un guscio, tre lettori.** Lo stesso pacchetto orientato viene renderizzato per chi sta per agire: l'**agente principale** lo legge come `north` (rilasciato — la porta d'ingresso qui sotto); un **subagente** lo riceverà come il Delegation Packet, la metà di retrieval della sua spec di spawn (progettato — [docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md), §O.12); l'**umano** lo vedrà come la Pre-Flight Card sul Living Tree — il tuo progetto come un albero navigabile con post-it di memoria, che mostra cosa l'agente ha verificato vs. supposto prima che una modifica atterri (progettato, in sviluppo — [docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)). Una verità, calcolata una volta sola.
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="Una verità, due lettori — lo stesso pacchetto renderizzato per l'agente e per l'umano" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Ciclo agente tradizionale vs ciclo m1nd-grounded" width="960" />
 </p>
 
-## Novità nella 1.2.0 — il primo rilascio dell'era OMEGA
+### Cosa succede quando invii un messaggio
 
-La 1.2.0 trasforma il ciclo da "recupera, poi spera" in **pre-orientarsi → agire su verdetti calibrati → catturare ciò che hai imparato**. Il tema è lo stesso del layer di trust: un *no* onesto batte una supposizione sicura.
+Chiedi al tuo agente di sistemare qualcosa. Ecco cosa fa il guscio attorno a quel messaggio:
 
-- **`north(task)` — pre-orientamento in una sola chiamata.** La nuova porta d'ingresso compone trust, contesto del task (nodi di focus + anchor PageRank), memoria pregressa cross-sessione, un segnale di sufficienza, un `next_move`, e `honest_gaps` (ciò che m1nd *non* sa ancora). `needs_ingest` è una risposta reale per un grafo vuoto. (La composizione L1GHT-recall che integra la memoria pregressa nel packet è arrivata su `main` subito dopo il tag 1.2.0 — non è presente nel binario 1.2.0.)
-- **Calibrazione conforme sulla predizione.** `calibrate_predict` arma un gate per-repo; i verdetti leggono poi `act` / `reverify` / `abstain`, dove `abstain` significa *non calibrato o insufficiente* — un segnale per fermarsi, non un sì debole. Rilasciato dark: finché non calibri, i verdetti si fermano a `reverify`.
-- **`trust_envelope` su `seek`** (rilasciato dark) e un **verdetto `closure` su `why`** — `blocked` significa che il percorso poggia su un edge irrisolto/supposto. **`trust_band: insufficient_evidence`** è ora distinto da una banda di rischio: significa *nessuna evidenza*, la risposta onesta a freddo, non "rischio medio".
-- **La memoria ha acquisito una spina dorsale di provenienza** — le affermazioni portano età + autore reali, soppiantano affermazioni più vecchie, decadono nel tempo, e rispettano un limite di recency, così la conoscenza ricordata dichiara la propria freschezza invece di andare silenziosamente obsoleta.
-- **Co-change con Jaccard smussato** — `ghost_edges` / `predict` ora normalizzano l'accoppiamento invece di contare i co-commit grezzi (calibrazione-provata: +3 punti rispetto ai conteggi grezzi).
-- **Versione del binario + fingerprint sha** — `--version` stampa `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permettono a un host di rilevare e rifiutare un binario andato in drift.
-- **Istruzioni MCP agent-native + field report solo-locali.** Le istruzioni di `initialize` che ogni host riceve *sono* ora il ciclo operativo qui sopra. Gli agenti possono lasciare un solo segnale di telemetria per sessione — `learn` su un verdetto di retrieval, o una riga in `~/.m1nd/field-reports.jsonl` quando m1nd stesso si comporta male. Quel file è solo-locale; **m1nd non telefona mai a casa.**
+1. **Prima che il tuo agente agisca**, m1nd gli consegna la mappa viva del tuo progetto, ciò che le sessioni passate hanno imparato, quanto fidarsi di ogni pezzo — e ciò che *non* sa (`north`).
+2. **Mentre lavora**, indossa verdetti: controlla cosa romperebbe una modifica *prima* di toccare il codice (`impact`), e dove l'evidenza è sottile riceve un onesto "non lo so" invece di una supposizione sicura (`abstain`).
+3. Può chiedere perché due pezzi di codice sono connessi ed essere avvisato quando la risposta poggia su una supposizione (`why`), ed è allertato prima di attraversare un confine architetturale (`xray_gate`).
+4. **Quando finisce**, la decisione viene annotata insieme all'evidenza che la sostiene (`memorize`).
+5. Quella memoria è ancorata al codice reale — se il codice cambia in seguito, la memoria si segnala da sola come obsoleta invece di mentire in silenzio (`cross_verify`).
+6. **La tua prossima sessione parte già sapendo** — qualsiasi agente, qualsiasi strumento: Claude Code, Codex, Cursor, Gemini. Ciò che un agente impara, il successivo lo eredita.
 
-## Avvio Rapido
+## BEFORE — nasce orientato
 
-Il percorso minimo funzionante — installa dai sorgenti (sempre aggiornato), verifica la salute, collega il tuo host:
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-Poi collega il tuo host — gli stessi due comandi, uno per host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
-
-| Host | Installa l'agent pack | Collega la config MCP |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-Oppure dal canale npm: `npm install -g @maxkle1nz/m1nd`.
-
-Mappa di installazione completa, pack per host, build del runtime nativo e flag di aggiornamento: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configurazione client per client: [matrice di integrazione](../docs/IDE-INTEGRATIONS.md).
-
-### Punto di Ingresso per Agenti
+*Il tuo agente inizia ogni sessione conoscendo già il tuo progetto — e sapendo ciò che non sa.*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task): una sola chiamata d'ingresso restituisce l'intero pacchetto orientato" /></p>
 
-Gli agenti analizzano questo README. All'interno di una sessione MCP, la porta d'ingresso è un'unica chiamata — `north(task)` compone trust, contesto del task, memoria pregressa cross-sessione, un segnale di sufficienza, un `next_move` e `honest_gaps` (ciò che m1nd *non* sa ancora) in un unico pacchetto. Se riporta `needs_ingest` (grafo vuoto), o sei su un binario più vecchio, ricorri al ciclo di trust esplicito — stabilisci il trust *prima* di fidarti di qualsiasi retrieval:
+All'interno di una sessione MCP, la porta d'ingresso è un'unica chiamata — `north(task)` compone trust, contesto del task (nodi di focus + anchor PageRank), memoria pregressa cross-sessione, un segnale di sufficienza, un `next_move` e `honest_gaps` (ciò che m1nd *non* sa ancora) in un unico pacchetto, prima di qualsiasi query:
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+La risposta è un pacchetto orientato — verdetto di trust, la memoria lasciata dall'ultima sessione, e un elenco onesto di gap. Una cattura reale dal binario di `main`, leggermente rifilata:
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` compone `trust_selftest` + `orient` + `boot_memory` + `focus` — l'agente ricorre a un pezzo singolo solo quando gliene serve esattamente uno. `focus` è il runtime di attenzione di questa stazione: il working set minimo e delimitato dal budget per un obiettivo, con una coda onesta di ciò che ha lasciato fuori e un segnale che indica se quel contesto è già *sufficiente*. `needs_ingest` è una risposta reale per un grafo vuoto.
+
+Se `north` riporta `needs: "needs_ingest"`, o sei su un binario precedente alla 1.2.1 senza la composizione L1GHT-recall, l'agente ricorre al ciclo di trust esplicito — stabilire il trust *prima* di fidarsi di qualsiasi retrieval:
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ Gli agenti analizzano questo README. All'interno di una sessione MCP, la porta d
 
 **Ciclo prima sessione, in quattro mosse:** `north` (o `trust_selftest` → `ingest`) → `seek`/`audit` → `memorize` il risultato duraturo così la sessione successiva parte avvantaggiata.
 
-Quando non c'è una sessione MCP viva in cui chiamare `north` — è obsoleta, associata al repository sbagliato, o non ancora caricata — ricorri invece alla CLI host-neutral come via di fuga. Lancia un runtime isolato, lo associa al repository, e restituisce un unico envelope leggibile da macchina che definisce lo scope, stabilisce il trust, esegue l'ingest se necessario, restituisce anchor, e fa l'handoff alla prova diretta:
+## DURING — verdetti indossati mentre lavora
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*Mentre lavora, ogni risposta arriva con quanto ci si può fidare — e "non lo so" è una risposta reale.*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Ogni risultato è un verdetto — act, reverify o abstain — come porte che l'agente sceglie" /></p>
+
+L'agente non consulta m1nd; lo indossa. Ogni risposta a metà lavoro è un verdetto calibrato, non una sensazione:
+
+- **`impact` prima di toccare** mostra il blast radius che non avevi letto; `ghost_edges` fa emergere i file che cambiano sempre insieme ma non condividono alcun import.
+- **`why` porta un verdetto `closure`** — `blocked` significa che il percorso poggia su un edge irrisolto o supposto: verifica quell'edge prima di fidarti del percorso.
+- **`predict` ha calibrazione conforme** — `calibrate_predict` arma un gate per-repo; i verdetti leggono poi `act` / `reverify` / `abstain`, dove `abstain` significa *non calibrato o insufficiente* — un segnale per fermarsi, non un sì debole. Rilasciato dark: finché non calibri, i verdetti si fermano a `reverify`. L'accoppiamento di co-change è normalizzato con Jaccard smussato, non conteggi grezzi di commit (calibrazione-provata: +3 punti). *Avvertenza:* `predict` ha solo fallback strutturale finché `ghost_edges` non carica la matrice di co-change git — eseguilo prima per la reale probabilità di co-change.
+- **`xray_gate` sorveglia i confini dell'architettura** — chiamato prima di una modifica, risponde "questo cambiamento attraversa un confine di modulo proibito?" con `clear` / `caution` / `blocked`; solo un manifest ratificato può bloccare (anti-fatica da guardrail).
+- **Mission Control è disciplina della prova** — `mission_next` restituisce esattamente una mossa più guardrail `do_not`; in modalità `bug_hunt` è richiesto uno sweep diretto finale prima della chiusura, così gli agenti controllano lo spazio negativo.
+
+La stessa onestà accompagna il retrieval. Un hit di `seek` porta una lettura di `sufficiency` e un `trust_envelope` — e quando l'envelope non ha ancora alcuna riga di calibrazione misurata, limita il proprio verdetto invece di esagerare. Una cattura reale, rifilata (il primo hit è una memoria scritta dall'ultima sessione):
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### Servi un grafo, collega molti agenti
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact traccia il raggio d'impatto attraverso la rete di codice connesso prima che tu modifichi" /></p>
+
+## AFTER — il grafo si scalda
+
+*Quando il lavoro atterra, ciò che è stato imparato viene annotato con l'evidenza che lo sostiene — e resta onesto quando il codice va avanti.*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="La memoria è ancorata al codice reale; quando il codice cambia, la memoria si segnala da sola" /></p>
+
+La maggior parte degli strumenti dà all'agente un *retrieval* migliore. In questa stazione l'agente **crea conoscenza durevole e leggibile dalla macchina** che si accumula tra le sessioni e rimane onesta rispetto al codice. L1GHT trasforma la conoscenza creata in struttura graph-native che si auto-segnala quando il codice che cita cambia — le affermazioni sicure diffondono più attivazione di quelle incerte.
+
+1. **Concludi** — l'agente raggiunge qualcosa di duraturo (una decisione, un risultato verificato, perché il codice è così) e chiama `memorize` con affermazioni strutturate e percorsi `evidence`.
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+La chiamata restituisce la prova che è atterrata — questa è una risposta reale catturata, rifilata:
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **Ancora** — m1nd scrive un `.light.md` graph-native sotto `<runtime>/agent-memory/`, lo ingerisce (`adapter=light mode=merge`), e risolve ogni percorso `evidence` al nodo reale del codice tramite un edge `grounded_in` — così la conoscenza vive nello stesso spazio di attivazione del codice e emerge in `seek` / `activate` / `impact`.
+3. **Auto-load** — all'inizio di ogni sessione futura, `m1nd` ingerisce `agent-memory/` automaticamente e lo riporta in `session_handshake.agent_memory`. I risultati passati sopravvivono a un ingest `mode=replace` e sono semplicemente *lì*.
+4. **Auto-segnala la staleness** — `cross_verify(check: ["evidence_freshness"])` ri-hash ogni file citato e nomina quali affermazioni sono diventate obsolete perché il loro codice è cambiato — così la memoria ti dice quando mente invece di ingannarti. La memoria porta una spina dorsale di provenienza: le affermazioni dichiarano età + autore reali, soppiantano affermazioni più vecchie, decadono nel tempo e rispettano un limite di recency — la conoscenza ricordata dichiara la propria freschezza invece di andare silenziosamente obsoleta.
+
+Questo ciclo è stato provato live end-to-end: `memorize` → edge `grounded_in` → segnale di freshness su file modificato → sopravvive a `mode=replace` → boot auto-load. Stai chiudendo una missione delimitata? Passa `write_light_memory: true` a `mission_close` per persistere le sue affermazioni verificate allo stesso modo.
+
+**COMPOUND — la sessione successiva nasce dentro il guscio riscaldato.** Uccidi quel processo, avviane uno **nuovo** contro lo stesso runtime, e il suo primo `north(task)` porta già l'affermazione della sessione precedente — questo è uno scambio reale catturato (le due chiamate qui sopra sono avvenute in processi separati), rifilato:
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` nomina chi l'ha scritta e `stale` ri-verifica il codice citato — la sessione successiva eredita la conoscenza *e* la sua provenienza, non una stringa nuda.
+
+### Un grafo, molti agenti
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="Un processo proprietario tiene il grafo vivo; molti agenti si collegano allo stesso nucleo" /></p>
 
-L'Avvio Rapido qui sopra collega un server stdio per host — va bene per un solo agente, ma ogni processo carica il proprio grafo e detiene il proprio lease. Il deployment per cui m1nd è costruito è un proprietario, molti agenti collegati. Un unico processo proprietario detiene il grafo live:
+L'Avvio Rapido qui sotto collega un server stdio per host — va bene per un solo agente, ma ogni processo carica il proprio grafo e detiene il proprio lease. Il deployment per cui m1nd è costruito è un proprietario, molti agenti collegati. Un unico processo proprietario detiene il grafo live:
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 Un numero qualsiasi di bridge punta all'unico proprietario e ne condivide il singolo grafo live, così ciò che un agente `memorize` un altro lo richiama immediatamente — nessun reingest, nessuna copia per-agente. Le query passano su localhost, quindi resta local-first (il bind resta `127.0.0.1` a meno che tu non scelga `--bind 0.0.0.0`). Un `seek` a caldo sul bridge ha misurato ≈0.7ms su un grafo piccolo su una singola macchina — ordine di grandezza, non una garanzia: il collegamento aggiunge un round-trip su localhost, e la latenza scala con la dimensione del grafo e il carico.
 
-## Cosa m1nd Non È
+## Il materiale: onestà
 
-`m1nd` non è solo:
+*L'intero guscio è fatto di un solo materiale — m1nd preferisce dire al tuo agente "non fidarti di questo" piuttosto che lasciarlo indovinare.*
 
-- uno strumento di ricerca del codice con un indice più grande
-- un layer di RAG sul repository che recupera solo file o chunk
-- un database a grafo che lascia le decisioni di workflow al client
-- un sostituto dell'analisi statica per compilatore, test o strumenti di sicurezza
-- un bundle MCP di utility non correlate
-
-È il layer che trasforma quelle superfici in un sistema operativo su cui un agente può ragionare e agire. Non per ricerche su singolo file, semplici grep, o verità del compilatore — usa strumenti semplici in quei casi.
-
-## Perché gli Agenti ne Hanno Bisogno
-
-Senza m1nd, ogni sessione inizia con loop di grep e riorientamento manuale; i risultati della settimana scorsa sono persi, e un risultato di ricerca vuoto è indistinguibile da un binding workspace sbagliato. Con m1nd, la sessione inizia con un verdetto di trust, i risultati passati si caricano automaticamente già ancorati al codice che li supporta, e i risultati vuoti dicono *perché*.
-
-Gli agenti su codebase reali non falliscono perché non sanno cercare. Falliscono perché non hanno un modello operativo. Ricostruiscono il contesto da zero ad ogni sessione, modificano senza conoscere il blast radius, e non riescono a distinguere un risultato vuoto che significa "non esiste nulla" da uno che significa "repository sbagliato."
-
-Funziona per codebase piccoli. Crolla quando il progetto ha artefatti generati, spec, doc, cronologia nascosta di co-change, più agenti e handoff lunghi. Il problema non è solo il ragionamento dell'agente — l'agente non ha un modello duraturo della struttura del codebase. `m1nd` glielo dà: un grafo causale del codice con spreading activation attraverso dimensioni strutturali, semantiche, temporali e causali, più plasticità Hebbiana che si accumula per agente tra le sessioni.
-
-## Memoria Composta (L1GHT)
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="La memoria è ancorata al codice reale; quando il codice cambia, la memoria si segnala da sola" /></p>
-
-La maggior parte degli strumenti dà all'agente un *retrieval* migliore. `m1nd` permette anche all'agente di **creare conoscenza durevole e leggibile dalla macchina** che si accumula tra le sessioni e rimane onesta rispetto al codice. L1GHT trasforma la conoscenza creata in struttura graph-native che si auto-segnala quando il codice che cita cambia — le affermazioni sicure diffondono più attivazione di quelle incerte.
-
-Il ciclo, dall'inizio alla fine:
-
-1. **Concludi** — l'agente raggiunge qualcosa di duraturo (una decisione, un risultato verificato, perché il codice è così) e chiama `memorize` con affermazioni strutturate e percorsi `evidence`.
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **Ancora** — m1nd scrive un `.light.md` graph-native sotto `<runtime>/agent-memory/`, lo ingerisce (`adapter=light mode=merge`), e risolve ogni percorso `evidence` al nodo reale del codice tramite un edge `grounded_in` — così la conoscenza vive nello stesso spazio di attivazione del codice e emerge in `seek` / `activate` / `impact`.
-3. **Auto-load** — all'inizio di ogni sessione futura, `m1nd` ingerisce `agent-memory/` automaticamente e lo riporta in `session_handshake.agent_memory`. I risultati passati sopravvivono a un ingest `mode=replace` e sono semplicemente *lì*.
-4. **Auto-segnala la staleness** — `cross_verify(check: ["evidence_freshness"])` ri-hash ogni file citato e nomina quali affermazioni sono diventate obsolete perché il loro codice è cambiato — così la memoria ti dice quando mente invece di ingannarti.
-
-Questo ciclo è stato provato live end-to-end: `memorize` → edge `grounded_in` → segnale di freshness su file modificato → sopravvive a `mode=replace` → boot auto-load. Stai chiudendo una missione delimitata? Passa `write_light_memory: true` a `mission_close` per persistere le sue affermazioni verificate allo stesso modo. L'abitudine è documentata nelle `instructions` del server che ogni client MCP riceve all'`initialize` — host-agnostic, nessun plugin client-specifico richiesto.
-
-## Il Layer di Trust / Onestà
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Ogni risultato è un verdetto — act, reverify o abstain — come porte che l'agente sceglie" /></p>
-
-Questa è la cosa più difendibile che m1nd fa, e nessun concorrente la offre. La dottrina: **la credibilità viene dall'onestà, non dal vincere sempre.**
+Questa è la cosa più difendibile che m1nd fa, e nessun concorrente la offre. La dottrina: **la credibilità viene dall'onestà, non dal vincere sempre.** Un *no* onesto batte una supposizione sicura — ogni stazione qui sopra è fatta di quel materiale.
 
 - **`trust_selftest`** restituisce un verdetto *prima* di qualsiasi retrieval: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected`, o `degraded_host_tool_surface`. L'agente sa se procedere, eseguire ingest, rebindare, o fare fallback.
 - **`agent_runtime_contract`** è presente in ogni risposta di retrieval, portando un `trust_mode`. Un risultato vuoto è disambiguato — associato al repository sbagliato vs. genuinamente niente lì — mai riportato silenziosamente come "nessun risultato."
+- **`trust_band: insufficient_evidence` significa NESSUNA evidenza — non rischio medio.** La risposta onesta a freddo, distinta da basso/medio/alto.
 - **Array `non_claims`** presenti su ogni tool di missione. m1nd dice all'agente cosa *non* ha provato.
 - **`mission_verify` può dire no — e lo fa, nel codice testato.** Rifiuta prove solo da grafo: un'affermazione non può chiudersi senza una lettura di file, un'esecuzione di test, o un probe di runtime. Il test si chiama letteralmente `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** restituisce un elenco di passi deterministico e ordinato per riparare il binding.
 
-La prova dell'impegno è ciò che è stato eliminato per esso: `savings` e `resonate` sono stati rimossi dalla superficie pubblicizzata nella beta.7 perché uno strumento che afferma sempre di vincere non è credibile. Nessun concorrente — né mem0, Zep, Letta, Sourcegraph, né alcun MCP code-graph — offre un layer che dice all'agente cosa *non* fidarsi e come recuperare.
+Mostrato, non raccontato. Chiama `trust_selftest` su un runtime senza binding e il verdetto *è* l'istruzione di riparazione — una cattura reale, rifilata:
 
-**Il ciclo di field-triage si chiude su sé stesso.** La telemetria di sessione che gli agenti lasciano in `~/.m1nd/field-reports.jsonl` (solo-locale — m1nd non telefona mai a casa) non è un log passivo: i report vengono sottoposti a triage, e un bug sul campo *confermato* diventa un caso rosso della battery **prima** della fix, così la regressione è provata, non solo descritta. Quel ciclo è già stato eseguito una volta end-to-end: due bug segnalati sul campo sono diventati casi della battery falliti e poi fix merge — `north` ora compone il recall L1GHT nel suo packet di memoria, e la sentinella del grafo `temp` si risolve in una vera tempdir invece di sporcare la directory di lavoro.
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
 
-## Copertura Linguistica
+La prova dell'impegno è ciò che è stato eliminato per esso: `savings` e `resonate` sono stati rimossi dalla superficie pubblicizzata nella beta.7 perché uno strumento che afferma sempre di vincere non è credibile. Nessun concorrente — né mem0, Zep, Letta, Sourcegraph, né alcun MCP code-graph — offre un layer che dice all'agente di cosa *non* fidarsi e come recuperare.
 
-Il ragionamento sul grafo (`impact`, `why`, `predict`, `trace`, `taint_trace`) è valido solo quanto l'estrattore. m1nd risolve sia gli **edge `calls`** (call graph) che i **`imports` cross-file** (risoluzione delle dipendenze file→file) per linguaggio. La matrice sotto è stata provata live in un singolo ingest poliglotta:
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="I report sul campo alimentano un loop di triage che trasforma il difetto in test prima della correzione" /></p>
 
-| Linguaggio | `calls` | import cross-file |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅ (package) |
-| Java | ✅ | ✅ (FQCN + wildcard) |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅ (package) |
-| PHP | ✅ | ✅ (PSR-4) |
-| Scala | ✅ | ✅ (package) |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | — (i namespace non mappano 1:1 ai file) |
-| Swift | ✅ | — |
+**Il ciclo di field-triage si chiude su sé stesso.** La telemetria di sessione che gli agenti lasciano in `~/.m1nd/field-reports.jsonl` (solo-locale — m1nd non telefona mai a casa) non è un log passivo: i report vengono sottoposti a triage, e un bug sul campo *confermato* diventa un caso rosso della battery **prima** della fix, così la regressione è provata, non solo descritta. Quel ciclo è già stato eseguito end-to-end in uno sweep completo di field-triage: quattro bug segnalati sul campo sono diventati casi della battery falliti e poi fix merge, tutti rilasciati nella **1.2.1** — `north` ora compone il recall L1GHT nel suo packet di memoria, la sentinella del grafo `temp` si risolve in una vera tempdir invece di sporcare la directory di lavoro, `memorize` accetta una `confidence` numerica, e il tag di ambiguità della closure ora scatta solo su pareggi genuini (il falso allarme: ambiguous-blocked è sceso da 9/11 → 0/11).
 
-Tutte le righe ✅ sono verificate end-to-end (un import `caller`→`callee` si risolve e il caller emette edge di chiamata). Gli altri linguaggi cadono sull'estrattore generico (solo `contains`). Gli import non risolvibili (pacchetti esterni, gem, stdlib, header di sistema) sono onestamente lasciati irrisolti anziché indovinati.
+## Avvio Rapido
 
-## Mappa delle Capacità
+*Installa una volta, collega l'host del tuo agente e togliti di mezzo — da qui in poi, guida il tuo agente.*
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact traccia il raggio d'impatto attraverso la rete di codice connesso prima che tu modifichi" /></p>
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-La superficie MCP live si evolve con i rilasci. Usa `tools/list` per il conteggio esatto degli strumenti e i nomi nella tua build corrente.
+Poi collega il tuo host — gli stessi due comandi, uno per host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
 
-| Area | Cosa abilita | Strumenti rappresentativi |
+| Host | Installa l'agent pack | Collega la config MCP |
 |---|---|---|
-| Fondamenta del grafo | ingerire codice, mantenere lo stato del grafo, diagnosticare la continuità della sessione, rinforzare i percorsi utili, e rilevare il drift dei pesi tra sessioni | `trust_selftest`, `session_handshake`, `recovery_playbook`, `ingest`, `health`, `doctor`, `learn`, `warmup`, `drift` |
-| Retrieval e orientamento | cercare per testo, percorso, intento, struttura, o relazione prima delle letture manuali dei file | `audit`, `search`, `glob`, `seek`, `activate`, `why`, `trace` |
-| Doc e binding della conoscenza | ingerire doc universali o `L1GHT` graph-native, poi collegare i concetti al codice | `ingest(adapter="universal"\|"light")`, `document_resolve`, `document_provider_health`, `document_bindings`, `document_drift`, `auto_ingest_*` |
-| Navigazione e continuità | mantenere route stateful, handoff, baseline, e memoria investigativa tra sessioni | `perspective_*`, `trail_*`, `coverage_session`, `boot_memory`, `persist` |
-| Mission control e disciplina della prova | mantenere una route delimitata, registrare eventi, passare dall'orientamento sul grafo alla prova diretta, fare handoff, e chiudere con gap espliciti | `mission_start`, `mission_event`, `mission_next`, `mission_verify`, `mission_handoff`, `mission_close` |
-| Pianificazione e prova dei cambiamenti | ragionare su impatto, co-change, passi mancanti, percorsi di fallimento, e affermazioni strutturali | `impact`, `predict`, `validate_plan`, `missing`, `hypothesize`, `counterfactual`, `differential` |
-| Qualità, sicurezza e architettura | rilevare pattern, percorsi di taint, confini di trust, duplicazioni, violazioni di layer, flussi di tipo e target di refactoring | `scan`, `scan_all`, `heuristics_surface`, `antibody_*`, `taint_trace`, `type_trace`, `trust`, `layers`, `layer_inspect`, `twins`, `fingerprint`, `flow_simulate`, `epidemic`, `tremor`, `refactor_plan` |
-| Tempo, runtime e lavoro multi-repo | ispezionare la cronologia git, drift, edge di co-change nascosti, overlay di runtime e riferimenti cross-repo | `timeline`, `diverge`, `ghost_edges`, `runtime_overlay`, `external_references`, `federate`, `federate_auto` |
-| Operazioni e monitoraggio | verificare lo stato del repo, verificare la verità grafo-vs-disco, eseguire watch daemon, persistere lo stato, e far emergere alert durevoli | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `panoramic`, `metrics`, `report`, `persist`, `diagram`, `help` |
-| Preparazione ed esecuzione di modifiche chirurgiche | estrarre contesto connesso compatto, anteprima delle scritture, e applicare modifiche graph-aware | `surgical_context`, `surgical_context_v2`, `view`, `batch_view`, `edit_preview`, `edit_commit`, `apply`, `apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**Livelli:** 27 strumenti essenziali sono pubblicizzati di default per ridurre il costo di selezione degli strumenti; imposta `M1ND_TOOL_TIER=full` per pubblicizzare la superficie completa (100+ strumenti: RETROBUILDER, perspectives, federation, daemon). Alcuni strumenti (`resonate`, `savings`, `lock_*`) rimangono chiamabili per nome ma non sono sulla superficie pubblicizzata. Gli strumenti nascosti sono sempre chiamabili via `tools/call` — il livello controlla solo ciò che `tools/list` espone.
+Oppure dal canale npm: `npm install -g @maxkle1nz/m1nd`. `install-skills` consegna l'agent pack — il ciclo operativo stesso in cinque protocolli nominati, non documentazione decorativa.
 
-## I Cicli Operativi
+**La superficie dell'operatore è questa CLI; la superficie dell'agente è MCP.** Un umano ogni tanto esegue `m1nd doctor`, `install-skills`, `mcp-config` — l'agente esegue tutto il resto. Esiste una via di fuga host-neutral per quando non c'è una sessione MCP viva in cui chiamare `north` (obsoleta, associata al repository sbagliato, o non ancora caricata): lancia un runtime isolato, lo associa al repository, e restituisce un unico envelope leggibile da macchina che definisce lo scope, stabilisce il trust, esegue l'ingest se necessario, restituisce anchor, e fa l'handoff alla prova diretta:
 
-Il pack per agenti è parte del prodotto, non documentazione decorativa. m1nd è più potente quando l'agente riceve il *ciclo operativo*, non solo un endpoint del grafo. Cinque protocolli nominati sono inclusi nel pack:
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **Avvio Sessione** — `trust_selftest` → `recovery_playbook` se il trust non è pieno → `ingest` se necessario → `seek`/`audit`.
-- **Ricerca** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` qualsiasi risultato duraturo.
-- **Modifica Codice** — `impact(node)` per il blast radius → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` la decisione e il perché.
-- **Analisi Approfondita** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (la lente RETROBUILDER) per accoppiamento nascosto, percorsi di sicurezza, duplicati strutturali e calore di runtime.
-- **Memoria** — persisti conclusioni durevoli con `memorize`, portando `confidence` e percorsi `evidence`.
+Blocca il binario se ti serve: `--version` stampa `1.2.x (<sha>)`, e `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permettono a un host di rilevare e rifiutare un binario andato in drift.
 
-Mission Control è disciplina della prova, non un elenco di funzionalità. `mission_next` restituisce esattamente una mossa più guardrail `do_not`; `mission_verify` rifiuta affermazioni solo da grafo; `mission_close` spinge sempre l'agente a persistere la conoscenza verificata e registra gap e non-claim. In modalità `bug_hunt`, MC0 richiede un `direct_sweep` finale dopo i risultati verificati prima della chiusura, così gli agenti controllano lo spazio negativo.
-
-**Avvertenza:** `predict` ha **solo fallback strutturale** finché `ghost_edges` non carica la matrice di co-change git — esegui `ghost_edges` prima quando hai bisogno della reale probabilità di co-change.
+Mappa di installazione completa, pack per host, build del runtime nativo e flag di aggiornamento: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configurazione client per client: [matrice di integrazione](../docs/IDE-INTEGRATIONS.md).
 
 ## Evidenze
 
@@ -282,9 +331,6 @@ Ogni riga è calibrata esattamente a ciò che è stato misurato. m1nd non guida 
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="La calibrazione si guadagna per repo prima che i verdetti possano leggere act" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="Un'affermazione si chiude solo quando l'evidenza colma il divario — una lettura di file, test o sonda" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="I report sul campo alimentano un loop di triage che trasforma il difetto in test prima della correzione" />
-</p>
 </details>
 
 ## Limiti
@@ -298,6 +344,40 @@ Ogni riga è calibrata esattamente a ciò che è stato misurato. m1nd non guida 
 - il task è un'azione locale banale su file senza incertezza strutturale
 
 **Necessita di alimentazione:** `trust` e `tremor` partono con prior neutri finché non si accumula feedback da `learn` / dati da `ghost_edges`, e `predict` ha bisogno che `ghost_edges` sia caricato prima che il suo segnale di co-change sia significativo. Migliorano con l'uso; sono onesti sull'essere non informati all'avvio.
+
+## Cosa m1nd Non È
+
+`m1nd` non è solo:
+
+- uno strumento di ricerca del codice con un indice più grande
+- un layer di RAG sul repository che recupera solo file o chunk
+- un database a grafo che lascia le decisioni di workflow al client
+- un sostituto dell'analisi statica per compilatore, test o strumenti di sicurezza
+- un bundle MCP di utility non correlate
+- una superficie di strumenti che l'umano deve imparare — i verbi sono dell'agente; il tuo è la piccola [CLI di setup](#avvio-rapido)
+
+È il layer che trasforma quelle superfici in un sistema operativo su cui un agente può ragionare e agire. Non per ricerche su singolo file, semplici grep, o verità del compilatore — usa strumenti semplici in quei casi.
+
+## Copertura Linguistica
+
+Il ragionamento sul grafo (`impact`, `why`, `predict`, `trace`, `taint_trace`) è valido solo quanto l'estrattore. m1nd risolve sia gli **edge `calls`** (call graph) che i **`imports` cross-file** (risoluzione delle dipendenze file→file) per linguaggio. La matrice sotto è stata provata live in un singolo ingest poliglotta:
+
+| Linguaggio | `calls` | import cross-file |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅ (package) |
+| Java | ✅ | ✅ (FQCN + wildcard) |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅ (package) |
+| PHP | ✅ | ✅ (PSR-4) |
+| Scala | ✅ | ✅ (package) |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | — (i namespace non mappano 1:1 ai file) |
+| Swift | ✅ | — |
+
+Tutte le righe ✅ sono verificate end-to-end (un import `caller`→`callee` si risolve e il caller emette edge di chiamata). Gli altri linguaggi cadono sull'estrattore generico (solo `contains`). Gli import non risolvibili (pacchetti esterni, gem, stdlib, header di sistema) sono onestamente lasciati irrisolti anziché indovinati.
 
 ## Architettura in Sintesi
 
@@ -314,7 +394,7 @@ Versioni correnti dei crate: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` tutti `1.2.0
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Panoramica architettura m1nd" width="960" />
 </p>
 
-Per federation, perspectives, RETROBUILDER, coordinamento multi-agente e il riferimento completo del pack agenti e operatore, consulta il [wiki canonico](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) e [EXAMPLES.md](../EXAMPLES.md).
+La superficie MCP live si evolve con i rilasci — usa `tools/list` per il conteggio esatto degli strumenti e i nomi nella tua build. **Livelli:** 27 strumenti essenziali sono pubblicizzati di default per ridurre il costo di selezione degli strumenti; imposta `M1ND_TOOL_TIER=full` per pubblicizzare la superficie completa (100+ strumenti: RETROBUILDER, perspectives, federation, daemon). Gli strumenti nascosti sono sempre chiamabili via `tools/call` — il livello controlla solo ciò che `tools/list` espone. Il catalogo strumento per strumento non vive in questo README: vedi il [wiki canonico](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) e [EXAMPLES.md](../EXAMPLES.md) per la profondità, e [CHANGELOG.md](../CHANGELOG.md) per la cronologia dei rilasci.
 
 ## Contribuire
 

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd はコーディングエージェントのためのオペレーショナルインテリジェンスであり、単なる検索ではなく操作ループを統括する。**
+**m1nd はあなたのコーディングエージェントを包むシェルだ——エージェントがその中で生きる操作ループ：行動する前に方向づけられ、働いている間は誠実なバーディクトを身につけ、終えた後には証拠つきのメモリを残し、セッションをまたいで複利していく。**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="散らばったファイルの山が、何が何につながるかを示す接続されたグラフになる" /></p>
 
 > `grep` はテキストを見つける。ベクトル検索は類似チャンクを見つける。`m1nd` はエージェントに、何が繋がっていて、何が変わって、何が壊れて、何がドリフトして、どこから再開すべきかを示すローカルグラフを与える。
 
-以下の三つは他のどのツールにも同時には存在しない：
+## m1nd とは：エージェントを包むシェル
 
-- **因果コードグラフ** — 編集前に `impact` を呼ぶと、読んでいなかった爆発半径が分かる；`ghost_edges` は import 関係がないのに常に一緒に変更されるファイルを浮かび上がらせる。
-- **自己検証メモリ** — `memorize` は発見を実際のコードノードに固定する；コードが変更されると `cross_verify` がそれを古いものとして警告する。
-- **トラスト／リカバリレイヤー** — すべての結果はトラストモードを持つ；`trust_selftest` と `recovery_playbook` は、ワークスペースバインディングが間違っているときとその回復方法をエージェントに伝える。
+*m1nd はあなたのコーディングエージェントをループで包む：行動する前に方向づけ、働いている間は誠実に保ち、終えたときに学んだことを覚えておく。*
 
-加えて**アテンションランタイム** — `focus` はゴールに対する最小限で予算に制限された作業セットをエージェントに渡し、切り捨てたものの誠実なテールと、それが*十分な*コンテキストかどうかのシグナルを添える。
+- **エージェントで作る人なら** — 新しく学ぶことは何もない：一度インストールして、いつも通りエージェントと話し続けるだけ。エージェントは当て推量をやめ、記憶し始め、「わからない」が真実のときはそう言うようになる。
+- **エンジニアなら** — MCP サーバーの背後にあるローカルファーストの Rust グラフエンジン：因果コードグラフ（構造・意味・時間・因果のエッジ）、コンフォーマルにキャリブレーションされたバーディクト、プロヴェナンスつきでコードノードに固定されたメモリ。何一つあなたのマシンから出ていかない。
+
+実際のコードベースで働くエージェントが失敗するのは、検索できないからではない——操作モデルを持っていないからだ。毎セッションゼロからコンテキストを再構築し、爆発半径を知らずに編集し、「何もない」という空の結果と「間違ったリポジトリ」という空の結果を区別できない。m1nd はエージェントにコードベースの永続モデルを与える——拡散活性化と Hebbian 可塑性を持つ因果グラフ——そしてエージェントのループ全体をその周りに巻きつける。ここにある機能はカタログではない；このシェルのステーションだ：
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd を操作するのはあなたのエージェントであって、あなたではない。** 以下のすべてのツールはエージェント自身が呼び出す——働く前と後に、自動的に。通常の使用で人間がそれらを実行することはない；一度インストールしたら（[クイックスタート](#クイックスタート)）、いつも通りエージェントと話し続けるだけだ。
+
+**一つのシェル、三種類の読者。** 同じ方向づけパケットが、これから行動する者のためにレンダリングされる：**メインエージェント**はそれを `north` として読む（出荷済み——下のフロントドア）；**サブエージェント**はそれを Delegation Packet として受け取ることになる——スポーン仕様の検索半分だ（設計済み——[docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md)、§O.12）；**人間**はそれを Living Tree 上の Pre-Flight Card として見ることになる——メモリの付箋が貼られたナビゲート可能なツリーとしてのあなたのプロジェクトで、編集が着地する前にエージェントが何を検証し何を推測したかを示す（設計済み、開発中——[docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)）。一つの真実、一度だけ計算される。
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="一つの真実、二つの読者——同じパケットがエージェント用と人間用にレンダリングされる" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="従来のエージェントループ vs m1ndグラウンドループ" width="960" />
 </p>
 
-## 1.2.0 の新機能 — 最初の OMEGA 期リリース
+### メッセージを送ると何が起きるか
 
-1.2.0 はループを「取得して、あとは祈る」から**事前定向 → キャリブレーション済みの判定に基づいて行動する → 学んだことを取り込む**へと変える。テーマはトラストレイヤーと同じ：誠実な*ノー*は自信ありげな推測に勝る。
+あなたはエージェントに何かの修正を頼む。シェルはそのメッセージの周りでこう動く：
 
-- **`north(task)` — 一回の呼び出しで事前定向。** 新しいフロントドアは、トラスト、タスクコンテキスト（focus ノード + PageRank アンカー）、以前のクロスセッションメモリ、十分性シグナル、一つの `next_move`、そして `honest_gaps`（m1nd が*まだ*知らないこと）を合成する。`needs_ingest` は空のグラフに対する本物の答えだ。（以前のメモリをパケットに畳み込む L1GHT リコール合成は 1.2.0 タグの直後に `main` に着地した——1.2.0 のバイナリには含まれていない。）
-- **予測に対するコンフォーマルキャリブレーション。** `calibrate_predict` はリポジトリごとのゲートを起動する；その後、判定は `act` / `reverify` / `abstain` を読み、`abstain` は*キャリブレーションされていないか不十分*を意味する——弱い「イエス」ではなく、止まれというシグナルだ。ダークで出荷される：キャリブレーションするまで、判定は `reverify` で頭打ちになる。
-- **`seek` の `trust_envelope`**（ダークで出荷）と **`why` の `closure` 判定** — `blocked` は、パスが未解決／推測されたエッジに依存していることを意味する。**`trust_band: insufficient_evidence`** はいまやリスクバンドとは別物だ：それは*証拠なし*、誠実なコールドスタートの答えを意味し、「中リスク」ではない。
-- **メモリはプロヴェナンスの背骨を得た** — 主張は本物の経過時間 + 著者を持ち、古い主張を上書きし、時とともに失効し、リーセンシー上限を尊重する——だから記憶された知識は、静かに古びていくのではなく、自分自身のフレッシュネスを表明する。
-- **平滑化 Jaccard 共変更** — `ghost_edges` / `predict` はいまや生の共コミット数を数えるのではなく、結合を正規化する（キャリブレーションで生の数え上げに対して +3 ポイントが実証された）。
-- **バイナリバージョン + sha フィンガープリント** — `--version` は `1.2.0 (<sha>)` を印字する；`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`（+ `M1ND_STRICT_VERSION`）により、ホストはドリフトしたバイナリを検出して拒否できる。
-- **エージェントネイティブな MCP instructions + ローカル限定のフィールドレポート。** すべてのホストが受け取る `initialize` instructions は、いまや上記の操作ループそのものだ。エージェントはセッションごとに一つのテレメトリシグナルを残せる——検索判定に対する `learn`、または m1nd 自身が誤動作したときの `~/.m1nd/field-reports.jsonl` への一行。そのファイルはローカル限定だ；**m1nd は決して外部に通信しない。**
+1. **エージェントが行動する前に**、m1nd はプロジェクトの生きた地図、過去のセッションが学んだこと、各情報をどれだけ信頼すべきか——そして m1nd が*知らない*ことを手渡す（`north`）。
+2. **働いている間**、エージェントはバーディクトを身につける：コードに触れる*前に*編集が何を壊すかを確認し（`impact`）、証拠が薄いところでは自信ありげな推測の代わりに誠実な「わからない」を受け取る（`abstain`）。
+3. 二つのコードがなぜ繋がっているのかを尋ね、答えが推測に依存しているときには警告され（`why`）、アーキテクチャの境界を越える前にはアラートを受ける（`xray_gate`）。
+4. **終えたとき**、その決定は裏づけとなる証拠とともに書き留められる（`memorize`）。
+5. そのメモリは実コードに固定されている——後でコードが変わったら、メモリは黙って嘘をつく代わりに自分自身を古いものとしてフラグする（`cross_verify`）。
+6. **次のセッションは、すでに知った状態で始まる**——どのエージェントでも、どのツールでも：Claude Code、Codex、Cursor、Gemini。一つのエージェントが学んだことを、次のエージェントが継承する。
 
-## クイックスタート
+## BEFORE — 方向づけられて生まれる
 
-最小限のハッピーパス——ソースからインストール（常に最新）、ヘルスチェック、ホストへの接続：
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-次にホストを接続する——ホストごとに同じ二つのコマンド（`codex`、`claude`、`gemini`、`antigravity`、`generic`）：
-
-| ホスト | エージェントパックをインストール | MCP 設定を接続 |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-または npm から：`npm install -g @maxkle1nz/m1nd`。
-
-完全なインストールマップ、ホストパック、ネイティブランタイムビルド、更新フラグ：[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · クライアント別セットアップ：[統合マトリクス](../docs/IDE-INTEGRATIONS.md)。
-
-### エージェントエントリーポイント
+*あなたのエージェントは、毎セッションをプロジェクトをすでに知った状態で始める——そして自分が知らないことも知っている。*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task)：一度の入口呼び出しで、方向づけられたパケット全体が返る" /></p>
 
-エージェントはこの README をパースする。MCP セッション内では、フロントドアは一回の呼び出しだ——`north(task)` はトラスト、タスクコンテキスト、以前のクロスセッションメモリ、十分性シグナル、一つの `next_move`、そして `honest_gaps`（m1nd が*まだ*知らないこと）を一つのパケットに合成する。`needs_ingest`（空のグラフ）が報告された場合、または古いバイナリを使っている場合は、明示的なトラストループにフォールバックする——検索結果を信じる*前に*トラストを確立する：
+MCP セッション内では、フロントドアは一回の呼び出しだ——`north(task)` はトラスト、タスクコンテキスト（focus ノード + PageRank アンカー）、以前のクロスセッションメモリ、十分性シグナル、一つの `next_move`、そして `honest_gaps`（m1nd が*まだ*知らないこと）を、いかなるクエリよりも先に一つのパケットに合成する：
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+レスポンスは一つの方向づけパケット——トラスト判定、前のセッションが残したメモリ、そして誠実なギャップのリスト。`main` バイナリからの実際のキャプチャ、軽くトリム済み：
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` は `trust_selftest` + `orient` + `boot_memory` + `focus` を合成する——エージェントが個々の部品に直接手を伸ばすのは、まさに一つだけが必要なときだけだ。`focus` はこのステーションのアテンションランタイム：ゴールに対する最小限で予算に制限された作業セットを、切り捨てたものの誠実なテールと、それが*十分な*コンテキストかどうかのシグナルとともに渡す。`needs_ingest` は空のグラフに対する本物の答えだ。
+
+`north` が `needs: "needs_ingest"` を報告した場合、または L1GHT リコール合成のない 1.2.1 以前のバイナリを使っている場合、エージェントは明示的なトラストループにフォールバックする——検索結果を信じる*前に*トラストを確立する：
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ m1nd doctor
 
 **初回セッションループ、四ステップで：** `north`（または `trust_selftest` → `ingest`）→ `seek`/`audit` → `memorize` で永続的な発見を残し、次のセッションを先行スタートさせる。
 
-`north` を呼べるライブ MCP セッションがない場合——古くなっている、間違ったリポジトリにバインドされている、またはまだロードされていない場合——代わりにホスト中立 CLI をエスケープハッチとして使う。これは独立したランタイムを起動し、リポジトリにバインドし、スコープを定め、トラストを確立し、必要に応じてインジェストし、アンカーを返し、直接証明へとハンドオフする、機械可読な単一のエンベロープを返す：
+## DURING — 働きながら身につけるバーディクト
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*働いている間、すべての答えはどれだけ信頼すべきかとともに届く——そして「わからない」は本物の答えだ。*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="すべての結果は裁定——act、reverify、abstain——エージェントが選ぶ扉のようなもの" /></p>
+
+エージェントは m1nd に問い合わせるのではなく、身にまとう。作業中のすべての答えは、感覚ではなくキャリブレーションされたバーディクトだ：
+
+- **触れる前の `impact`** は、読んでいなかった爆発半径を見せる；`ghost_edges` は import 関係がないのに常に一緒に変更されるファイルを浮かび上がらせる。
+- **`why` は `closure` 判定を運ぶ** — `blocked` は、パスが未解決または推測されたエッジに依存していることを意味する：そのパスに頼る前に、そのエッジを検証すること。
+- **`predict` はコンフォーマルにキャリブレーションされている** — `calibrate_predict` がリポジトリごとのゲートを起動する；その後、判定は `act` / `reverify` / `abstain` を読み、`abstain` は*キャリブレーションされていないか不十分*を意味する——弱い「イエス」ではなく、止まれというシグナルだ。ダークで出荷される：キャリブレーションするまで、判定は `reverify` で頭打ちになる。共変更の結合は生のコミット数ではなく平滑化 Jaccard で正規化される（キャリブレーションで +3 ポイントが実証済み）。*注意：*`predict` は `ghost_edges` が git 共変更マトリクスをロードするまで構造的フォールバックのみ——本当の共変更可能性が必要なら先に実行すること。
+- **`xray_gate` はアーキテクチャの境界を守る** — 編集の前に呼ばれ、「この変更は禁止されたモジュール境界を越えるか？」に `clear` / `caution` / `blocked` で答える；ブロックできるのは批准されたマニフェストだけだ（ガードレール疲労対策）。
+- **Mission Control は証明の規律** — `mission_next` はちょうど一つのアクションと `do_not` ガードレールを返す；`bug_hunt` モードではクローズ前に最終の直接スイープが要求され、エージェントが負の空間を確認するようにする。
+
+同じ誠実さが検索にも乗っている。`seek` のヒットは `sufficiency` の読みと `trust_envelope` を運ぶ——そしてエンベロープにまだ計測されたキャリブレーション行がないとき、誇張する代わりに自らの判定に上限をかける。実際のキャプチャ、トリム済み（先頭のヒットは前のセッションが著述したメモリ）：
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### 一つのグラフをサーブし、多数のエージェントをアタッチする
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="編集する前に、impact が接続されたコードの網を通じて影響半径を辿る" /></p>
+
+## AFTER — グラフが温まっていく
+
+*仕事が着地したとき、学んだことは裏づけの証拠とともに書き留められる——そしてコードが先に進んでも誠実であり続ける。*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="メモリは実コードに固定される。コードが変われば、メモリ自身がフラグを立てる" /></p>
+
+ほとんどのツールはエージェントにより良い*検索*を与える。このステーションでは、エージェントが**永続的で機械可読な知識を著述**し、その知識はセッションをまたいで複利し、コードに対して誠実であり続ける。L1GHT は著述された知識をグラフネイティブな構造に変換し、引用しているコードが変更されると自動でフラグを立てる——高確信度の主張はより多くの活性化を伝播する。
+
+1. **結論を出す** — エージェントが永続的なもの（決定、検証済みの発見、コードがそうなっている理由）に到達し、構造化された主張と `evidence` パスを持って `memorize` を呼ぶ。
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+呼び出しは着地の証明を返す——これは実際にキャプチャされたレスポンス、トリム済み：
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **固定する** — m1nd は `<runtime>/agent-memory/` 下にグラフネイティブな `.light.md` を書き、インジェストし（`adapter=light mode=merge`）、`grounded_in` エッジで各 `evidence` パスを実際のコードノードに解決する——知識がコードと同じ活性化空間に存在し、`seek` / `activate` / `impact` でサーフェスされるようになる。
+3. **自動ロード** — すべての将来のセッション開始時に、`m1nd` は `agent-memory/` を自動的にインジェストし、`session_handshake.agent_memory` で報告する。過去の発見は `mode=replace` インジェストを生き延び、ただそこに*存在する*。
+4. **古さの自己フラグ立て** — `cross_verify(check: ["evidence_freshness"])` はすべての引用ファイルを再ハッシュし、コードが変更されたために古くなった主張を名指しする——だからメモリは、誤解させるのではなく、嘘をつくときに教えてくれる。メモリはプロヴェナンスの背骨を持つ：主張は本物の経過時間 + 著者を表明し、古い主張を上書きし、時とともに失効し、リーセンシー上限を尊重する——記憶された知識は、静かに古びていくのではなく、自分自身のフレッシュネスを表明する。
+
+このループはエンドツーエンドでライブ実証されている：`memorize` → `grounded_in` エッジ → 編集されたファイルのフレッシュネスフラグ → `mode=replace` を生き延びる → 起動時の自動ロード。有界ミッションを閉じるとき？`write_light_memory: true` を `mission_close` に渡すと、その検証済みの主張を同じ方法で永続化できる。
+
+**COMPOUND — 次のセッションは温まったシェルの中で生まれる。** そのプロセスを殺し、同じランタイムに対して**新しい**プロセスを起動すると、その最初の `north(task)` はすでに前のセッションの主張を運んでいる——これは実際にキャプチャされたやりとり（上の二つの呼び出しは別々のプロセスで実行された）、トリム済み：
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` は誰が著述したかを名指しし、`stale` は引用されたコードを再チェックする——次のセッションは知識を*そのプロヴェナンスごと*継承する。裸の文字列ではない。
+
+### 一つのグラフ、多数のエージェント
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="一つのオーナープロセスが生きたグラフを保持し、多数のエージェントが同じコアにアタッチする" /></p>
 
-上記のクイックスタートはホストごとに stdio サーバーを接続する——一つのエージェントには十分だが、各プロセスは自身のグラフをロードし、自身のリースを保持する。m1nd が本来向けて作られているデプロイは、一人のオーナーと多数のアタッチされたエージェントだ。一つのオーナープロセスがライブグラフを保持する：
+下のクイックスタートはホストごとに stdio サーバーを接続する——一つのエージェントには十分だが、各プロセスは自身のグラフをロードし、自身のリースを保持する。m1nd が本来向けて作られているデプロイは、一人のオーナーと多数のアタッチされたエージェントだ。一つのオーナープロセスがライブグラフを保持する：
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 任意の数のブリッジが一つのオーナーを指し、その単一のライブグラフを共有する。だから、あるエージェントが `memorize` したものを別のエージェントが即座にリコールする——再インジェストなし、エージェントごとのコピーなし。クエリは localhost を経由するので、ローカルファーストを保つ（`--bind 0.0.0.0` をオプトインしない限り、bind は `127.0.0.1` のままだ）。ブリッジ越しのウォームな `seek` は、一台のマシンの小さなグラフで ≈0.7ms を計測した——桁のオーダーであり、保証ではない：アタッチは localhost のラウンドトリップを加え、レイテンシはグラフサイズと負荷に応じてスケールする。
 
-## m1nd ではないもの
+## 素材：誠実さ
 
-`m1nd` は単なる：
+*シェル全体が一つの素材でできている——m1nd はエージェントに推測させるくらいなら、「これを信頼するな」と告げるほうを選ぶ。*
 
-- より大きなインデックスを持つコード検索ツールではない
-- ファイルやチャンクを取得するだけのリポジトリ RAG レイヤーではない
-- ワークフローの決定をクライアントに任せるグラフデータベースではない
-- コンパイラ、テスト、またはセキュリティツールの代替となる静的解析ツールではない
-- 無関係なユーティリティの MCP バンドルではない
-
-それらのサーフェスをエージェントが推論し行動できる運用システムに変えるレイヤーこそが m1nd だ。単一ファイルの検索、単純な grep、コンパイラの真実には向かない——そこでは普通のツールを使え。
-
-## エージェントがそれを必要とする理由
-
-m1nd がなければ、すべてのセッションは grep ループと手動の再定向から始まる；先週の発見は消え、空の検索結果は間違ったワークスペースバインドと区別できない。m1nd があれば、セッションはトラスト判定から始まり、過去の発見はそれを支えるコードに固定された状態で自動ロードされ、空の結果は*理由*を語る。
-
-実際のコードベースで働くエージェントが失敗するのは、検索できないからではない。操作モデルを持っていないからだ。毎セッションゼロからコンテキストを再構築し、爆発半径を知らずに編集し、「何もない」という空の結果と「間違ったリポジトリ」という空の結果を区別できない。
-
-小さなコードベースではこれでも通用する。プロジェクトに生成された成果物、仕様書、ドキュメント、隠れた共変更履歴、複数のエージェント、長い引き継ぎがあると崩壊する。問題はエージェントの推論だけではない——エージェントにはコードベースの構造に関する永続モデルがないのだ。`m1nd` がそれを与える：構造的、意味的、時間的、因果的な次元にわたって拡散活性化するとともに、セッションをまたいでエージェントごとに複利する Hebbian 可塑性を持つ因果コードグラフ。
-
-## 複利メモリ（L1GHT）
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="メモリは実コードに固定される。コードが変われば、メモリ自身がフラグを立てる" /></p>
-
-ほとんどのツールはエージェントにより良い*検索*を与える。`m1nd` はエージェントが**永続的で機械可読な知識を著述**できるようにし、その知識はセッションをまたいで複利し、コードに対して誠実であり続ける。L1GHT は著述された知識をグラフネイティブな構造に変換し、引用しているコードが変更されると自動でフラグを立てる——高確信度の主張はより多くの活性化を伝播する。
-
-エンドツーエンドのループ：
-
-1. **結論を出す** — エージェントが永続的なもの（決定、検証済みの発見、コードがそうなっている理由）に到達し、構造化された主張と `evidence` パスを持って `memorize` を呼ぶ。
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **固定する** — m1nd は `<runtime>/agent-memory/` 下にグラフネイティブな `.light.md` を書き、インジェストし（`adapter=light mode=merge`）、`grounded_in` エッジで各 `evidence` パスを実際のコードノードに解決する——知識がコードと同じ活性化空間に存在し、`seek` / `activate` / `impact` でサーフェスされるようになる。
-3. **自動ロード** — すべての将来のセッション開始時に、`m1nd` は `agent-memory/` を自動的にインジェストし、`session_handshake.agent_memory` で報告する。過去の発見は `mode=replace` インジェストを生き延び、ただそこに*存在する*。
-4. **古さの自己フラグ立て** — `cross_verify(check: ["evidence_freshness"])` はすべての引用ファイルを再ハッシュし、コードが変更されたために古くなった主張を名指しする——だからメモリは、誤解させるのではなく、嘘をつくときに教えてくれる。
-
-このループはエンドツーエンドでライブ実証されている：`memorize` → `grounded_in` エッジ → 編集されたファイルのフレッシュネスフラグ → `mode=replace` を生き延びる → 起動時の自動ロード。有界ミッションを閉じるとき？`write_light_memory: true` を `mission_close` に渡すと、その検証済みの主張を同じ方法で永続化できる。この習慣は、すべての MCP クライアントが `initialize` 時に受け取るサーバーの `instructions` に文書化されている——ホスト非依存、クライアント固有のプラグイン不要。
-
-## トラスト／誠実性レイヤー
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="すべての結果は裁定——act、reverify、abstain——エージェントが選ぶ扉のようなもの" /></p>
-
-これは m1nd が行う最も防御力の高いことであり、競合他社は誰も提供していない。教義：**信頼性は誠実さから来る、常に勝つことからではない。**
+これは m1nd が行う最も防御力の高いことであり、競合他社は誰も提供していない。教義：**信頼性は誠実さから来る、常に勝つことからではない。** 誠実な*ノー*は自信ありげな推測に勝る——上のすべてのステーションはこの素材でできている。
 
 - **`trust_selftest`** は検索*前*に判定を返す：`full_trust`、`needs_ingest`、`wrong_workspace_binding`、`stale_binding_suspected`、または `degraded_host_tool_surface`。エージェントは進むべきか、インジェストすべきか、再バインドすべきか、フォールバックすべきかを知る。
 - **`agent_runtime_contract`** はすべての検索レスポンスに乗り、`trust_mode` を運ぶ。空の結果は明確に区別される——間違ったリポジトリにバインドされているのか、本当に何もないのか——「結果なし」として静かに報告されることはない。
+- **`trust_band: insufficient_evidence` は証拠ゼロを意味する——中リスクではない。** 誠実なコールドスタートの答えであり、低／中／高とは別物だ。
 - **`non_claims` 配列** はすべてのミッションツールに付く。m1nd はエージェントに何を*証明していない*かを伝える。
 - **`mission_verify` は「ノー」と言える——そして、テストされたコードで実際にそうする。** グラフのみの証拠を拒否する：ファイル読み取り、テスト実行、またはランタイムプローブなしには主張をクローズできない。テストは文字通り `graph_only_evidence_is_not_enough` という名前だ。
 - **`recovery_playbook`** はバインディングを修復するための決定論的な順序付きステップリストを返す。
 
+語るのではなく、見せる。バインドされていないランタイムで `trust_selftest` を呼ぶと、判定そのものが修復指示になる——実際のキャプチャ、トリム済み：
+
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
+
 この約束の証明は、そのために犠牲にしたもの：`savings` と `resonate` は beta.7 で公告サーフェスから削除された、なぜなら常に勝つと主張するツールは信頼できないからだ。競合他社——mem0、Zep、Letta、Sourcegraph、またはいかなるコードグラフ MCP も——エージェントに何を*信頼しないべきか*そして回復方法を伝えるレイヤーを提供していない。
 
-**フィールドトリアージのループはそれ自身の上で閉じる。** エージェントが `~/.m1nd/field-reports.jsonl` に残すセッションテレメトリ（ローカル限定——m1nd は決して外部に通信しない）は受動的なログではない：レポートはトリアージされ、*確認された*フィールドバグは修正の**前に**赤いバッテリーケースになる——だからリグレッションは記述されるだけでなく、証明される。そのループはすでにエンドツーエンドで一度回った：二つのフィールド報告バグが失敗するバッテリーケースになり、その後マージされた修正になった——`north` はいまや L1GHT リコールをそのメモリパケットに合成し、`temp` グラフのセンチネルは作業ディレクトリを散らかす代わりに本物の tempdir に解決される。
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="フィールドレポートはトリアージループに流れ込み、修正の前に不具合をテストへ変える" /></p>
 
-## 言語カバレッジ
+**フィールドトリアージのループはそれ自身の上で閉じる。** エージェントが `~/.m1nd/field-reports.jsonl` に残すセッションテレメトリ（ローカル限定——m1nd は決して外部に通信しない）は受動的なログではない：レポートはトリアージされ、*確認された*フィールドバグは修正の**前に**赤いバッテリーケースになる——だからリグレッションは記述されるだけでなく、証明される。そのループはすでに完全なフィールドトリアージスイープでエンドツーエンドに回った：四つのフィールド報告バグが失敗するバッテリーケースになり、その後マージされた修正になり、すべて **1.2.1** で出荷された——`north` はいまや L1GHT リコールをそのメモリパケットに合成し、`temp` グラフのセンチネルは作業ディレクトリを散らかす代わりに本物の tempdir に解決され、`memorize` は数値の `confidence` を受け入れ、クロージャの曖昧さタグは本物の引き分けでのみ発火するようになった（オオカミ少年：ambiguous-blocked は 9/11 → 0/11 に低下）。
 
-グラフ推論（`impact`、`why`、`predict`、`trace`、`taint_trace`）はエクストラクターの品質に依存する。m1nd は言語ごとに **`calls` エッジ**（コールグラフ）と**クロスファイル `imports`**（ファイル→ファイルの依存解決）の両方を解決する。以下のマトリクスは単一のポリグロットインジェストでライブ実証された：
+## クイックスタート
 
-| 言語 | `calls` | クロスファイル imports |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅（パッケージ） |
-| Java | ✅ | ✅（FQCN + ワイルドカード） |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅（パッケージ） |
-| PHP | ✅ | ✅（PSR-4） |
-| Scala | ✅ | ✅（パッケージ） |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | —（名前空間はファイルに 1:1 でマップされない） |
-| Swift | ✅ | — |
+*一度インストールし、エージェントのホストを接続したら、あとは道を譲る——ここから先は、あなたのエージェントが運転する。*
 
-すべての ✅ 行はエンドツーエンドで検証されている（`caller`→`callee` の import が解決され、呼び出し元がコールエッジを発する）。他の言語はジェネリックエクストラクター（`contains` のみ）にフォールバックする。解決できない import（外部パッケージ、gem、stdlib、システムヘッダー）は、推測せず誠実に未解決のままにされる。
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-## ケイパビリティマップ
+次にホストを接続する——ホストごとに同じ二つのコマンド（`codex`、`claude`、`gemini`、`antigravity`、`generic`）：
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="編集する前に、impact が接続されたコードの網を通じて影響半径を辿る" /></p>
-
-ライブ MCP サーフェスはリリースとともに進化する。現在のビルドにおける正確なツール数と名前は `tools/list` を使って確認すること。
-
-| エリア | 有効にすること | 代表的なツール |
+| ホスト | エージェントパックをインストール | MCP 設定を接続 |
 |---|---|---|
-| グラフ基盤 | コードのインジェスト、グラフ状態の維持、セッション継続性の診断、有用なパスの強化、クロスセッションの重みドリフト検出 | `trust_selftest`、`session_handshake`、`recovery_playbook`、`ingest`、`health`、`doctor`、`learn`、`warmup`、`drift` |
-| 検索と定向 | 手動ファイル読み取りの前にテキスト、パス、意図、構造、または関係で検索 | `audit`、`search`、`glob`、`seek`、`activate`、`why`、`trace` |
-| ドキュメントと知識バインディング | ユニバーサルドキュメントまたはグラフネイティブ `L1GHT` をインジェストし、コンセプトをコードにリンクバックする | `ingest(adapter="universal"\|"light")`、`document_resolve`、`document_provider_health`、`document_bindings`、`document_drift`、`auto_ingest_*` |
-| ナビゲーションと継続性 | セッションをまたいでステートフルなルート、引き継ぎ、ベースライン、調査メモリを維持する | `perspective_*`、`trail_*`、`coverage_session`、`boot_memory`、`persist` |
-| Mission Control と証明の規律 | 有界ルートを維持し、イベントを記録し、グラフ定向から直接証明に切り替え、引き継ぎ、明示的なギャップでクローズする | `mission_start`、`mission_event`、`mission_next`、`mission_verify`、`mission_handoff`、`mission_close` |
-| 変更計画と証明 | 影響、共変更、欠落ステップ、失敗パス、構造的主張について推論する | `impact`、`predict`、`validate_plan`、`missing`、`hypothesize`、`counterfactual`、`differential` |
-| 品質、セキュリティ、アーキテクチャ | パターン、汚染パス、トラスト境界、重複、レイヤー違反、型フロー、リファクタリング対象を検出する | `scan`、`scan_all`、`heuristics_surface`、`antibody_*`、`taint_trace`、`type_trace`、`trust`、`layers`、`layer_inspect`、`twins`、`fingerprint`、`flow_simulate`、`epidemic`、`tremor`、`refactor_plan` |
-| 時間、ランタイム、マルチリポジトリ作業 | git 履歴、ドリフト、隠れた共変更エッジ、ランタイムオーバーレイ、クロスリポジトリ参照を検査する | `timeline`、`diverge`、`ghost_edges`、`runtime_overlay`、`external_references`、`federate`、`federate_auto` |
-| 運用と監視 | リポジトリの状態を監査し、グラフとディスクの真実を検証し、デーモン監視を実行し、状態を永続化し、永続アラートを浮かび上がらせる | `audit`、`cross_verify`、`daemon_*`、`alerts_*`、`panoramic`、`metrics`、`report`、`persist`、`diagram`、`help` |
-| サージカル編集の準備と実行 | コンパクトな接続済みコンテキストを取得し、書き込みをプレビューし、グラフ対応編集を適用する | `surgical_context`、`surgical_context_v2`、`view`、`batch_view`、`edit_preview`、`edit_commit`、`apply`、`apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**ティアリング：** ツール選択コストを削減するため、デフォルトでは 27 のエッセンシャルツールが公告される；`M1ND_TOOL_TIER=full` を設定するとフルサーフェス（100 以上のツール：RETROBUILDER、perspectives、federation、daemon）が公告される。いくつかのツール（`resonate`、`savings`、`lock_*`）は名前で呼び出せるが公告サーフェスには載っていない。隠されたツールは常に `tools/call` で呼び出せる——ティアリングは `tools/list` がサーフェスするものだけを制御する。
+または npm から：`npm install -g @maxkle1nz/m1nd`。`install-skills` が届けるのはエージェントパック——五つの命名されたプロトコルとしての操作ループそのものであり、装飾的なドキュメントではない。
 
-## 操作ループ
+**オペレーターのサーフェスはこの CLI；エージェントのサーフェスは MCP。** 人間が時折実行するのは `m1nd doctor`、`install-skills`、`mcp-config`——残りすべてはエージェントが実行する。`north` を呼べるライブ MCP セッションがないとき（古くなっている、間違ったリポジトリにバインドされている、まだロードされていない）のために、ホスト中立のエスケープハッチが一つ存在する：独立したランタイムを起動し、リポジトリにバインドし、スコープを定め、トラストを確立し、必要に応じてインジェストし、アンカーを返し、直接証明へとハンドオフする、機械可読な単一のエンベロープを返す：
 
-エージェントパックは製品の一部であり、装飾的なドキュメントではない。エージェントがグラフエンドポイントだけでなく*操作ループ*を受け取るとき、m1nd は最も強力になる。パックには五つの命名されたプロトコルが含まれる：
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **セッション開始** — `trust_selftest` → トラストが完全でない場合 `recovery_playbook` → 必要に応じて `ingest` → `seek`/`audit`。
-- **リサーチ** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → 永続的な発見を `memorize`。
-- **コード変更** — 爆発半径のために `impact(node)` → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → 決定と理由を `memorize`。
-- **深い分析** — `fingerprint`、`diverge`、`ghost_edges`、`taint_trace`、`twins`、`refactor_plan`、`runtime_overlay`（RETROBUILDER レンズ）、隠れた結合、セキュリティパス、構造的重複、ランタイムヒートのために。
-- **メモリ** — `confidence` と `evidence` パスを持って `memorize` で永続的な結論を残す。
+必要ならバイナリを固定できる：`--version` は `1.2.x (<sha>)` を印字し、`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`（+ `M1ND_STRICT_VERSION`）により、ホストはドリフトしたバイナリを検出して拒否できる。
 
-Mission Control は証明の規律であり、機能リストではない。`mission_next` はちょうど一つのアクションと `do_not` ガードレールを返す；`mission_verify` はグラフのみの主張を拒否する；`mission_close` は常にエージェントが検証済みの知識を永続化するよう促し、ギャップと非主張を記録する。`bug_hunt` モードでは、MC0 は検証済みの発見の後にクローズ前の最終 `direct_sweep` を要求し、エージェントが負の空間を確認するようにする。
-
-**注意：** `predict` は `ghost_edges` が git 共変更マトリクスをロードするまで**構造的フォールバックのみ**——本当の共変更可能性が必要なときは先に `ghost_edges` を実行すること。
+完全なインストールマップ、ホストパック、ネイティブランタイムビルド、更新フラグ：[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · クライアント別セットアップ：[統合マトリクス](../docs/IDE-INTEGRATIONS.md)。
 
 ## 証拠
 
@@ -282,9 +331,6 @@ Mission Control は証明の規律であり、機能リストではない。`mis
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="裁定が act を読めるようになる前に、キャリブレーションはリポジトリごとに獲得される" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="主張は、証拠が隙間に橋を架けたときにのみ閉じる——ファイル読み取り、テスト、またはプローブ" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="フィールドレポートはトリアージループに流れ込み、修正の前に不具合をテストへ変える" />
-</p>
 </details>
 
 ## 制限事項
@@ -298,6 +344,40 @@ Mission Control は証明の規律であり、機能リストではない。`mis
 - 構造的な不確実性のない単純なローカルファイル操作の場合
 
 **フィーディングが必要：** `trust` と `tremor` は `learn` フィードバック / `ghost_edges` データが蓄積されるまで中立的な事前分布から始まり、`predict` はその共変更シグナルが意味を持つ前にまず `ghost_edges` のロードが必要だ。これらは使うほど改善する；起動時に情報がないことについて誠実だ。
+
+## m1nd ではないもの
+
+`m1nd` は単なる：
+
+- より大きなインデックスを持つコード検索ツールではない
+- ファイルやチャンクを取得するだけのリポジトリ RAG レイヤーではない
+- ワークフローの決定をクライアントに任せるグラフデータベースではない
+- コンパイラ、テスト、またはセキュリティツールの代替となる静的解析ツールではない
+- 無関係なユーティリティの MCP バンドルではない
+- 人間が学ばなければならないツールサーフェスではない——動詞はエージェントのもの；あなたのものは小さな[セットアップ CLI](#クイックスタート)だ
+
+それらのサーフェスをエージェントが推論し行動できる運用システムに変えるレイヤーこそが m1nd だ。単一ファイルの検索、単純な grep、コンパイラの真実には向かない——そこでは普通のツールを使え。
+
+## 言語カバレッジ
+
+グラフ推論（`impact`、`why`、`predict`、`trace`、`taint_trace`）はエクストラクターの品質に依存する。m1nd は言語ごとに **`calls` エッジ**（コールグラフ）と**クロスファイル `imports`**（ファイル→ファイルの依存解決）の両方を解決する。以下のマトリクスは単一のポリグロットインジェストでライブ実証された：
+
+| 言語 | `calls` | クロスファイル imports |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅（パッケージ） |
+| Java | ✅ | ✅（FQCN + ワイルドカード） |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅（パッケージ） |
+| PHP | ✅ | ✅（PSR-4） |
+| Scala | ✅ | ✅（パッケージ） |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | —（名前空間はファイルに 1:1 でマップされない） |
+| Swift | ✅ | — |
+
+すべての ✅ 行はエンドツーエンドで検証されている（`caller`→`callee` の import が解決され、呼び出し元がコールエッジを発する）。他の言語はジェネリックエクストラクター（`contains` のみ）にフォールバックする。解決できない import（外部パッケージ、gem、stdlib、システムヘッダー）は、推測せず誠実に未解決のままにされる。
 
 ## アーキテクチャ概観
 
@@ -314,7 +394,7 @@ Mission Control は証明の規律であり、機能リストではない。`mis
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="m1nd アーキテクチャ概観" width="960" />
 </p>
 
-フェデレーション、perspectives、RETROBUILDER、マルチエージェント協調、および完全なエージェントパックとオペレーターリファレンスについては、[公式 wiki](https://m1nd.world/wiki/)、[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md)、[EXAMPLES.md](../EXAMPLES.md) を参照。
+ライブ MCP サーフェスはリリースとともに進化する——使用中のビルドにおける正確なツール数と名前は `tools/list` で確認すること。**ティアリング：** ツール選択コストを削減するため、デフォルトでは 27 のエッセンシャルツールが公告される；`M1ND_TOOL_TIER=full` を設定するとフルサーフェス（100 以上のツール：RETROBUILDER、perspectives、federation、daemon）が公告される。隠されたツールは常に `tools/call` で呼び出せる——ティアリングは `tools/list` がサーフェスするものだけを制御する。ツールごとのカタログはこの README には載っていない：深掘りは[公式 wiki](https://m1nd.world/wiki/)、[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md)、[EXAMPLES.md](../EXAMPLES.md) を、リリース履歴は [CHANGELOG.md](../CHANGELOG.md) を参照。
 
 ## コントリビューション
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd é inteligência operacional para agentes de código — ele governa o loop operacional, não apenas a recuperação de dados.**
+**m1nd é a casca em volta do seu agente de código — o loop operacional dentro do qual ele vive: orientado antes de agir, vereditos honestos enquanto trabalha, memória com evidência depois que termina, acumulando entre sessões.**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="Uma pilha de arquivos soltos vira um grafo conectado do que se liga a quê" /></p>
 
 > `grep` encontra texto. Busca vetorial encontra chunks similares. `m1nd` dá aos agentes um grafo local do que se conecta, o que mudou, o que quebra, o que derivou e onde retomar.
 
-Três coisas aqui coexistem em nenhuma outra ferramenta:
+## O que o m1nd é: a casca em volta do seu agente
 
-- **Grafo causal de código** — `impact` antes de editar mostra o blast radius que você não leu; `ghost_edges` revela arquivos que sempre mudam juntos mas não compartilham nenhum import.
-- **Memória auto-verificável** — `memorize` ancora descobertas a nós reais do código; `cross_verify` os marca como obsoletos quando esse código muda.
-- **Uma camada de confiança e recuperação** — cada resultado carrega um modo de confiança; `trust_selftest` e `recovery_playbook` avisam o agente quando o binding de workspace está errado e como se recuperar.
+*O m1nd envolve seu agente de código em um loop que o orienta antes de agir, o mantém honesto enquanto trabalha e lembra o que ele aprendeu quando termina.*
 
-Além de um **runtime de atenção** — `focus` entrega ao agente o conjunto de trabalho mínimo e delimitado por orçamento para um objetivo, com uma cauda honesta do que deixou de fora e um sinal de se aquilo já é contexto *suficiente*.
+- **Se você constrói com agentes** — nada novo para aprender: instale uma vez e continue conversando com seu agente. Ele para de chutar, começa a lembrar e diz "não sei" quando essa é a verdade.
+- **Se você é engenheiro** — um motor de grafo em Rust, local-first, atrás de um servidor MCP: um grafo causal de código (arestas estruturais, semânticas, temporais e causais), vereditos com calibração conformal e memória ancorada a nós de código com proveniência. Nada sai da sua máquina.
+
+Agentes em codebases reais não falham porque não sabem pesquisar — falham porque não têm um modelo operacional. Cada sessão reconstrói contexto do zero, edita sem conhecer o blast radius e não consegue distinguir um resultado vazio que significa "não existe nada" de um que significa "repositório errado". O m1nd dá ao agente um modelo durável do codebase — um grafo causal com spreading activation e plasticidade Hebbiana — e envolve o loop inteiro do agente em torno dele. As funcionalidades aqui não são um catálogo; são as estações dessa casca:
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**O m1nd é operado pelo seu agente, não por você.** Cada ferramenta abaixo é chamada pelo próprio agente — automaticamente, antes e depois de trabalhar. Um humano nunca as executa no uso normal; você instala uma vez ([Início Rápido](#início-rápido)) e continua conversando com seu agente como sempre.
+
+**Uma casca, três leitores.** O mesmo pacote orientado é renderizado para quem está prestes a agir: o **agente principal** o lê como `north` (entregue — a porta de entrada abaixo); um **subagente** vai recebê-lo como o Delegation Packet, a metade de recuperação da sua spec de spawn (projetado — [docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md), §O.12); o **humano** vai vê-lo como o Pre-Flight Card sobre a Living Tree — seu projeto como uma árvore navegável com post-its de memória, mostrando o que o agente verificou vs. chutou antes de uma edição aterrissar (projetado, em desenvolvimento — [docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)). Uma verdade, computada uma vez.
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="Uma verdade, dois leitores — o mesmo pacote renderizado para o agente e para o humano" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="Loop tradicional de agente vs loop ancorado no m1nd" width="960" />
 </p>
 
-## Novidades na 1.2.0 — o primeiro release da era OMEGA
+### O que acontece quando você manda uma mensagem
 
-A 1.2.0 transforma o loop de "recupere, depois torça" em **pré-orientar → agir sobre veredictos calibrados → capturar o que você aprendeu**. O tema é o mesmo da camada de confiança: um *não* honesto vence um palpite confiante.
+Você pede ao seu agente para consertar algo. Eis o que a casca faz em volta dessa mensagem:
 
-- **`north(task)` — pré-orientação em uma chamada.** A nova porta de entrada compõe confiança, contexto da tarefa (nós de foco + âncoras de PageRank), memória prévia entre sessões, um sinal de suficiência, um `next_move` e `honest_gaps` (o que o m1nd ainda *não* sabe). `needs_ingest` é uma resposta real para um grafo vazio. (A composição de recall L1GHT que dobra a memória prévia dentro do pacote entrou na `main` logo após a tag 1.2.0 — ela não está no binário 1.2.0.)
-- **Calibração conformal na predição.** `calibrate_predict` arma um gate por repositório; os veredictos passam então a ler `act` / `reverify` / `abstain`, onde `abstain` significa *não calibrado ou insuficiente* — um sinal para parar, não um sim fraco. Vem desativado: até você calibrar, os veredictos ficam limitados a `reverify`.
-- **`trust_envelope` no `seek`** (vem desativado) e um **veredicto `closure` no `why`** — `blocked` significa que o caminho se apoia em uma aresta não resolvida/adivinhada. **`trust_band: insufficient_evidence`** agora é distinto de uma banda de risco: significa *sem evidência*, a resposta honesta de partida a frio, não "risco médio".
-- **A memória ganhou uma espinha de proveniência** — afirmações carregam idade + autor reais, substituem afirmações mais antigas, expiram e respeitam um teto de recência, de modo que o conhecimento lembrado declara seu próprio frescor em vez de silenciosamente ficar obsoleto.
-- **Co-mudança com Jaccard suavizado** — `ghost_edges` / `predict` agora normalizam o acoplamento em vez de contar co-commits brutos (comprovado em calibração como +3 pontos sobre contagens brutas).
-- **Versão do binário + fingerprint sha** — `--version` imprime `1.2.0 (<sha>)`; `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permitem que um host detecte e recuse um binário que derivou.
-- **Instruções MCP nativas de agente + relatórios de campo apenas locais.** As instruções de `initialize` que todo host recebe agora *são* o loop operacional acima. Agentes podem deixar um sinal de telemetria por sessão — `learn` sobre um veredicto de recuperação, ou uma linha em `~/.m1nd/field-reports.jsonl` quando o próprio m1nd se comporta mal. Esse arquivo é apenas local; **o m1nd nunca liga para casa.**
+1. **Antes de o seu agente agir**, o m1nd entrega a ele o mapa vivo do seu projeto, o que sessões passadas aprenderam, quanto confiar em cada peça — e o que ele *não* sabe (`north`).
+2. **Enquanto trabalha**, ele veste vereditos: verifica o que uma edição quebraria *antes* de tocar no código (`impact`), e onde a evidência é fina recebe um honesto "não sei" em vez de um chute confiante (`abstain`).
+3. Ele pode perguntar por que duas partes do código estão conectadas e ser avisado quando a resposta se apoia em um palpite (`why`), e é alertado antes de cruzar uma fronteira de arquitetura (`xray_gate`).
+4. **Quando termina**, a decisão é anotada junto com a evidência que a sustenta (`memorize`).
+5. Essa memória é ancorada ao código real — se o código mudar depois, a memória se marca sozinha como obsoleta em vez de mentir em silêncio (`cross_verify`).
+6. **Sua próxima sessão já começa sabendo** — qualquer agente, qualquer ferramenta: Claude Code, Codex, Cursor, Gemini. O que um agente aprende, o próximo herda.
 
-## Início Rápido
+## BEFORE — nasce orientado
 
-O caminho mínimo feliz — instale a partir do fonte (sempre atualizado), verifique a saúde, conecte seu host:
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-Depois conecte seu host — os mesmos dois comandos, um por host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
-
-| Host | Instalar o pacote de agente | Conectar a config MCP |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-Ou pelo npm: `npm install -g @maxkle1nz/m1nd`.
-
-Mapa completo de instalação, pacotes de host, build nativo do runtime e flags de atualização: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuração por cliente: [matriz de integração](../docs/IDE-INTEGRATIONS.md).
-
-### Ponto de Entrada do Agente
+*Seu agente começa cada sessão já conhecendo o seu projeto — e sabendo o que não sabe.*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task): uma única chamada de entrada devolve o pacote orientado inteiro" /></p>
 
-Agentes fazem parse deste README. Dentro de uma sessão MCP, a porta de entrada é uma única chamada — `north(task)` compõe confiança, contexto da tarefa, memória prévia entre sessões, um sinal de suficiência, um `next_move` e `honest_gaps` (o que o m1nd ainda *não* sabe) em um único pacote. Se ele reportar `needs_ingest` (grafo vazio), ou você estiver em um binário mais antigo, recorra ao loop explícito de confiança — estabeleça confiança *antes* de acreditar em qualquer recuperação:
+Dentro de uma sessão MCP, a porta de entrada é uma única chamada — `north(task)` compõe confiança, contexto da tarefa (nós de foco + âncoras de PageRank), memória prévia entre sessões, um sinal de suficiência, um `next_move` e `honest_gaps` (o que o m1nd ainda *não* sabe) em um único pacote, antes de qualquer consulta:
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+A resposta é um pacote orientado — veredito de confiança, a memória que a última sessão deixou e uma lista honesta de lacunas. Uma captura real do binário da `main`, levemente aparada:
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` compõe `trust_selftest` + `orient` + `boot_memory` + `focus` — o agente só recorre a uma peça isolada quando precisa de apenas uma. `focus` é o runtime de atenção desta estação: o conjunto de trabalho mínimo e delimitado por orçamento para um objetivo, com uma cauda honesta do que ficou de fora e um sinal de se aquilo já é contexto *suficiente*. `needs_ingest` é uma resposta real para um grafo vazio.
+
+Se o `north` reportar `needs: "needs_ingest"`, ou você estiver em um binário anterior à 1.2.1 sem a composição de recall L1GHT, o agente recorre ao loop explícito de confiança — estabelecer confiança *antes* de acreditar em qualquer recuperação:
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ Agentes fazem parse deste README. Dentro de uma sessão MCP, a porta de entrada 
 
 **Loop de primeira sessão, em quatro movimentos:** `north` (ou `trust_selftest` → `ingest`) → `seek`/`audit` → `memorize` a descoberta durável para que a próxima sessão comece à frente.
 
-Quando não há uma sessão MCP viva para chamar `north` — ela está obsoleta, vinculada ao repositório errado ou ainda não carregada — recorra ao CLI neutro de host como escape hatch. Ele inicia um runtime isolado, vincula ao repositório e retorna um único envelope legível por máquina que delimita o escopo, estabelece confiança, ingere se necessário, retorna âncoras e faz o handoff para prova direta:
+## DURING — vereditos vestidos durante o trabalho
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*Enquanto ele trabalha, cada resposta chega com quanto se pode confiar nela — e "não sei" é uma resposta real.*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Todo resultado é um veredito — act, reverify ou abstain — como portas que o agente escolhe" /></p>
+
+O agente não consulta o m1nd; ele o veste. Cada resposta no meio do trabalho é um veredito calibrado, não uma vibe:
+
+- **`impact` antes de tocar** mostra o blast radius que você não leu; `ghost_edges` revela arquivos que sempre mudam juntos mas não compartilham nenhum import.
+- **`why` carrega um veredito `closure`** — `blocked` significa que o caminho se apoia em uma aresta não resolvida ou adivinhada: verifique essa aresta antes de confiar no caminho.
+- **`predict` tem calibração conformal** — `calibrate_predict` arma um gate por repositório; os vereditos passam a ler `act` / `reverify` / `abstain`, onde `abstain` significa *não calibrado ou insuficiente* — um sinal para parar, não um sim fraco. Vem desativado: até você calibrar, os vereditos ficam limitados a `reverify`. O acoplamento de co-mudança é normalizado com Jaccard suavizado, não contagens brutas de commits (comprovado em calibração: +3 pontos). *Ressalva:* `predict` tem fallback somente estrutural até que `ghost_edges` carregue a matriz de co-mudança do git — rode-o primeiro para probabilidade real de co-mudança.
+- **`xray_gate` guarda as fronteiras da arquitetura** — chamado antes de uma edição, responde "esta mudança cruza uma fronteira de módulo proibida?" com `clear` / `caution` / `blocked`; só um manifesto ratificado pode bloquear (anti-fadiga de guardrail).
+- **Mission Control é disciplina de prova** — `mission_next` retorna exatamente um movimento mais guardrails `do_not`; no modo `bug_hunt` uma varredura direta final é exigida antes do encerramento, para que agentes chequem o espaço negativo.
+
+A mesma honestidade acompanha a recuperação. Um hit de `seek` carrega uma leitura de `sufficiency` e um `trust_envelope` — e quando o envelope ainda não tem nenhuma linha de calibração medida, ele limita o próprio veredito em vez de exagerar. Uma captura real, aparada (o primeiro hit é uma memória que a última sessão escreveu):
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### Sirva um grafo, conecte muitos agentes
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact traça o raio de impacto pela teia de código conectado antes de você editar" /></p>
+
+## AFTER — o grafo fica mais quente
+
+*Quando o trabalho aterrissa, o que foi aprendido é anotado com a evidência que o sustenta — e continua honesto quando o código segue em frente.*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="A memória é ancorada ao código real; quando o código muda, a memória se sinaliza sozinha" /></p>
+
+A maioria das ferramentas dá ao agente melhor *recuperação*. Nesta estação o agente **produz conhecimento durável e legível por máquina** que se acumula entre sessões e se mantém honesto com relação ao código. L1GHT transforma o conhecimento produzido em estrutura nativa de grafo que se auto-sinaliza quando o código que cita muda — afirmações confiantes propagam mais ativação do que as incertas.
+
+1. **Concluir** — o agente chega a algo durável (uma decisão, uma descoberta verificada, por que o código é do jeito que é) e chama `memorize` com afirmações estruturadas e caminhos de `evidence`.
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+A chamada retorna a prova de que aterrissou — esta é uma resposta real capturada, aparada:
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **Ancorar** — o m1nd grava um `.light.md` nativo de grafo em `<runtime>/agent-memory/`, ingere (`adapter=light mode=merge`) e resolve cada caminho de `evidence` ao nó de código real via aresta `grounded_in` — fazendo o conhecimento viver no mesmo espaço de ativação que o código e emergir em `seek` / `activate` / `impact`.
+3. **Carga automática** — a cada início de sessão futuro, o `m1nd` ingere `agent-memory/` automaticamente e o reporta em `session_handshake.agent_memory`. Descobertas passadas sobrevivem a uma ingestão `mode=replace` e simplesmente *estão lá*.
+4. **Auto-sinalização de obsolescência** — `cross_verify(check: ["evidence_freshness"])` re-faz o hash de cada arquivo citado e nomeia quais afirmações ficaram obsoletas porque seu código mudou — assim a memória avisa quando está mentindo, em vez de induzir ao erro. A memória carrega uma espinha de proveniência: afirmações declaram idade + autor reais, substituem afirmações mais antigas, expiram e respeitam um teto de recência — o conhecimento lembrado declara seu próprio frescor em vez de silenciosamente ficar obsoleto.
+
+Este loop foi provado ao vivo de ponta a ponta: `memorize` → aresta `grounded_in` → flag de frescor em arquivo editado → sobrevive a `mode=replace` → carga automática no boot. Encerrando uma missão delimitada? Passe `write_light_memory: true` para `mission_close` para persistir suas afirmações verificadas da mesma forma.
+
+**COMPOUND — a próxima sessão nasce dentro da casca aquecida.** Mate esse processo, inicie um **novo** contra o mesmo runtime, e seu primeiro `north(task)` já carrega a afirmação da sessão anterior — esta é uma troca real capturada (as duas chamadas acima rodaram em processos separados), aparada:
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` nomeia quem a escreveu e `stale` re-verifica o código citado — a próxima sessão herda o conhecimento *e* sua proveniência, não uma string solta.
+
+### Um grafo, muitos agentes
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="Um processo dono mantém o grafo vivo; muitos agentes se conectam ao mesmo núcleo" /></p>
 
-O Início Rápido acima conecta um servidor stdio por host — ótimo para um agente, mas cada processo carrega seu próprio grafo e mantém seu próprio lease. O deployment para o qual o m1nd foi construído é um dono, muitos agentes conectados. Um processo dono mantém o grafo vivo:
+O Início Rápido abaixo conecta um servidor stdio por host — ótimo para um agente, mas cada processo carrega seu próprio grafo e mantém seu próprio lease. O deployment para o qual o m1nd foi construído é um dono, muitos agentes conectados. Um processo dono mantém o grafo vivo:
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 Qualquer número de pontes aponta para o único dono e compartilha seu único grafo vivo, de modo que o que um agente `memorize` outro recupera imediatamente — sem reingestão, sem cópia por agente. As consultas passam por localhost, então continua local-first (o bind permanece `127.0.0.1` a menos que você opte por `--bind 0.0.0.0`). Um `seek` quente sobre a ponte mediu ≈0.7ms em um grafo pequeno em uma máquina — ordem de grandeza, não uma garantia: o attach adiciona um round-trip de localhost, e a latência escala com o tamanho e a carga do grafo.
 
-## O Que o m1nd Não É
+## O material: honestidade
 
-`m1nd` não é apenas:
+*A casca inteira é feita de um único material — o m1nd prefere dizer ao seu agente "não confie nisto" a deixá-lo chutar.*
 
-- uma ferramenta de busca de código com índice maior
-- uma camada de RAG de repositório que só recupera arquivos ou chunks
-- um banco de dados de grafo que deixa as decisões de workflow para o cliente
-- um substituto de análise estática para o compilador, testes ou ferramentas de segurança
-- um bundle MCP de utilitários sem relação entre si
+Esta é a coisa mais defensável que o m1nd faz, e nenhum concorrente a entrega. A doutrina: **credibilidade vem da honestidade, não de sempre vencer.** Um *não* honesto vence um chute confiante — cada estação acima é feita desse material.
 
-Ele é a camada que transforma essas superfícies em um sistema operacional sobre o qual um agente pode raciocinar e agir. Não serve para lookups de um único arquivo, grep simples ou verdade do compilador — use ferramentas simples nesses casos.
-
-## Por Que Agentes Precisam Disso
-
-Sem o m1nd, toda sessão começa com loops de grep e reorientação manual; as descobertas da semana passada se foram, e um resultado de busca vazio é indistinguível de um binding de workspace errado. Com o m1nd, a sessão começa com um veredicto de confiança, descobertas passadas carregam automaticamente já ancoradas ao código que as sustenta, e resultados vazios dizem *por quê*.
-
-Agentes em codebases reais não falham porque não sabem pesquisar. Eles falham porque não têm um modelo operacional. Reconstroem contexto do zero a cada sessão, editam sem conhecer o blast radius, e não conseguem distinguir um resultado vazio que significa "não existe nada" de um que significa "repositório errado."
-
-Isso funciona para codebases pequenas. Desmorona quando o projeto tem artefatos gerados, specs, docs, histórico oculto de co-mudança, múltiplos agentes e handoffs longos. O problema não é apenas o raciocínio do agente — o agente não tem um modelo durável da estrutura do codebase. `m1nd` lhe dá um: um grafo causal de código com spreading activation por dimensões estruturais, semânticas, temporais e causais, mais plasticidade Hebbiana que se acumula por agente entre sessões.
-
-## Memória Composta (L1GHT)
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="A memória é ancorada ao código real; quando o código muda, a memória se sinaliza sozinha" /></p>
-
-A maioria das ferramentas dá ao agente melhor *recuperação*. `m1nd` também permite que um agente **produza conhecimento durável e legível por máquina** que se acumula entre sessões e se mantém honesto com relação ao código. L1GHT transforma o conhecimento produzido em estrutura nativa de grafo que se auto-sinaliza quando o código que cita muda — afirmações confiantes propagam mais ativação do que as incertas.
-
-O loop, do começo ao fim:
-
-1. **Concluir** — o agente chega a algo durável (uma decisão, uma descoberta verificada, por que o código é do jeito que é) e chama `memorize` com afirmações estruturadas e caminhos de `evidence`.
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **Ancorar** — o m1nd grava um `.light.md` nativo de grafo em `<runtime>/agent-memory/`, ingere (`adapter=light mode=merge`) e resolve cada caminho de `evidence` ao nó de código real via aresta `grounded_in` — fazendo o conhecimento viver no mesmo espaço de ativação que o código e emergir em `seek` / `activate` / `impact`.
-3. **Carga automática** — a cada início de sessão futuro, `m1nd` ingere `agent-memory/` automaticamente e o reporta em `session_handshake.agent_memory`. Descobertas passadas sobrevivem a uma ingestão `mode=replace` e simplesmente *estão lá*.
-4. **Auto-sinalização de obsolescência** — `cross_verify(check: ["evidence_freshness"])` re-faz o hash de cada arquivo citado e nomeia quais afirmações ficaram obsoletas porque seu código mudou — assim a memória avisa quando está mentindo, em vez de induzir ao erro.
-
-Este loop foi provado ao vivo de ponta a ponta: `memorize` → aresta `grounded_in` → flag de frescor em arquivo editado → sobrevive a `mode=replace` → carga automática no boot. Encerrando uma missão delimitada? Passe `write_light_memory: true` para `mission_close` para persistir suas afirmações verificadas da mesma forma. O hábito está documentado nas `instructions` do servidor que cada cliente MCP recebe no `initialize` — agnóstico de host, sem plugin específico de cliente necessário.
-
-## A Camada de Confiança e Honestidade
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="Todo resultado é um veredito — act, reverify ou abstain — como portas que o agente escolhe" /></p>
-
-Esta é a coisa mais defensável que o m1nd faz, e nenhum concorrente a entrega. A doutrina: **credibilidade vem da honestidade, não de sempre vencer.**
-
-- **`trust_selftest`** retorna um veredicto *antes* de qualquer recuperação: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected` ou `degraded_host_tool_surface`. O agente sabe se deve prosseguir, ingerir, rebindar ou recuar.
+- **`trust_selftest`** retorna um veredito *antes* de qualquer recuperação: `full_trust`, `needs_ingest`, `wrong_workspace_binding`, `stale_binding_suspected` ou `degraded_host_tool_surface`. O agente sabe se deve prosseguir, ingerir, rebindar ou recuar.
 - **`agent_runtime_contract`** acompanha toda resposta de recuperação, carregando um `trust_mode`. Um resultado vazio é disambiguado — vinculado ao repositório errado versus genuinamente nada lá — nunca reportado silenciosamente como "sem resultados."
+- **`trust_band: insufficient_evidence` significa NENHUMA evidência — não risco médio.** A resposta honesta de partida a frio, distinta de baixo/médio/alto.
 - **Arrays `non_claims`** são enviados em toda ferramenta de missão. O m1nd diz ao agente o que ele *não* provou.
 - **`mission_verify` pode dizer não — e diz, em código testado.** Ele rejeita evidência apenas de grafo: uma afirmação não pode ser fechada sem uma leitura de arquivo, uma execução de teste ou uma sonda de runtime. O teste literalmente se chama `graph_only_evidence_is_not_enough`.
 - **`recovery_playbook`** retorna uma lista de passos determinística e ordenada para reparar o binding.
 
+Mostrado, não contado. Chame `trust_selftest` em um runtime sem binding e o veredito *é* a instrução de reparo — uma captura real, aparada:
+
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
+
 A prova do compromisso está no que foi sacrificado por ele: `savings` e `resonate` foram removidos da superfície anunciada no beta.7 porque uma ferramenta que sempre afirma vencer não é crível. Nenhum concorrente — nem mem0, Zep, Letta, Sourcegraph ou qualquer MCP de grafo de código — entrega uma camada que diz ao agente no que *não* confiar e como se recuperar.
 
-**O loop de triagem de campo se fecha sobre si mesmo.** A telemetria de sessão que os agentes deixam em `~/.m1nd/field-reports.jsonl` (apenas local — o m1nd nunca liga para casa) não é um log passivo: os relatórios são triados, e um bug de campo *confirmado* vira um caso de bateria vermelho **antes** da correção, de modo que a regressão é provada, não apenas descrita. Esse loop já rodou uma vez de ponta a ponta: dois bugs reportados em campo viraram casos de bateria que falhavam e depois correções mergeadas — o `north` agora compõe recall L1GHT em seu pacote de memória, e a sentinela de grafo `temp` resolve para um tempdir real em vez de sujar o diretório de trabalho.
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="Relatos de campo alimentam um loop de triagem que vira o defeito em teste antes do conserto" /></p>
 
-## Cobertura de Linguagens
+**O loop de triagem de campo se fecha sobre si mesmo.** A telemetria de sessão que os agentes deixam em `~/.m1nd/field-reports.jsonl` (apenas local — o m1nd nunca liga para casa) não é um log passivo: os relatórios são triados, e um bug de campo *confirmado* vira um caso de bateria vermelho **antes** da correção, de modo que a regressão é provada, não apenas descrita. Esse loop já rodou de ponta a ponta em uma varredura completa de triagem de campo: quatro bugs reportados em campo viraram casos de bateria que falhavam e depois correções mergeadas, todos entregues na **1.2.1** — o `north` agora compõe recall L1GHT em seu pacote de memória, a sentinela de grafo `temp` resolve para um tempdir real em vez de sujar o diretório de trabalho, `memorize` aceita uma `confidence` numérica, e a tag de ambiguidade de closure agora só dispara em empates genuínos (o alarme-falso: ambiguous-blocked caiu de 9/11 → 0/11).
 
-O raciocínio de grafo (`impact`, `why`, `predict`, `trace`, `taint_trace`) é tão bom quanto o extrator. O m1nd resolve tanto **arestas `calls`** (grafo de chamadas) quanto **`imports` entre arquivos** (resolução de dependência arquivo→arquivo) por linguagem. A matriz abaixo foi provada ao vivo em uma única ingestão poliglota:
+## Início Rápido
 
-| Linguagem | `calls` | imports entre arquivos |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅ (package) |
-| Java | ✅ | ✅ (FQCN + wildcard) |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅ (package) |
-| PHP | ✅ | ✅ (PSR-4) |
-| Scala | ✅ | ✅ (package) |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | — (namespaces não mapeiam 1:1 para arquivos) |
-| Swift | ✅ | — |
+*Instale uma vez, conecte o host do seu agente e saia da frente — daqui em diante, quem dirige é o seu agente.*
 
-Todas as linhas ✅ são verificadas de ponta a ponta (um import `caller`→`callee` resolve e o caller emite arestas de chamada). Outras linguagens recaem no extrator genérico (somente `contains`). Imports não resolvíveis (pacotes externos, gems, stdlib, cabeçalhos de sistema) são honestamente deixados sem resolução em vez de serem adivinhados.
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-## Mapa de Capacidades
+Depois conecte seu host — os mesmos dois comandos, um por host (`codex`, `claude`, `gemini`, `antigravity`, `generic`):
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="impact traça o raio de impacto pela teia de código conectado antes de você editar" /></p>
-
-A superfície MCP ativa evolui com os releases. Use `tools/list` para a contagem exata de ferramentas e nomes no seu build atual.
-
-| Área | O que permite | Ferramentas representativas |
+| Host | Instalar o pacote de agente | Conectar a config MCP |
 |---|---|---|
-| Fundação do grafo | ingerir código, manter estado do grafo, diagnosticar continuidade de sessão, reforçar caminhos úteis e detectar drift de peso entre sessões | `trust_selftest`, `session_handshake`, `recovery_playbook`, `ingest`, `health`, `doctor`, `learn`, `warmup`, `drift` |
-| Recuperação e orientação | buscar por texto, caminho, intenção, estrutura ou relacionamento antes de leituras manuais de arquivo | `audit`, `search`, `glob`, `seek`, `activate`, `why`, `trace` |
-| Documentos e binding de conhecimento | ingerir docs universais ou `L1GHT` nativo de grafo e linkar conceitos de volta ao código | `ingest(adapter="universal"\|"light")`, `document_resolve`, `document_provider_health`, `document_bindings`, `document_drift`, `auto_ingest_*` |
-| Navegação e continuidade | manter rotas com estado, handoffs, baselines e memória de investigação entre sessões | `perspective_*`, `trail_*`, `coverage_session`, `boot_memory`, `persist` |
-| Mission control e disciplina de prova | manter uma rota delimitada, registrar eventos, passar de orientação por grafo para prova direta, fazer handoff e encerrar com lacunas explícitas | `mission_start`, `mission_event`, `mission_next`, `mission_verify`, `mission_handoff`, `mission_close` |
-| Planejamento e prova de mudança | raciocinar sobre impacto, co-mudança, passos faltando, caminhos de falha e afirmações estruturais | `impact`, `predict`, `validate_plan`, `missing`, `hypothesize`, `counterfactual`, `differential` |
-| Qualidade, segurança e arquitetura | detectar padrões, caminhos de taint, fronteiras de confiança, duplicação, violações de camada, fluxos de tipo e alvos de refatoração | `scan`, `scan_all`, `heuristics_surface`, `antibody_*`, `taint_trace`, `type_trace`, `trust`, `layers`, `layer_inspect`, `twins`, `fingerprint`, `flow_simulate`, `epidemic`, `tremor`, `refactor_plan` |
-| Tempo, runtime e trabalho multi-repo | inspecionar histórico git, drift, arestas ocultas de co-mudança, overlays de runtime e referências entre repositórios | `timeline`, `diverge`, `ghost_edges`, `runtime_overlay`, `external_references`, `federate`, `federate_auto` |
-| Operações e monitoramento | auditar estado do repo, verificar verdade grafo-vs-disco, rodar watches de daemon, persistir estado e surfaçar alertas duráveis | `audit`, `cross_verify`, `daemon_*`, `alerts_*`, `panoramic`, `metrics`, `report`, `persist`, `diagram`, `help` |
-| Preparação e execução de edição cirúrgica | extrair contexto conectado compacto, pré-visualizar escritas e aplicar edições conscientes do grafo | `surgical_context`, `surgical_context_v2`, `view`, `batch_view`, `edit_preview`, `edit_commit`, `apply`, `apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**Camadas:** 27 ferramentas essenciais são anunciadas por padrão para reduzir o custo de seleção de ferramentas; defina `M1ND_TOOL_TIER=full` para anunciar a superfície completa (100+ ferramentas: RETROBUILDER, perspectives, federação, daemon). Algumas ferramentas (`resonate`, `savings`, `lock_*`) permanecem chamáveis pelo nome mas não estão na superfície anunciada. Ferramentas ocultas são sempre chamáveis via `tools/call` — o tiering só controla o que `tools/list` surfaça.
+Ou pelo npm: `npm install -g @maxkle1nz/m1nd`. `install-skills` entrega o pacote de agente — o próprio loop operacional em cinco protocolos nomeados, não documentação decorativa.
 
-## Os Loops Operacionais
+**A superfície do operador é este CLI; a superfície do agente é MCP.** Um humano ocasionalmente roda `m1nd doctor`, `install-skills`, `mcp-config` — o agente roda todo o resto. Existe um escape hatch neutro de host para quando não há uma sessão MCP viva para chamar `north` (obsoleta, vinculada ao repositório errado ou ainda não carregada): ele inicia um runtime isolado, vincula ao repositório e retorna um único envelope legível por máquina que delimita o escopo, estabelece confiança, ingere se necessário, retorna âncoras e faz o handoff para prova direta:
 
-O pacote de agente é parte do produto, não documentação decorativa. O m1nd é mais poderoso quando o agente recebe o *loop operacional*, não apenas um endpoint de grafo. Cinco protocolos nomeados são entregues no pacote:
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **Início de Sessão** — `trust_selftest` → `recovery_playbook` se a confiança não for total → `ingest` se necessário → `seek`/`audit`.
-- **Pesquisa** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` qualquer descoberta durável.
-- **Mudança de Código** — `impact(node)` para blast radius → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` a decisão e o porquê.
-- **Análise Profunda** — `fingerprint`, `diverge`, `ghost_edges`, `taint_trace`, `twins`, `refactor_plan`, `runtime_overlay` (a lente RETROBUILDER) para acoplamento oculto, caminhos de segurança, duplicatas estruturais e calor de runtime.
-- **Memória** — persista conclusões duráveis com `memorize`, carregando `confidence` e caminhos de `evidence`.
+Fixe o binário se precisar: `--version` imprime `1.2.x (<sha>)`, e `M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA` (+ `M1ND_STRICT_VERSION`) permitem que um host detecte e recuse um binário que derivou.
 
-Mission Control é disciplina de prova, não uma lista de funcionalidades. `mission_next` retorna exatamente um movimento mais guardrails `do_not`; `mission_verify` rejeita afirmações apenas de grafo; `mission_close` sempre incita o agente a persistir conhecimento verificado e registra lacunas e non-claims. No modo `bug_hunt`, o MC0 exige um `direct_sweep` final direto após as descobertas verificadas antes do encerramento, para que os agentes verifiquem o espaço negativo.
-
-**Ressalva:** `predict` tem **fallback somente estrutural** até que `ghost_edges` carregue a matriz de co-mudança do git — rode `ghost_edges` primeiro quando precisar de probabilidade real de co-mudança.
+Mapa completo de instalação, pacotes de host, build nativo do runtime e flags de atualização: [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · configuração por cliente: [matriz de integração](../docs/IDE-INTEGRATIONS.md).
 
 ## Evidências
 
@@ -282,9 +331,6 @@ Cada linha é calibrada exatamente ao que foi medido. O m1nd não lidera com nú
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="A calibração é conquistada por repo antes de os vereditos poderem ler act" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="Uma afirmação só fecha quando a evidência faz a ponte — uma leitura de arquivo, teste ou sonda" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="Relatos de campo alimentam um loop de triagem que vira o defeito em teste antes do conserto" />
-</p>
 </details>
 
 ## Limites
@@ -298,6 +344,40 @@ Cada linha é calibrada exatamente ao que foi medido. O m1nd não lidera com nú
 - a tarefa é uma ação local trivial em arquivo sem incerteza estrutural
 
 **Precisa ser alimentado:** `trust` e `tremor` começam com priors neutros até que o feedback de `learn` / os dados de `ghost_edges` se acumulem, e `predict` precisa que `ghost_edges` esteja carregado primeiro para que seu sinal de co-mudança seja significativo. Eles melhoram com o uso; são honestos sobre estarem sem informação no boot.
+
+## O Que o m1nd Não É
+
+`m1nd` não é apenas:
+
+- uma ferramenta de busca de código com índice maior
+- uma camada de RAG de repositório que só recupera arquivos ou chunks
+- um banco de dados de grafo que deixa as decisões de workflow para o cliente
+- um substituto de análise estática para o compilador, testes ou ferramentas de segurança
+- um bundle MCP de utilitários sem relação entre si
+- uma superfície de ferramentas que o humano precisa aprender — os verbos são do agente; o seu é o pequeno [CLI de setup](#início-rápido)
+
+Ele é a camada que transforma essas superfícies em um sistema operacional sobre o qual um agente pode raciocinar e agir. Não serve para lookups de um único arquivo, grep simples ou verdade do compilador — use ferramentas simples nesses casos.
+
+## Cobertura de Linguagens
+
+O raciocínio de grafo (`impact`, `why`, `predict`, `trace`, `taint_trace`) é tão bom quanto o extrator. O m1nd resolve tanto **arestas `calls`** (grafo de chamadas) quanto **`imports` entre arquivos** (resolução de dependência arquivo→arquivo) por linguagem. A matriz abaixo foi provada ao vivo em uma única ingestão poliglota:
+
+| Linguagem | `calls` | imports entre arquivos |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅ (package) |
+| Java | ✅ | ✅ (FQCN + wildcard) |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅ (package) |
+| PHP | ✅ | ✅ (PSR-4) |
+| Scala | ✅ | ✅ (package) |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | — (namespaces não mapeiam 1:1 para arquivos) |
+| Swift | ✅ | — |
+
+Todas as linhas ✅ são verificadas de ponta a ponta (um import `caller`→`callee` resolve e o caller emite arestas de chamada). Outras linguagens recaem no extrator genérico (somente `contains`). Imports não resolvíveis (pacotes externos, gems, stdlib, cabeçalhos de sistema) são honestamente deixados sem resolução em vez de serem adivinhados.
 
 ## Arquitetura em Resumo
 
@@ -314,7 +394,7 @@ Versões atuais dos crates: `m1nd-core`, `m1nd-ingest`, `m1nd-mcp` todos em `1.2
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="Visão geral da arquitetura do m1nd" width="960" />
 </p>
 
-Para federação, perspectives, RETROBUILDER, coordenação multiagente e a referência completa de pacote de agente e operador, consulte a [wiki canônica](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) e [EXAMPLES.md](../EXAMPLES.md).
+A superfície MCP ativa evolui com os releases — use `tools/list` para a contagem exata de ferramentas e nomes no seu build. **Camadas:** 27 ferramentas essenciais são anunciadas por padrão para reduzir o custo de seleção de ferramentas; defina `M1ND_TOOL_TIER=full` para anunciar a superfície completa (100+ ferramentas: RETROBUILDER, perspectives, federação, daemon). Ferramentas ocultas são sempre chamáveis via `tools/call` — o tiering só controla o que `tools/list` anuncia. O catálogo ferramenta a ferramenta não vive neste README: veja a [wiki canônica](https://m1nd.world/wiki/), [docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) e [EXAMPLES.md](../EXAMPLES.md) para profundidade, e [CHANGELOG.md](../CHANGELOG.md) para o histórico de releases.
 
 ## Contribuindo
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -36,65 +36,83 @@
 
 ---
 
-**m1nd 是面向代码智能体的操作智能——它掌管的是操作循环，而不仅仅是检索。**
+**m1nd 是包裹你的代码智能体的外壳——它生活于其中的操作循环：行动之前先定向，工作之中带着诚实的裁决，完成之后留下带证据的记忆，并且跨会话复利。**
 
 <p align="center"><img src="../docs/assets/visuals/01-code-to-graph.png" width="520" alt="一堆散乱的文件变成一张相互连接的图，展示什么与什么相连" /></p>
 
 > grep 能找到文本。向量搜索能找到相似片段。`m1nd` 给智能体一张本地图，显示什么与什么相连、什么发生了变化、什么会崩溃、什么产生了漂移，以及从哪里恢复。
 
-以下三点在任何其他工具中都不同时存在：
+## m1nd 是什么：包裹智能体的外壳
 
-- **因果代码图** — 编辑前调用 `impact` 可看清你没读到的爆炸半径；`ghost_edges` 会找出那些总是一起变动但没有任何 import 关系的文件。
-- **自我验证记忆** — `memorize` 将发现锚定到真实代码节点；当代码变更时，`cross_verify` 会将其标记为过期。
-- **信任 / 恢复层** — 每个结果都附带信任模式；`trust_selftest` 和 `recovery_playbook` 会告知智能体工作区绑定何时出错以及如何恢复。
+*m1nd 用一个循环包裹你的代码智能体：行动之前为它定向，工作之中让它保持诚实，完成之后记住它学到的东西。*
 
-此外还有一个**注意力运行时**——`focus` 为一个目标向智能体交付最小的、受预算约束的工作集，附带一条诚实的尾部列出它遗漏了什么，以及一个信号来判断上下文*是否已足够*。
+- **如果你用智能体来构建** — 没有任何新东西要学：装一次，继续和你的智能体对话。它不再瞎猜、开始记忆，并在"不知道"是真话时说"不知道"。
+- **如果你是工程师** — 一个本地优先的 Rust 图引擎，藏在一个 MCP 服务器之后：一张因果代码图（结构、语义、时间和因果边）、保形校准的裁决，以及带溯源、锚定在代码节点上的记忆。没有任何东西离开你的机器。
+
+在真实代码库上工作的智能体失败，不是因为不会搜索——而是因为没有操作模型。每次会话都从头重建上下文，在不知道爆炸半径的情况下编辑，无法区分意味着"什么都不存在"的空结果和意味着"仓库错误"的空结果。m1nd 给智能体一个代码库的持久模型——一张带扩散激活和 Hebbian 可塑性的因果图——并把智能体的整个循环包在它周围。这里的功能不是一份目录；它们是这个外壳的各个站点：
+
+```mermaid
+flowchart LR
+    B["<b>BEFORE</b><br/>born oriented<br/>map + memory + trust + honest gaps"]
+    D["<b>DURING</b><br/>verdicts worn while working<br/>impact before touching · act / reverify / abstain"]
+    A["<b>AFTER</b><br/>memorized with evidence<br/>the graph gets warmer"]
+    C["<b>COMPOUND</b><br/>the next session starts ahead<br/>any host, any agent"]
+    B --> D --> A --> C --> B
+```
+
+**m1nd 由你的智能体来操作，而不是由你。** 下面的每个工具都由智能体自己调用——在它工作之前和之后自动进行。正常使用中人类从不运行它们；你安装一次（[快速开始](#快速开始)），然后像往常一样继续和你的智能体对话。
+
+**一个外壳，三种读者。** 同一个定向数据包为即将行动的任何一方渲染：**主智能体**以 `north` 的形式读取它（已交付——见下方的前门）；**子智能体**将以 Delegation Packet 的形式接收它，即其孵化规格的检索半部（已设计——[docs/NEXTGEN-AGENT-PRD.md](../docs/NEXTGEN-AGENT-PRD.md)，§O.12）；**人类**将在 Living Tree 上以 Pre-Flight Card 的形式看到它——你的项目化作一棵可导航的树，贴着记忆便利贴，在编辑落地之前展示智能体验证了什么、猜测了什么（已设计，开发中——[docs/HUMAN-LAYER-PRD.md](../docs/HUMAN-LAYER-PRD.md)）。一个真相，只计算一次。
+
+<p align="center"><img src="../docs/assets/plates/p6.png" width="560" alt="一个真相，两种读者——同一个数据包为智能体和人类分别渲染" /></p>
 
 <p align="center">
   <img src="../.github/m1nd-agent-first-map-v2.jpeg" alt="传统智能体循环 vs m1nd 接地循环" width="960" />
 </p>
 
-## 1.2.0 新特性——首个 OMEGA 时代版本
+### 当你发出一条消息时会发生什么
 
-1.2.0 将循环从"检索，然后寄希望"转变为**预定向 → 依据校准过的裁决行动 → 捕获所学**。主题与信任层一致：诚实的"不"胜过自信的猜测。
+你请智能体修复某个东西。外壳围绕这条消息做的事情如下：
 
-- **`north(task)` — 一次调用即可预定向。** 这个新的前门整合了信任、任务上下文（focus 节点 + PageRank 锚点）、先前的跨会话记忆、一个充分性信号、一个 `next_move`，以及 `honest_gaps`（m1nd *尚不*知道的内容）。对于空图，`needs_ingest` 是一个真实的答案。（将先前记忆折叠进数据包的 L1GHT-recall 整合是在 1.2.0 标签之后才落到 `main` 上的——它不在 1.2.0 二进制文件中。）
-- **预测上的保形校准。** `calibrate_predict` 为每个仓库装配一道闸门；此后裁决读作 `act` / `reverify` / `abstain`，其中 `abstain` 意味着*未校准或不充分*——一个停止信号，而不是弱肯定。默认隐藏出厂：在你校准之前，裁决最高只到 `reverify`。
-- **`seek` 上的 `trust_envelope`**（隐藏出厂）以及 **`why` 上的 `closure` 裁决**——`blocked` 意味着该路径依赖于一条未解析/猜测的边。**`trust_band: insufficient_evidence`** 现在与风险等级截然不同：它意味着*没有证据*，是诚实的冷启动答案，而非"中等风险"。
-- **记忆长出了一条溯源脊柱**——声明携带真实的年龄 + 作者、取代更旧的声明、随时间老化，并遵守一个新近度上限，因此被记住的知识会陈述自己的新鲜度，而不是悄然过期。
-- **平滑化 Jaccard 共变更**——`ghost_edges` / `predict` 现在对耦合进行归一化，而不是统计原始的共提交次数（经校准证明，比原始计数高出 +3 个点）。
-- **二进制版本 + sha 指纹**——`--version` 打印 `1.2.0 (<sha>)`；`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`（+ `M1ND_STRICT_VERSION`）让宿主能够检测并拒绝一个漂移的二进制文件。
-- **智能体原生的 MCP 指令 + 仅本地的现场报告。** 每个宿主收到的 `initialize` 指令现在*就是*上述操作循环。智能体每个会话可以留下一个遥测信号——对某个检索裁决执行 `learn`，或在 m1nd 自身行为异常时在 `~/.m1nd/field-reports.jsonl` 中写一行。该文件仅在本地；**m1nd 从不回传数据。**
+1. **在你的智能体行动之前**，m1nd 把项目的活地图、过去会话学到的内容、每条信息该信多少——以及它*不*知道什么——交到它手上（`north`）。
+2. **在它工作时**，它佩戴着裁决：在碰代码*之前*先检查一次编辑会弄坏什么（`impact`）；在证据单薄之处，它得到一句诚实的"我不知道"，而不是一个自信的猜测（`abstain`）。
+3. 它可以问两段代码为何相连，并在答案依赖猜测时被告知（`why`）；在跨越架构边界之前会被警告（`xray_gate`）。
+4. **当它完成时**，决策连同支撑它的证据一起被记录下来（`memorize`）。
+5. 这份记忆锚定在真实代码上——如果代码后来变了，记忆会自我标记为过期，而不是默默撒谎（`cross_verify`）。
+6. **你的下一次会话开局就已知情**——任何智能体、任何工具：Claude Code、Codex、Cursor、Gemini。一个智能体学到的，下一个继承。
 
-## 快速开始
+## BEFORE — 生来就有方向
 
-最简快捷路径——从源码安装（始终最新）、检查健康状态、连接你的宿主：
-
-```bash
-git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
-npm install -g .
-m1nd doctor
-```
-
-然后连接你的宿主——每个宿主使用相同的两条命令（`codex`、`claude`、`gemini`、`antigravity`、`generic`）：
-
-| 宿主 | 安装智能体包 | 连接 MCP 配置 |
-|---|---|---|
-| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
-| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
-| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
-| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
-| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
-
-或通过 npm：`npm install -g @maxkle1nz/m1nd`。
-
-完整安装指南、宿主包、原生运行时构建和更新标志：[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · 逐客户端配置：[集成矩阵](../docs/IDE-INTEGRATIONS.md)。
-
-### 智能体入口点
+*你的智能体每次会话开始时就已经了解你的项目——并且知道自己不知道什么。*
 
 <p align="center"><img src="../docs/assets/visuals/02-north-one-call.png" width="520" alt="north(task)：一次入口调用即返回完整的定向数据包" /></p>
 
-智能体会解析此 README。在 MCP 会话内，前门是一次调用——`north(task)` 将信任、任务上下文、先前的跨会话记忆、一个充分性信号、一个 `next_move` 以及 `honest_gaps`（m1nd *尚不*知道的内容）整合成一个数据包。如果它报告 `needs_ingest`（空图），或者你使用的是较旧的二进制文件，则退回到显式的信任循环——在相信任何检索结果*之前*先建立信任：
+在 MCP 会话内，前门是一次调用——`north(task)` 将信任、任务上下文（focus 节点 + PageRank 锚点）、先前的跨会话记忆、一个充分性信号、一个 `next_move` 以及 `honest_gaps`（m1nd *尚不*知道的内容）整合成一个数据包，先于任何查询：
+
+```jsonc
+{"method":"tools/call","params":{"name":"north",
+  "arguments":{"agent_id":"dev","task":"harden the JWT auth token validation flow"}}}
+```
+
+响应是一个定向数据包——信任裁决、上次会话留下的记忆，以及一份诚实的缺口清单。来自 `main` 二进制的一次真实捕获，略作裁剪：
+
+```jsonc
+{
+  "binding": { "trust_mode": "full_trust", "ok": true },      // verdict before retrieval
+  "memory": [                                                 // recalled from a PRIOR session
+    { "claim": "AuthTokenFlow", "source_agent": "authbot", "age_ms": 221, "stale": false }
+    // …other claims from the same authored note, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.64,
+    "why": "the strongest match left out still scores 0.30 — relevant context did not fit …" },
+  "next_move": "Call `surgical_context` on the top focus node to ground the task before editing.",
+  "honest_gaps": []                                           // nothing withheld on this graph
+}
+```
+
+`north` 由 `trust_selftest` + `orient` + `boot_memory` + `focus` 组合而成——智能体只有在恰好只需要一件时才单独调用某个部件。`focus` 是这个站点的注意力运行时：为一个目标交付最小的、受预算约束的工作集，附带一条诚实的尾部列出它遗漏了什么，以及一个信号来判断上下文*是否已足够*。对于空图，`needs_ingest` 是一个真实的答案。
+
+如果 `north` 报告 `needs: "needs_ingest"`，或者你使用的是 1.2.1 之前、没有 L1GHT-recall 整合的二进制，智能体会退回到显式的信任循环——在相信任何检索结果*之前*先建立信任：
 
 ```jsonc
 // 0. Trust the binding in one call (verdict before retrieval)
@@ -112,17 +130,100 @@ m1nd doctor
 
 **首次会话循环，四步完成：** `north`（或 `trust_selftest` → `ingest`）→ `seek`/`audit` → `memorize` 持久化发现，让下次会话提前起跑。
 
-当没有可供调用 `north` 的活跃 MCP 会话时——它已过期、绑定到错误仓库，或尚未加载——请转而使用宿主中立的 CLI 作为应急出口。它会启动一个隔离的运行时、将其绑定到仓库，并返回一个机器可读的信封，完成界定范围、建立信任、按需摄入、返回锚点，并交接给直接证明：
+## DURING — 工作时佩戴的裁决
 
-```bash
-m1nd agent first-minute --repo /your/project --query "understand this system" --json
+*在它工作时，每个答案都附带可信程度——而"我不知道"是一个真实的答案。*
+
+<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="每个结果都是一个裁决——act、reverify 或 abstain——如同智能体必须选择的门" /></p>
+
+智能体不是查询 m1nd；它把 m1nd 穿在身上。工作过程中的每个答案都是校准过的裁决，而不是感觉：
+
+- **动手前先 `impact`**，看清你没读到的爆炸半径；`ghost_edges` 会找出那些总是一起变动但没有任何 import 关系的文件。
+- **`why` 附带一个 `closure` 裁决**——`blocked` 意味着该路径依赖于一条未解析或猜测的边：在依赖这条路径之前先验证那条边。
+- **`predict` 经过保形校准**——`calibrate_predict` 为每个仓库装配一道闸门；此后裁决读作 `act` / `reverify` / `abstain`，其中 `abstain` 意味着*未校准或不充分*——一个停止信号，而不是弱肯定。默认隐藏出厂：在你校准之前，裁决最高只到 `reverify`。共变更耦合采用平滑化 Jaccard 归一化，而不是原始提交计数（经校准证明 +3 个点）。*注意：*在 `ghost_edges` 加载 git 共变更矩阵之前，`predict` 仅有结构回退——需要真实共变更可能性时请先运行它。
+- **`xray_gate` 守卫架构边界**——在编辑之前调用，它回答"这次变更是否跨越了被禁止的模块边界？"，给出 `clear` / `caution` / `blocked`；只有经过批准的清单才能阻止（防护栏疲劳对策）。
+- **Mission Control 是证明纪律**——`mission_next` 恰好返回一个动作加 `do_not` 护栏；在 `bug_hunt` 模式下，关闭前要求一次最终的直接扫查，以便智能体检查负空间。
+
+同样的诚实也贯穿检索。一次 `seek` 命中附带一份 `sufficiency` 读数和一个 `trust_envelope`——当信封还没有测量过任何校准行时，它会限制自己的裁决而不是夸大。一次真实捕获，略作裁剪（首个命中是上次会话撰写的一条记忆）：
+
+```jsonc
+{
+  "results": [
+    { "label": "AuthTokenFlow", "source_agent": "authbot", "authored_ms_ago": 101161, "score": 0.48 }
+    // …code-node hits, trimmed…
+  ],
+  "sufficiency": { "state": "gathering", "top_score": 0.48,
+    "why": "the strongest match left out still scores 0.25 — relevant context did not fit …" },
+  "trust_envelope": {
+    "calibrated": false,               // no calibration row measured
+    "verdict": "reverify",             // …so the verdict is capped below `act`
+    "next_repair_call": "trust_selftest"
+  }
+}
 ```
 
-### 服务一张图，附着多个智能体
+<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="在你编辑之前，impact 沿着相互连接的代码之网追踪影响半径" /></p>
+
+## AFTER — 图谱越来越热
+
+*当工作落地时，所学的内容连同支撑它的证据一起被记录下来——并且在代码继续演进时保持诚实。*
+
+<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="记忆锚定在真实代码上；代码一旦变化，记忆会自我标记" /></p>
+
+大多数工具给智能体更好的*检索*。在这个站点，智能体**撰写持久的、机器可读的知识**，这些知识跨会话复利，并对代码保持诚实。L1GHT 将撰写的知识转化为图原生结构，当其所引用的代码发生变化时自动标记——高置信度的声明比不确定的声明传播更多激活。
+
+1. **得出结论** — 智能体得到持久性结论（一个决策、一个经过验证的发现、代码为何如此设计），并用结构化声明和 `evidence` 路径调用 `memorize`。
+
+```jsonc
+memorize({
+  "agent_id": "authbot",
+  "node_label": "AuthTokenFlow",
+  "claims": [
+    { "label": "TokenValidator",
+      "text": "TokenValidator validates JWTs via HMAC — rotate keys via KMS only",
+      "confidence": "high", "evidence": ["src/auth/token.rs"] }
+  ]
+})
+```
+
+调用返回落地的证明——这是一条真实捕获的响应，略作裁剪：
+
+```jsonc
+{
+  "ok": true,
+  "claims_written": 1,
+  "light_evidence_resolved": 1, "light_evidence_unresolved": 0,   // the evidence path bound to a real code node
+  "path": ".../agent-memory/authtokenflow.light.md",
+  "next_action": "Memory anchored to code and will auto-load next session; cross_verify(check:[\"evidence_freshness\"]) flags it if the cited code changes."
+}
+```
+
+2. **锚定** — m1nd 在 `<runtime>/agent-memory/` 下写入图原生 `.light.md`，摄入它（`adapter=light mode=merge`），并通过 `grounded_in` 边将每条 `evidence` 路径解析到真实代码节点——让知识与代码处于同一激活空间，并在 `seek` / `activate` / `impact` 中浮现。
+3. **自动加载** — 在每次未来会话开始时，`m1nd` 自动摄入 `agent-memory/` 并在 `session_handshake.agent_memory` 中报告。过去的发现在 `mode=replace` 摄入后依然存活，随时*就在那里*。
+4. **自动标记过期** — `cross_verify(check: ["evidence_freshness"])` 对每个引用文件重新哈希，并指出哪些声明因其代码变更而过期——这样记忆会在它撒谎时告诉你，而不是误导你。记忆还带有一条溯源脊柱：声明陈述真实的年龄 + 作者、取代更旧的声明、随时间老化，并遵守一个新近度上限——被记住的知识陈述自己的新鲜度，而不是悄然过期。
+
+这个循环已被端到端实时验证：`memorize` → `grounded_in` 边 → 编辑文件上的新鲜度标志 → 在 `mode=replace` 后存活 → 启动自动加载。关闭一个有界任务？向 `mission_close` 传入 `write_light_memory: true`，以同样方式持久化其经过验证的声明。
+
+**COMPOUND — 下一次会话诞生在预热好的外壳里。** 杀掉那个进程，对着同一个运行时启动一个**全新的**进程，它的第一次 `north(task)` 就已携带前一次会话的声明——这是一次真实捕获的交换（上面两次调用运行在不同进程中），略作裁剪：
+
+```jsonc
+// north.memory, from a process that never called memorize itself:
+"memory": [
+  { "claim": "AuthTokenFlow",                   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 evidence: src/auth/token.rs",   "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "⍂ entity: TokenValidator",        "source_agent": "authbot", "age_ms": 221, "stale": false },
+  { "claim": "𝔻 confidence: high",              "source_agent": "authbot", "age_ms": 221, "stale": false }
+  // …the authored-note file node, trimmed…
+]
+```
+
+`source_agent` 记录撰写者，`stale` 重新检查所引用的代码——下一次会话继承的是知识*连同*它的溯源，而不是一个裸字符串。
+
+### 一张图，多个智能体
 
 <p align="center"><img src="../docs/assets/visuals/10-attach-core.png" width="520" alt="一个属主进程持有活的图；许多智能体附着到同一内核" /></p>
 
-上面的快速开始为每个宿主连接了一个 stdio 服务器——对单个智能体来说没问题，但每个进程都加载自己的图并持有自己的租约。m1nd 为之而生的部署形态是一个所有者、多个附着的智能体。一个所有者进程持有活图：
+下面的快速开始为每个宿主连接了一个 stdio 服务器——对单个智能体来说没问题，但每个进程都加载自己的图并持有自己的租约。m1nd 为之而生的部署形态是一个所有者、多个附着的智能体。一个所有者进程持有活图：
 
 ```bash
 m1nd-mcp --serve --no-gui --port 1337 --runtime-dir /your/project/.m1nd
@@ -136,124 +237,72 @@ m1nd-mcp --attach http://127.0.0.1:1337 --stdio    # or set M1ND_ATTACH_URL and 
 
 任意数量的桥接都指向那一个所有者并共享其单一的活图，因此一个智能体 `memorize` 的内容，另一个能立即调回——无需重新摄入，无需每个智能体各存一份。查询走 localhost，因此它保持本地优先（除非你选择加入 `--bind 0.0.0.0`，否则 bind 保持 `127.0.0.1`）。在单台机器上的一张小图上，经桥接的热 `seek` 测得 ≈0.7ms——这是数量级参考，而非保证：附着会增加一次 localhost 往返，延迟随图规模和负载而变化。
 
-## m1nd 不是什么
+## 材料：诚实
 
-`m1nd` 不只是：
+*整个外壳由一种材料制成——m1nd 宁愿告诉你的智能体"别信这个"，也不让它去猜。*
 
-- 一个索引更大的代码搜索工具
-- 一个只检索文件或片段的仓库 RAG 层
-- 一个把工作流决策留给客户端的图数据库
-- 一个替代编译器、测试或安全工具的静态分析工具
-- 一个无关工具的 MCP 捆绑包
-
-它是将这些界面转化为智能体可以推理并据以行动的操作系统的那一层。不适用于单文件查找、简单 grep 或编译器真相——那些情况请用普通工具。
-
-## 为什么智能体需要它
-
-没有 m1nd，每次会话都从 grep 循环和手动重新定向开始；上周的发现已消失，空搜索结果与错误工作区绑定无从区分。有了 m1nd，会话以信任裁决开始，过去的发现已自动加载并锚定到支撑它们的代码，空结果会说明*原因*。
-
-在真实代码库上工作的智能体失败，不是因为无法搜索，而是因为没有操作模型。它们每次会话都从头重建上下文，在不知道爆炸半径的情况下编辑，无法区分意味着"什么都不存在"的空结果和意味着"仓库错误"的空结果。
-
-对于小型代码库，这还行得通。当项目有生成产物、规格、文档、隐藏的共变更历史、多个智能体和漫长的交接时，就会崩溃。问题不仅在于智能体的推理——智能体根本没有代码库结构的持久模型。`m1nd` 给了它这个模型：一个跨结构、语义、时间和因果维度进行扩散激活的因果代码图，加上每个智能体跨会话复利的 Hebbian 可塑性。
-
-## 复利记忆（L1GHT）
-
-<p align="center"><img src="../docs/assets/visuals/06-l1ght-anchored.png" width="520" alt="记忆锚定在真实代码上；代码一旦变化，记忆会自我标记" /></p>
-
-大多数工具给智能体更好的*检索*。`m1nd` 还让智能体能够**撰写持久的、机器可读的知识**，这些知识跨会话复利，并对代码保持诚实。L1GHT 将撰写的知识转化为图原生结构，当其所引用的代码发生变化时自动标记——高置信度的声明比不确定的声明传播更多激活。
-
-端到端的完整循环：
-
-1. **得出结论** — 智能体得到持久性结论（一个决策、一个经过验证的发现、代码为何如此设计），并用结构化声明和 `evidence` 路径调用 `memorize`。
-
-```jsonc
-memorize({
-  "agent_id": "dev",
-  "node_label": "AuthTokenFlow",
-  "claims": [
-    { "label": "TokenValidator", "text": "validates JWTs via HMAC",
-      "confidence": "high", "evidence": ["src/auth/token.rs"] }
-  ]
-})
-```
-
-2. **锚定** — m1nd 在 `<runtime>/agent-memory/` 下写入图原生 `.light.md`，摄入它（`adapter=light mode=merge`），并通过 `grounded_in` 边将每条 `evidence` 路径解析到真实代码节点——让知识与代码处于同一激活空间，并在 `seek` / `activate` / `impact` 中浮现。
-3. **自动加载** — 在每次未来会话开始时，`m1nd` 自动摄入 `agent-memory/` 并在 `session_handshake.agent_memory` 中报告。过去的发现在 `mode=replace` 摄入后依然存活，随时*就在那里*。
-4. **自动标记过期** — `cross_verify(check: ["evidence_freshness"])` 对每个引用文件重新哈希，并指出哪些声明因其代码变更而过期——这样记忆会在它撒谎时告诉你，而不是误导你。
-
-这个循环已被端到端实时验证：`memorize` → `grounded_in` 边 → 编辑文件上的新鲜度标志 → 在 `mode=replace` 后存活 → 启动自动加载。关闭一个有界任务？向 `mission_close` 传入 `write_light_memory: true`，以同样方式持久化其经过验证的声明。该习惯记录在每个 MCP 客户端在 `initialize` 时收到的服务器 `instructions` 中——与宿主无关，无需特定客户端插件。
-
-## 信任 / 诚实层
-
-<p align="center"><img src="../docs/assets/visuals/03-verdicts-doors.png" width="520" alt="每个结果都是一个裁决——act、reverify 或 abstain——如同智能体必须选择的门" /></p>
-
-这是 m1nd 最无可替代的事情，没有竞争对手提供它。教义：**可信度来自诚实，而非永远获胜。**
+这是 m1nd 最无可替代的事情，没有竞争对手提供它。教义：**可信度来自诚实，而非永远获胜。** 诚实的"不"胜过自信的猜测——上面的每个站点都由这种材料构成。
 
 - **`trust_selftest`** 在任何检索*之前*返回裁决：`full_trust`、`needs_ingest`、`wrong_workspace_binding`、`stale_binding_suspected` 或 `degraded_host_tool_surface`。智能体由此知道是继续、摄入、重新绑定还是降级。
 - **`agent_runtime_contract`** 附在每个检索响应上，携带一个 `trust_mode`。空结果得到明确区分——绑定到错误仓库还是真的什么都没有——绝不会静默报告为"无结果"。
+- **`trust_band: insufficient_evidence` 意味着没有证据——不是中等风险。** 这是诚实的冷启动答案，与低/中/高截然不同。
 - **`non_claims` 数组** 附在每个任务工具上。m1nd 告诉智能体它*没有*证明什么。
 - **`mission_verify` 可以说不——并且在经过测试的代码中确实如此。** 它拒绝纯图证据：一个声明在没有文件读取、测试运行或运行时探针的情况下无法关闭。该测试的名称字面上就是 `graph_only_evidence_is_not_enough`。
 - **`recovery_playbook`** 返回一份修复绑定的确定性、有序步骤列表。
 
+用展示说话，而非空谈。在一个未绑定的运行时上调用 `trust_selftest`，裁决本身*就是*修复指令——一次真实捕获，略作裁剪：
+
+```jsonc
+{
+  "ok": false,
+  "status": "blocked",
+  "verdict": "needs_ingest",          // not "no results" — it says why
+  "next_action": "call_ingest",
+  "checks": { "graph_populated": false, "needs_ingest": true, "recovery_playbook_attached": true },
+  "recovery_playbook": {
+    "recovery_goal": "Populate this binding's active graph for the intended repository.",
+    "steps": [ { "action": "Call ingest for the intended repository on this same binding." } /* …trimmed… */ ]
+  }
+}
+```
+
 对这一承诺的证明是为此牺牲的东西：`savings` 和 `resonate` 在 beta.7 中从公告的界面中撤下，因为一个总声称获胜的工具不可信。没有竞争对手——不是 mem0、Zep、Letta、Sourcegraph，也不是任何代码图 MCP——提供一个告诉智能体*不该信任什么*以及如何恢复的层。
 
-**现场分诊循环闭合于自身。** 智能体留在 `~/.m1nd/field-reports.jsonl` 中的会话遥测（仅本地——m1nd 从不回传数据）并不是被动日志：报告会被分诊，一个*已确认*的现场 bug 会在修复**之前**变成一个红色的电池用例，因此该回归是被证明的，而非仅仅被描述。那个循环已经端到端运行过一次：两个现场上报的 bug 变成了失败的电池用例，随后是合并的修复——`north` 现在将 L1GHT recall 整合进其记忆数据包，而 `temp` 图哨兵会解析到一个真实的临时目录，而不是把工作目录弄乱。
+<p align="center"><img src="../docs/assets/visuals/11-triage-loop.png" width="520" alt="现场报告喂入一个分诊循环，在修复之前先把异常变成测试" /></p>
 
-## 语言覆盖
+**现场分诊循环闭合于自身。** 智能体留在 `~/.m1nd/field-reports.jsonl` 中的会话遥测（仅本地——m1nd 从不回传数据）并不是被动日志：报告会被分诊，一个*已确认*的现场 bug 会在修复**之前**变成一个红色的电池用例，因此该回归是被证明的，而非仅仅被描述。那个循环已经通过一次完整的现场分诊扫查端到端运行：四个现场上报的 bug 变成了失败的电池用例，随后是合并的修复，全部随 **1.2.1** 交付——`north` 现在将 L1GHT recall 整合进其记忆数据包，`temp` 图哨兵解析到一个真实的临时目录而不是弄乱工作目录，`memorize` 接受数值型 `confidence`，闭合歧义标签现在只在真正的平局时触发（狼来了效应：ambiguous-blocked 从 9/11 降到 0/11）。
 
-图推理（`impact`、`why`、`predict`、`trace`、`taint_trace`）的好坏取决于提取器。m1nd 为每种语言解析 **`calls` 边**（调用图）和**跨文件 `imports`**（文件→文件依赖解析）。下表在单次多语言摄入中得到实时验证：
+## 快速开始
 
-| 语言 | `calls` | 跨文件 imports |
-|---|:---:|:---:|
-| Rust | ✅ | ✅ (`mod`/`use crate::`) |
-| Python | ✅ | ✅ |
-| JavaScript / TypeScript | ✅ | ✅ |
-| Go | ✅ | ✅（包） |
-| Java | ✅ | ✅（FQCN + 通配符） |
-| C / C++ | ✅ | ✅ (`#include "..."`) |
-| Kotlin | ✅ | ✅（包） |
-| PHP | ✅ | ✅（PSR-4） |
-| Scala | ✅ | ✅（包） |
-| Ruby | ⏳ | ✅ (`require_relative`) |
-| C# | ✅ | —（命名空间不能 1:1 映射到文件） |
-| Swift | ✅ | — |
+*装一次，接好你智能体的宿主，然后让开——从这里开始，方向盘在你的智能体手里。*
 
-所有 ✅ 行均经过端到端验证（一条 `caller`→`callee` import 可解析且调用者生成 call 边）。其他语言回退到通用提取器（仅 `contains`）。无法解析的 import（外部包、gem、标准库、系统头文件）会如实留作未解析，而不是猜测。
+```bash
+git clone https://github.com/maxkle1nz/m1nd.git && cd m1nd
+npm install -g .
+m1nd doctor
+```
 
-## 能力图
+然后连接你的宿主——每个宿主使用相同的两条命令（`codex`、`claude`、`gemini`、`antigravity`、`generic`）：
 
-<p align="center"><img src="../docs/assets/visuals/04-impact-web.png" width="520" alt="在你编辑之前，impact 沿着相互连接的代码之网追踪影响半径" /></p>
-
-Live MCP 界面随版本更新。使用 `tools/list` 获取当前构建中确切的工具数量和名称。
-
-| 领域 | 功能 | 代表性工具 |
+| 宿主 | 安装智能体包 | 连接 MCP 配置 |
 |---|---|---|
-| 图基础 | 摄入代码、维护图状态、诊断会话连续性、强化有用路径，以及检测跨会话权重漂移 | `trust_selftest`、`session_handshake`、`recovery_playbook`、`ingest`、`health`、`doctor`、`learn`、`warmup`、`drift` |
-| 检索与定向 | 在手动读取文件之前按文本、路径、意图、结构或关系搜索 | `audit`、`search`、`glob`、`seek`、`activate`、`why`、`trace` |
-| 文档与知识绑定 | 摄入通用文档或图原生 `L1GHT`，然后将概念链接回代码 | `ingest(adapter="universal"\|"light")`、`document_resolve`、`document_provider_health`、`document_bindings`、`document_drift`、`auto_ingest_*` |
-| 导航与连续性 | 跨会话维护有状态路由、交接、基线和调查记忆 | `perspective_*`、`trail_*`、`coverage_session`、`boot_memory`、`persist` |
-| Mission Control 与证明纪律 | 维护有界路由、记录事件、从图定向切换到直接证明、交接，并带明确缺口关闭 | `mission_start`、`mission_event`、`mission_next`、`mission_verify`、`mission_handoff`、`mission_close` |
-| 变更规划与证明 | 推理影响、共变更、缺失步骤、失败路径和结构声明 | `impact`、`predict`、`validate_plan`、`missing`、`hypothesize`、`counterfactual`、`differential` |
-| 质量、安全与架构 | 检测模式、污点路径、信任边界、重复、层违规、类型流和重构目标 | `scan`、`scan_all`、`heuristics_surface`、`antibody_*`、`taint_trace`、`type_trace`、`trust`、`layers`、`layer_inspect`、`twins`、`fingerprint`、`flow_simulate`、`epidemic`、`tremor`、`refactor_plan` |
-| 时间、运行时与多仓库工作 | 检查 git 历史、漂移、隐藏共变更边、运行时叠加和跨仓库引用 | `timeline`、`diverge`、`ghost_edges`、`runtime_overlay`、`external_references`、`federate`、`federate_auto` |
-| 运维与监控 | 审计仓库状态、验证图与磁盘真相、运行守护进程监控、持久化状态和浮现持久告警 | `audit`、`cross_verify`、`daemon_*`、`alerts_*`、`panoramic`、`metrics`、`report`、`persist`、`diagram`、`help` |
-| 外科编辑准备与执行 | 拉取紧凑的关联上下文、预览写入并应用图感知编辑 | `surgical_context`、`surgical_context_v2`、`view`、`batch_view`、`edit_preview`、`edit_commit`、`apply`、`apply_batch` |
+| Codex | `m1nd install-skills codex` | `m1nd mcp-config codex --project /your/project` |
+| Claude Code | `m1nd install-skills claude --project /your/project` | `m1nd mcp-config claude --project /your/project` |
+| Gemini | `m1nd install-skills gemini --project /your/project` | `m1nd mcp-config gemini --project /your/project` |
+| Antigravity | `m1nd install-skills antigravity --project /your/project` | `m1nd mcp-config antigravity --project /your/project` |
+| Generic | `m1nd install-skills generic --project /your/project` | `m1nd mcp-config generic --project /your/project` |
 
-**分层：** 默认公告 27 个基础工具以降低工具选择成本；设置 `M1ND_TOOL_TIER=full` 可公告完整界面（100+ 工具：RETROBUILDER、perspectives、federation、daemon）。少数工具（`resonate`、`savings`、`lock_*`）仍可按名称调用，但不在公告界面上。隐藏工具始终可通过 `tools/call` 调用——分层仅控制 `tools/list` 显示什么。
+或通过 npm：`npm install -g @maxkle1nz/m1nd`。`install-skills` 交付的是智能体包——操作循环本身，以五个命名协议的形式，而非装饰性文档。
 
-## 操作循环
+**操作员的界面是这个 CLI；智能体的界面是 MCP。** 人类偶尔运行 `m1nd doctor`、`install-skills`、`mcp-config`——其余一切由智能体运行。当没有可供调用 `north` 的活跃 MCP 会话（已过期、绑定到错误仓库，或尚未加载）时，存在一个宿主中立的应急出口：它会启动一个隔离的运行时、将其绑定到仓库，并返回一个机器可读的信封，完成界定范围、建立信任、按需摄入、返回锚点，并交接给直接证明：
 
-智能体包是产品的一部分，而不是装饰性文档。当智能体收到的是*操作循环*而不仅仅是图端点时，m1nd 最为强大。包中附带五个命名协议：
+```bash
+m1nd agent first-minute --repo /your/project --query "understand this system" --json
+```
 
-- **会话开始** — `trust_selftest` → 若信任不完整则 `recovery_playbook` → 若需要则 `ingest` → `seek`/`audit`。
-- **研究** — `ingest` → `activate(query)` → `why(source, target)` → `missing(topic)` → `learn(feedback)` → `memorize` 任何持久性发现。
-- **代码变更** — `impact(node)` 获取爆炸半径 → `predict(node)` → `counterfactual(nodes)` → `surgical_context_v2` → `memorize` 决策及其原因。
-- **深度分析** — `fingerprint`、`diverge`、`ghost_edges`、`taint_trace`、`twins`、`refactor_plan`、`runtime_overlay`（RETROBUILDER 镜头），用于隐藏耦合、安全路径、结构重复和运行时热点。
-- **记忆** — 用 `memorize` 持久化持久性结论，携带 `confidence` 和 `evidence` 路径。
+需要时可固定二进制版本：`--version` 打印 `1.2.x (<sha>)`，`M1ND_EXPECTED_VERSION` / `M1ND_EXPECTED_SHA`（+ `M1ND_STRICT_VERSION`）让宿主能够检测并拒绝一个漂移的二进制文件。
 
-Mission Control 是证明纪律，而不是功能列表。`mission_next` 恰好返回一个动作加 `do_not` 护栏；`mission_verify` 拒绝纯图声明；`mission_close` 始终推动智能体持久化经过验证的知识并记录缺口和非声明。在 `bug_hunt` 模式下，MC0 要求在关闭前、在验证发现之后进行一次最终的直接 `direct_sweep`，以便智能体检查负空间。
-
-**注意：** 在 `ghost_edges` 加载 git 共变更矩阵之前，`predict` **仅有结构回退**——当你需要真实的共变更可能性时，请先运行 `ghost_edges`。
+完整安装指南、宿主包、原生运行时构建和更新标志：[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) · 逐客户端配置：[集成矩阵](../docs/IDE-INTEGRATIONS.md)。
 
 ## 证据
 
@@ -282,9 +331,6 @@ Mission Control 是证明纪律，而不是功能列表。`mission_next` 恰好�
   <img src="../docs/assets/visuals/08-calibration-earned.png" width="380" alt="校准需按仓库赢得，裁决才能读到 act" />
   <img src="../docs/assets/visuals/09-closure-bridge.png" width="380" alt="只有当证据架起桥梁——一次文件读取、测试或探针——主张才会闭合" />
 </p>
-<p align="center">
-  <img src="../docs/assets/visuals/11-triage-loop.png" width="380" alt="现场报告喂入一个分诊循环，在修复之前先把异常变成测试" />
-</p>
 </details>
 
 ## 局限性
@@ -298,6 +344,40 @@ Mission Control 是证明纪律，而不是功能列表。`mission_next` 恰好�
 - 任务是无结构不确定性的简单本地文件操作
 
 **需要喂数据：** `trust` 和 `tremor` 从中性先验开始，直到 `learn` 反馈 / `ghost_edges` 数据积累起来，而 `predict` 需要先加载 `ghost_edges`，其共变更信号才有意义。这些会随使用而改善；它们对启动时的无信息状态保持诚实。
+
+## m1nd 不是什么
+
+`m1nd` 不只是：
+
+- 一个索引更大的代码搜索工具
+- 一个只检索文件或片段的仓库 RAG 层
+- 一个把工作流决策留给客户端的图数据库
+- 一个替代编译器、测试或安全工具的静态分析工具
+- 一个无关工具的 MCP 捆绑包
+- 一个人类必须学会的工具界面——那些动词属于智能体；属于你的是那个小小的[安装 CLI](#快速开始)
+
+它是将这些界面转化为智能体可以推理并据以行动的操作系统的那一层。不适用于单文件查找、简单 grep 或编译器真相——那些情况请用普通工具。
+
+## 语言覆盖
+
+图推理（`impact`、`why`、`predict`、`trace`、`taint_trace`）的好坏取决于提取器。m1nd 为每种语言解析 **`calls` 边**（调用图）和**跨文件 `imports`**（文件→文件依赖解析）。下表在单次多语言摄入中得到实时验证：
+
+| 语言 | `calls` | 跨文件 imports |
+|---|:---:|:---:|
+| Rust | ✅ | ✅ (`mod`/`use crate::`) |
+| Python | ✅ | ✅ |
+| JavaScript / TypeScript | ✅ | ✅ |
+| Go | ✅ | ✅（包） |
+| Java | ✅ | ✅（FQCN + 通配符） |
+| C / C++ | ✅ | ✅ (`#include "..."`) |
+| Kotlin | ✅ | ✅（包） |
+| PHP | ✅ | ✅（PSR-4） |
+| Scala | ✅ | ✅（包） |
+| Ruby | ⏳ | ✅ (`require_relative`) |
+| C# | ✅ | —（命名空间不能 1:1 映射到文件） |
+| Swift | ✅ | — |
+
+所有 ✅ 行均经过端到端验证（一条 `caller`→`callee` import 可解析且调用者生成 call 边）。其他语言回退到通用提取器（仅 `contains`）。无法解析的 import（外部包、gem、标准库、系统头文件）会如实留作未解析，而不是猜测。
 
 ## 架构概览
 
@@ -314,7 +394,7 @@ Mission Control 是证明纪律，而不是功能列表。`mission_next` 恰好�
   <img src="../.github/m1nd-architecture-overview-v2.jpeg" alt="m1nd 架构概览" width="960" />
 </p>
 
-关于联邦、perspectives、RETROBUILDER、多智能体协调以及完整的智能体包和运维参考，请参阅[官方 wiki](https://m1nd.world/wiki/)、[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) 和 [EXAMPLES.md](../EXAMPLES.md)。
+Live MCP 界面随版本演进——使用 `tools/list` 获取你所用构建中确切的工具数量和名称。**分层：** 默认公告 27 个基础工具以降低工具选择成本；设置 `M1ND_TOOL_TIER=full` 可公告完整界面（100+ 工具：RETROBUILDER、perspectives、federation、daemon）。隐藏工具始终可通过 `tools/call` 调用——分层仅控制 `tools/list` 显示什么。逐工具目录不在这份 README 中：深入内容见[官方 wiki](https://m1nd.world/wiki/)、[docs/AGENT-PACKS.md](../docs/AGENT-PACKS.md) 和 [EXAMPLES.md](../EXAMPLES.md)，版本历史见 [CHANGELOG.md](../CHANGELOG.md)。
 
 ## 贡献
 


### PR DESCRIPTION
## The founder's final product definition

> "Before, m1nd was many features — impact, blast radius, x-ray etc. Now we closed the operating loop of what the product REALLY is: **the shell (casca) that wraps the agent**, always helping it with these more-than-precious pieces of information. That wireframe around the agent is the final definition of m1nd."

This PR re-spines the README around that definition. Features stop being a catalog; they appear as the **stations of the shell**. Reorganization + reframing — the strong existing material (hedged Evidence table, real captured envelopes, per-host Quick Start, serve/attach, Limits, language matrix, visual series, i18n switcher) is **relocated, not rewritten**.

## Skeleton: before → after

| Old (14 H2) | New (13 H2) |
|---|---|
| Head + "three things" + attention runtime | Head (thesis sharpened to the shell) |
| New in 1.2.0 | *(dissolved into the stations; 1.2.1 facts live in the field-triage paragraph)* |
| Quick Start › Agent Entry Point › serve/attach | **What m1nd is: the shell** — loop diagram (mermaid), dual-lane intro, operated-by-the-agent, three readers (`north` shipped · Delegation Packet §O.12 designed · Pre-Flight Card/Living Tree designed, [HUMAN-LAYER-PRD](docs/HUMAN-LAYER-PRD.md)), plate p6 "one truth, two readers", **walkthrough: what happens when you send a message** |
| What m1nd Is Not / Why Agents Need It | **BEFORE — born oriented** (north + captured envelope, focus, fallback trust loop) |
| Compounding Memory (L1GHT) | **DURING — verdicts worn while working** (impact, why+closure, predict+calibration, xray_gate, mission discipline, seek trust_envelope capture) |
| The Trust / Honesty Layer | **AFTER — the graph gets warmer** (memorize envelopes, provenance spine, COMPOUND two-session capture, serve/attach as "One graph, many agents") |
| Language Coverage / Capability Map / Operating Loops | **The material: honesty** (trust_selftest capture, non_claims, killed features, field-triage loop) |
| Evidence / Limits / Architecture / Contributing / License | Quick Start (+ operator CLI: doctor / install-skills / first-minute / version pinning) → Evidence → Limits → What m1nd Is Not → Language Coverage → Architecture (+ tiering & depth pointers; tool catalog stays out of the README) → Contributing → License |

## Founder addendum folded in

- Each station opens with one plain-language line (vibecoder lane), then technical depth.
- "What happens when you send a message" — 6 numbered zero-jargon lines, tool names in parentheses.
- Stated plainly: **m1nd is operated 100% by the agent**; the human's surface is the small setup CLI.
- Human layer mentioned in honest tense (designed / in development), linked to docs/HUMAN-LAYER-PRD.md; Delegation Packet linked to docs/NEXTGEN-AGENT-PRD.md §O.12.

## i18n mirror

All 7 translations re-mirrored to the same skeleton: **13 H2 / 2 H3 / 405 lines in every file** (EN included); all fenced code blocks (mermaid, jsonc envelopes, bash) byte-identical to English (verified by hash); `../` paths and translated in-page anchors verified.

Docs-only: `git diff --stat` = README.md + 7 i18n files; `cargo fmt --check` is a no-op. README length 411 → 405 lines (did not grow).
