### PR TITLE
chore(registry): published — sync description + matrix §6b SHIPPED

### DIFF
--- a/docs/HOST-INTEGRATION-MATRIX.md
+++ b/docs/HOST-INTEGRATION-MATRIX.md
@@ -446,11 +446,12 @@ Straight from the research, stated as **built / unbuilt / unverified** — never
    print; `apply --yes` writes owned hook JSON (merge, never-clobber) and doctrine files, and
    PRINTS the Claude/Cline/Kiro host-managed hook blocks rather than writing them.
 
-### 6b. Publish `server.json` to the official registry
+### 6b. Publish `server.json` to the official registry — **SHIPPED 2026-07-04**
 
-Publish m1nd to `registry.modelcontextprotocol.io` as `io.github.maxkle1nz/m1nd` via the
-registry publish action. **Cheap, real, unblocked** — the registry is LIVE (§5.4). This is a
-*build* action, not a research question.
+Published: `io.github.maxkle1nz/m1nd` **v1.3.0** is live on `registry.modelcontextprotocol.io`
+(device-flow auth by Max as maxkle1nz; verified via the public search API). Ownership proof =
+`mcpName` inside the npm package `@maxkle1nz/m1nd@1.3.0`. Gotcha learned: the registry caps
+`description` at **100 chars** — the repo `server.json` carries the published 95-char form.
 
 ### 6c. The `[unverified]` probe list — with verification steps
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.maxkle1nz/m1nd",
-  "description": "The shell around your coding agent: a neuro-symbolic code graph with calibrated trust. North orients before work, verdicts guard during, memory compounds after — via MCP.",
+  "description": "The shell around your coding agent: a neuro-symbolic code graph with calibrated trust, via MCP.",
   "repository": {
     "url": "https://github.com/maxkle1nz/m1nd",
     "source": "github"


### PR DESCRIPTION
m1nd está NO AR no MCP Registry oficial: `io.github.maxkle1nz/m1nd` v1.3.0, publicado via device-flow (maxkle1nz) e verificado na API pública de busca.

- `server.json`: descrição sincronizada com a forma publicada (o registry valida ≤100 chars — gotcha aprendido no `mcp-publisher validate`)
- Matrix §6b: marcado **SHIPPED 2026-07-04**