### PR TITLE
release: v1.3.2 — the launch-funnel patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-core"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "axum",
  "clap",

--- a/docs/wiki/src/changelog.md
+++ b/docs/wiki/src/changelog.md
@@ -10,6 +10,28 @@ No unreleased changes.
 
 ---
 
+## [1.3.2] — 2026-07-04
+
+The launch-funnel patch — a stranger's first minute now works.
+
+### Fixed
+
+- **`--version` flag (#254).** `npx -y @maxkle1nz/m1nd --version` errored ("missing value")
+  — a stranger's most common first command. Now prints the version.
+- **Fresh installs fetched a months-old beta (#254).** A brand-new HOME received
+  m1nd-mcp `0.9.0-beta.6` plus confusing channel advice; fresh installs now fetch the
+  runtime matching the npm package's own version, with an honest fallback to the latest
+  release.
+
+### Added
+
+- **README conversion pass (#256):** 30-second real-session demo GIF, badges row,
+  a "60-second start", and `llms-install.md` (agent-legible install) — in all 8 languages.
+- **m1nd.world launch-week hero (#255):** the shell story, registry install, honest
+  proof points; stale claims removed.
+
+---
+
 ## [1.3.1] — 2026-07-04
 
 Discoverability patch — metadata only, no behavior change.

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -43,7 +43,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.3.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.3.2" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -20,8 +20,8 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.3.1" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.3.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.3.2" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.3.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/maxkle1nz/m1nd",
     "source": "github"
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@maxkle1nz/m1nd",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bumps + changelog do patch de lançamento: funil cold-start consertado (#254), README-conversão (#256), site (#255). Pós-merge: tag v1.3.2 → workflow publica npm+crates — o npx do estranho passa a funcionar de primeira.