### PR TITLE
feat(medulla): M5a — storage split, Origin-Brain, brainless-root refusal, reversible migration (ladder R2)

### DIFF
--- a/docs/MEDULLA-PRD.md
+++ b/docs/MEDULLA-PRD.md
@@ -338,8 +338,24 @@ Each event that survives triage adds its case to the battery of the brain it bit
 
 **Numbering note (the 2R precedent, deliberately):** Two-Tier's §14 already assigns Slice 6 (hooks v2) and Slice 7 (migration runbook) — renumbering them would ripple through every cross-reference for zero information. The medulla ladder is therefore lettered **M5a → M7b**: it extends Slice 5's medulla scope, pulls TT §15 V2-item-2 (promotion mechanization) into a gated slice, and lands the §O.12/§11 dovetail. The TT slices keep their numbers; runbook M4/M5 execute WITH M5a. Every slice is independently shippable, ends at the documentation gate, and holds all TT-INV + MED-INV.
 
-### M5a — Storage split + migration (the medulla becomes a real store)
-- **Scope:** `Origin-Brain` stamping in `memorize` (`light_author_handlers.rs:316-331` frontmatter block); the medulla store formalized at the existing `agent-memory/` path (no move); the §4.2 triage executed (deepened runbook M4: m1nd-repo claims → the m1nd project store; doctrine stays; count-conserving gates); ghost-pointer sweep of `ingest_roots.json`; S2 closed — **an unbootstrapped root's `memorize` is refused with the one-call bootstrap as the typed fix** (`reception.options[]` already carries the exact invocation) instead of silently writing into the medulla-to-be.
+### M5a — Storage split + migration (the medulla becomes a real store) — [SHIPPED 2026-07-05]
+> **Shipped variant (honest):** all four M5a pieces landed as designed. The
+> `Origin-Brain` stamp is derived in `SessionState::origin_brain()` (medulla vs
+> project brain distinguished by `workspace_root_source == "project_brain_manifest"`)
+> and rendered in `render_light_markdown`'s frontmatter (after `Source-Agent`, per
+> §3.3). The brainless-root refusal lives at the TOP of `handle_light_author`
+> (`light_author_handlers.rs`), gated on `is_medulla_store() && caller_root set &&
+> !covers_root(caller_root)` — so a covered owner-doctrine write and a headerless
+> session (absent ≠ wrong) are NOT refused. The **migration is a standalone,
+> pure-filesystem module** (`medulla_migration.rs`, `MedullaMigration::{plan,apply,
+> rollback}`) — `plan` is the pure-read dry-run default; `apply` is backup-first +
+> count-conserving; `rollback` restores byte-for-byte. It operates on directory
+> paths, never a live `SessionState`, so it is structurally incapable of touching a
+> running owner's graph. **CODE-LAND-ONLY: the LIVE migration is NOT run — it is
+> held for the maintainer.** Reversibility proven by a migrate→rollback round-trip
+> test; ghost-pointer sweep prunes dangling per-file `.light.md` pointers and
+> collapses live ones into the dir root.
+- **Scope:** `Origin-Brain` stamping in `memorize` (`light_author_handlers.rs` frontmatter block); the medulla store formalized at the existing `agent-memory/` path (no move); the §4.2 triage logic (deepened runbook M4: m1nd-repo claims → the m1nd project store; doctrine stays; count-conserving gates); ghost-pointer sweep of `ingest_roots.json`; S2 closed — **an unbootstrapped root's `memorize` is refused with the one-call bootstrap as the typed fix** (`reception.options[]` already carries the exact invocation) instead of silently writing into the medulla-to-be.
 - **RED (live now):** the §2.2c inventory — 25 mixed claims in one dir, zero `Origin-Brain` fields, `tokenvalidator.light.md` ghost root; a memorize with `M1nd-Caller-Root` on a brainless root lands in the shared dir (assert today's silence).
 - **GREEN:** every live claim carries a tier by directory + `Origin-Brain` (or is on the ambiguous-triage list); count-conservation gate green; the brainless-root memorize returns the typed refusal naming the bootstrap; legacy files without `Origin-Brain` still parse and render "unknown".
 - **Battery:** triage count-conservation case · brainless-root refusal case · legacy-frontmatter tolerance case · ghost-root sweep case.

--- a/docs/ORGANISM-PRD.md
+++ b/docs/ORGANISM-PRD.md
@@ -694,7 +694,18 @@ soul headline) enters under the one-line rule. *(R0 ∥ R1 — both small, both 
 pre-medulla.)*
 
 **R2 — M5a: storage split + `Origin-Brain` + migration + brainless-root refusal** (MEDULLA §11).
-*RED:* 25 mixed claims, zero `Origin-Brain`, ghost root; brainless-root memorize lands silently.
+**[SHIPPED 2026-07-05]** *What:* the tier IS the directory — `Origin-Brain` stamped on every
+`memorize` (`SessionState::origin_brain()` → project root, or `medulla` for the owner store;
+rendered in `render_light_markdown`); the brainless-root refusal at the top of
+`handle_light_author` (medulla store + known foreign caller root → refused with the typed one-call
+bootstrap, never a silent shared-store write); the migration as a standalone, pure-filesystem
+`MedullaMigration` (`medulla_migration.rs`) — `plan` (pure-read dry-run default) → `apply`
+(backup-first + count-conserving) → `rollback` (byte-for-byte restore), with the ghost-pointer sweep
+of `ingest_roots.json`. *RED→GREEN:* today 25 mixed claims, zero `Origin-Brain`, ghost root, and a
+brainless-root memorize lands silently → now every claim carries a tier by directory + `Origin-Brain`,
+the refusal redirects honestly, and the migration maps claims to the right store with a proven
+migrate→rollback round-trip (no data loss). **CODE-LAND-ONLY: the LIVE migration is HELD for the
+maintainer — the code lands and is scratch-proven, but no live owner is migrated here.**
 *Unblocks:* R3 (labels), R4 (a real store to promote into), all provenance law (§C8).
 
 **R15 — the eviction gate (§C9.1). [SHIPPED 2026-07-05]** *What:* LRU + persist-on-evict in the

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -19,6 +19,7 @@ pub mod instance_registry;
 pub mod layer_handlers;
 pub mod light_author_handlers;
 pub mod lock_handlers;
+pub mod medulla_migration;
 pub mod mission_handlers;
 pub mod persist_handlers;
 pub mod perspective;

--- a/m1nd-mcp/src/light_author_handlers.rs
+++ b/m1nd-mcp/src/light_author_handlers.rs
@@ -148,6 +148,14 @@ pub struct LightAuthorInput {
     /// invalidate-and-keep sequence.
     #[serde(skip)]
     pub supersedes: Option<String>,
+    /// Internal only (never from the tool call): the `Origin-Brain` this claim is
+    /// born in — the routed brain's project root, or `medulla` for the owner's own
+    /// doctrine store (MEDULLA-PRD §6). `#[serde(skip)]` keeps it off the public
+    /// schema; the handler fills it from the session before rendering. `None` (only
+    /// on hand-built inputs that never went through the handler) renders no line —
+    /// honestly "unknown", the legacy-file behavior.
+    #[serde(skip)]
+    pub origin_brain: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +167,55 @@ pub fn handle_light_author(
     state: &mut SessionState,
     mut input: LightAuthorInput,
 ) -> M1ndResult<Value> {
+    // 0. Brainless-root refusal (MEDULLA-PRD §2.3 S2 / §11 M5a).
+    //    A default-path memorize routed to the MEDULLA store (the owner's own
+    //    doctrine store) whose caller root is a KNOWN foreign repo the medulla does
+    //    NOT cover is a session on a root with no project brain. Routing step 4
+    //    (`mcp_http.rs`) defaults such a write into the shared store — silently
+    //    polluting the doctrine-to-be with one repo's private fact. Refuse it, and
+    //    hand back the exact one-call bootstrap that fixes it (the same directive
+    //    `reception.options[]` already carries). Only fires when:
+    //      - this is the medulla store (a project brain owns its own writes), and
+    //      - the caller root is KNOWN (a header was sent — absent ≠ wrong), and
+    //      - the medulla does not cover that root (a bound/covered caller is home).
+    //    An explicit `output_path` override bypasses (migration + tests write
+    //    into a named store directly); doctrine-born medulla writes come from
+    //    covered/headerless owner sessions and are unaffected.
+    if input.output_path.is_none() && state.is_medulla_store() {
+        if let Some(caller_root) = state.caller_root.clone() {
+            if !state.covers_root(&caller_root) {
+                return Ok(json!({
+                    "ok": false,
+                    "schema": "m1nd-memorize-v0",
+                    "refused": "brainless_root",
+                    "caller_root": caller_root,
+                    "reason": format!(
+                        "this session's root '{caller_root}' has no project brain — a memorize here would land in the shared medulla store and pollute cross-project doctrine. Bootstrap your repo's own brain first (one call), then memorize routes there automatically.",
+                    ),
+                    "fix": {
+                        "action": "ingest_your_repo",
+                        "call": format!(
+                            "ingest with project_root={caller_root} — ONE call: creates a per-project brain inside this owner, ingests your repo into it, binds this session to it; thereafter every memorize from this root lands project-private (silent on match)"
+                        ),
+                    },
+                    "bytes_written": 0,
+                    "claims_written": 0,
+                    "ingested": false,
+                    "superseded": false,
+                }));
+            }
+        }
+    }
+
+    // Stamp the Origin-Brain this claim is born in (MEDULLA-PRD §6). The handler
+    // is the single honest source: a project brain stamps its project root, the
+    // medulla stamps `medulla`. Only for the default agent-memory path — an
+    // explicit `output_path` write (migration carries its own stamp in the claim)
+    // keeps its input's origin_brain untouched.
+    if input.output_path.is_none() {
+        input.origin_brain = Some(state.origin_brain());
+    }
+
     // 1. Resolve output path.
     let out_path = resolve_output_path(state, &input)?;
 
@@ -322,6 +379,13 @@ pub fn render_light_markdown(input: &LightAuthorInput) -> String {
     // ignores unknown frontmatter keys, so these are backward-compatible.
     out.push_str(&format!("Created: {}\n", now_ms()));
     out.push_str(&format!("Source-Agent: {}\n", input.agent_id));
+    // Provenance: WHERE the claim was born (MEDULLA-PRD §6 · §3.3). Absent on
+    // legacy files (and on hand-built inputs that never went through the handler)
+    // means "unknown" — the parser ignores unknown keys, so this is
+    // backward-compatible and never backfilled by guess (MED-INV-4 / TT-INV-2).
+    if let Some(origin) = &input.origin_brain {
+        out.push_str(&format!("Origin-Brain: {}\n", origin));
+    }
     // Supersession lineage: names the slug whose prior belief this write invalidates
     // (the prior copy is retained in `agent-memory/.history/` as `State: outdated`).
     // Frontmatter-only for now; the parser tolerates unknown keys. A graph-visible
@@ -678,6 +742,7 @@ mod tests {
             ingest_after: false,
             mode: "merge".into(),
             supersedes: None,
+            origin_brain: None,
         }
     }
 
@@ -816,6 +881,7 @@ mod tests {
             ingest_after: true,
             mode: "merge".into(),
             supersedes: None,
+            origin_brain: None,
         };
 
         let result = handle_light_author(&mut state, input).expect("memorize ok");
@@ -981,6 +1047,7 @@ mod tests {
             ingest_after: false,
             mode: "merge".into(),
             supersedes: None,
+            origin_brain: None,
         }
     }
 
@@ -1355,6 +1422,160 @@ mod tests {
         assert!(
             md.contains("[𝔻 confidence: 0.9]"),
             "rendered markdown must carry the coerced confidence marker, got:\n{md}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // MEDULLA slice M5a — Origin-Brain stamping + brainless-root refusal
+    // -----------------------------------------------------------------------
+
+    /// The medulla store (the owner's own session) stamps `Origin-Brain: medulla`
+    /// on every claim it writes (MEDULLA-PRD §6). RED before M5a: no Origin-Brain
+    /// line was rendered at all.
+    #[test]
+    fn m5a_medulla_session_stamps_origin_brain_medulla() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_session(temp.path());
+        // A default-boot session is the medulla store (not a project brain).
+        assert!(state.is_medulla_store(), "default session is the medulla");
+
+        let input = super_input("DoctrineClaim", "authored", "0.7");
+        handle_light_author(&mut state, input).expect("memorize");
+
+        let live = state
+            .runtime_root
+            .join("agent-memory")
+            .join("doctrineclaim.light.md");
+        let text = std::fs::read_to_string(&live).expect("read live");
+        assert!(
+            text.contains("Origin-Brain: medulla"),
+            "medulla claim must be stamped Origin-Brain: medulla, got:\n{text}"
+        );
+    }
+
+    /// A project brain (a session wearing the `project_brain_manifest` source with
+    /// its project root as workspace) stamps `Origin-Brain: <project root>`
+    /// (MEDULLA-PRD §6). This is the provenance promotion/recall needs to tell
+    /// which brain a claim came from.
+    #[test]
+    fn m5a_project_brain_stamps_origin_brain_with_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_session(temp.path());
+        // Make this session a project brain, exactly as `boot_store` does.
+        state.workspace_root = Some("/path/to/repo".into());
+        state.workspace_root_source = Some("project_brain_manifest".into());
+        state.ingest_roots = vec!["/path/to/repo".into()];
+        assert!(!state.is_medulla_store(), "now it is a project brain");
+        assert_eq!(state.origin_brain(), "/path/to/repo");
+
+        let input = super_input("ProjectFact", "authored", "0.7");
+        handle_light_author(&mut state, input).expect("memorize");
+
+        let live = state
+            .runtime_root
+            .join("agent-memory")
+            .join("projectfact.light.md");
+        let text = std::fs::read_to_string(&live).expect("read live");
+        assert!(
+            text.contains("Origin-Brain: /path/to/repo"),
+            "project claim must be stamped with its project root, got:\n{text}"
+        );
+    }
+
+    /// Brainless-root refusal (MEDULLA-PRD §2.3 S2 / §11 M5a). A memorize on the
+    /// medulla session whose caller root is a KNOWN foreign repo the medulla does
+    /// not cover must be REFUSED (not silently written into the shared store), and
+    /// the refusal must hand back the one-call bootstrap that fixes it. RED today:
+    /// step-4 routing writes it silently into the medulla-to-be.
+    #[test]
+    fn m5a_brainless_root_memorize_is_refused_with_bootstrap_fix() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_session(temp.path());
+        // A foreign caller root the medulla does not cover.
+        state.caller_root = Some("/path/to/project-a".into());
+        assert!(
+            !state.covers_root("/path/to/project-a"),
+            "precondition: the medulla does not cover this root"
+        );
+
+        let input = super_input("ForeignFact", "authored", "0.7");
+        let result = handle_light_author(&mut state, input).expect("call returns");
+
+        assert_eq!(result["ok"], false, "the write must be refused");
+        assert_eq!(result["refused"], "brainless_root");
+        assert_eq!(result["ingested"], false);
+        let call = result["fix"]["call"].as_str().unwrap_or("");
+        assert!(
+            call.contains("ingest with project_root=/path/to/project-a"),
+            "refusal must carry the typed one-call bootstrap, got: {call}"
+        );
+
+        // And NOTHING was written into the shared medulla store (no pollution).
+        let live = state
+            .runtime_root
+            .join("agent-memory")
+            .join("foreignfact.light.md");
+        assert!(
+            !live.exists(),
+            "a refused brainless-root write must not touch the shared store"
+        );
+    }
+
+    /// The refusal must NOT fire for a caller whose root the medulla DOES cover
+    /// (an owner-session doctrine write is legitimate — the one exception, §3.1).
+    #[test]
+    fn m5a_covered_caller_on_medulla_is_not_refused() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_session(temp.path());
+        // Make a known root the medulla covers, and call from it.
+        state.ingest_roots = vec!["/path/to/owner-repo".into()];
+        state.caller_root = Some("/path/to/owner-repo".into());
+        assert!(state.covers_root("/path/to/owner-repo"));
+
+        let input = super_input("OwnerDoctrine", "authored", "0.7");
+        let result = handle_light_author(&mut state, input).expect("memorize");
+        assert_ne!(
+            result["refused"], "brainless_root",
+            "a covered caller must not be refused"
+        );
+        let live = state
+            .runtime_root
+            .join("agent-memory")
+            .join("ownerdoctrine.light.md");
+        assert!(live.exists(), "the covered doctrine write lands");
+        let text = std::fs::read_to_string(&live).unwrap();
+        assert!(text.contains("Origin-Brain: medulla"));
+    }
+
+    /// A headerless medulla session (no caller_root — direct HTTP / stdio) is NOT
+    /// refused: absent ≠ wrong (§9.5.4). It writes as a medulla doctrine claim.
+    #[test]
+    fn m5a_headerless_medulla_write_is_allowed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_session(temp.path());
+        assert!(state.caller_root.is_none(), "no caller header");
+
+        let input = super_input("HeaderlessDoctrine", "authored", "0.7");
+        let result = handle_light_author(&mut state, input).expect("memorize");
+        assert_ne!(result["refused"], "brainless_root");
+        let live = state
+            .runtime_root
+            .join("agent-memory")
+            .join("headerlessdoctrine.light.md");
+        assert!(live.exists());
+    }
+
+    /// Legacy tolerance: a hand-built input with `origin_brain: None` (never went
+    /// through the handler) renders NO Origin-Brain line — honestly "unknown",
+    /// backward-compatible (MED-INV-4).
+    #[test]
+    fn m5a_absent_origin_brain_renders_no_line() {
+        let input = super_input("NoOrigin", "authored", "0.7");
+        assert!(input.origin_brain.is_none());
+        let md = render_light_markdown(&input);
+        assert!(
+            !md.contains("Origin-Brain:"),
+            "absent origin_brain must render no line (unknown, never faked), got:\n{md}"
         );
     }
 }

--- a/m1nd-mcp/src/medulla_migration.rs
+++ b/m1nd-mcp/src/medulla_migration.rs
@@ -1,0 +1,896 @@
+//! MEDULLA slice M5a — the storage-split migration (MEDULLA-PRD §4.2).
+//!
+//! Today the owner's shared `<runtime_root>/agent-memory/` holds ONE
+//! undifferentiated mix (§2.3 S1): m1nd-repo facts (ship notes, hall fixes, CI
+//! flake gotchas, code-anchored findings) tangled with maintainer doctrine,
+//! preferences, and product vocabulary. The medulla-to-be is polluted by project
+//! fact. M5a formalizes the medulla at that SAME path (no move — the kill-the-move
+//! precedent, §4.1) and triages the mix ONE claim, ONE row, ONE destination:
+//!
+//! | class                          | destination                              |
+//! |--------------------------------|------------------------------------------|
+//! | m1nd-repo fact                 | the m1nd PROJECT brain store             |
+//! | maintainer doctrine/vocabulary | STAY on the medulla (stamp Origin-Brain) |
+//! | ambiguous                      | STAY + flagged for maintainer triage     |
+//!
+//! ## Safety posture — CODE-LAND-ONLY (this ladder's absolute rule)
+//!
+//! This module BUILDS and PROVES the migration; it NEVER runs it on a live owner
+//! by default. [`MedullaMigration::plan`] is the default and is pure-read (a
+//! dry-run: it enumerates + classifies + reports, mutating nothing).
+//! [`MedullaMigration::apply`] is the gated executor — backup-first and
+//! count-conserving — and is exercised ONLY in scratch stores by the battery /
+//! unit tests. The live maintainer store is migrated by the maintainer, never by
+//! an agent.
+//!
+//! ## Reversibility (proven by a migrate → rollback round-trip)
+//!
+//! `apply` snapshots the ENTIRE medulla `agent-memory/` dir into a timestamped
+//! backup BEFORE the first mutation. [`MedullaMigration::rollback`] restores that
+//! backup byte-for-byte. The battery proves a plan → apply → rollback cycle
+//! returns the store to its exact original bytes — no claim lost, no claim
+//! altered.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use m1nd_core::error::{M1ndError, M1ndResult};
+use serde::{Deserialize, Serialize};
+
+use crate::util::now_ms;
+
+/// Where a triaged claim is routed (MEDULLA-PRD §4.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Destination {
+    /// A repo-anchored fact → moves to the project brain's store.
+    Project,
+    /// Doctrine / preference / vocabulary → stays on the medulla.
+    Medulla,
+    /// Doubt → stays on the medulla, flagged for maintainer triage
+    /// (the M4 hand-curated judgment: doubt → don't move).
+    AmbiguousStay,
+}
+
+/// One triaged claim in the plan (§4.2, one claim = one row).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimPlan {
+    /// The `.light.md` filename (slug + extension) inside the medulla store.
+    pub file_name: String,
+    /// Where it will land.
+    pub destination: Destination,
+    /// Whether the file already carries an `Origin-Brain:` frontmatter line.
+    pub has_origin_brain: bool,
+    /// One-line, human-readable classification reason (for the maintainer's
+    /// review before the gated `apply`).
+    pub reason: String,
+}
+
+/// A ghost pointer found in `ingest_roots.json`: a per-file `.light.md` entry
+/// whose file no longer exists (live example: `tokenvalidator.light.md`, §2.2c),
+/// or the collapse of per-file entries into the one dir root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhostPointer {
+    /// The offending ingest-root entry.
+    pub entry: String,
+    /// Why it is being pruned.
+    pub reason: String,
+}
+
+/// The full dry-run plan — everything `apply` WOULD do, computed by pure read
+/// (MEDULLA-PRD §11 M5a: the migration is a dry-run by default).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationPlan {
+    /// Every live `.light.md` claim in the medulla store, triaged.
+    pub claims: Vec<ClaimPlan>,
+    /// Ghost `ingest_roots.json` entries the sweep would prune (§4.2).
+    pub ghost_pointers: Vec<GhostPointer>,
+    /// `count(baseline)` — live claims before migration.
+    pub baseline_count: usize,
+    /// `count(project-active)` the plan would produce.
+    pub project_count: usize,
+    /// `count(medulla-active)` the plan would produce (medulla + ambiguous-stay).
+    pub medulla_count: usize,
+    /// Whether the count-conservation gate holds:
+    /// `baseline == project + medulla` (§4.2 gate; no claim lost).
+    pub count_conserved: bool,
+    /// Absolute path to the medulla `agent-memory/` store this plan is for.
+    pub medulla_dir: String,
+    /// Absolute path to the m1nd project brain's `agent-memory/` store.
+    pub project_dir: String,
+}
+
+/// The migration engine (MEDULLA-PRD §4.2). Holds the two store dirs + the
+/// `ingest_roots.json` path. Pure filesystem — no live `SessionState`, so it is
+/// trivially scratch-testable and structurally incapable of touching a running
+/// owner's in-memory graph.
+pub struct MedullaMigration {
+    /// `<owner runtime_root>/agent-memory/` — the medulla store.
+    medulla_dir: PathBuf,
+    /// The m1nd project brain's `agent-memory/` store (destination for repo facts).
+    project_dir: PathBuf,
+    /// `<owner runtime_root>/ingest_roots.json` — swept for ghost pointers.
+    ingest_roots_path: PathBuf,
+    /// The `Origin-Brain` value stamped on repo-fact claims moved to the project
+    /// store (the m1nd repo root, e.g. `/path/to/repo`).
+    project_origin: String,
+}
+
+/// Prefix that marks the timestamped backup dirs `apply` writes before mutating.
+const BACKUP_PREFIX: &str = ".m5a-backup-";
+
+impl MedullaMigration {
+    /// Build a migration for a medulla store, a project-brain destination store,
+    /// and the owner's `ingest_roots.json`.
+    pub fn new(
+        medulla_dir: impl Into<PathBuf>,
+        project_dir: impl Into<PathBuf>,
+        ingest_roots_path: impl Into<PathBuf>,
+        project_origin: impl Into<String>,
+    ) -> Self {
+        Self {
+            medulla_dir: medulla_dir.into(),
+            project_dir: project_dir.into(),
+            ingest_roots_path: ingest_roots_path.into(),
+            project_origin: project_origin.into(),
+        }
+    }
+
+    /// Enumerate the LIVE `.light.md` claims in the medulla store — never the
+    /// `.history/` archive, never dot-dirs, never backups. Sorted for a stable,
+    /// reproducible plan. This is the ONLY source of the baseline (§4.2: the
+    /// live inventory at migration time, never from the PRD document).
+    fn live_claims(&self) -> M1ndResult<Vec<PathBuf>> {
+        let mut out = Vec::new();
+        let entries = match std::fs::read_dir(&self.medulla_dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(M1ndError::Io(e)),
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            // Skip dot-dirs (.history/.locks) and any dotfile/backup.
+            if name.starts_with('.') {
+                continue;
+            }
+            if path.is_file() && name.ends_with(".light.md") {
+                out.push(path);
+            }
+        }
+        out.sort();
+        Ok(out)
+    }
+
+    /// Classify one claim by the shape of its text (§4.2 triage). Repo-fact
+    /// signals: an `[𝔻 evidence: ...]` marker anchoring to code, or ship-note /
+    /// hall-fix / flake vocabulary. Doctrine signals: preference / vocabulary /
+    /// cross-project language. Everything unclear → ambiguous-stay (doubt → don't
+    /// move). Returns `(Destination, reason)`.
+    fn classify(text: &str) -> (Destination, String) {
+        let lower = text.to_ascii_lowercase();
+
+        // Strongest project signal: the claim anchors to code evidence.
+        let has_code_evidence = text.lines().any(|l| {
+            let t = l.trim();
+            t.starts_with("[𝔻 evidence:")
+                && (t.contains(".rs")
+                    || t.contains(".ts")
+                    || t.contains(".py")
+                    || t.contains(".js")
+                    || t.contains(".md")
+                    || t.contains('/'))
+        });
+        if has_code_evidence {
+            return (
+                Destination::Project,
+                "code-anchored: carries a [𝔻 evidence:] marker to a repo path".into(),
+            );
+        }
+
+        // Repo-fact vocabulary (ship notes, hall fixes, CI flake gotchas, slice work).
+        const PROJECT_MARKERS: &[&str] = &[
+            "slice",
+            "shipped",
+            "hall fix",
+            "hall-fix",
+            "flake",
+            "ci flake",
+            "ladder",
+            "pr #",
+            "merged",
+            "handler",
+            "invariant tt-",
+            "regression",
+            "gate",
+        ];
+        if let Some(hit) = PROJECT_MARKERS.iter().find(|m| lower.contains(*m)) {
+            return (
+                Destination::Project,
+                format!("m1nd-repo fact: mentions '{hit}' (ship/fix/flake vocabulary)"),
+            );
+        }
+
+        // Doctrine / preference / vocabulary — the medulla is already home.
+        const DOCTRINE_MARKERS: &[&str] = &[
+            "doctrine",
+            "preference",
+            "prefers",
+            "maintainer",
+            "vocabulary",
+            "cross-project",
+            "always",
+            "never ",
+            "rule:",
+            "policy",
+        ];
+        if let Some(hit) = DOCTRINE_MARKERS.iter().find(|m| lower.contains(*m)) {
+            return (
+                Destination::Medulla,
+                format!("doctrine/preference: mentions '{hit}' — already home on the medulla"),
+            );
+        }
+
+        // Doubt → don't move (the M4 hand-curated judgment).
+        (
+            Destination::AmbiguousStay,
+            "ambiguous: no clear repo-fact or doctrine signal — stays, flagged for maintainer triage"
+                .into(),
+        )
+    }
+
+    /// True when a `.light.md` already carries an `Origin-Brain:` line (a whole-file
+    /// scan — the marker only ever lives in the frontmatter, and the file is tiny).
+    fn has_origin_brain(text: &str) -> bool {
+        text.lines()
+            .any(|l| l.trim_start().starts_with("Origin-Brain:"))
+    }
+
+    /// The ghost-pointer sweep (§4.2): `ingest_roots.json` entries that point at
+    /// a `.light.md` FILE which no longer exists are pruned; per-file `.light.md`
+    /// entries are collapsed into the one dir root. Returns the ghosts found +
+    /// the swept root list (the second used by `apply`).
+    fn sweep_ingest_roots(&self) -> M1ndResult<(Vec<GhostPointer>, Option<Vec<String>>)> {
+        let text = match std::fs::read_to_string(&self.ingest_roots_path) {
+            Ok(t) => t,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((Vec::new(), None)),
+            Err(e) => return Err(M1ndError::Io(e)),
+        };
+        let roots: Vec<String> = serde_json::from_str(&text).map_err(M1ndError::Serde)?;
+
+        let mem_dir_str = self.medulla_dir.to_string_lossy().to_string();
+        let mut ghosts = Vec::new();
+        let mut swept: Vec<String> = Vec::new();
+        let mut collapsed_dir = false;
+
+        for entry in &roots {
+            let is_light_file = entry.ends_with(".light.md");
+            if is_light_file {
+                // A per-file .light.md pointer. Prune if the file is gone (ghost);
+                // otherwise collapse it into the single dir root.
+                if !Path::new(entry).exists() {
+                    ghosts.push(GhostPointer {
+                        entry: entry.clone(),
+                        reason: "dangling: the .light.md file no longer exists".into(),
+                    });
+                } else {
+                    ghosts.push(GhostPointer {
+                        entry: entry.clone(),
+                        reason: "collapsed: per-file .light.md pointer folds into the dir root"
+                            .into(),
+                    });
+                    collapsed_dir = true;
+                }
+            } else {
+                swept.push(entry.clone());
+            }
+        }
+        // Ensure the one dir root survives when we collapsed per-file entries.
+        if collapsed_dir && !swept.iter().any(|r| r == &mem_dir_str) {
+            swept.push(mem_dir_str);
+        }
+
+        if ghosts.is_empty() {
+            Ok((ghosts, None))
+        } else {
+            Ok((ghosts, Some(swept)))
+        }
+    }
+
+    /// THE DRY-RUN (default, pure-read). Enumerate + classify every live claim,
+    /// find the ghost pointers, and compute the count-conservation gate — WITHOUT
+    /// mutating anything. This is what runs against the live owner: it reports the
+    /// migration it WOULD perform, and stops (§11 M5a: dry-run default).
+    pub fn plan(&self) -> M1ndResult<MigrationPlan> {
+        let files = self.live_claims()?;
+        let baseline_count = files.len();
+
+        let mut claims = Vec::with_capacity(baseline_count);
+        let mut project_count = 0usize;
+        let mut medulla_count = 0usize;
+
+        for path in &files {
+            let text = std::fs::read_to_string(path).map_err(M1ndError::Io)?;
+            let (destination, reason) = Self::classify(&text);
+            match destination {
+                Destination::Project => project_count += 1,
+                Destination::Medulla | Destination::AmbiguousStay => medulla_count += 1,
+            }
+            claims.push(ClaimPlan {
+                file_name: path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+                destination,
+                has_origin_brain: Self::has_origin_brain(&text),
+                reason,
+            });
+        }
+
+        let (ghost_pointers, _swept) = self.sweep_ingest_roots()?;
+
+        Ok(MigrationPlan {
+            claims,
+            ghost_pointers,
+            baseline_count,
+            project_count,
+            medulla_count,
+            count_conserved: baseline_count == project_count + medulla_count,
+            medulla_dir: self.medulla_dir.to_string_lossy().to_string(),
+            project_dir: self.project_dir.to_string_lossy().to_string(),
+        })
+    }
+
+    /// Snapshot the WHOLE medulla `agent-memory/` dir into a timestamped backup
+    /// beside it, BEFORE any mutation (backup-first posture). Returns the backup
+    /// dir path — the rollback anchor. Copies files + the `.history/` subtree so
+    /// a rollback restores the store's exact bytes.
+    fn backup(&self) -> M1ndResult<PathBuf> {
+        let backup_dir = self
+            .medulla_dir
+            .join(format!("{BACKUP_PREFIX}{}", now_ms()));
+        std::fs::create_dir_all(&backup_dir).map_err(M1ndError::Io)?;
+        copy_tree(&self.medulla_dir, &backup_dir, &backup_dir)?;
+        Ok(backup_dir)
+    }
+
+    /// THE GATED EXECUTOR (never run on a live owner by default — scratch/tests
+    /// only). Backup-first, then: move project-fact claims into the project store
+    /// (stamping `Origin-Brain: <project root>`), stamp `Origin-Brain: medulla`
+    /// on doctrine/ambiguous claims that lack it, prune ghost ingest-root
+    /// pointers, and verify count-conservation. Returns the [`MigrationReceipt`]
+    /// with the backup path for [`rollback`].
+    ///
+    /// Non-destructive on the project side: a move writes the claim into the
+    /// project store then removes it from the medulla (the backup holds the
+    /// original, so the move is fully reversible). If count-conservation fails
+    /// AFTER the moves, the caller should `rollback` immediately.
+    pub fn apply(&self) -> M1ndResult<MigrationReceipt> {
+        let plan = self.plan()?;
+        let backup_dir = self.backup()?;
+
+        std::fs::create_dir_all(&self.project_dir).map_err(M1ndError::Io)?;
+
+        let mut moved = 0usize;
+        let mut stamped = 0usize;
+
+        for claim in &plan.claims {
+            let src = self.medulla_dir.join(&claim.file_name);
+            let text = std::fs::read_to_string(&src).map_err(M1ndError::Io)?;
+            match claim.destination {
+                Destination::Project => {
+                    // Stamp the project origin, write into the project store, then
+                    // remove from the medulla. The backup keeps the original.
+                    let stamped_text = stamp_origin_brain(&text, &self.project_origin);
+                    let dst = self.project_dir.join(&claim.file_name);
+                    std::fs::write(&dst, stamped_text).map_err(M1ndError::Io)?;
+                    std::fs::remove_file(&src).map_err(M1ndError::Io)?;
+                    moved += 1;
+                }
+                Destination::Medulla | Destination::AmbiguousStay => {
+                    // Stays home. Stamp Origin-Brain: medulla if it lacks one.
+                    if !claim.has_origin_brain {
+                        let stamped_text = stamp_origin_brain(&text, "medulla");
+                        std::fs::write(&src, stamped_text).map_err(M1ndError::Io)?;
+                        stamped += 1;
+                    }
+                }
+            }
+        }
+
+        // Prune ghost ingest-root pointers (write the swept list back).
+        let (_ghosts, swept) = self.sweep_ingest_roots()?;
+        if let Some(roots) = swept {
+            let json = serde_json::to_string_pretty(&roots).map_err(M1ndError::Serde)?;
+            std::fs::write(&self.ingest_roots_path, json).map_err(M1ndError::Io)?;
+        }
+
+        // Count-conservation gate: the live medulla + project stores together must
+        // hold exactly the baseline count.
+        let medulla_after = self.live_claims()?.len();
+        let project_after = std::fs::read_dir(&self.project_dir)
+            .map(|e| {
+                e.flatten()
+                    .filter(|d| {
+                        d.path()
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|n| !n.starts_with('.') && n.ends_with(".light.md"))
+                    })
+                    .count()
+            })
+            .unwrap_or(0);
+        let count_conserved = plan.baseline_count == medulla_after + project_after;
+
+        Ok(MigrationReceipt {
+            backup_dir: backup_dir.to_string_lossy().to_string(),
+            moved_to_project: moved,
+            stamped_medulla: stamped,
+            ghosts_pruned: plan.ghost_pointers.len(),
+            baseline_count: plan.baseline_count,
+            medulla_after,
+            project_after,
+            count_conserved,
+        })
+    }
+
+    /// Reverse an `apply`: restore the medulla store from a backup dir written by
+    /// `apply` and remove any claims the migration moved into the project store.
+    /// After a rollback the medulla store is byte-identical to its pre-migration
+    /// state (the reversibility proof).
+    ///
+    /// `moved_file_names` are the project-store files the migration created — they
+    /// are removed so the project store returns to its pre-migration contents.
+    pub fn rollback(&self, backup_dir: &str, moved_file_names: &[String]) -> M1ndResult<()> {
+        let backup = PathBuf::from(backup_dir);
+        if !backup.is_dir() {
+            return Err(M1ndError::InvalidParams {
+                tool: "medulla_migration".into(),
+                detail: format!("backup dir '{backup_dir}' does not exist — cannot rollback"),
+            });
+        }
+
+        // 1. Remove the claims the migration created in the project store.
+        for name in moved_file_names {
+            let dst = self.project_dir.join(name);
+            if dst.exists() {
+                std::fs::remove_file(&dst).map_err(M1ndError::Io)?;
+            }
+        }
+
+        // 2. Wipe the LIVE medulla claims (not backups/dot-dirs) and restore from
+        //    the backup, byte-for-byte.
+        for path in self.live_claims()? {
+            std::fs::remove_file(&path).map_err(M1ndError::Io)?;
+        }
+        restore_tree(&backup, &self.medulla_dir)?;
+        Ok(())
+    }
+}
+
+/// The result of an `apply` (also the rollback anchor).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationReceipt {
+    /// The backup dir written before mutation — pass to `rollback`.
+    pub backup_dir: String,
+    /// Claims moved into the project store.
+    pub moved_to_project: usize,
+    /// Claims that stayed and were stamped `Origin-Brain: medulla`.
+    pub stamped_medulla: usize,
+    /// Ghost ingest-root pointers pruned.
+    pub ghosts_pruned: usize,
+    /// Live claim count before migration.
+    pub baseline_count: usize,
+    /// Live medulla claims after migration.
+    pub medulla_after: usize,
+    /// Project-store claims after migration.
+    pub project_after: usize,
+    /// The count-conservation gate: `baseline == medulla_after + project_after`.
+    pub count_conserved: bool,
+}
+
+/// Insert an `Origin-Brain: <value>` frontmatter line into a `.light.md` if it
+/// lacks one, placed after `Source-Agent:` (or, absent that, after the opening
+/// `---`). Idempotent: a file already carrying `Origin-Brain:` is returned
+/// unchanged. This preserves original `Created`/`Source-Agent` stamps (§4.2:
+/// carry the original provenance).
+fn stamp_origin_brain(text: &str, value: &str) -> String {
+    if text
+        .lines()
+        .any(|l| l.trim_start().starts_with("Origin-Brain:"))
+    {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len() + 40);
+    let mut inserted = false;
+    let mut seen_open_fence = false;
+    for line in text.lines() {
+        out.push_str(line);
+        out.push('\n');
+        if inserted {
+            continue;
+        }
+        let trimmed = line.trim();
+        if trimmed == "---" && !seen_open_fence {
+            seen_open_fence = true;
+            continue;
+        }
+        // Prefer inserting right after Source-Agent (keeps the §3.3 grammar order).
+        if seen_open_fence && trimmed.starts_with("Source-Agent:") {
+            out.push_str(&format!("Origin-Brain: {value}\n"));
+            inserted = true;
+        }
+    }
+    // If there was no Source-Agent line, insert right after the opening fence.
+    if !inserted && seen_open_fence {
+        let mut rebuilt = String::with_capacity(out.len() + 40);
+        let mut done = false;
+        for line in out.lines() {
+            rebuilt.push_str(line);
+            rebuilt.push('\n');
+            if !done && line.trim() == "---" {
+                rebuilt.push_str(&format!("Origin-Brain: {value}\n"));
+                done = true;
+            }
+        }
+        return rebuilt;
+    }
+    out
+}
+
+/// Recursively copy `src`'s live files + `.history/` into `dst`, skipping any
+/// backup dir under `src` (never back up a backup). `backup_self` names the
+/// backup dir currently being written so the walk does not recurse into it.
+fn copy_tree(src: &Path, dst: &Path, backup_self: &Path) -> M1ndResult<()> {
+    std::fs::create_dir_all(dst).map_err(M1ndError::Io)?;
+    for entry in std::fs::read_dir(src).map_err(M1ndError::Io)?.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Never back up prior backups (or the backup we are writing right now).
+        if name.starts_with(BACKUP_PREFIX) || path == backup_self {
+            continue;
+        }
+        let target = dst.join(name);
+        if path.is_dir() {
+            copy_tree(&path, &target, backup_self)?;
+        } else {
+            std::fs::copy(&path, &target).map_err(M1ndError::Io)?;
+        }
+    }
+    Ok(())
+}
+
+/// Restore a backup tree back over the medulla dir (files + `.history/`). Does
+/// not delete files already present (the caller wipes live claims first); it
+/// overwrites/creates from the backup so the store returns to backup bytes.
+fn restore_tree(backup: &Path, dst: &Path) -> M1ndResult<()> {
+    std::fs::create_dir_all(dst).map_err(M1ndError::Io)?;
+    for entry in std::fs::read_dir(backup).map_err(M1ndError::Io)?.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let target = dst.join(name);
+        if path.is_dir() {
+            restore_tree(&path, &target)?;
+        } else {
+            std::fs::copy(&path, &target).map_err(M1ndError::Io)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal `.light.md` with the given frontmatter + body.
+    fn light_doc(node: &str, source_agent: &str, body: &str) -> String {
+        format!(
+            "---\nProtocol: L1GHT/1.0\nNode: {node}\nState: authored\nCreated: 1700000000000\nSource-Agent: {source_agent}\n---\n\n# {node}\n\n## {node}\n\n{body}\n"
+        )
+    }
+
+    struct Scratch {
+        _tmp: tempfile::TempDir,
+        medulla: PathBuf,
+        project: PathBuf,
+        roots: PathBuf,
+    }
+
+    fn scratch() -> Scratch {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let medulla = tmp.path().join("runtime").join("agent-memory");
+        let project = tmp
+            .path()
+            .join("runtime")
+            .join("project-brains")
+            .join("fp")
+            .join("agent-memory");
+        std::fs::create_dir_all(&medulla).expect("medulla dir");
+        let roots = tmp.path().join("runtime").join("ingest_roots.json");
+        Scratch {
+            _tmp: tmp,
+            medulla,
+            project,
+            roots,
+        }
+    }
+
+    fn write_claim(dir: &Path, file: &str, contents: &str) {
+        std::fs::write(dir.join(file), contents).expect("write claim");
+    }
+
+    /// RED framing (M5a acceptance): a store with mixed claims, zero
+    /// `Origin-Brain` fields, and a ghost ingest-root pointer. The plan must
+    /// triage them ONE row per claim, count-conserving, without mutating.
+    #[test]
+    fn plan_triages_mixed_store_count_conserving_and_pure_read() {
+        let s = scratch();
+        // A code-anchored repo fact.
+        write_claim(
+            &s.medulla,
+            "sliceship.light.md",
+            &light_doc(
+                "SliceShip",
+                "closer-agent",
+                "The slice shipped.\n\n[⍂ entity: SliceShip]\n[𝔻 evidence: m1nd-mcp/src/server.rs]\n",
+            ),
+        );
+        // A doctrine/preference claim.
+        write_claim(
+            &s.medulla,
+            "maxpref.light.md",
+            &light_doc(
+                "MaxPref",
+                "orchestrator",
+                "The maintainer prefers pt-BR replies always.\n\n[⍂ entity: MaxPref]\n",
+            ),
+        );
+        // An ambiguous claim (no strong signal).
+        write_claim(
+            &s.medulla,
+            "mystery.light.md",
+            &light_doc(
+                "Mystery",
+                "someone",
+                "A thing happened once.\n\n[⍂ entity: Mystery]\n",
+            ),
+        );
+
+        // A ghost ingest-root pointer at a deleted .light.md + the dir root.
+        let ghost = s.medulla.join("deleted.light.md");
+        std::fs::write(
+            &s.roots,
+            serde_json::to_string_pretty(&vec![
+                s.medulla.to_string_lossy().to_string(),
+                ghost.to_string_lossy().to_string(),
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Snapshot the store bytes BEFORE plan to prove plan is pure-read.
+        let before: BTreeMap<String, String> = std::fs::read_dir(&s.medulla)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().is_file())
+            .map(|e| {
+                (
+                    e.file_name().to_string_lossy().to_string(),
+                    std::fs::read_to_string(e.path()).unwrap(),
+                )
+            })
+            .collect();
+
+        let mig = MedullaMigration::new(&s.medulla, &s.project, &s.roots, "/path/to/repo");
+        let plan = mig.plan().expect("plan");
+
+        assert_eq!(plan.baseline_count, 3, "three live claims");
+        assert_eq!(plan.project_count, 1, "one repo fact → project");
+        assert_eq!(plan.medulla_count, 2, "doctrine + ambiguous stay");
+        assert!(plan.count_conserved, "baseline == project + medulla");
+        assert_eq!(plan.ghost_pointers.len(), 1, "one dangling ghost pruned");
+        assert!(
+            plan.claims.iter().all(|c| !c.has_origin_brain),
+            "RED: zero Origin-Brain fields today"
+        );
+
+        // PURE-READ: the store is byte-identical after plan.
+        let after: BTreeMap<String, String> = std::fs::read_dir(&s.medulla)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().is_file())
+            .map(|e| {
+                (
+                    e.file_name().to_string_lossy().to_string(),
+                    std::fs::read_to_string(e.path()).unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(before, after, "plan must not mutate the store (dry-run)");
+    }
+
+    /// GREEN: apply moves repo facts, stamps Origin-Brain, prunes ghosts, and the
+    /// count-conservation gate holds.
+    #[test]
+    fn apply_splits_stores_stamps_origin_and_conserves_count() {
+        let s = scratch();
+        write_claim(
+            &s.medulla,
+            "sliceship.light.md",
+            &light_doc(
+                "SliceShip",
+                "closer",
+                "shipped.\n\n[⍂ entity: SliceShip]\n[𝔻 evidence: m1nd-mcp/src/x.rs]\n",
+            ),
+        );
+        write_claim(
+            &s.medulla,
+            "maxpref.light.md",
+            &light_doc(
+                "MaxPref",
+                "orch",
+                "maintainer doctrine.\n\n[⍂ entity: MaxPref]\n",
+            ),
+        );
+        std::fs::write(
+            &s.roots,
+            serde_json::to_string_pretty(&vec![s.medulla.to_string_lossy().to_string()]).unwrap(),
+        )
+        .unwrap();
+
+        let mig = MedullaMigration::new(&s.medulla, &s.project, &s.roots, "/path/to/repo");
+        let receipt = mig.apply().expect("apply");
+
+        assert!(receipt.count_conserved, "no claim lost");
+        assert_eq!(receipt.moved_to_project, 1);
+        assert_eq!(receipt.medulla_after, 1, "only doctrine stays");
+        assert_eq!(receipt.project_after, 1, "the repo fact moved");
+
+        // The moved claim is stamped with the project origin.
+        let moved = std::fs::read_to_string(s.project.join("sliceship.light.md")).unwrap();
+        assert!(
+            moved.contains("Origin-Brain: /path/to/repo"),
+            "moved claim carries the project origin, got:\n{moved}"
+        );
+        assert!(
+            moved.contains("Source-Agent: closer"),
+            "original provenance preserved"
+        );
+        // The staying claim is stamped medulla.
+        let stayed = std::fs::read_to_string(s.medulla.join("maxpref.light.md")).unwrap();
+        assert!(
+            stayed.contains("Origin-Brain: medulla"),
+            "doctrine claim stamped medulla, got:\n{stayed}"
+        );
+    }
+
+    /// REVERSIBILITY PROOF (§11 M5a): plan → apply → rollback returns the medulla
+    /// store to its EXACT original bytes and empties the project store.
+    #[test]
+    fn migrate_then_rollback_restores_original_bytes() {
+        let s = scratch();
+        let ship = light_doc(
+            "SliceShip",
+            "closer",
+            "shipped.\n\n[⍂ entity: SliceShip]\n[𝔻 evidence: m1nd-mcp/src/x.rs]\n",
+        );
+        let pref = light_doc(
+            "MaxPref",
+            "orch",
+            "maintainer doctrine.\n\n[⍂ entity: MaxPref]\n",
+        );
+        write_claim(&s.medulla, "sliceship.light.md", &ship);
+        write_claim(&s.medulla, "maxpref.light.md", &pref);
+        std::fs::write(
+            &s.roots,
+            serde_json::to_string_pretty(&vec![s.medulla.to_string_lossy().to_string()]).unwrap(),
+        )
+        .unwrap();
+
+        // Capture the exact original bytes of the whole live store.
+        let original: BTreeMap<String, String> = std::fs::read_dir(&s.medulla)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().is_file())
+            .map(|e| {
+                (
+                    e.file_name().to_string_lossy().to_string(),
+                    std::fs::read_to_string(e.path()).unwrap(),
+                )
+            })
+            .collect();
+
+        let mig = MedullaMigration::new(&s.medulla, &s.project, &s.roots, "/path/to/repo");
+        let receipt = mig.apply().expect("apply");
+        assert!(receipt.count_conserved);
+        // Post-apply the store changed (moved + stamped).
+        assert!(s.project.join("sliceship.light.md").exists());
+
+        mig.rollback(&receipt.backup_dir, &["sliceship.light.md".to_string()])
+            .expect("rollback");
+
+        // The medulla store is byte-identical to the original.
+        let restored: BTreeMap<String, String> = std::fs::read_dir(&s.medulla)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.path().is_file()
+                    && e.file_name()
+                        .to_string_lossy()
+                        .to_string()
+                        .ends_with(".light.md")
+            })
+            .map(|e| {
+                (
+                    e.file_name().to_string_lossy().to_string(),
+                    std::fs::read_to_string(e.path()).unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            original, restored,
+            "rollback must restore the medulla store byte-for-byte"
+        );
+        // The project store is empty of the moved claim again.
+        assert!(
+            !s.project.join("sliceship.light.md").exists(),
+            "rollback removed the moved claim from the project store"
+        );
+    }
+
+    /// Ghost-pointer sweep: a dangling per-file pointer is pruned; a live per-file
+    /// pointer collapses into the dir root.
+    #[test]
+    fn ghost_pointer_sweep_prunes_dangling_and_collapses_live() {
+        let s = scratch();
+        // One live per-file pointer (real file) + one dangling.
+        write_claim(&s.medulla, "real.light.md", &light_doc("Real", "a", "x"));
+        let real = s.medulla.join("real.light.md");
+        let dangling = s.medulla.join("gone.light.md");
+        std::fs::write(
+            &s.roots,
+            serde_json::to_string_pretty(&vec![
+                s.medulla.to_string_lossy().to_string(),
+                real.to_string_lossy().to_string(),
+                dangling.to_string_lossy().to_string(),
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+
+        let mig = MedullaMigration::new(&s.medulla, &s.project, &s.roots, "/path/to/repo");
+        let (ghosts, swept) = mig.sweep_ingest_roots().expect("sweep");
+        assert_eq!(ghosts.len(), 2, "one dangling + one collapsed");
+        let roots = swept.expect("swept list");
+        assert!(
+            roots.iter().all(|r| !r.ends_with(".light.md")),
+            "no per-file .light.md pointers remain, got: {roots:?}"
+        );
+        assert!(
+            roots.contains(&s.medulla.to_string_lossy().to_string()),
+            "the dir root survives"
+        );
+    }
+
+    /// Idempotent stamping: a claim already carrying Origin-Brain is untouched.
+    #[test]
+    fn stamp_origin_brain_is_idempotent() {
+        let already = "---\nProtocol: L1GHT/1.0\nNode: X\nState: authored\nSource-Agent: a\nOrigin-Brain: medulla\n---\n\n# X\n";
+        assert_eq!(stamp_origin_brain(already, "medulla"), already);
+
+        let fresh =
+            "---\nProtocol: L1GHT/1.0\nNode: X\nState: authored\nSource-Agent: a\n---\n\n# X\n";
+        let stamped = stamp_origin_brain(fresh, "/path/to/repo");
+        assert!(stamped.contains("Origin-Brain: /path/to/repo"));
+        assert!(
+            stamped.find("Origin-Brain:").unwrap() > stamped.find("Source-Agent:").unwrap(),
+            "Origin-Brain lands after Source-Agent"
+        );
+    }
+}

--- a/m1nd-mcp/src/mission_handlers.rs
+++ b/m1nd-mcp/src/mission_handlers.rs
@@ -424,6 +424,8 @@ fn try_write_light_memory(
         ingest_after: true,
         mode: "merge".into(),
         supersedes: None,
+        // Default path: the handler stamps Origin-Brain from the session (§6).
+        origin_brain: None,
     };
 
     let result = handle_light_author(state, light_input)

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -83,6 +83,12 @@ space as code, surfaces in later `seek`/`north`, and self-flags as stale via \
 Pass `write_light_memory:true` to `mission_close` to persist its verified claims in one \
 step. This is how knowledge compounds instead of being lost between sessions.
 
+Every `memorize` is stamped with an `Origin-Brain` (the project root it was born in, or \
+`medulla` for the owner's own doctrine store) so recall can always say WHICH brain a claim \
+came from. If your session's root has no project brain, a `memorize` is REFUSED (not \
+silently written into the shared medulla) — the refusal hands you the one-call bootstrap \
+(`ingest project_root=<your repo>`); run it, then your memory lands project-private.
+
 Then leave ONE field-telemetry signal and keep working (report, never detour): when a \
 retrieval was right or wrong, `learn(correct|wrong|partial)`; when m1nd ITSELF misbehaves \
 (a bug, friction, or an honesty miss — it claimed fresh/closed/act and was wrong), append \

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -973,6 +973,40 @@ impl SessionState {
         self.project_root_display().map(|root| basename_of(&root))
     }
 
+    /// True when THIS store is the medulla — the owner's own memory-of-doctrine
+    /// store, not a per-project brain (MEDULLA-PRD §4.1: the tier IS the directory).
+    ///
+    /// A project brain is born through [`ProjectBrainRegistry::boot_store`], which
+    /// stamps `workspace_root_source = "project_brain_manifest"` — the one honest
+    /// signal that a session is a routed per-project store rather than the bound
+    /// owner. Everything else (the bound dev graph today; the owner's own store)
+    /// is the medulla store: its `agent-memory/` dir holds `promoted` /
+    /// doctrine-born claims (post-migration) and is what every session's default
+    /// beat reads beside its own project memory.
+    pub fn is_medulla_store(&self) -> bool {
+        self.workspace_root_source.as_deref() != Some("project_brain_manifest")
+    }
+
+    /// The `Origin-Brain` label to stamp on a claim born in THIS store
+    /// (MEDULLA-PRD §6 · §3.3 frontmatter grammar):
+    /// - a per-project brain → its project root (`/path/to/repo`), the WHERE-born;
+    /// - the medulla store → the literal `medulla` (doctrine-born, no project origin).
+    ///
+    /// This is metadata, not a security boundary — it is rendered everywhere so
+    /// promotion/recall can say which brain a claim came from. Absent on legacy
+    /// files means "unknown", never faked (TT-INV-2 / MED-INV-4).
+    pub fn origin_brain(&self) -> String {
+        if self.is_medulla_store() {
+            "medulla".to_string()
+        } else {
+            // A project brain: its project root is the origin. Prefer the real
+            // repo root over the runtime sidecar, mirroring display naming.
+            self.project_root_display()
+                .or_else(|| self.workspace_root.clone())
+                .unwrap_or_else(|| "medulla".to_string())
+        }
+    }
+
     /// How many durable L1GHT memory claims exist on disk in this brain's store
     /// (`<runtime_root>/agent-memory/*.light.md`). This is the ground-truth count
     /// of the memory store itself, independent of whether recall surfaced any of

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -5272,6 +5272,7 @@ mod tests {
                 ingest_after: true,
                 mode: "merge".into(),
                 supersedes: None,
+                origin_brain: None,
             },
         )
         .expect("memorize");
@@ -5404,6 +5405,7 @@ mod tests {
                 ingest_after: true,
                 mode: "merge".into(),
                 supersedes: None,
+                origin_brain: None,
             },
         )
         .expect("memorize");
@@ -5469,6 +5471,7 @@ mod tests {
                     ingest_after: true,
                     mode: "merge".into(),
                     supersedes: None,
+                    origin_brain: None,
                 },
             )
             .expect("memorize");

--- a/m1nd-mcp/tests/attach_self_echo.rs
+++ b/m1nd-mcp/tests/attach_self_echo.rs
@@ -213,9 +213,15 @@ fn write_tools_return_real_envelopes_through_the_bridge() {
     wait_until_serving(&base_url);
 
     // 2. The REAL `--attach` bridge, stdio host on one side, owner on the other.
+    //    Pin the bridge's caller root to the ingested repo (via M1ND_WORKSPACE_ROOT)
+    //    so its hop-2 header names a root the bound graph COVERS after the ingest
+    //    below — otherwise the bridge's own cwd is a foreign brainless root and the
+    //    memorize is correctly refused (MEDULLA M5a S2), which this test is not
+    //    exercising.
     let mut bridge = Command::new(BIN)
         .arg("--attach")
         .arg(&base_url)
+        .env("M1ND_WORKSPACE_ROOT", &repo)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -256,6 +256,8 @@ Quick pattern:
 4. After code changes, `cross_verify(check:["evidence_freshness"])` tells you which memorized claims now cite stale code. A merge re-ingest also returns `memory_freshness` inline.
 5. `mission_close(write_light_memory:true)` combines closing a mission and persisting its verified claims in one step.
 
+Provenance and scope (MEDULLA M5a): every `memorize` is stamped with an `Origin-Brain` — the project root it was born in, or `medulla` for the owner's own doctrine store — so recall can always name WHICH brain a claim came from. If your session's root has no project brain, a `memorize` is REFUSED rather than written into the shared medulla store; the refusal carries the one-call bootstrap (`ingest project_root=<your repo>`). Run it once, then your memory lands project-private in your own brain.
+
 Caveat: `ingest mode:replace` wipes agent memory nodes. Use `mode:merge` when re-ingesting code to keep agent memory intact.
 
 ## Skip Conditions

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -112,6 +112,12 @@ this loop by default:
    JSON line in `~/.m1nd/field-reports.jsonl` when m1nd itself misbehaves
    (local-only; never fix m1nd mid-mission — report). Record the investigation
    path: m1nd calls, recovery path, files inspected, commands run.
+   Every `memorize` is stamped with an `Origin-Brain` (its project root, or
+   `medulla` for the owner's doctrine store), so recall names which brain a claim
+   came from. A `memorize` from a root with NO project brain is REFUSED (never
+   silently written into the shared medulla); the refusal hands you the one-call
+   bootstrap `ingest project_root=<your repo>` — run it, then memory lands
+   project-private.
 
 This is the trained-agent behavior to preserve across hosts: m1nd is graph plus
 operating doctrine, not graph alone.


### PR DESCRIPTION
## What M5a ships (MEDULLA-PRD §11 · ORGANISM §C10 R2)

The medulla becomes a real store: **the tier IS the directory**. Four pieces land atomically.

**1. Origin-Brain labels** — every `memorize` is stamped with an `Origin-Brain` in its frontmatter: the project root it was born in, or `medulla` for the owner's own doctrine store. `SessionState::origin_brain()` derives it (medulla vs project brain via `workspace_root_source == "project_brain_manifest"`); `render_light_markdown` renders it after `Source-Agent` (§3.3 grammar). Absent on legacy files = unknown, never faked (MED-INV-4). This is the provenance promotion/recall needs to tell which brain a claim came from.

**2. Brainless-root refusal (closes S2)** — a default-path `memorize` on the medulla store whose caller root is a KNOWN foreign repo it does not cover is now REFUSED, instead of silently writing into the shared doctrine-to-be. The refusal hands back the exact one-call bootstrap (`ingest project_root=<repo>`). A covered owner-doctrine write and a headerless session (absent ≠ wrong, §9.5.4) are not refused.

**3. Storage split** — the medulla is formalized at the existing `agent-memory/` path (no move — the kill-the-move precedent, §4.1). The per-brain stores already exist (#260/#262/R15); M5a adds the tier grammar (Origin-Brain) + the refusal + the migration on top of working routing.

**4. Migration logic (reversible, backup-first)** — a new standalone, pure-filesystem module `medulla_migration.rs`:
- `plan()` — the pure-read **dry-run default**: enumerate live claims, classify each (repo-fact → project store; doctrine → stays; ambiguous → stays + flagged), find ghost `ingest_roots.json` pointers, and compute the count-conservation gate — mutating nothing.
- `apply()` — the **gated executor**: snapshots the WHOLE store into a timestamped backup BEFORE the first mutation (backup-first), moves repo-fact claims into the project store (stamping the project origin), stamps `Origin-Brain: medulla` on stayers, prunes ghost pointers, and verifies `baseline == medulla_after + project_after`.
- `rollback()` — restores the store byte-for-byte from a backup and removes moved claims.

It operates on directory paths, never a live `SessionState`, so it is structurally incapable of touching a running owner's in-memory graph.

## RED → green (all in scratch, never a live owner)

- **RED (today):** claims carry zero `Origin-Brain`; a `memorize` from a root with no project brain lands silently in the shared store; the store is an undifferentiated mix with a dangling ghost ingest-root pointer.
- **GREEN:** every claim carries a tier by directory + `Origin-Brain`; the brainless-root memorize returns the typed refusal naming the bootstrap; legacy files without `Origin-Brain` still parse and render "unknown"; the migration `plan` triages count-conserving and pure-read, `apply` splits + stamps, and a migrate → rollback round-trip restores the original bytes (no data loss).

Tests: 6 handler unit tests + 5 migration tests (including the reversibility round-trip and the ghost sweep). The `attach_self_echo` integration test was updated to the post-M5a agent flow (its bridge now names a covered root; a real agent bootstraps a brain first).

## Reversibility proof

`migrate_then_rollback_restores_original_bytes` captures the exact original bytes of the whole live store, runs `apply` (which changes it — moves + stamps + backup), then `rollback`, and asserts the medulla store is byte-identical to the original and the project store is emptied of the moved claim.

## THE LIVE MIGRATION IS NOT RUN HERE — held for the maintainer

This is **CODE-LAND-ONLY**. The migration logic is built and scratch-proven, but no live owner is migrated by this PR: `plan` is the dry-run default and `apply` runs only against scratch stores in the tests. Moving the maintainer's live memory is a separate, explicit maintainer act.

## Gates

- `cargo test -p m1nd-mcp` — green (556 lib + all integration files)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- battery (`scratchpad/m1nd_battery.py`) — 38/38 all-pass

## Doc + agent-surface gate (same PR)

- MEDULLA §11 M5a and ORGANISM §C10 R2 marked `[SHIPPED]` with the shipped-variant note + the live-migration-held caveat.
- The memorize contract (Origin-Brain + brainless refusal) added to the MCP agent instructions, `skills/m1nd-first`, and the universal agent pack.