### PR TITLE
fix(npm): cold-start funnel — --version flag + fresh installs fetch the package's own runtime (was 0.9.0-beta.6)

### DIFF
--- a/docs/AGENT-PACKS.md
+++ b/docs/AGENT-PACKS.md
@@ -22,6 +22,7 @@ same operating model.
 
 ```bash
 npm install -g .
+m1nd version   # prints the package version (also: m1nd --version, m1nd -V)
 m1nd doctor
 ```
 
@@ -224,13 +225,15 @@ orientation and hypothesis tools; direct source reads, tests, compiler/runtime
 output, logs, or focused probes remain final truth.
 
 If the host is stale because it is still launching an older native binary, use
-the self-update surface first:
+the self-update surface first. The default channel is `latest`, so a fresh
+install lands on the package's own version; pass `--channel beta` only to opt
+into prereleases:
 
 ```bash
-m1nd update check --channel beta
-m1nd update status --channel beta
-m1nd update plan --channel beta
-m1nd update apply --channel beta --yes
+m1nd update check
+m1nd update status
+m1nd update plan
+m1nd update apply --yes
 m1nd update verify --repo /path/to/m1nd --transport stdio
 m1nd hosts status --host all --project /path/to/project --json
 m1nd hosts plan --host all --project /path/to/project --json

--- a/npm/lib/agent-cli.js
+++ b/npm/lib/agent-cli.js
@@ -1350,7 +1350,7 @@ async function agentDoctor(args, deps, repo, agentId) {
   });
   envelope.package_doctor = deps.doctor();
   envelope.hosts = deps.hostStatus({ ...args, host: args.host || "all", project: repo, binary });
-  envelope.update = deps.selfUpdate({ ...args, _: ["update", "status"], channel: args.channel || "beta", binary, "no-kill": true });
+  envelope.update = deps.selfUpdate({ ...args, _: ["update", "status"], channel: args.channel || "latest", binary, "no-kill": true });
   envelope.pack = deps.assertPackShape();
   envelope.next_actions.push("If any host/runtime surface needs attention, apply the emitted update/hosts plan and restart/rebind the host.");
   envelope.next_actions.push("After host rebind, call trust_selftest or run m1nd agent trust --ensure-ingest.");
@@ -1401,11 +1401,11 @@ function recoveryPlan(type, repo, binary) {
     return [
       {
         action: "inspect_install",
-        command: "m1nd update status --channel beta --json",
+        command: "m1nd update status --json",
       },
       {
         action: "plan_update_if_needed",
-        command: "m1nd update plan --channel beta --json",
+        command: "m1nd update plan --json",
       },
       {
         action: "check_host_wiring",

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -35,6 +35,7 @@ Usage:
   m1nd hosts plan [--host codex|claude|gemini|antigravity|generic|all] [--project <dir>] [--binary <path>] [--json]
   m1nd hosts apply [--host codex|claude|gemini|antigravity|generic|qwen|kiro|cline|continue|grok|...|all] [--project <dir>] [--binary <path>] [--yes] [--no-skills] [--no-config] [--no-hooks] [--json]
   m1nd doctor [--json]
+  m1nd version   (also: m1nd --version, m1nd -V)
   m1nd restart [--source <dir>] [--binary <path>] [--yes] [--json]
   m1nd update check [--channel beta|latest] [--json]
   m1nd update status [--channel beta|latest] [--json]
@@ -128,6 +129,7 @@ function parseArgs(args) {
         "no-skills",
         "shared-runtime",
         "skip-ingest",
+        "version",
         "yes",
       ].includes(key)
     ) {
@@ -1193,7 +1195,7 @@ function hostStatus(args) {
     const nextActions = [];
     const warnings = [];
     if (!runtimeCurrent) {
-      nextActions.push("Run m1nd update status --channel beta --json, then m1nd update plan/apply if the runtime is stale or missing.");
+      nextActions.push("Run m1nd update status --json, then m1nd update plan/apply if the runtime is stale or missing.");
     }
     if (pathShadow.status === "actionable") {
       nextActions.push("Align the m1nd-mcp binary found on PATH or pass --binary to target the runtime this host launches.");
@@ -1744,7 +1746,7 @@ function doctor() {
     result.next_actions.push(`From a source checkout: cargo build --release -p m1nd-mcp, then copy ${runtimeBinaryName()} to ${defaultRuntimePath()}`);
   }
   if (binary && (!binaryVersion || !binaryVersion.includes(packageVersion))) {
-    result.next_actions.push(`Runtime version ${binaryVersion || "unknown"} does not match package ${packageVersion}; run m1nd update plan --channel beta, then m1nd update apply --channel beta --yes and rebind the host.`);
+    result.next_actions.push(`Runtime version ${binaryVersion || "unknown"} does not match package ${packageVersion}; run m1nd update apply --yes to install the matching runtime, then rebind the host.`);
   }
   if (!codexSkillsInstalled) {
     result.next_actions.push("For Codex: m1nd install-skills codex");
@@ -1864,7 +1866,10 @@ function safeJsonParse(text) {
 }
 
 function normalizeChannel(channel) {
-  const normalized = channel || "beta";
+  // Default to `latest`: a fresh install must land on the shipped package version. The
+  // `beta` dist-tag trails far behind (an old 0.9.x) — defaulting to it dragged new users
+  // onto a months-old prerelease. Opt into beta explicitly with --channel beta.
+  const normalized = channel || "latest";
   if (!["beta", "latest"].includes(normalized)) {
     throw new Error(`unsupported update channel '${normalized}'. Supported channels: beta, latest`);
   }
@@ -2480,7 +2485,7 @@ function buildSelfUpdateStatus(args) {
   };
 
   if (hasPlannedActions) {
-    proof.next_actions.push("Run m1nd update plan --channel beta --json, inspect actions, then apply with --yes when ready.");
+    proof.next_actions.push("Run m1nd update plan --json, inspect actions, then apply with --yes when ready.");
   }
   if (blockingActions.length > 0) {
     proof.next_actions.push("Resolve blocking_actions before treating this install as agent-ready.");
@@ -2905,6 +2910,11 @@ function print(value, asJson) {
 async function main(rawArgs) {
   const args = parseArgs(rawArgs);
   const command = args._[0] === "/restart" ? "restart" : args._[0] || "help";
+
+  if (args.version || ["version", "-V", "--version"].includes(command)) {
+    console.log(readPackageVersion());
+    return;
+  }
 
   if (args.help || ["help", "-h", "--help"].includes(command)) {
     console.log(usage());

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -102,6 +102,19 @@ assert(help.stdout.includes("m1nd agent next"));
 assert(help.stdout.includes("m1nd pack-routing-check"));
 assert(help.stdout.includes("RETROBUILDER capability_suggestions"));
 
+// Cold-start bug 1: `m1nd --version` (a stranger's most common first command) must
+// print the package version and exit 0 — not "missing value for --version". The bare
+// `version` subcommand and the conventional `-V` short flag behave identically.
+for (const versionArgs of [["--version"], ["-V"], ["version"]]) {
+  const versionRun = spawnSync(process.execPath, [cli, ...versionArgs], { encoding: "utf8" });
+  assert.strictEqual(versionRun.status, 0, `${versionArgs.join(" ")} exit: ${versionRun.stderr}`);
+  assert.strictEqual(
+    versionRun.stdout.trim(),
+    CURRENT_VERSION,
+    `${versionArgs.join(" ")} should print the package version`
+  );
+}
+
 const packCheck = spawnSync(process.execPath, [cli, "pack-check", "--json"], { encoding: "utf8" });
 assert.strictEqual(packCheck.status, 0, packCheck.stderr);
 assert.strictEqual(JSON.parse(packCheck.stdout).schema, "m1nd-agent-pack-check-v0");
@@ -818,6 +831,79 @@ const updateStatusJson = JSON.parse(updateStatus.stdout);
 assert.strictEqual(updateStatusJson.schema, "m1nd-self-update-v0");
 assert.strictEqual(updateStatusJson.command, "status");
 assert(updateStatusJson.status_summary);
+
+// Cold-start bug 2: a fresh install must land on the PACKAGE's own version, never on a
+// months-old beta. In the real registry the `beta` dist-tag trails far behind (an old
+// 0.9.x) while `latest` tracks the shipped package — so the default channel must resolve
+// `latest`, and target/plan must point at the package version, not the stale beta tag.
+const registryBetaStale = JSON.stringify({
+  "dist-tags": { beta: "0.9.0-beta.8", latest: CURRENT_VERSION },
+  version: CURRENT_VERSION,
+});
+withEnv(
+  {
+    M1ND_TEST_NPM_VIEW_JSON: registryBetaStale,
+    M1ND_TEST_GITHUB_RELEASE_AVAILABLE: "true",
+    M1ND_TEST_CRATE_VERSION: CURRENT_VERSION,
+    M1ND_TEST_HOME: mkTmpDir(),
+  },
+  () => {
+    // Fresh install: no managed runtime yet (binary path does not exist).
+    const freshPlan = selfUpdate({
+      _: ["update", "plan"],
+      binary: path.join(mkTmpDir(), "no-such-m1nd-mcp"),
+      "no-kill": true,
+    });
+    // Default channel must be `latest`, and it must resolve the package version — not beta.
+    assert.strictEqual(freshPlan.channel, "latest", "default channel must be latest, not beta");
+    assert.strictEqual(
+      freshPlan.latest_version,
+      CURRENT_VERSION,
+      "default channel must resolve the package version, not the stale beta dist-tag"
+    );
+    assert.strictEqual(freshPlan.target_version, CURRENT_VERSION, "target must be the package version");
+    assert.strictEqual(freshPlan.install_state, "missing");
+    const runtimeAction = freshPlan.planned_actions.find((entry) => entry.kind === "runtime");
+    assert(runtimeAction, "a fresh install must plan a runtime install");
+    assert.strictEqual(
+      runtimeAction.target_version,
+      CURRENT_VERSION,
+      "runtime install must target the package version"
+    );
+    // The GitHub release for the package version is the primary source (v<CURRENT>).
+    assert.strictEqual(runtimeAction.id, "runtime-install-github-release");
+    assert(
+      String(runtimeAction.url || "").includes(`/download/v${CURRENT_VERSION}/`),
+      "runtime install must fetch the package-version GitHub release asset"
+    );
+    // No beta in the actions that actually execute (the registry echoes all dist-tags
+    // for transparency, but nothing a fresh install RUNS may target the stale beta).
+    assert(
+      !JSON.stringify(freshPlan.planned_actions).includes("0.9.0-beta"),
+      "fresh-install actions must not target the stale beta version"
+    );
+
+    // Doctor's fresh-install "next" advice must be a single sane step toward the package
+    // version — no `--channel beta` gymnastics that would drag a stranger onto the old beta.
+    const doctorRun = spawnSync(process.execPath, [cli, "doctor", "--json"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        M1ND_TEST_NPM_VIEW_JSON: registryBetaStale,
+        M1ND_TEST_GITHUB_RELEASE_AVAILABLE: "true",
+        M1ND_TEST_CRATE_VERSION: CURRENT_VERSION,
+        // Simulate a stale runtime already on disk so the mismatch advice fires.
+        M1ND_MCP_BINARY: process.execPath,
+        M1ND_TEST_RUNTIME_VERSION: "m1nd-mcp 0.9.0-beta.8",
+      },
+    });
+    assert.strictEqual(doctorRun.status, 0, doctorRun.stderr);
+    const doctorJson = JSON.parse(doctorRun.stdout);
+    const mismatchAdvice = doctorJson.next_actions.find((entry) => entry.includes("does not match package"));
+    assert(mismatchAdvice, "doctor must flag the runtime/package mismatch");
+    assert(!mismatchAdvice.includes("--channel beta"), "doctor must not steer a fresh user onto the beta channel");
+  }
+);
 
 const hostStatusCliProject = mkTmpDir();
 installSkills("generic", hostStatusCliProject);


### PR DESCRIPTION
Two cold-start bugs broke a stranger's first minute with m1nd, proven live hours before launch traffic. JS-only fix (`npm/lib/cli.js` + `npm/lib/agent-cli.js` + `npm/test/cli.test.js`).

## Bug 1 — `m1nd --version` fails (a stranger's most common first command)

Repro (verbatim):
```
npx -y @maxkle1nz/m1nd --version
→ m1nd: missing value for --version
```

Root cause: `parseArgs()` treats any `--flag` not in its boolean allowlist as an option that expects a following value. `--version` had no next arg → it threw `missing value for --version`.

Fix:
- Add `version` to the `parseArgs` boolean allowlist.
- Intercept `version` / `-V` / `--version` in `main()` **before** the help fallback and print `readPackageVersion()`. (Ordering matters: a bare `--version` leaves `args._` empty, so `command` defaults to `"help"` and was otherwise swallowed by the help branch.)
- Add a `m1nd version` usage line.

All three forms now print the package version and exit 0:
```
m1nd --version  → 1.3.1   (exit 0)
m1nd -V         → 1.3.1   (exit 0)
m1nd version    → 1.3.1   (exit 0)
```

## Bug 2 — fresh install fetches a months-old beta runtime

Repro (verbatim):
```
HOME=<empty dir> npx -y @maxkle1nz/m1nd@latest doctor
→ Runtime version m1nd-mcp 0.9.0-beta.6 does not match package 1.3.1;
  run m1nd update plan --channel beta…
```

Root cause: the update channel defaulted to `beta` (`normalizeChannel()` in `cli.js`, `agentDoctor` in `agent-cli.js`). `readNpmRegistry` resolves `latest_version = distTags[channel]`; the npm `beta` dist-tag trails far behind (`0.9.0-beta.x`) while `latest` tracks the shipped package (`1.3.1`). On top of that, the doctor / hostStatus / update-status / recovery-plan `next_actions` hardcoded `--channel beta`, actively steering a brand-new user onto the old prerelease and confusing channel instructions.

Fix (reuse-first — the `latest` channel and the `selectTargetVersion` clamp already existed; the default was just pointed at the wrong tag):
- Default channel `beta` → `latest`, so a fresh install resolves the package's own version.
- Strip hardcoded `--channel beta` from all auto-generated advice; the doctor's fresh-install "next" is now a single sane step: `run m1nd update apply --yes to install the matching runtime, then rebind the host.`

**Fallback chain (all pre-existing, now reachable):** default `latest` dist-tag → `selectTargetVersion` clamps to the local package version if the registry channel lags → GitHub Release asset for `v<packageVersion>` (v1.3.1 has all 3 target binaries) → cargo `install --version <pkg>` fallback if a release asset is missing. A fresh user now lands on the package's own version and never on a hardcoded old beta.

Explicit `--channel beta` remains a valid opt-in; the beta-update runbooks in `docs/` and `skills/` that intentionally demonstrate it were left unchanged (this PR changed the *default* and the *auto-generated advice*, not the meaning of the explicit flag).

## Proof: red → green (each test fails without the fix, passes with it)

New tests in `npm/test/cli.test.js` (the existing fixtures set both `beta` and `latest` to the current version, masking the real-world divergence — the new `registryBetaStale` fixture models `beta: 0.9.0-beta.8, latest: <current>`):

- `--version` / `-V` / `version` subprocess test — asserts each prints the package version, exit 0.
- Fresh-install resolution with the default channel — asserts `channel === "latest"`, `latest_version`/`target_version` === package version, the runtime action targets the package version and its `v<pkg>` GitHub-release URL, and the executed actions carry no beta.
- Doctor fresh-install advice — asserts the mismatch `next_action` fires and does **not** contain `--channel beta`.

Red (source reverted, tests kept):
```
Bug 1:  AssertionError: --version exit: m1nd: missing value for --version   (1 !== 0)
Bug 2:  AssertionError: default channel must be latest, not beta            ('beta' !== 'latest')
```

Green (fix applied):
```
# tests 1 | # pass 1 | # fail 0     (node --test npm/test/cli.test.js)
```

## Scope

JS-only. No Rust, no m1nd-ui, no README touched (a sibling owns the README rework). No doc changes: the fix invalidated the default channel + machine-generated advice (both handled in code), not the explicit-opt-in `--channel beta` runbooks.

## Ship note

After merge this reaches users only via a new npm publish. A **v1.3.2 patch tag is warranted immediately** — both bugs are in the stranger funnel and every fresh `npx @maxkle1nz/m1nd` install hits them until the patch is on npm's `latest`.
