### PR TITLE
release: v1.3.0 — the shell reaches every host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "axum",
  "clap",

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -47,6 +47,15 @@ degrading to UNPROVABLE rather than a fake green — the same bar, applied to bu
 
 ## Current State (2026-07-03, checkpoint 9 — THE CONSTRUCTION ERA OPENS)
 
+> **cp9 addendum (2026-07-04): v1.3.0 CUT.** The construction era's first release — the
+> mailbox-zero fixes (#230/#231/#233/#235/#240), the Living Tree LIVE (graph_changed SSE +
+> vendored fonts, #242), `m1nd hosts` grown 5→22 hosts + the new `m1nd-north-shim` (#244),
+> the HOST-INTEGRATION-MATRIX (#241), reception §9.5 (#238), and the MCP-Registry manifest
+> (`server.json` + npm `mcpName`, #243) — semver MINOR for the new host surfaces. Tagged on
+> the merge commit; crates.io + npm + GitHub Release via the release workflow; registry
+> publish follows once npm serves 1.3.0 (`mcp-publisher login github` is Max's device-code
+> moment). The wiki changelog's never-tagged `1.2.2` draft was absorbed into 1.3.0.
+
 **The 24h harvest: OMEGA shipped as the floor, three PRDs made official, the first human
 surface landed, and the field-report mailbox went from full to empty.** This is the checkpoint
 where m1nd stops being only "a better `rg` for agents" and becomes a substrate with a *human

--- a/docs/wiki/src/changelog.md
+++ b/docs/wiki/src/changelog.md
@@ -10,29 +10,74 @@ No unreleased changes.
 
 ---
 
-## [1.2.2] — 2026-07-03
+## [1.3.0] — 2026-07-04
 
-Brand gate G1 + G1.5 — honesty is the product.
+The construction-era release: **the shell reaches every host.** One 24-hour sweep —
+fourteen PRs — empties the field-triage mailbox to zero, takes the Living Tree live,
+teaches `m1nd hosts` twenty-two agent hosts, and steps m1nd into the official MCP
+Registry. (A `1.2.2` section was drafted here but never tagged; its content ships in
+this release.)
+
+### Added
+
+- **`m1nd hosts` learns 22 hosts (#244).** From 5 to 22: seven TIER-A hook recipes
+  (`SessionStart`/`agentSpawn`/`TaskStart` families — claude, codex, qwen, kiro, cline,
+  continue, grok) plus fifteen B-tier doctrine emitters (cursor, windsurf, zed, vscode,
+  gemini, antigravity, opencode, warp, trae, jetbrains, amp, goose, crush, aider, generic).
+  `plan` is pure print; `apply` is idempotent and never clobbers foreign config (the codex
+  duplicate-TOML incident is now a regression test); on claude, apply never writes
+  `settings.json` — it prints the block for explicit pasting.
+- **`m1nd-north-shim` (#244).** New fail-open bin that wraps `m1nd agent first-minute`
+  and renders its envelope into the hook contract
+  (`{"hookSpecificOutput":{"additionalContext":…}}`) — one stable command every
+  session-start hook can call.
+- **The Living Tree goes live (#242).** A shared mutation predicate now derives a
+  browser `graph_changed` event on the existing `/api/events` SSE stream (closing the
+  known pure-reader relay gap); the UI refetches with a calm ~500 ms debounce and falls
+  back to polling. Fonts are vendored (Instrument Sans, IBM Plex Mono, Fraunces — OFL,
+  ~116 KB): the UI renders fully offline, zero external hosts in `dist/`.
+- **HOST-INTEGRATION-MATRIX (#241).** The canonical map of ~24 agent hosts ×
+  (session-start hooks / MCP `instructions` rendering / roots / rules files), every cell
+  carrying its verification label, with copy-pasteable TIER-A recipes and the honest
+  spec limit: a server speaks only when called — the in-band packet is the universal floor.
+- **First-Contact Reception protocol (#238).** TWO-TIER-BRAIN-PRD §9.5: on first contact
+  the bridge/owner answers with where-you-are, what-exists, machine-executable options,
+  a suggested default, and honest gaps — silent binding only when cwd matches (TT-INV-12).
+  Field-evidenced by the Antigravity silent-bind report.
+- **Two-Tier Brain PRD (#227)**, **Human-Layer PRD (#222)** + Living Tree Slice 0 (#232),
+  and the **§O.12 subagent Delegation Layer (#224)** — the construction era's three official
+  blueprints.
+- **PATHOS auto-refresh + checkpoint 9 (#236/#237/#239).** git-cliff + GitHub Action keep
+  the auto sections fresh on every main push (fail-soft under branch protection); cp9
+  consolidates the era.
+- **MCP Registry manifest (#243).** Root `server.json` (2025-12-11 schema) + `mcpName`
+  in the npm package — the ownership proof the official registry validates.
+- **agent-docs CI gate (#229)** and the **README re-spined around "the shell" (#228)**
+  in all eight languages.
+
+### Fixed
+
+- **Warm-boot immortal graph (#230).** Relative persist targets anchor on the runtime
+  root; the launchd owner stopped failing persistence (39 consecutive failures → 0) and
+  now warm-boots the full graph.
+- **Marker fragments excluded from recall/anchors (#231).** `::tag::` structural
+  fragments no longer pollute north's memory beat or anchor slots.
+- **Attach re-init covers every unknown-session shape (#233)** — including the frameless
+  404 — with restart-survival proven end-to-end.
+- **Attach self-echo (#235).** Write-tool responses return real envelopes through the
+  bridge; `graph_changed` notifications no longer race the response into the stdout sink.
+- **auto_ingest CI flake killed at the source (#240).** Watch events for existing
+  directories are dropped before the queue, so `queue_depth` is an honest signal and the
+  single forced tick is deterministic — proven 20/20 across three configurations.
 
 ### Removed
 
-- **The unmeasured `savings` envelope (brand gate G1).** Every response used to
-  carry `_m1nd.savings`, `_m1nd.tokens_saved`, and `_m1nd.gaia.global_tokens_never_burned`
-  — a confidently-stated "tokens saved" number with no measured basis. An uncalibrated
-  claim is the confident guess, and it has no place in a product whose whole promise is
-  calibrated trust. The envelope's honest neighbors (`suggest_next`, `read_only`,
-  `summary`) are kept.
-- **The opt-in `savings`/`report` unmeasured-claims surface (brand gate G1.5) —
-  completes the beta.7 de-advertisement.** G1 removed the per-response envelope, but the
-  standalone opt-in tools still emitted the same uncalibrated tokens-saved numbers when
-  explicitly called — a living remnant of the confident guess behind an explicit call. The
-  brand cannot say it killed the unmeasured claim while a tool named `savings` still emits
-  it. So the `savings` tool is **removed entirely** (dispatch arm + handler + `SavingsInput`/
-  `SavingsOutput`/`SavingsSessionRecord` types + the `SavingsTracker`/`GlobalSavingsState`
-  accounting; nothing writes `savings_state.json` anymore). `report` **survives, stripped**:
-  its honest content — query counts, elapsed time, graph size, and the highest-risk heuristic
-  hotspots — is kept, while every `tokens_saved_session` / `tokens_saved_global` /
-  `co2_saved_grams` field is gone.
+- **The unmeasured `savings` envelope (brand gate G1) and the opt-in `savings`/`report`
+  unmeasured-claims surface (G1.5) (#234).** An uncalibrated "tokens saved" number is a
+  confident guess, and it has no place in a product whose promise is calibrated trust.
+  `savings` is gone entirely (dispatch arm, handler, types, tracker state); `report`
+  survives stripped to its honest content — query counts, elapsed time, graph size,
+  heuristic hotspots. Completes the beta.7 de-advertisement.
 
 ---
 

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -41,7 +41,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.2.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.3.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -18,8 +18,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.2.1" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.2.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.3.0" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.3.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/maxkle1nz/m1nd",
     "source": "github"
   },
-  "version": "1.2.2",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@maxkle1nz/m1nd",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Corte do release da era de construção. Bumps 1.2.1→1.3.0 (workspace Cargo.toml ×3 + deps internas, Cargo.lock, package.json, server.json ×2), changelog do wiki com a seção [1.3.0] (absorvendo o draft 1.2.2 nunca tagueado) e addendum cp9 no PATHOS.

Pós-merge: tag `v1.3.0` no merge commit → release workflow builda os 3 alvos, corta o GitHub Release e publica crates.io + npm (o npm nasce com `mcpName` → destrava o publish no MCP Registry oficial).