### PR TITLE
fix(persist): all persist targets resolve against runtime_root, never cwd (field-triage batch B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
-No unreleased changes.
+### Fixed
+
+- **Persist targets now resolve against the runtime root, never the process cwd
+  (field-triage batch B).** A relative `graph_source` / `plasticity_state` (the
+  defaults are `./graph_snapshot.json` / `./plasticity_state.json`) is now
+  anchored on the configured `--runtime-dir` / `M1ND_RUNTIME_DIR` instead of the
+  current working directory. A launchd-spawned `--serve` owner with no
+  `WorkingDirectory` runs with `cwd=/` (a sealed, read-only volume), so every
+  persist — the graph snapshot, the plasticity state, and the `ingest_roots.json`
+  written next to the snapshot — used to fail silently with `Read-only file
+  system (os error 30)`. The medulla therefore re-ingested the whole repo on
+  every boot and warm-boot never worked (`graph_path_exists: false`, "No graph
+  snapshot found, starting fresh"). An explicit absolute `--graph` override is
+  left untouched, and with no runtime dir the historical cwd-relative behavior is
+  preserved. Proven with a red→green test that spawns the real binary under
+  `cwd=/` and asserts a second process warm-boots from the persisted snapshot.
 
 ---
 

--- a/docs/wiki/src/faq.md
+++ b/docs/wiki/src/faq.md
@@ -142,6 +142,8 @@ Yes. Pass `"incremental": true` to the `ingest` tool. Incremental ingest only re
 
 In memory during runtime. Optionally persisted to JSON files on disk via the `M1ND_GRAPH_SOURCE` and `M1ND_PLASTICITY_STATE` environment variables.
 
+A relative persist path (the defaults are `./graph_snapshot.json` / `./plasticity_state.json`) is anchored on the configured runtime dir (`--runtime-dir` / `M1ND_RUNTIME_DIR`) when one is set, so a managed owner persists into its always-writable runtime dir regardless of its working directory — never against `cwd`. An explicit absolute path is used exactly as given.
+
 Without persistence configured, the graph is lost when the process exits. Always configure persistence for production use.
 
 ### How often does it persist?

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -108,6 +108,31 @@ fn resolve_graph_source(path: PathBuf) -> PathBuf {
     }
 }
 
+/// Anchor a persist target against the runtime root when it is relative.
+///
+/// BUG (field-triage batch B): the launchd-spawned `serve` owner runs with
+/// `cwd=/` (the plist has no `WorkingDirectory`; `/` is a sealed, read-only
+/// volume). The default `graph_source` / `plasticity_state` are RELATIVE
+/// (`./graph_snapshot.json`, `./plasticity_state.json`), so every persist —
+/// the graph snapshot, the plasticity state, and `ingest_roots.json` (written
+/// next to the snapshot) — resolved against `/` and failed with
+/// `Read-only file system (os error 30)`. The medulla therefore re-ingested
+/// the whole repo on every boot and warm-boot never worked (`graph_path_exists:
+/// false`, "No graph snapshot found, starting fresh").
+///
+/// When a `runtime_dir` is configured, a RELATIVE persist target must resolve
+/// against it (the runtime dir is always writable and process-independent of
+/// cwd — the embedding cache, boot memory, and daemon state already anchor
+/// there). An EXPLICIT absolute override (a real `--graph /abs/path`) is left
+/// exactly as given. With no runtime_dir, behavior is unchanged (relative to
+/// cwd), preserving the plain `m1nd-mcp` stdio-in-a-repo workflow.
+fn anchor_persist_target(path: PathBuf, runtime_dir: Option<&std::path::Path>) -> PathBuf {
+    match runtime_dir {
+        Some(root) if path.is_relative() => root.join(path),
+        _ => path,
+    }
+}
+
 fn load_config_from_cli(cli: &Cli) -> McpConfig {
     // Priority: --config file > --graph/--plasticity/--domain flags > env vars > defaults
 
@@ -131,6 +156,16 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
     }
 
     // 2. Build from CLI flags + env vars
+
+    // Resolve the runtime dir FIRST: relative persist targets anchor against it
+    // so they never resolve against cwd (field-triage batch B: launchd cwd=/ is
+    // read-only). `--runtime-dir` wins over `M1ND_RUNTIME_DIR`.
+    let runtime_dir = cli
+        .runtime_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("M1ND_RUNTIME_DIR").ok().map(PathBuf::from));
+
     let graph_source = cli
         .graph
         .as_ref()
@@ -139,6 +174,7 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
         .or_else(|| std::env::var("GRAPH_SNAPSHOT_PATH").ok().map(PathBuf::from))
         .map(resolve_graph_source)
         .unwrap_or_else(|| PathBuf::from("./graph_snapshot.json"));
+    let graph_source = anchor_persist_target(graph_source, runtime_dir.as_deref());
 
     let plasticity_state = cli
         .plasticity
@@ -155,9 +191,8 @@ fn load_config_from_cli(cli: &Cli) -> McpConfig {
                 .map(PathBuf::from)
         })
         .unwrap_or_else(|| PathBuf::from("./plasticity_state.json"));
+    let plasticity_state = anchor_persist_target(plasticity_state, runtime_dir.as_deref());
 
-    let runtime_dir = std::env::var("M1ND_RUNTIME_DIR").ok().map(PathBuf::from);
-    let runtime_dir = cli.runtime_dir.as_ref().map(PathBuf::from).or(runtime_dir);
     let registry_dir = cli
         .registry_dir
         .as_ref()
@@ -406,8 +441,62 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_graph_source, strict_version_verdict};
+    use super::{anchor_persist_target, resolve_graph_source, strict_version_verdict};
     use std::path::PathBuf;
+
+    // --- field-triage batch B: relative persist targets must anchor on the
+    // runtime dir, never resolve against cwd (launchd cwd=/ is read-only) ---
+
+    #[test]
+    fn relative_persist_target_anchors_on_runtime_dir() {
+        // BUG (field report L27/L29): the plist has no WorkingDirectory, so the
+        // owner runs with cwd=/. The default `./graph_snapshot.json` then resolved
+        // against `/` and every persist failed with os error 30 (read-only fs).
+        let runtime = PathBuf::from("/Users/kle1nz/.m1nd/runtimes/claude");
+
+        let graph = anchor_persist_target(
+            PathBuf::from("./graph_snapshot.json"),
+            Some(runtime.as_path()),
+        );
+        assert_eq!(
+            graph,
+            runtime.join("./graph_snapshot.json"),
+            "relative graph snapshot must land under the runtime dir"
+        );
+        assert!(
+            graph.starts_with(&runtime),
+            "anchored graph path must be under the runtime dir, got {graph:?}"
+        );
+
+        // A bare relative filename anchors too (the ingest_roots.json neighbor
+        // is derived from graph_source.parent(), so this fixes it transitively).
+        let plas = anchor_persist_target(
+            PathBuf::from("plasticity_state.json"),
+            Some(runtime.as_path()),
+        );
+        assert_eq!(plas, runtime.join("plasticity_state.json"));
+    }
+
+    #[test]
+    fn explicit_absolute_persist_target_is_never_rewritten() {
+        // A real `--graph /abs/path` override must pass through untouched even
+        // when a runtime dir is set: the operator asked for that exact location.
+        let runtime = PathBuf::from("/Users/kle1nz/.m1nd/runtimes/claude");
+        let explicit = PathBuf::from("/data/snapshots/graph_snapshot.json");
+        assert_eq!(
+            anchor_persist_target(explicit.clone(), Some(runtime.as_path())),
+            explicit,
+            "explicit absolute path must not be re-anchored"
+        );
+    }
+
+    #[test]
+    fn no_runtime_dir_leaves_relative_target_unchanged() {
+        // With no runtime dir (plain `m1nd-mcp` stdio-in-a-repo), the historical
+        // cwd-relative behavior is preserved.
+        let rel = PathBuf::from("./graph_snapshot.json");
+        assert_eq!(anchor_persist_target(rel.clone(), None), rel);
+    }
 
     // --- field-triage #2: the `temp` graph-source sentinel must not litter CWD ---
 

--- a/m1nd-mcp/tests/persist_runtime_root.rs
+++ b/m1nd-mcp/tests/persist_runtime_root.rs
@@ -1,0 +1,285 @@
+//! Field-triage batch B — persist targets must resolve against the runtime
+//! root, never against the process cwd.
+//!
+//! THE BUG (root-caused in `~/.m1nd/field-reports.jsonl`, L27/L29): the
+//! launchd-spawned `--serve` owner (`com.kle1nz.m1nd-serve`) has NO
+//! `WorkingDirectory` key, so it runs with `cwd=/` — a sealed, read-only
+//! volume. The default `graph_source` / `plasticity_state` are RELATIVE
+//! (`./graph_snapshot.json`), so every persist resolved against `/` and failed
+//! with `Read-only file system (os error 30)`:
+//!
+//!   [m1nd] WARNING: ingest roots persist failed: Read-only file system (os error 30)
+//!   [m1nd] auto-persist after ingest failed: I/O error: Read-only file system (os error 30)
+//!   [m1nd] No graph snapshot found, starting fresh
+//!
+//! The medulla therefore re-ingested the whole repo on every boot and warm-boot
+//! never worked (`graph_path_exists: false`). Absolute-anchored writes (the
+//! embedding cache, boot memory, daemon state — all `runtime_root.join(...)`)
+//! kept working; only the cwd-relative ones failed.
+//!
+//! THE FIX (proved here red→green): a relative persist target is anchored on the
+//! configured `runtime_dir` (`main.rs::anchor_persist_target`), so the snapshot
+//! and its `ingest_roots.json` neighbor land under the always-writable runtime
+//! dir regardless of cwd. This test reproduces the EXACT launchd condition (it
+//! spawns the real binary with `cwd=/` and a relative graph source) and proves
+//! two things.
+//!
+//! First: after `ingest` + `persist`, `<runtime>/graph_snapshot.json` and
+//! `<runtime>/ingest_roots.json` exist (on `main`: neither does — the writes hit
+//! `/` and fail). Second: a SECOND process on a DIFFERENT cwd WARM-BOOTS from
+//! that snapshot — it loads the graph (node_count preserved) WITHOUT
+//! re-ingesting.
+//!
+//! Driving the real binary over stdio JSON-RPC is the faithful seam: the fix
+//! lives in the binary's config resolution (`load_config_from_cli`), which only
+//! the process entry point exercises — an in-process `SessionState` test would
+//! bypass it entirely.
+//!
+//! Unix-only: the bug is a launchd sealed-volume `cwd=/` condition and the
+//! reproduction pins cwd to `/`, whose semantics (and read-only-ness) are
+//! POSIX-specific. The portable path-resolution contract itself
+//! (`anchor_persist_target`) is covered by cross-platform unit tests in
+//! `m1nd-mcp/src/main.rs`.
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Path to the compiled binary under test (Cargo sets `CARGO_BIN_EXE_<name>`).
+const BIN: &str = env!("CARGO_BIN_EXE_m1nd-mcp");
+
+/// A read-only, always-present directory that stands in for the sealed launchd
+/// cwd. On macOS/Linux `/` is not writable by a normal user, which is exactly
+/// the condition that made relative persists fail with os error 30.
+const READ_ONLY_CWD: &str = "/";
+
+/// A tiny two-file Rust crate to ingest, written under the runtime's sibling
+/// source dir. Small + deterministic so node_count is stable across boots.
+fn write_fixture_repo(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).expect("mk src");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"persistfix\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write Cargo.toml");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub mod helper;\npub fn top() -> i64 { helper::help() + 1 }\n",
+    )
+    .expect("write lib.rs");
+    std::fs::write(
+        root.join("src/helper.rs"),
+        "pub fn help() -> i64 { 41 }\npub struct Helper { pub v: i64 }\n",
+    )
+    .expect("write helper.rs");
+}
+
+/// A live stdio JSON-RPC connection to a spawned owner process.
+struct Owner {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Owner {
+    /// Spawn the binary in stdio mode with a specific cwd + a RELATIVE graph
+    /// source, mirroring the launchd invocation (no WorkingDirectory ⇒ cwd=/,
+    /// `--runtime-dir` set, default relative `./graph_snapshot.json`).
+    fn spawn(cwd: &Path, runtime_dir: &Path) -> Owner {
+        let mut child = Command::new(BIN)
+            .arg("--no-gui")
+            .current_dir(cwd)
+            .env("M1ND_RUNTIME_DIR", runtime_dir)
+            // RELATIVE on purpose — this is the default the launchd owner runs
+            // with. Pre-fix it resolves against `cwd`; post-fix against runtime.
+            .env("M1ND_GRAPH_SOURCE", "./graph_snapshot.json")
+            .env("M1ND_PLASTICITY_STATE", "./plasticity_state.json")
+            // Deterministic + isolated: never touch the developer's real runtime.
+            .env("M1ND_REGISTRY_DIR", runtime_dir.join("registry"))
+            .env("M1ND_NO_GUI", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn m1nd-mcp stdio owner");
+        let stdin = child.stdin.take().expect("child stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+        let mut owner = Owner {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+        };
+        owner.initialize();
+        owner
+    }
+
+    fn send(&mut self, line: &str) {
+        self.stdin
+            .write_all(line.as_bytes())
+            .expect("write request");
+        self.stdin.write_all(b"\n").expect("write newline");
+        self.stdin.flush().expect("flush request");
+    }
+
+    /// Read newline-delimited JSON responses until one carries our `id` (the
+    /// server may interleave nothing else in stdio Line mode, but be robust).
+    fn read_reply(&mut self, id: i64) -> serde_json::Value {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            if Instant::now() >= deadline {
+                panic!("timed out waiting for reply id={id}");
+            }
+            let mut line = String::new();
+            let n = self.stdout.read_line(&mut line).expect("read reply line");
+            if n == 0 {
+                panic!("owner stdout closed before reply id={id}");
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+                continue;
+            };
+            if v.get("id").and_then(|x| x.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+
+    fn initialize(&mut self) {
+        self.next_id += 1;
+        let id = self.next_id;
+        let req = serde_json::json!({
+            "jsonrpc": "2.0", "id": id, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "persist-runtime-root-probe", "version": "1.0" }
+            }
+        });
+        self.send(&req.to_string());
+        let reply = self.read_reply(id);
+        assert!(
+            reply.get("result").is_some(),
+            "initialize must succeed, got {reply}"
+        );
+    }
+
+    /// Call a tool, returning the parsed `result` payload (structuredContent when
+    /// present, else the raw result).
+    fn call(&mut self, tool: &str, args: serde_json::Value) -> serde_json::Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let req = serde_json::json!({
+            "jsonrpc": "2.0", "id": id, "method": "tools/call",
+            "params": { "name": tool, "arguments": args }
+        });
+        self.send(&req.to_string());
+        let reply = self.read_reply(id);
+        let result = reply
+            .get("result")
+            .unwrap_or_else(|| panic!("tool {tool} returned no result: {reply}"))
+            .clone();
+        // MCP wraps tool output; the structured payload lives under
+        // structuredContent, or the first content text is JSON we can parse.
+        if let Some(sc) = result.get("structuredContent") {
+            return sc.clone();
+        }
+        if let Some(text) = result
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|a| a.first())
+            .and_then(|item| item.get("text"))
+            .and_then(|t| t.as_str())
+        {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(text) {
+                return parsed;
+            }
+        }
+        result
+    }
+
+    /// Read the live graph node_count from the `health` tool. `health` carries a
+    /// top-level `node_count`; the binding fingerprint mirrors it (and its
+    /// `graph_path` / `graph_path_exists` are exactly the field-report signals).
+    fn node_count(&mut self) -> u64 {
+        let health = self.call("health", serde_json::json!({ "agent_id": "probe" }));
+        health
+            .get("node_count")
+            .and_then(|n| n.as_u64())
+            .unwrap_or_else(|| panic!("no node_count in health body: {health}"))
+    }
+
+    fn shutdown(mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn persist_lands_under_runtime_root_and_second_process_warm_boots() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("mk runtime dir");
+    let repo = tmp.path().join("repo");
+    write_fixture_repo(&repo);
+
+    // The snapshot + ingest_roots MUST land here (under the runtime), never in
+    // the read-only cwd. Pre-fix they resolve to `/graph_snapshot.json` etc.
+    let snapshot = runtime_dir.join("graph_snapshot.json");
+    let ingest_roots = runtime_dir.join("ingest_roots.json");
+
+    // --- Boot #1: cwd = "/" (the sealed launchd volume). Ingest + persist. ---
+    let mut owner = Owner::spawn(Path::new(READ_ONLY_CWD), &runtime_dir);
+
+    let ingest = owner.call(
+        "ingest",
+        serde_json::json!({ "path": repo.to_string_lossy(), "agent_id": "probe" }),
+    );
+    // Sanity: the fixture crate really produced a non-trivial graph.
+    let ingested_nodes = owner.node_count();
+    assert!(
+        ingested_nodes >= 3,
+        "fixture ingest should create several nodes, got {ingested_nodes} (ingest reply: {ingest})"
+    );
+
+    // Explicit persist (the field bug fired on BOTH auto-persist-after-ingest and
+    // explicit persist; we drive the explicit path so success is unambiguous).
+    let _ = owner.call("persist", serde_json::json!({ "agent_id": "probe" }));
+    owner.shutdown();
+
+    // THE CORE ASSERTIONS (RED on main — these files never appear because the
+    // writes hit the read-only `/`; GREEN with the fix — they land under runtime).
+    assert!(
+        snapshot.exists(),
+        "graph snapshot must be persisted under the runtime root at {}; \
+         on the bug it silently failed against cwd=/ (os error 30)",
+        snapshot.display()
+    );
+    assert!(
+        ingest_roots.exists(),
+        "ingest_roots.json must be persisted next to the snapshot under the \
+         runtime root at {} (this is the exact 'ingest roots persist failed' line)",
+        ingest_roots.display()
+    );
+
+    // --- Boot #2: a DIFFERENT cwd (the tempdir itself, which is writable) but the
+    // SAME runtime. If persist had leaked into cwd, this fresh cwd would NOT see
+    // it and would re-ingest from zero. A true warm boot loads the snapshot. ---
+    let mut owner2 = Owner::spawn(tmp.path(), &runtime_dir);
+    let warm_nodes = owner2.node_count();
+    owner2.shutdown();
+
+    assert!(
+        warm_nodes >= ingested_nodes,
+        "second process (different cwd, same runtime) must WARM-BOOT from the \
+         snapshot with node_count preserved: booted with {warm_nodes} nodes but \
+         the persisted graph had {ingested_nodes}. A lower count means it \
+         re-ingested / started fresh — the warm boot the fix restores."
+    );
+}


### PR DESCRIPTION
## The bug (root-caused by the field)

Two field reports in `~/.m1nd/field-reports.jsonl` nailed this — the persist bug that makes the launchd medulla re-ingest the whole repo on every boot and never warm-boot:

> **L27** (`claude:architect-twotier`): *"The launchd-spawned medulla logs repeated 'ingest roots persist failed: Read-only file system (os error 30)' and 'No graph snapshot found, starting fresh' — it re-ingests /Users/kle1nz/m1nd on every boot and never persists graph_snapshot.json (graph_path_exists=false). The same runtime-dir is writable from a normal shell, so the owner is running under a write-restricted sandbox."*

> **L29** (`fable:seat-b-lifecycle`): *"Root-cause refinement: launchd plist `com.kle1nz.m1nd-serve` has NO WorkingDirectory key, so cwd=/ (sealed volume). Absolute-path writes SUCCEED (embeddings_cache.bin + calibration_state.json in runtime-dir have fresh mtimes) while relative-path writes (default `./graph_snapshot.json` + ingest_roots persist) fail with os error 30. Consequence live-proven: every launchd restart silently drops the code graph (6221-node graph gone, 6.2MB embed cache overwritten to 82KB)."*

The `--serve` owner runs with `cwd=/` (no `WorkingDirectory` in the plist; `/` is a sealed, read-only volume). The default `graph_source` / `plasticity_state` are **relative** (`./graph_snapshot.json`, `./plasticity_state.json`), so every persist — the graph snapshot, the plasticity state, and the `ingest_roots.json` written next to the snapshot — resolved against `/` and failed with `Read-only file system (os error 30)`. The load side is symmetric: `./graph_snapshot.json` never exists relative to `/`, so boot always says *"No graph snapshot found, starting fresh"* and re-ingests. The neighbors that already anchor on the runtime dir (embedding cache, boot memory, daemon state — all `runtime_root.join(...)`) kept working; only the cwd-relative ones failed.

## The fix (universal, code)

Anchor a **relative** persist target on the configured runtime dir (`--runtime-dir` / `M1ND_RUNTIME_DIR`) at config-build time — `load_config_from_cli` in `m1nd-mcp/src/main.rs`, the single chokepoint feeding `McpConfig`. One new `anchor_persist_target(path, runtime_dir)` helper (mirroring the spirit of `resolve_graph_source`, #212) applied to both `graph_source` and `plasticity_state`; `ingest_roots.json` follows `graph_source.parent()` and is fixed transitively.

- An **explicit absolute** `--graph /abs/path` override is left exactly as given.
- With **no** runtime dir, the historical cwd-relative behavior is preserved (plain `m1nd-mcp` stdio-in-a-repo).

Swept for any other relative-default persist target (event logs, boot memory, daemon state, savings): `graph_source` + `plasticity_state` are the only two; everything else already anchors absolutely.

## Proof (red → green)

**Unit** (`main.rs`): `anchor_persist_target` anchors a relative target under the runtime dir, never rewrites an explicit absolute, and is a no-op with no runtime dir.

**Integration** (`m1nd-mcp/tests/persist_runtime_root.rs`): spawns the **real binary** with `cwd=/` (the exact launchd condition) and a relative graph source, then asserts:
1. after `ingest` + `persist`, `<runtime>/graph_snapshot.json` **and** `<runtime>/ingest_roots.json` exist — on `main` **neither does**, the writes hit `/` and fail (RED);
2. a **second process on a different cwd** WARM-BOOTS from that snapshot with `node_count` preserved (no re-ingest).

Driving the real binary is the faithful seam: the fix lives in the binary's config resolution, which only the process entry point exercises — an in-process `SessionState` test would bypass it.

RED was demonstrated by neutralizing only the fix's behavior (no-op passthrough): the integration test failed exactly on `snapshot.exists()` with the health envelope showing `"graph_path":"./graph_snapshot.json"`, `"graph_path_exists":false` — the field fingerprint reproduced in-test. Restoring the fix turns it green.

## Env (this machine, belt-and-suspenders)

The plist `com.kle1nz.m1nd-serve` also gains `<key>WorkingDirectory</key><string>/Users/kle1nz/.m1nd/runtimes/claude</string>` (validated with `plutil -lint`), and the fixed binary is installed + the owner kickstarted with a live warm-boot verification. (Env steps are applied out-of-band, not in this PR.)

## Gate

`cargo fmt --check` · `cargo clippy --workspace --all-targets -- -D warnings` (0) · `cargo test --workspace` (0 failed) · battery **37/37**, 0 grep-losses.
