### PR TITLE
feat(north): packet honesty + diet + separator-agnostic display_name (ladder R0/R1/R5)

### DIFF
--- a/docs/ORGANISM-PRD.md
+++ b/docs/ORGANISM-PRD.md
@@ -647,20 +647,31 @@ graph TD
     R16["R16 · SOUL-PRD + slices — LAST<br/>bound by C8.6"]
 ```
 
-**R0 — the honesty patch (MED-INV-6 hotfix).** *What:* the false-absence fix carved OUT of M5b and
-shipped first as a defect fix: a beat over a non-empty store surfaces memory or stamps
-`memory_exists: n` — never "No durable memory yet". *RED:* on file three times over — letter#52,
-the critic's session, and THIS session's own opening north (store ≥20 light roots, `memory: []`).
-*Unblocks:* trust in the flagship packet — every later rung's packets are honest. *(Adjudicates
-F24: urgency adopted by the split; the literal M5b-before-M5a reorder is refused — tier recall
-needs M5a's `Origin-Brain` labels; the dependency is real.)*
+**R0 — the honesty patch (MED-INV-6 hotfix). [SHIPPED 2026-07-05]** *What:* the false-absence fix
+carved OUT of M5b and shipped first as a defect fix: a beat over a non-empty store surfaces memory
+or stamps `memory_exists: n` — never "No durable memory yet". *RED:* on file three times over —
+letter#52, the critic's session, and THIS session's own opening north (store ≥20 light roots,
+`memory: []`). *Shipped:* north stamps `memory_exists` = the on-disk L1GHT store count; the false
+absence line fires only when the store is truly empty; RED→GREEN unit tests
+(`north_over_nonempty_store_never_claims_no_durable_memory` + the empty-store companion) plus
+`SessionState::light_memory_count`. *Unblocks:* trust in the flagship packet — every later rung's
+packets are honest. *(Adjudicates F24: urgency adopted by the split; the literal M5b-before-M5a
+reorder is refused — tier recall needs M5a's `Origin-Brain` labels; the dependency is real.)*
 
-**R1 — the packet diet (Budget Law enforcement, §C1.3).** *What:* dedup `fingerprint`/`graph_state`;
-the memorize write-path stops minting per-file ingest roots (flow fix); size battery-pinned on a
-reference graph (≤2k tokens MCP / ≤1,200 chars hook). *RED:* this session's live packet (dup arrays
-× 21 roots). *Unblocks:* the hook path can finally carry the packet it is doctrine-bound to
-deliver → R12; every satellite (inbox count, soul headline) enters under the one-line rule.
-*(R0 ∥ R1 — both small, both live defects, both pre-medulla.)*
+**R1 — the packet diet (Budget Law enforcement, §C1.3). [SHIPPED 2026-07-05]** *What:* dedup
+`fingerprint`/`graph_state`; the memorize write-path stops minting per-file ingest roots (flow fix);
+size battery-pinned on a reference graph (≤2k tokens MCP / ≤1,200 chars hook). *RED:* this session's
+live packet (dup arrays × 21 roots). *Shipped:* `graph_runtime_summary` carries only
+`ingest_root_count` (the full array lives once, in the fingerprint); a `.light.md` written into the
+`agent-memory` store collapses to the single store-dir root instead of one root per sidecar; the
+battery case `north_packet_within_budget` pins the live packet at ~1,419 tokens and fails CI on
+dup-arrays / sidecar-roots / >2k growth. RED→GREEN unit tests
+(`north_binding_serializes_ingest_roots_once_not_duplicated`,
+`memorize_does_not_mint_per_sidecar_ingest_roots`). *Measured:* the binding's roots footprint drops
+from ~356 tokens (array × 2, 21 roots) to ~12 (count + a 2-root array). *Unblocks:* the hook path
+can finally carry the packet it is doctrine-bound to deliver → R12; every satellite (inbox count,
+soul headline) enters under the one-line rule. *(R0 ∥ R1 — both small, both live defects, both
+pre-medulla.)*
 
 **R2 — M5a: storage split + `Origin-Brain` + migration + brainless-root refusal** (MEDULLA §11).
 *RED:* 25 mixed claims, zero `Origin-Brain`, ghost root; brainless-root memorize lands silently.

--- a/docs/wiki/src/api-reference/lifecycle.md
+++ b/docs/wiki/src/api-reference/lifecycle.md
@@ -13,6 +13,20 @@ nodes + PageRank anchors), prior cross-session memory (each claim with its real
 age and author — absent, never faked, when unknown), a sufficiency signal, one
 `next_move`, and `honest_gaps` (what m1nd does not yet know).
 
+The packet also carries **`memory_exists`** — the ground-truth count of durable
+L1GHT claims in the on-disk store. It exists so a beat that surfaces no
+task-relevant memory (`memory: []`) never lies about an **empty store**: when the
+store holds claims that simply did not match this task, `memory_exists` is `> 0`
+and `honest_gaps` says the store has memory that did not match — the false
+"no durable memory yet" line is emitted **only** when the store is truly empty.
+
+**Packet budget.** The binding serializes the `ingest_roots` array exactly once
+(in `binding.fingerprint`); `binding.graph_state` carries only the
+`ingest_root_count`, never a duplicate copy of the array. Durable memory sidecars
+in the `agent-memory` store collapse into the single store-directory root rather
+than minting one ingest root per `.light.md` file, so the packet stays within its
+2,000-token MCP budget as the memory store grows.
+
 On first contact the packet may also carry a `reception` field (First-Contact
 Reception, degraded mode): `reception.match == "caller_root_mismatch"` means the
 bound graph does **not** cover your current repo (its root ≠ your resolved

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -3326,10 +3326,21 @@ fn handle_north(
             "Binding is not full trust ({verdict}) — treat retrieval as orientation only and verify final truth against local files; see recovery_playbook for the repair."
         ));
     }
+    // Ground-truth count of the durable L1GHT store on disk. A beat that surfaced
+    // no memory must NOT claim "no durable memory yet" when the store is non-empty
+    // (MED-INV-6 false-absence): recall missing a task-relevant hit is not the same
+    // as an empty store. When N>0 we stamp `memory_exists: N` and say so honestly.
+    let light_memory_on_disk = state.light_memory_count();
     if memory.is_empty() {
-        honest_gaps.push(
-            "No durable memory yet — neither boot_memory nor L1GHT agent-memory holds a prior cross-session claim to carry.".into(),
-        );
+        if light_memory_on_disk > 0 {
+            honest_gaps.push(format!(
+                "The memory store holds {light_memory_on_disk} durable L1GHT claim(s), but none surfaced for this task — recall found no task-relevant match, not an empty store. Broaden the task text or seek the store directly."
+            ));
+        } else {
+            honest_gaps.push(
+                "No durable memory yet — neither boot_memory nor L1GHT agent-memory holds a prior cross-session claim to carry.".into(),
+            );
+        }
     } else if light_entries.is_empty() && graph_populated {
         // Boot KV facts exist but no memorized L1GHT claim surfaced — say so, so the
         // agent knows the primary (memorize) memory had nothing to add for this task.
@@ -3350,6 +3361,11 @@ fn handle_north(
         "binding": binding,
         "context": context,
         "memory": memory,
+        // Ground-truth size of the durable L1GHT store on disk (MED-INV-6). A
+        // consumer never has to infer "is the store empty?" from `memory: []` —
+        // an empty beat over a non-empty store carries `memory_exists > 0` and the
+        // honest gap says the store has claims that just did not match this task.
+        "memory_exists": light_memory_on_disk,
         "sufficiency": sufficiency,
         "next_move": next_move,
         "honest_gaps": honest_gaps,
@@ -7668,6 +7684,164 @@ mod tests {
             "a fresh memory must not be flagged stale"
         );
         assert_eq!(entry["tags"], serde_json::json!(["lease", "doctrine"]));
+    }
+
+    /// R0 — MED-INV-6 packet honesty (RED→GREEN): a north beat over a NON-EMPTY
+    /// memory store must NEVER emit the false "No durable memory yet" line. Recall
+    /// missing a task-relevant hit (the task does not match any stored claim) is a
+    /// no-match, not an empty store. The packet must instead carry `memory_exists`
+    /// = the on-disk store count (>0) and an honest gap that says the store HAS
+    /// claims that just did not match this task.
+    #[test]
+    fn north_over_nonempty_store_never_claims_no_durable_memory() {
+        let (_temp, mut state) = build_state_populated(false);
+
+        // Seed the durable L1GHT store on disk with claims that have NOTHING to do
+        // with the query task, so recall returns empty for this task.
+        let store = state.runtime_root.join("agent-memory");
+        std::fs::create_dir_all(&store).expect("agent-memory store dir");
+        let now_ms = super::now_ms();
+        for (i, node) in ["AlphaDoctrine", "BetaDoctrine", "GammaDoctrine"]
+            .iter()
+            .enumerate()
+        {
+            let md = format!(
+                "---\nProtocol: L1GHT/1.0\nNode: {node}\nState: verified\n\
+                 Created: {now_ms}\nSource-Agent: seeder\n---\n\n\
+                 # {node}\n\n## {node}\n\n\
+                 A durable claim about widget calibration cadence number {i}.\n\n\
+                 [⍂ entity: widget calibration cadence]\n[𝔻 confidence: 0.9]\n"
+            );
+            std::fs::write(store.join(format!("mem_{i}.light.md")), md).expect("write memory");
+        }
+
+        // The store now holds 3 claims on disk — ground truth, before any recall.
+        assert_eq!(
+            state.light_memory_count(),
+            3,
+            "the store must hold 3 durable claims on disk"
+        );
+
+        // A task that matches NONE of the stored claims → recall returns empty.
+        let out = super::dispatch_tool(
+            &mut state,
+            "north",
+            &serde_json::json!({
+                "agent_id": "northerner",
+                "task": "quantum flux capacitor tachyon inversion protocol",
+            }),
+        )
+        .expect("north over a non-empty store with an unmatched task");
+
+        // The recalled memory block may be empty (no task match) — that is fine.
+        // What is NOT fine is the false-absence line over a non-empty store.
+        let gaps = out["honest_gaps"]
+            .as_array()
+            .expect("honest_gaps array")
+            .iter()
+            .filter_map(|g| g.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            !gaps.contains("No durable memory yet"),
+            "MED-INV-6: a beat over a non-empty store must NOT claim 'No durable memory yet'; gaps were: {gaps}"
+        );
+        // The packet stamps the ground-truth store size so a consumer never has to
+        // infer emptiness from `memory: []`.
+        assert_eq!(
+            out["memory_exists"].as_u64(),
+            Some(3),
+            "memory_exists must carry the on-disk store count (3)"
+        );
+        // And when memory did not surface, the gap tells the honest story.
+        let memory_empty = out["memory"]
+            .as_array()
+            .map(|m| m.is_empty())
+            .unwrap_or(true);
+        if memory_empty {
+            assert!(
+                gaps.contains("memory store holds"),
+                "an empty beat over a non-empty store must say the store HAS claims that did not match; gaps: {gaps}"
+            );
+        }
+    }
+
+    /// R0 companion: over a TRULY empty store the honest "No durable memory yet"
+    /// line is still correct and `memory_exists` is 0 — the fix must not suppress
+    /// the true absence, only the FALSE one.
+    #[test]
+    fn north_over_empty_store_still_says_no_durable_memory() {
+        let (_temp, mut state) = build_state_populated(false);
+        assert_eq!(
+            state.light_memory_count(),
+            0,
+            "no store seeded → count is 0"
+        );
+        let out = super::dispatch_tool(
+            &mut state,
+            "north",
+            &serde_json::json!({
+                "agent_id": "northerner",
+                "task": "anything at all",
+            }),
+        )
+        .expect("north over an empty store");
+        assert_eq!(out["memory_exists"].as_u64(), Some(0));
+        let gaps = out["honest_gaps"]
+            .as_array()
+            .expect("honest_gaps array")
+            .iter()
+            .filter_map(|g| g.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            gaps.contains("No durable memory yet"),
+            "a truly empty store must still honestly say there is no durable memory; gaps: {gaps}"
+        );
+    }
+
+    /// R1(a) — Budget Law "no duplicate serialization" (RED→GREEN): a north packet
+    /// embeds BOTH `binding.fingerprint` and `binding.graph_state`. The full
+    /// `ingest_roots` array must appear exactly ONCE across the two (in the
+    /// fingerprint) — never byte-identically duplicated. `graph_state` carries only
+    /// the COUNT. Before the fix the same array was serialized in both blocks.
+    #[test]
+    fn north_binding_serializes_ingest_roots_once_not_duplicated() {
+        let (_temp, mut state) = build_state_populated(false);
+        // Give the binding several roots so a duplicated array is unmistakable.
+        state.ingest_roots = vec![
+            "/path/to/repo".into(),
+            "/path/to/other".into(),
+            "/path/to/third".into(),
+        ];
+
+        let out = super::dispatch_tool(
+            &mut state,
+            "north",
+            &serde_json::json!({
+                "agent_id": "northerner",
+                "task": "lease enforcement",
+            }),
+        )
+        .expect("north on a multi-root binding");
+
+        // The fingerprint is the ONE canonical home for the full array.
+        let fp_roots = out["binding"]["fingerprint"]["ingest_roots"]
+            .as_array()
+            .expect("fingerprint carries the full ingest_roots array");
+        assert_eq!(fp_roots.len(), 3, "fingerprint lists all three roots");
+
+        // graph_state must NOT re-serialize the full array — only the count.
+        assert!(
+            out["binding"]["graph_state"]["ingest_roots"].is_null(),
+            "graph_state must NOT duplicate the full ingest_roots array; it was: {}",
+            out["binding"]["graph_state"]["ingest_roots"]
+        );
+        assert_eq!(
+            out["binding"]["graph_state"]["ingest_root_count"].as_u64(),
+            Some(3),
+            "graph_state carries the COUNT instead of the duplicated array"
+        );
     }
 
     /// Field-triage #1: north must COMPOSE L1GHT agent-memory (written by

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -488,15 +488,33 @@ pub(crate) fn parse_cargo_package_version(cargo_toml: &str) -> Option<String> {
     None
 }
 
+/// A path is a "memory sidecar" when it is an individual `.light.md` claim file
+/// or the `agent-memory` runtime store directory itself — i.e. durable L1GHT
+/// memory, NOT a code root. Used both to skip sidecars when resolving the repo
+/// display name AND to keep the ingest write-path from minting a per-file ingest
+/// root for every claim (Budget Law §C1.3.4: the store DIR is the one root, not
+/// each sidecar). One definition, both call sites.
+pub(crate) fn is_memory_sidecar(p: &str) -> bool {
+    p.ends_with(".light.md")
+        || std::path::Path::new(p)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n == "agent-memory")
+            .unwrap_or(false)
+}
+
 /// The last path component of a filesystem root — the human name of a repo
-/// ("/Users/x/m1nd" → "m1nd"). Trailing slashes are tolerated; a rootless or
+/// ("/Users/x/m1nd" → "m1nd"). Separator-agnostic: splits on BOTH '/' and '\\'
+/// so a Windows backslash path ("C:\\Users\\dev\\m1nd" → "m1nd") names its repo
+/// the same as a POSIX one. Trailing separators are tolerated; a rootless or
 /// empty input returns the trimmed input unchanged (honest, never a panic).
 /// Shared by the bound-brain display name and the project-brain listing so both
 /// name a brain the same way. Mirrors the UI's `repoBasename` exactly.
 pub(crate) fn basename_of(root: &str) -> String {
+    let is_sep = |c: char| c == '/' || c == '\\';
     root.trim()
-        .trim_end_matches('/')
-        .rsplit('/')
+        .trim_end_matches(is_sep)
+        .rsplit(is_sep)
         .next()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| root.trim())
@@ -2286,7 +2304,7 @@ fn save_json_atomic<T: Serialize>(path: &Path, value: &T) -> M1ndResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SessionState, WORKSPACE_ROOT_ENV_CANDIDATES};
+    use super::{basename_of, SessionState, WORKSPACE_ROOT_ENV_CANDIDATES};
     use crate::server::McpConfig;
     use m1nd_core::domain::DomainConfig;
     use m1nd_core::graph::Graph;
@@ -2415,6 +2433,36 @@ mod tests {
         state.ingest_roots = vec![];
         state.workspace_root = Some("/Users/x/solo-repo".to_string());
         assert_eq!(state.display_name().as_deref(), Some("solo-repo"));
+    }
+
+    #[test]
+    fn basename_of_is_separator_agnostic() {
+        // POSIX still works (the '/' path).
+        assert_eq!(basename_of("/path/to/repo"), "repo");
+        assert_eq!(basename_of("~/m1nd"), "m1nd");
+        assert_eq!(basename_of("/path/to/repo/"), "repo", "trailing slash");
+        // Windows backslash paths: the chronic red Windows CI case — a '\\'
+        // separator must name the same repo a '/' separator does.
+        assert_eq!(
+            basename_of(r"C:\Users\dev\m1nd"),
+            "m1nd",
+            "backslash path must yield the repo basename, not the whole string"
+        );
+        assert_eq!(
+            basename_of(r"C:\Users\dev\m1nd\"),
+            "m1nd",
+            "trailing backslash tolerated"
+        );
+        // UNC path (\\server\share\repo).
+        assert_eq!(basename_of(r"\\server\share\repo"), "repo", "UNC path");
+        // Mixed separators (some tools emit these on Windows).
+        assert_eq!(
+            basename_of(r"C:\Users\dev/m1nd"),
+            "m1nd",
+            "mixed separators"
+        );
+        // A rootless bare name is returned unchanged (honest, never a panic).
+        assert_eq!(basename_of("repo"), "repo");
     }
 
     #[test]

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -676,6 +676,12 @@ impl SessionState {
 
     pub fn graph_runtime_summary(&self) -> serde_json::Value {
         let graph = self.graph.read();
+        // Budget Law (§C1.3.4 "no duplicate serialization"): the full `ingest_roots`
+        // array is serialized ONCE, in `binding_fingerprint`. Here we carry only the
+        // COUNT — a north packet embeds both this `graph_state` and the fingerprint,
+        // so listing the array in both duplicated the roots byte-identical and blew
+        // the packet budget. Count + the canonical array in the fingerprint is the
+        // whole truth without the duplication.
         serde_json::json!({
             "node_count": graph.num_nodes(),
             "edge_count": graph.num_edges(),
@@ -684,7 +690,6 @@ impl SessionState {
             "plasticity_generation": self.plasticity_generation,
             "cache_generation": self.cache_generation,
             "ingest_root_count": self.ingest_roots.len(),
-            "ingest_roots": self.ingest_roots,
             "workspace_root": self.workspace_root,
             "workspace_root_source": self.workspace_root_source,
             "runtime_root": self.runtime_root,
@@ -942,14 +947,6 @@ impl SessionState {
     /// resolves to that; the bound graph skips its memory sidecars to reach the
     /// repo. Returns `None` only when the brain has no roots at all (empty graph).
     pub fn project_root_display(&self) -> Option<String> {
-        let is_memory_sidecar = |p: &str| {
-            p.ends_with(".light.md")
-                || std::path::Path::new(p)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n == "agent-memory")
-                    .unwrap_or(false)
-        };
         // 1. First real code ingest root that is not a memory sidecar.
         for root in &self.ingest_roots {
             if !is_memory_sidecar(root) && std::path::Path::new(root).is_dir() {

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -976,6 +976,22 @@ impl SessionState {
         self.project_root_display().map(|root| basename_of(&root))
     }
 
+    /// How many durable L1GHT memory claims exist on disk in this brain's store
+    /// (`<runtime_root>/agent-memory/*.light.md`). This is the ground-truth count
+    /// of the memory store itself, independent of whether recall surfaced any of
+    /// them for a given task — so a beat that finds no task-relevant hit can still
+    /// tell the truth ("the store HAS N memories") instead of the false absence
+    /// "no durable memory yet". Cheap dir read; `0` when the store dir is absent.
+    pub fn light_memory_count(&self) -> usize {
+        let dir = self.runtime_root.join("agent-memory");
+        std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.path().to_string_lossy().ends_with(".light.md"))
+            .count()
+    }
+
     fn absolute_scope_path(scope: &str) -> Option<std::path::PathBuf> {
         let scope = scope.trim();
         if scope.is_empty() {

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -815,17 +815,41 @@ fn finalize_ingest(
         state.ingest_roots.clear();
         state.ingest_roots.push(input.path.clone());
     } else {
+        // Budget Law (§C1.3.4 write-path fix): a `.light.md` memory claim written
+        // into the `agent-memory` STORE must NOT mint a per-file ingest root — the
+        // store DIRECTORY is the one root, not each sidecar. Otherwise every
+        // `memorize` write grows the roots array by one, sprawling the packet.
+        // Narrowly scoped to files whose parent dir is `agent-memory`: a user
+        // ingesting an arbitrary `.light.md` by path elsewhere keeps its own root
+        // (that path is a deliberate root, not store sprawl).
+        let ingest_path = std::path::Path::new(&input.path);
+        let parent_is_agent_memory = ingest_path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(|n| n == "agent-memory")
+            .unwrap_or(false);
+        let root_to_track =
+            if input.path.ends_with(".light.md") && ingest_path.is_file() && parent_is_agent_memory
+            {
+                ingest_path
+                    .parent()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|| input.path.clone())
+            } else {
+                input.path.clone()
+            };
         // Keep the vector ordered oldest -> newest so path resolution can prefer
         // the most recent matching root deterministically.
         if let Some(pos) = state
             .ingest_roots
             .iter()
-            .position(|root| root == &input.path)
+            .position(|root| root == &root_to_track)
         {
             let root = state.ingest_roots.remove(pos);
             state.ingest_roots.push(root);
         } else {
-            state.ingest_roots.push(input.path.clone());
+            state.ingest_roots.push(root_to_track);
         }
     }
     let input_path = std::path::Path::new(&input.path);
@@ -5397,6 +5421,80 @@ mod tests {
         assert!(
             edges_after_memorize >= edges_baseline,
             "edge count must not collapse after memorize: was {edges_baseline}, now {edges_after_memorize}"
+        );
+    }
+
+    /// R1(b) — Budget Law write-path fix (RED→GREEN): the `memorize` write-path
+    /// must NOT mint a per-file ingest root for every `.light.md` claim it writes.
+    /// The store DIRECTORY is the one root; each sidecar file collapses into it.
+    /// Before the fix, memorizing N claims grew `ingest_roots` by N sidecar files,
+    /// sprawling the north packet. After: at most ONE `agent-memory` root appears,
+    /// and no individual `.light.md` file is listed as a root.
+    #[test]
+    fn memorize_does_not_mint_per_sidecar_ingest_roots() {
+        use crate::light_author_handlers::{handle_light_author, LightAuthorInput, LightClaim};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        // Memorize several distinct claims (default agent-memory path, ingest_after).
+        for i in 0..4 {
+            handle_light_author(
+                &mut state,
+                LightAuthorInput {
+                    agent_id: "test".into(),
+                    node_label: format!("Claim{i}"),
+                    title: None,
+                    state: None,
+                    claims: vec![LightClaim {
+                        label: format!("Fact{i}"),
+                        text: Some(format!("durable fact number {i}")),
+                        kind: Some("entity".into()),
+                        confidence: Some("high".into()),
+                        ambiguity: None,
+                        evidence: vec![],
+                        depends_on: vec![],
+                    }],
+                    output_path: None,
+                    namespace: None,
+                    ingest_after: true,
+                    mode: "merge".into(),
+                    supersedes: None,
+                },
+            )
+            .expect("memorize");
+        }
+
+        // No individual `.light.md` file may appear as an ingest root.
+        let sidecar_roots: Vec<&String> = state
+            .ingest_roots
+            .iter()
+            .filter(|r| r.ends_with(".light.md"))
+            .collect();
+        assert!(
+            sidecar_roots.is_empty(),
+            "no per-file `.light.md` sidecar may be an ingest root; found {sidecar_roots:?} in {:?}",
+            state.ingest_roots
+        );
+        // At most one `agent-memory` store dir root (the collapse target), not four.
+        let store_roots = state
+            .ingest_roots
+            .iter()
+            .filter(|r| r.ends_with("agent-memory"))
+            .count();
+        assert!(
+            store_roots <= 1,
+            "the memory store must collapse to at most ONE dir root, got {store_roots} in {:?}",
+            state.ingest_roots
         );
     }
 

--- a/scratchpad/m1nd_battery.py
+++ b/scratchpad/m1nd_battery.py
@@ -495,6 +495,58 @@ def north_recalls_memorized_claim(c):
                   f"no marker fragments in {len(mem)} memory + {len(anchors)} anchor rows")
 
 
+def north_packet_within_budget(c):
+    """R1 — the packet diet (Budget Law §C1.3). A north packet must obey the size
+    budget AND never serialize the ingest_roots array twice.
+
+    Two live defects reproduced in the field this session:
+      (a) the roots array serialized byte-identically in BOTH `binding.fingerprint`
+          and `binding.graph_state` — duplicated bytes on every packet;
+      (b) the memorize write-path minting a per-file ingest root for every memory
+          `.light.md`, sprawling the roots array with sidecar entries.
+
+    This check calls north on a real task, then asserts:
+      1. `binding.graph_state` does NOT carry the full `ingest_roots` array (only a
+         count); the fingerprint is the ONE canonical home for the array.
+      2. the roots array (in the fingerprint) lists no individual `.light.md`
+         sidecar — the store DIR is the one root.
+      3. the MCP surface stays within the 2,000-token budget (measured as a
+         ~4-chars/token proxy over the serialized packet).
+
+    RED on main (dup arrays + sidecar sprawl); GREEN after the fix. Returns
+    (passed, detail) and reports the measured token estimate either way.
+    """
+    nr, _ = c.tool("north", dict(agent_id="battery",
+                                 task="packet budget law enforcement on the north composer"))
+    binding = nr.get("binding") or {}
+    fp = binding.get("fingerprint") or {}
+    gs = binding.get("graph_state") or {}
+
+    # (1) graph_state must NOT duplicate the full array.
+    if isinstance(gs.get("ingest_roots"), list):
+        return False, (f"graph_state duplicates the full ingest_roots array "
+                       f"({len(gs['ingest_roots'])} entries) — must carry only the count")
+
+    # (2) no per-file .light.md sidecar may be an ingest root.
+    fp_roots = fp.get("ingest_roots")
+    if isinstance(fp_roots, list):
+        sidecars = [r for r in fp_roots if isinstance(r, str) and r.endswith(".light.md")]
+        if sidecars:
+            return False, (f"{len(sidecars)} per-file .light.md sidecar(s) listed as ingest roots "
+                           f"(sprawl): e.g. {sidecars[0]}")
+
+    # (3) packet within the 2k-token budget (4-chars/token proxy).
+    serialized = json.dumps(nr, default=str)
+    est_tokens = len(serialized) // 4
+    if est_tokens > 2000:
+        return False, (f"north packet ~{est_tokens} tokens exceeds the 2,000-token MCP budget "
+                       f"({len(serialized)} chars)")
+
+    root_count = gs.get("ingest_root_count")
+    return True, (f"north packet ~{est_tokens} tokens (<=2000); graph_state carries count "
+                  f"({root_count}) not the duplicated array; no sidecar roots")
+
+
 # --------------------------------------------------------------------------- #
 # Query suites (each: id, intent, tool, args, expect_symbol, rg_pattern, rg_extra) #
 # Cross-file / relationship-correctness cases also carry a `check` callable.     #
@@ -1095,6 +1147,21 @@ def suite_m1nd(repo):
              expect=None, expect_file="server.rs",
              rg_pat=r"fn handle_north", rg_extra=["-t", "rust"],
              check=lambda res, q, c: north_recalls_memorized_claim(c)),
+
+        # ---- R1: the packet diet / Budget Law (§C1.3) ----
+        # THE BUG (live this session): the north binding serialized the ingest_roots
+        # array TWICE byte-identically (fingerprint + graph_state), and the memorize
+        # write-path minted a per-file ingest root for every memory .light.md — the
+        # roots array sprawled with sidecar entries. The `check` calls north and
+        # asserts graph_state carries only a COUNT (not the dup array), no .light.md
+        # sidecar is a root, and the packet stays under the 2,000-token budget.
+        # RED on main (dup arrays + sidecar sprawl); GREEN after the fix.
+        dict(id="north_packet_within_budget",
+             intent="north packet obeys the Budget Law: roots serialized once, no sidecar roots, <=2k tokens",
+             tool="session_handshake", args=dict(agent_id=aid),
+             expect=None, expect_file="session.rs",
+             rg_pat=r"fn graph_runtime_summary", rg_extra=["-t", "rust"],
+             check=lambda res, q, c: north_packet_within_budget(c)),
 
         # ---- memory provenance + supersession (#187/#189/#200) ----
         # memorize a claim -> seek returns the hit with source_agent + a fresh


### PR DESCRIPTION
Three ORGANISM ladder rungs, each a live defect fixed RED→GREEN. All from a fresh branch off main.

## R0 — packet honesty (false-absence fix)
`north`'s memory beat emitted the honest_gap "No durable memory yet" whenever recall surfaced nothing for the task — even when the durable memory store on disk was non-empty. A recall that finds no task-relevant match is **not** an empty store. Reproduced live: a beat over a non-empty memory store returned `memory: []` while claiming no durable memory.

**Fix:** the packet now stamps `memory_exists` = the ground-truth on-disk count of L1GHT claims; the "No durable memory yet" line fires **only** when the store is truly empty. Over a non-empty store the gap honestly says the store holds claims that did not match this task.

RED tests: a beat over a 3-claim store with an unmatched task must not claim no memory and must carry `memory_exists=3`; the true-absence line is preserved when the store is empty.

## R1 — packet diet (Budget Law)
The north binding blew its token budget two ways, both reproduced live:
- the `ingest_roots` array was serialized **twice byte-identically** — once in `binding.fingerprint`, again in `binding.graph_state`;
- the memorize write-path minted a **per-file ingest root for every memory sidecar**, so the array sprawled with one entry per claim.

**Fix:** `graph_state` carries only `ingest_root_count` (the full array lives once, in the fingerprint); a memory sidecar written into the store collapses to the single store-directory root instead of one root per file. A battery case pins the packet size (≤2k-token MCP surface) and fails CI on dup-arrays, sidecar-roots, or budget growth. Measured: the roots footprint in the binding drops from ~356 tokens (array × 2, 21 roots) to ~12 (a count + a 2-root array); the full packet measures ~1,419 tokens.

RED tests: the binding serializes the roots array once (graph_state carries the count, not a duplicate); memorizing N claims mints no per-file sidecar roots.

## R5 — separator-agnostic display_name
`basename_of()` / `display_name()` assumed `/` separators and misfired on Windows backslash paths — the chronic red Windows CI test. Now splits on both `/` and `\\` (trailing-sep, UNC, and mixed separators covered); the POSIX path resolves the same. **This un-reds the Windows CI check** — a gate described as blocking now blocks.

RED test: a backslash path `C:\Users\dev\m1nd` yields `m1nd`, not the whole string.

## Gates
`cargo build --release`, `cargo test -p m1nd-mcp` (all green), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --all --check`, and the battery (all-pass, packet pinned at ~1,419 tokens) — all green. Docs updated in the same PR: the north packet contract (the `memory_exists` field and the once-only roots rule) in the wiki lifecycle reference, and the R0/R1 rungs marked shipped in the ORGANISM roadmap.