### PR TITLE
chore(discoverability): fill empty npm+crates keywords + glama.json (v1.3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "axum",
  "clap",

--- a/docs/wiki/src/changelog.md
+++ b/docs/wiki/src/changelog.md
@@ -10,6 +10,19 @@ No unreleased changes.
 
 ---
 
+## [1.3.1] — 2026-07-04
+
+Discoverability patch — metadata only, no behavior change.
+
+### Added
+
+- **npm keywords** (`mcp`, `mcp-server`, `model-context-protocol`, `code-graph`, …) and
+  **crates.io keywords + categories** on all three crates — both were shipping **empty**,
+  so the published packages were invisible to registry search. Repo GitHub topics set to
+  match. `glama.json` added (Glama listing claim). `server.json` synced to 1.3.1.
+
+---
+
 ## [1.3.0] — 2026-07-04
 
 The construction-era release: **the shell reaches every host.** One 24-hour sweep —

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "m1nd-core"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"
+keywords = ["mcp", "mcp-server", "code-graph", "agent", "ai"]
+categories = ["development-tools", "command-line-utilities"]
 repository = "https://github.com/maxkle1nz/m1nd"
 
 [dependencies]

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "m1nd-ingest"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
+keywords = ["mcp", "mcp-server", "code-graph", "agent", "ai"]
+categories = ["development-tools", "command-line-utilities"]
 repository = "https://github.com/maxkle1nz/m1nd"
 
 [features]
@@ -41,7 +43,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.3.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.3.1" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "m1nd-mcp"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
+keywords = ["mcp", "mcp-server", "code-graph", "agent", "ai"]
+categories = ["development-tools", "command-line-utilities"]
 repository = "https://github.com/maxkle1nz/m1nd"
 
 [features]
@@ -18,8 +20,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.3.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.3.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.3.1" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.3.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",
@@ -47,5 +47,18 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "modelcontextprotocol",
+    "code-graph",
+    "code-intelligence",
+    "coding-agent",
+    "ai-agent",
+    "neuro-symbolic",
+    "developer-tools",
+    "rust"
+  ]
 }

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.maxkle1nz/m1nd",
-  "description": "The shell around your coding agent: a neuro-symbolic code graph with calibrated trust. North orients before work, verdicts guard during, memory compounds after — via MCP.",
+  "description": "The shell around your coding agent: a neuro-symbolic code graph with calibrated trust, via MCP.",
   "repository": {
     "url": "https://github.com/maxkle1nz/m1nd",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@maxkle1nz/m1nd",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
A pesquisa de distribuição descobriu: **npm sem `keywords` e crates.io com `keywords/categories` vazios nos 3 crates** — os pacotes publicados eram invisíveis pra busca dos registries. Este patch: 11 keywords npm, keywords+categorias nos crates, `glama.json` (claim do listing existente no Glama), server.json→1.3.1, changelog. Topics do repo já setados via API. Pós-merge: tag `v1.3.1` republica npm+crates com a metadata.