### PR TITLE
fix(attach): re-init covers all unknown-session shapes + restart-survival proof (field-triage batch C)

### DIFF
--- a/m1nd-mcp/src/attach_client.rs
+++ b/m1nd-mcp/src/attach_client.rs
@@ -147,9 +147,21 @@ impl AttachSession {
 
 /// JSON-RPC error code the owner returns when a forwarded request carries an
 /// `Mcp-Session-Id` it no longer knows (e.g. after an owner restart). Per the MCP
-/// spec the owner also answers HTTP 404, but the JSON-RPC code is the
-/// authoritative, transport-independent signal we key the re-init on.
+/// spec the owner also answers HTTP 404; we treat BOTH shapes as the
+/// session-expired signal (see [`SESSION_EXPIRED_STATUS`] and
+/// [`PostOutcome::signals_session_expired`]) so the re-init trigger does not
+/// depend on the owner always delivering a parseable JSON-RPC frame.
 const SESSION_EXPIRED_CODE: i64 = -32001;
+
+/// HTTP status the owner returns for an unknown/expired `Mcp-Session-Id` (per the
+/// MCP Streamable-HTTP spec: "re-initialize"). The owner's `POST /mcp` currently
+/// pairs this with a JSON body carrying the `-32001` frame, but its `GET /mcp`
+/// (SSE relay) answers 404 with a PLAIN-TEXT body and NO JSON-RPC frame — and an
+/// intermediary/proxy could strip the body on either path. Keying re-init on this
+/// status too (not only the frame) makes recovery robust to every unknown-session
+/// SHAPE the transport can present. Locked against owner drift by
+/// `tests/attach_reinit.rs::owner_unknown_session_wire_shape_is_recoverable`.
+const SESSION_EXPIRED_STATUS: u16 = 404;
 
 /// Outcome of one POST to the owner's `/mcp`, demuxed to a single JSON-RPC value.
 ///
@@ -166,9 +178,27 @@ pub struct PostOutcome {
     pub status: u16,
 }
 
+impl PostOutcome {
+    /// Does this outcome mean the owner no longer knows our session (restart)?
+    ///
+    /// True if EITHER the demuxed response frame carries the `-32001` error code
+    /// OR the owner answered the session-expired HTTP status (`404`). Covering
+    /// both shapes is the field-triage batch-C hardening: #225 keyed re-init only
+    /// on the parseable `-32001` frame, so an unknown-session response delivered
+    /// WITHOUT a JSON-RPC frame (the owner's own SSE/GET path already does this
+    /// with a plain-text 404 body; a proxy could do it on POST) slipped past the
+    /// trigger and the bridge failed with "no JSON-RPC response frame" instead of
+    /// recovering. The status check closes that.
+    pub fn signals_session_expired(&self) -> bool {
+        self.status == SESSION_EXPIRED_STATUS || self.value.as_ref().is_some_and(is_session_expired)
+    }
+}
+
 /// Does this response frame carry the owner's "session unknown/expired" error?
 /// Keyed on the JSON-RPC error `code == -32001` so it works whether the owner
-/// delivered the error as `application/json` or inside an SSE frame.
+/// delivered the error as `application/json` or inside an SSE frame. This is the
+/// FRAME-level check; the transport-level shape (HTTP 404 with or without a frame)
+/// is handled by [`PostOutcome::signals_session_expired`].
 fn is_session_expired(value: &serde_json::Value) -> bool {
     value
         .get("error")
@@ -333,15 +363,19 @@ pub async fn reinitialize(
 }
 
 /// Forward one JSON-RPC `payload` to the owner, transparently recovering from an
-/// owner restart. If the owner answers with `-32001` (session unknown/expired),
-/// re-initialize ONCE (replaying the retained host params) and retry the original
-/// request under the fresh session, returning that result to the host as if
-/// nothing happened. Guarded to a single re-init attempt per call: if re-init or
-/// the retry still yields `-32001`, the honest error is returned rather than
-/// looping. `session` is updated in place across a successful re-init.
+/// owner restart. If the owner signals an unknown/expired session — in ANY shape:
+/// the `-32001` JSON-RPC frame OR a bare HTTP `404` with no usable body (see
+/// [`PostOutcome::signals_session_expired`]) — re-initialize ONCE (replaying the
+/// retained host params) and retry the original request under the fresh session,
+/// returning that result to the host as if nothing happened. Guarded to a single
+/// re-init attempt per call: if re-init or the retry still signals expiry, the
+/// honest error is returned rather than looping. `session` is updated in place
+/// across a successful re-init.
 ///
-/// This is the field-triage #5 fix. It is exercised end-to-end (real owner
-/// restart, red→green) by `tests/attach_reinit.rs`.
+/// This is the field-triage #5 fix, hardened in field-triage batch-C to key on
+/// the unknown-session HTTP status (not only the frame) so recovery is robust to
+/// every transport shape. Exercised end-to-end (real owner restart, incl. a
+/// double-restart / binary-swap cycle, red→green) by `tests/attach_reinit.rs`.
 pub async fn forward_with_reinit(
     client: &reqwest::Client,
     endpoint: &str,
@@ -349,28 +383,52 @@ pub async fn forward_with_reinit(
     payload: &str,
 ) -> Result<serde_json::Value, String> {
     let outcome = post_and_demux(client, endpoint, session, payload).await?;
-    let value = outcome
-        .value
-        .ok_or_else(|| "owner returned no JSON-RPC response frame".to_string())?;
 
-    if !is_session_expired(&value) {
-        return Ok(value);
+    // Decide expiry from the WHOLE outcome (HTTP status + optional frame), not
+    // just a parsed frame — the owner may signal an unknown session at the
+    // transport layer (HTTP 404) with no usable JSON-RPC body (its SSE/GET path
+    // already does exactly that; a proxy could do it on POST). Reading `value`
+    // first would fail with "no response frame" and never reach re-init.
+    if !outcome.signals_session_expired() {
+        // Not a session-expiry outcome: return the frame, or surface the honest
+        // "no frame" transport error for anything else.
+        return outcome
+            .value
+            .ok_or_else(|| "owner returned no JSON-RPC response frame".to_string());
     }
+
+    // Preserve the exact session-expired error to pass through honestly if re-init
+    // or the retry cannot recover. Synthesize one when the owner sent no frame
+    // (e.g. a plain-text 404) so double-failure still yields a well-formed error.
+    let want_id = serde_json::from_str::<serde_json::Value>(payload)
+        .ok()
+        .and_then(|v| v.get("id").cloned())
+        .filter(|v| !v.is_null())
+        .unwrap_or(serde_json::Value::Null);
+    let expired_error = outcome.value.clone().unwrap_or_else(|| {
+        serde_json::to_value(jsonrpc_error(
+            want_id,
+            SESSION_EXPIRED_CODE as i32,
+            "Unknown or expired Mcp-Session-Id; re-initialize".to_string(),
+        ))
+        .unwrap_or(serde_json::Value::Null)
+    });
 
     // Owner-side session is gone (restart). Re-initialize once, then retry.
     eprintln!("[m1nd-mcp][attach] owner session expired — re-initialized");
     match reinitialize(client, endpoint, session).await {
         Ok(_) => {
+            // Single-retry guard: exactly one re-init + retry per call. Whatever
+            // the retry returns is final — its real result on success, or (if it
+            // STILL signals expiry / carried no frame) the preserved honest error,
+            // never a second re-init loop.
             let retry = post_and_demux(client, endpoint, session, payload).await?;
-            match retry.value {
-                Some(v) => Ok(v),
-                None => Ok(value), // no fresh frame — return the original -32001 honestly
-            }
+            Ok(retry.value.unwrap_or(expired_error))
         }
         Err(e) => {
             eprintln!("[m1nd-mcp][attach] re-init failed ({e}); passing error through");
             // Honest passthrough of the original session-expired error.
-            Ok(value)
+            Ok(expired_error)
         }
     }
 }
@@ -946,6 +1004,62 @@ mod tests {
         let got = extract_sse_response(body, Some(&want), TransportMode::Line, &sink)
             .expect("falls back to first response");
         assert_eq!(got["id"], 99);
+    }
+
+    #[test]
+    fn signals_session_expired_covers_frame_and_status_shapes() {
+        // Frame carries -32001 (owner's POST shape) → expired, whatever the status.
+        let frame = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": { "code": -32001, "message": "Unknown or expired Mcp-Session-Id" }
+        });
+        let with_frame = PostOutcome {
+            value: Some(frame),
+            session_id_header: None,
+            status: 404,
+        };
+        assert!(with_frame.signals_session_expired());
+
+        // 404 with NO frame (owner's SSE/GET shape, or a proxy stripping the body)
+        // → STILL expired, driven by the status alone. This is the batch-C fix.
+        let frameless = PostOutcome {
+            value: None,
+            session_id_header: None,
+            status: 404,
+        };
+        assert!(frameless.signals_session_expired());
+
+        // A 404 whose body happens to be some OTHER error is still treated as an
+        // unknown-session outcome (the owner only ever 404s for that reason on
+        // /mcp) — status is authoritative.
+        let other_404 = PostOutcome {
+            value: Some(
+                serde_json::json!({"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"x"}}),
+            ),
+            session_id_header: None,
+            status: 404,
+        };
+        assert!(other_404.signals_session_expired());
+
+        // A normal 200 result must NOT be treated as expired.
+        let ok = PostOutcome {
+            value: Some(serde_json::json!({"jsonrpc":"2.0","id":1,"result":{"ok":true}})),
+            session_id_header: None,
+            status: 200,
+        };
+        assert!(!ok.signals_session_expired());
+
+        // A non-404 error frame that is NOT -32001 must NOT be treated as expired
+        // (e.g. a genuine tool error under HTTP 200) — otherwise we'd re-init on
+        // ordinary failures.
+        let other_error = PostOutcome {
+            value: Some(
+                serde_json::json!({"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"boom"}}),
+            ),
+            session_id_header: None,
+            status: 200,
+        };
+        assert!(!other_error.signals_session_expired());
     }
 
     #[test]

--- a/m1nd-mcp/tests/attach_reinit.rs
+++ b/m1nd-mcp/tests/attach_reinit.rs
@@ -27,7 +27,7 @@ use std::net::TcpListener;
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
-use m1nd_mcp::attach_client::{forward_with_reinit, post_and_demux, AttachSession};
+use m1nd_mcp::attach_client::{forward_with_reinit, post_and_demux, AttachSession, PostOutcome};
 
 /// Path to the compiled binary under test (Cargo sets `CARGO_BIN_EXE_<name>`).
 const BIN: &str = env!("CARGO_BIN_EXE_m1nd-mcp");
@@ -120,6 +120,46 @@ fn tools_list_payload(id: i64) -> String {
     serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": "tools/list" }).to_string()
 }
 
+/// Poll a bare `initialize` against `endpoint` (with a FRESH throwaway session, so
+/// the caller's real bridge session is left untouched) until the owner answers a
+/// `result`, or panic after `timeout`. Used to know a (re)spawned owner is serving
+/// before driving the stale-session bridge through it — without racing the bind.
+async fn wait_until_serving(client: &reqwest::Client, endpoint: &str, timeout: Duration) {
+    let probe = initialize_payload();
+    let deadline = Instant::now() + timeout;
+    loop {
+        let fresh = AttachSession::default();
+        if let Ok(o) = post_and_demux(client, endpoint, &fresh, &probe).await {
+            if o.value.and_then(|v| v.get("result").cloned()).is_some() {
+                return;
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!("owner never came back to serving within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+/// Kill an owner child, wait for exit, give the OS a beat to release the port,
+/// then spawn a fresh owner on the SAME port + tmp (the launchd-kickstart /
+/// binary-swap event) and block until it is serving. Returns the new child.
+async fn restart_owner(
+    old: &mut Child,
+    client: &reqwest::Client,
+    endpoint: &str,
+    port: u16,
+    tmp: &std::path::Path,
+) -> Child {
+    let _ = old.kill();
+    let _ = old.wait();
+    // Give the OS a moment to release the port before rebinding.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let fresh = spawn_owner(port, tmp);
+    wait_until_serving(client, endpoint, Duration::from_secs(30)).await;
+    fresh
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn bridge_survives_owner_restart_transparently() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -200,5 +240,152 @@ async fn bridge_survives_owner_restart_transparently() {
     assert_ne!(
         first_session_id, second_session_id,
         "a transparent re-init must capture a fresh Mcp-Session-Id"
+    );
+}
+
+/// Field-triage batch-C / PRD §21.14 — "sessions ride #225" is a BUDGETED claim,
+/// so it needs a proof that survives MORE than one restart. The original test
+/// restarts once; this drives the SAME bridge session through TWO consecutive
+/// owner restarts (the second respawned after a full kill — the binary-swap /
+/// launchd-kickstart shape), asserting transparent recovery each time and a fresh
+/// session id after each. A regression that recovers once but not repeatedly
+/// (e.g. a re-init guard that latches) fails HERE.
+#[tokio::test(flavor = "multi_thread")]
+async fn bridge_survives_two_restarts_including_binary_swap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let port = free_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let endpoint = format!("{base_url}/mcp");
+    let client = reqwest::Client::builder().build().expect("reqwest client");
+
+    let mut owner = spawn_owner(port, tmp.path());
+    let mut session = wait_and_initialize(&client, &endpoint).await;
+    let mut last_sid = session.mcp_session_id.clone().expect("initial session id");
+
+    // A live call works before any restart.
+    let ok = forward_with_reinit(&client, &endpoint, &mut session, &tools_list_payload(2))
+        .await
+        .expect("first tools/list forwards");
+    assert!(ok.get("result").is_some(), "pre-restart call: {ok}");
+
+    // Two consecutive restarts, each driven through the SAME stale bridge session.
+    for cycle in 1..=2 {
+        owner = restart_owner(&mut owner, &client, &endpoint, port, tmp.path()).await;
+
+        // Distinct request id per cycle (10, 11) so a mismatched frame can't slip by.
+        let id = 10 + cycle;
+        let after = forward_with_reinit(&client, &endpoint, &mut session, &tools_list_payload(id))
+            .await
+            .unwrap_or_else(|e| panic!("cycle {cycle}: transport error: {e}"));
+        assert!(
+            after.get("error").is_none(),
+            "cycle {cycle}: bridge must transparently re-init, saw error frame: {after}"
+        );
+        assert!(
+            after.get("result").is_some(),
+            "cycle {cycle}: re-init should yield a real result, got: {after}"
+        );
+
+        let sid = session
+            .mcp_session_id
+            .clone()
+            .unwrap_or_else(|| panic!("cycle {cycle}: session id after re-init"));
+        assert_ne!(
+            last_sid, sid,
+            "cycle {cycle}: each restart must mint a FRESH Mcp-Session-Id"
+        );
+        last_sid = sid;
+    }
+
+    let _ = owner.kill();
+    let _ = owner.wait();
+}
+
+/// Field-triage batch-C — LOCK the owner's unknown-session wire SHAPE to the shape
+/// the bridge's re-init trigger matches, so a future owner change that alters it
+/// FAILS loudly here instead of silently re-breaking live sessions.
+///
+/// This is the gap the investigation surfaced: #225 keyed re-init ONLY on a
+/// parseable `-32001` JSON-RPC frame. The owner's `POST /mcp` currently pairs its
+/// `404` with that frame (so #225 works) — but its `GET /mcp` relay answers `404`
+/// with a PLAIN-TEXT body and no frame, and a proxy could strip the body on POST.
+/// The fix keys re-init on the 404 STATUS too. Here we assert:
+///   (a) the real owner's POST unknown-session response is `404` carrying the
+///       `-32001` frame — the shape the bridge matches; drift on EITHER trips it;
+///   (b) `PostOutcome::signals_session_expired()` fires on that real outcome;
+///   (c) it ALSO fires on a synthetic frame-less 404 (the plain-text / proxy
+///       shape), proving the status path — not only the frame — drives recovery.
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_unknown_session_wire_shape_is_recoverable() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let port = free_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let endpoint = format!("{base_url}/mcp");
+    let client = reqwest::Client::builder().build().expect("reqwest client");
+
+    let mut owner = spawn_owner(port, tmp.path());
+    wait_until_serving(&client, &endpoint, Duration::from_secs(30)).await;
+
+    // Drive a post-init request carrying a BOGUS session id (exactly what a stale
+    // bridge holds after an owner restart) and inspect the RAW outcome.
+    let bogus = AttachSession {
+        mcp_session_id: Some("00000000-0000-0000-0000-deadbeefdead".to_string()),
+        protocol_version: Some("2025-06-18".to_string()),
+        initialize_payload: None,
+    };
+    let outcome = post_and_demux(&client, &endpoint, &bogus, &tools_list_payload(2))
+        .await
+        .expect("owner reachable");
+
+    let _ = owner.kill();
+    let _ = owner.wait();
+
+    // (a) The owner's unknown-session shape is EXACTLY what the bridge matches.
+    assert_eq!(
+        outcome.status, 404,
+        "owner must answer HTTP 404 for an unknown Mcp-Session-Id (the re-init \
+         trigger status); got {}",
+        outcome.status
+    );
+    let frame = outcome
+        .value
+        .as_ref()
+        .expect("owner's 404 currently carries a JSON-RPC frame");
+    assert_eq!(
+        frame
+            .get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|c| c.as_i64()),
+        Some(-32001),
+        "owner's unknown-session frame must carry code -32001; got: {frame}"
+    );
+
+    // (b) The real outcome is recognized as session-expired → the bridge re-inits.
+    assert!(
+        outcome.signals_session_expired(),
+        "the real owner unknown-session outcome must trigger re-init"
+    );
+
+    // (c) The STATUS path (not the frame) is load-bearing: a frame-less 404 — the
+    // owner's own SSE/GET shape, or anything a proxy produces — still triggers.
+    let frameless_404 = PostOutcome {
+        value: None,
+        session_id_header: None,
+        status: 404,
+    };
+    assert!(
+        frameless_404.signals_session_expired(),
+        "a 404 with NO JSON-RPC frame must STILL trigger re-init (status-driven)"
+    );
+
+    // And a normal success outcome must NOT be mistaken for expiry.
+    let ok_200 = PostOutcome {
+        value: Some(serde_json::json!({"jsonrpc":"2.0","id":2,"result":{}})),
+        session_id_header: None,
+        status: 200,
+    };
+    assert!(
+        !ok_200.signals_session_expired(),
+        "a 200 result must never be treated as session-expired"
     );
 }


### PR DESCRIPTION
## The recurrence (field mailbox L30 / PRD risk §21.14)

The §O.13 PRD writer reported, against the live `:1338` medulla:
> both north calls returned `-32001` with **NO transparent re-init**; session handle predates the 16:44 medulla binary-swap restart; retry did not recover.

This is the exact open item the two-tier PRD flags (docs/TWO-TIER-BRAIN-PRD.md §21.14, :645): *"until it is green, 'sessions ride #225' is a **budgeted claim, not a fact**."* This PR closes it.

## Investigation verdict: TIMELINE ARTIFACT (not a hole in #225's core POST path)

**Evidence.** The binary was swapped to `f737931` (post-#225 `c797714`) at **16:44:46**; the pre-swap backup `m1nd-mcp.bak-pre-f737931` was created the same instant; the medulla restarted (`ps` shows the `--serve` owner started `16:44:57`). A `--attach` bridge is a **long-lived process**. The writer's own words are that its session *predated* the 16:44 restart — so its bridge **process** was spawned **before** the 16:44:46 swap → ran **pre-#225** code with no `forward_with_reinit` → forwarded the `-32001` verbatim. Exactly the reported symptom, retry included.

**Empirically confirmed** (hermetic owner on the current binary, raw HTTP probe): a post-init POST carrying a stale session id returns
```
HTTP/1.1 404 Not Found
content-type: application/json
{"jsonrpc":"2.0","id":2,"error":{"code":-32001,"message":"Unknown or expired Mcp-Session-Id; re-initialize"}}
```
`post_and_demux` parses that body (404 ≠ 202; content-type is JSON) and `is_session_expired` matches the `-32001` code → re-init fires. **#225 works for a bridge running the fixed binary.**

## The REAL gap this hardens

#225 keyed re-init **only** on a parseable `-32001` **frame**, ignoring `PostOutcome.status`. But the owner's own **GET `/mcp` (SSE relay)** already answers an unknown session with a **plain-text 404 and no JSON-RPC frame**:
```
HTTP/1.1 404 Not Found
content-type: text/plain; charset=utf-8
Unknown or expired Mcp-Session-Id; re-initialize
```
…and a proxy/intermediary could do the same on POST. In that shape `post_and_demux` returns `value: None` and `forward_with_reinit` failed with `"owner returned no JSON-RPC response frame"` — **never re-initializing.** 

**Fix:** extend the trigger to the unknown-session **HTTP status (404)** in addition to the frame, via `PostOutcome::signals_session_expired()`, and decide from the **whole outcome** (status + optional frame). Single-retry guard + honest passthrough preserved; a synthesized `-32001` frame is returned on double-failure when the owner sent no body. Diff scoped to `attach_client.rs` + tests — **`mcp_http.rs` untouched** (the owner's shape was already correct; the test *locks* it).

## Proof (red→green)

- **`bridge_survives_two_restarts_including_binary_swap`** — drives the SAME stale bridge session through **two** consecutive kill+respawn cycles (the binary-swap/launchd-kickstart shape), asserting transparent recovery + a fresh `Mcp-Session-Id` each cycle. This is the §21.14 "bounce-under-live-session" gate.
- **`owner_unknown_session_wire_shape_is_recoverable`** — LOCKS the owner's real unknown-session shape (`404` + `-32001` frame) so a future owner change that alters it **fails loudly**, and asserts a **frame-less 404** still triggers re-init (proving the status path is load-bearing).
- **`signals_session_expired_covers_frame_and_status_shapes`** (unit) — frame-only / status-only / 200-success. **RED proven:** revert to frame-only detection → the frame-less-404 assertion fails (`assertion failed: frameless.signals_session_expired()`); restore the status check → passes.

## Gate

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features serve -- -D warnings` — **0**
- `cargo test --workspace --features serve` — **1176 passed, 0 failed** (no `auto_ingest_universal` flake)
- m1nd battery `--suite m1nd` — **37/37**, pass_rate **1.0**, **0** grep wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)