### PR TITLE
ci(pathos): stage the refreshed PATHOS per-path — a missing pathspec made git add atomically stage nothing

### DIFF
--- a/.github/workflows/pathos-autorefresh.yml
+++ b/.github/workflows/pathos-autorefresh.yml
@@ -51,7 +51,11 @@ jobs:
           git config user.name "Max Kle1nz"
           git config user.email "kleinz@cosmophonix.com"
           # Tenta os 3 caminhos suportados; ignora os que não existem.
-          git add docs/internal/PATHOS.md docs/PATHOS.md PATHOS.md 2>/dev/null || true
+          # NÃO usar um único `git add a b c`: pathspec inexistente é erro ATÔMICO
+          # (nada é adicionado e o refresh se perde em silêncio — provado no primeiro run, 2026-07-03).
+          for f in docs/internal/PATHOS.md docs/PATHOS.md PATHOS.md; do
+            if [ -f "$f" ]; then git add "$f"; fi
+          done
           if git diff --cached --quiet; then
             echo "Nada para commitar (PATHOS já alinhado)."
           else


### PR DESCRIPTION
The first live run of `pathos-autorefresh` (on the #236 merge push) exposed a silent-drop bug: the script regenerated both auto sections ("atualizado" in the log), but the commit step said "Nada para commitar" and pushed nothing.

**Root cause:** `git add docs/internal/PATHOS.md docs/PATHOS.md PATHOS.md 2>/dev/null || true` — git add is **atomic on pathspec errors**. Only `docs/PATHOS.md` exists in this repo, so the two missing pathspecs made the whole add stage NOTHING, with stderr and the exit code both swallowed. The refresh was generated and silently dropped.

**Fix:** add each candidate path individually, guarded by `if [ -f ]` (the `if`-form, not bare `&&`, so the step survives `bash -e` when the last candidate is absent).

**Proof (local red-green, run under `bash -e` like the runner):** with a modified `docs/PATHOS.md`, the OLD form staged nothing (bug reproduced); the NEW loop staged it and exited 0.

The merge push of this PR will itself trigger the workflow (workflow file is not path-ignored), so the first REAL refresh commit — as Max Kle1nz, `[skip ci]` — should land right after, replacing the pre-populated overview (which still carries the local worktree values: `m1nd-cp9`/`docs/pathos-cp9`).

Also fixed at the source template (`~/.claude/skills/pathos/autorefresh/`) so the bug doesn't propagate to the next repo.