### PR TITLE
feat(medulla): pull-only tier recall — no-leak invariant, all-brains through eviction, provenance in recall (R3 / M5b)

### DIFF
--- a/docs/MEDULLA-PRD.md
+++ b/docs/MEDULLA-PRD.md
@@ -360,8 +360,28 @@ Each event that survives triage adds its case to the battery of the brain it bit
 - **GREEN:** every live claim carries a tier by directory + `Origin-Brain` (or is on the ambiguous-triage list); count-conservation gate green; the brainless-root memorize returns the typed refusal naming the bootstrap; legacy files without `Origin-Brain` still parse and render "unknown".
 - **Battery:** triage count-conservation case · brainless-root refusal case · legacy-frontmatter tolerance case · ghost-root sweep case.
 
-### M5b — Scoped recall + the no-leak invariant proven
-- **Scope:** the `tier` argument on `seek`/`boot_memory` (default `project+medulla` — zero caller change); north's beat composes the two labeled feeds (TT §10 shape); `all-brains` owner-side fan-out with origin grouping + dormant snapshot answers; recall rows gain `origin_brain`/`tier`; **the false-absence fix** (the broad fallback surfaces most-recent claims or stamps `memory_exists: n` — never "No durable memory yet" over a non-empty store).
+### M5b — Scoped recall + the no-leak invariant proven — [SHIPPED 2026-07-05]
+> **Shipped variant (honest):** tier recall landed at the ONE seam that can read
+> across stores — the HTTP routing layer (`mcp_http::serve_and_compose`), because a
+> tool handler holds a single `&mut SessionState` and structurally cannot reach a
+> sibling brain. `tier` is therefore NOT a `SeekInput` field (serde ignores the
+> unknown arg on the seek call); it is read from the raw tool arguments by the
+> routing layer, which dispatches the tool on the routed brain, then folds in the
+> tier-selected sibling feeds — each row labeled `origin_brain` + `tier`. The
+> default beat composes the routed brain's own store + the medulla (the bound owner
+> store today); the medulla feed is folded only when the primary is a project brain
+> (the owner IS the medulla by identity, so no double-read). `all-brains` resolves
+> every `disk_roster()` store through `ProjectBrainRegistry::resolve` — the SAME
+> path that routes through R15's `insert_with_eviction`, so the warm map stays ≤ cap
+> during a wide fan-out (§C9.1 honored, not merely referenced). Provenance flows
+> end-to-end: `Origin-Brain` frontmatter → `light:origin_brain:` prov tag
+> (`l1ght_adapter`) → `SeekResultEntry.origin_brain` (`layer_handlers`) → recall rows.
+> Lock discipline held: the primary lock is dropped before any sibling is read;
+> never two session locks at once. **The false-absence fix (MED-INV-6) shipped in
+> R0/M5a** (`memory_exists: n` stamp, live on `north`); M5b did not re-touch it.
+> **CODE-LAND-ONLY: the live `:1338` was NOT migrated/restarted — held for the
+> maintainer.** `tier:"medulla"`/`"project"` explicit selectors also shipped.
+- **Scope:** the `tier` argument on `seek`/`boot_memory`/`north` (default `project+medulla` — zero caller change); north's beat composes the two labeled feeds (TT §10 shape); `all-brains` owner-side fan-out with origin grouping + dormant snapshot answers; recall rows gain `origin_brain`/`tier`; **the false-absence fix** (the broad fallback surfaces most-recent claims or stamps `memory_exists: n` — never "No durable memory yet" over a non-empty store; shipped in R0/M5a).
 - **RED (on file, mechanized):** the probe pair — `northB` returned `memory: []` + "No durable memory yet" while `seek(scope:"light::")` found claims (field row 2026-07-05); plus the leak assertion: seed brain Y with a claim, assert brain X's default beat NEVER carries it (green today via routing — pinned so it can never regress), and assert `tier:"all-brains"` DOES return it, labeled `origin_brain: Y`.
 - **GREEN:** MED-INV-1 test green across bound/project/medulla permutations; MED-INV-6 case green (non-empty store never yields false absence); `tier` absent = byte-identical behavior for existing callers (golden test); fan-out latency **measured and recorded**, not claimed (TT-INV-5).
 - **Battery:** the probe repro (this PRD's §2.2, mechanized as the seed case) · no-leak permutation matrix · false-absence case · default-unchanged golden.

--- a/docs/ORGANISM-PRD.md
+++ b/docs/ORGANISM-PRD.md
@@ -721,9 +721,20 @@ flush). *Unblocks:* R3's `all-brains` half and any onboarding past brain #4. **H
 R3's `all-brains` does not ship without it, and its fan-out must warm-boot through this same gate.**
 
 **R3 — M5b: `tier` recall + no-leak proven + `all-brains`** (MEDULLA §11; gated by R15).
-*RED:* the leak permutation matrix (seed Y, assert X's beat never carries it; assert `all-brains`
-does, labeled) + the mechanized probe pair. *Unblocks:* R4's read path, R7's tier-labeled packet
-rows, the real doctrine beat.
+**[SHIPPED 2026-07-05.]** *What landed:* pull-only tier recall at the routing seam — a routed
+brain X's default beat composes exactly X's own store + the medulla; `tier` (`project` |
+`medulla` | `project+medulla` (default) | `all-brains`) selects which stores the memory beat of
+`seek`/`north`/`boot_memory` reads. The no-leak law (MED-INV-1) is mechanical: a claim from brain
+Y reaches X's default beat ONLY if it is a medulla claim (promoted/doctrine-born). `all-brains`
+fans out over every hosted store, **each warm-boot routed through the R15 eviction gate** (so a
+wide fan-out never pins more than the cap), grouped/labeled by `origin_brain`. Provenance-in-recall:
+`Origin-Brain` flows frontmatter → `light:origin_brain:` graph tag → `SeekResultEntry.origin_brain`
+→ every recall row. *Proof:* the leak permutation matrix (seed Y, assert X's default beat never
+carries it, assert `all-brains` does — labeled `origin_brain: Y`), the medulla-doctrine-surfaces-
+cross-brain case, the default-labeled case, and the `all-brains`-through-eviction (warm map ≤ cap)
+case — all RED-first (`m1nd-mcp/tests/medulla_m5b_tier_recall.rs`). *Held for the maintainer:* the
+live `:1338` was NOT migrated/restarted — CODE-LAND-ONLY. *Unblocks:* R4's read path, R7's
+tier-labeled packet rows, the real doctrine beat.
 
 **R4 — M6: the `promote` verb WITH the C8 riders** — step 2.5 origin-qualified evidence (§C8.2),
 P3 verified-only gate (§C8.3), demotion documented, agent-workflow surfaces in the SAME PR

--- a/m1nd-ingest/src/l1ght_adapter.rs
+++ b/m1nd-ingest/src/l1ght_adapter.rs
@@ -49,6 +49,10 @@ struct HeaderMeta {
     /// honestly "unknown", never faked.
     created: Option<String>,
     source_agent: Option<String>,
+    /// The brain a claim was born in (`Origin-Brain:` frontmatter, MEDULLA-PRD §6):
+    /// a project root, or the literal `medulla` for doctrine-born claims. Absent on
+    /// legacy files — honestly "unknown", never faked (MED-INV-4).
+    origin_brain: Option<String>,
     depends_on: Vec<String>,
     next: Vec<String>,
 }
@@ -284,6 +288,9 @@ impl L1ghtIngestAdapter {
             } else if let Some(value) = trimmed.strip_prefix("Source-Agent:") {
                 meta.source_agent = Some(value.trim().to_string());
                 current_list = None;
+            } else if let Some(value) = trimmed.strip_prefix("Origin-Brain:") {
+                meta.origin_brain = Some(value.trim().to_string());
+                current_list = None;
             } else if trimmed == "Depends on:" {
                 current_list = Some("depends_on");
             } else if trimmed == "Next:" {
@@ -340,6 +347,11 @@ impl L1ghtIngestAdapter {
         }
         if let Some(source_agent) = &header_meta.source_agent {
             prov_tags.push(format!("light:source_agent:{}", source_agent.trim()));
+        }
+        // Origin-Brain (MEDULLA-PRD §6): WHERE the claim was born, stamped so recall
+        // can label which brain a hit came from. Absent → no tag (honest "unknown").
+        if let Some(origin_brain) = &header_meta.origin_brain {
+            prov_tags.push(format!("light:origin_brain:{}", origin_brain.trim()));
         }
 
         Self::push_node(
@@ -798,11 +810,13 @@ mod confidence_tests {
             "State: verified",
             "Created: 1700000000000",
             "Source-Agent: agent-B",
+            "Origin-Brain: /path/to/repo",
             "---",
         ];
         let meta = A::parse_header(&lines);
         assert_eq!(meta.created.as_deref(), Some("1700000000000"));
         assert_eq!(meta.source_agent.as_deref(), Some("agent-B"));
+        assert_eq!(meta.origin_brain.as_deref(), Some("/path/to/repo"));
     }
 
     #[test]
@@ -823,6 +837,10 @@ mod confidence_tests {
         assert!(
             meta.source_agent.is_none(),
             "Source-Agent must be None on legacy files"
+        );
+        assert!(
+            meta.origin_brain.is_none(),
+            "Origin-Brain must be None on legacy files"
         );
     }
 }

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -674,6 +674,7 @@ pub fn handle_seek(
             // the intent summary. `tags` (sans provenance) still feeds the summary.
             let mut authored_ms_ago: Option<u64> = None;
             let mut source_agent: Option<String> = None;
+            let mut origin_brain: Option<String> = None;
             let tags: Vec<String> = all_tags
                 .into_iter()
                 .filter(|t| {
@@ -686,6 +687,11 @@ pub fn handle_seek(
                         false
                     } else if let Some(agent) = t.strip_prefix("light:source_agent:") {
                         source_agent = Some(agent.trim().to_string());
+                        false
+                    } else if let Some(brain) = t.strip_prefix("light:origin_brain:") {
+                        // Provenance-in-recall (MEDULLA-PRD §6): WHICH brain this
+                        // claim was born in. Absent tag → absent field ("unknown").
+                        origin_brain = Some(brain.trim().to_string());
                         false
                     } else {
                         true
@@ -742,6 +748,7 @@ pub fn handle_seek(
                 excerpt: prov.excerpt,
                 authored_ms_ago,
                 source_agent,
+                origin_brain,
                 connections,
             }
         })

--- a/m1nd-mcp/src/mcp_http.rs
+++ b/m1nd-mcp/src/mcp_http.rs
@@ -36,7 +36,8 @@ use parking_lot::Mutex;
 
 use crate::http_server::{AppState, SseEvent};
 use crate::protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
-use crate::server::handle_mcp_method;
+use crate::server::{dispatch_tool, handle_mcp_method};
+use crate::session::SessionState;
 use crate::util::now_ms;
 
 /// Per-spec MCP session header name (case-insensitive on the wire).
@@ -547,11 +548,10 @@ async fn route_and_run(
             };
             if let Some(root) = sticky {
                 if let Some(brain) = app.project_brains.resolve(&root) {
-                    let mut state = brain.lock();
-                    // The brain's own reception stays silent for its root and
-                    // honest for a traveled caller (scope-guard backstop).
-                    state.caller_root = caller_root.clone();
-                    return handle_mcp_method(&mut state, &request);
+                    // Served by a PROJECT brain → its default beat is project + medulla,
+                    // and it can fan out to `all-brains` (MEDULLA-PRD §5); compose runs
+                    // AROUND the primary dispatch, holding one lock at a time.
+                    return serve_and_compose(&app, brain, &request, caller_root.clone(), true);
                 }
                 // Brain store vanished mid-session — fall through to the bound
                 // graph, whose reception will say so honestly.
@@ -566,17 +566,15 @@ async fn route_and_run(
                         if let Some(s) = app.mcp_sessions.lock().get_mut(&session_id) {
                             s.bound_project_root = Some(key);
                         }
-                        let mut state = brain.lock();
-                        state.caller_root = caller_root.clone();
-                        return handle_mcp_method(&mut state, &request);
+                        return serve_and_compose(&app, brain, &request, caller_root.clone(), true);
                     }
                 }
             }
 
-            // 4. Default: the bound graph (reception flags true unknowns there).
-            let mut session = app.session.lock();
-            session.caller_root = caller_root;
-            handle_mcp_method(&mut session, &request)
+            // 4. Default: the bound graph (reception flags true unknowns there). This
+            // IS the medulla store today — its own beat is already project+medulla by
+            // identity; `all-brains` still fans out to the hosted project brains.
+            serve_and_compose(&app, app.session.clone(), &request, caller_root, false)
         }),
     )
     .await;
@@ -603,6 +601,401 @@ async fn route_and_run(
                 data: None,
             }),
         },
+    }
+}
+
+// =========================================================================
+// MEDULLA M5b — pull-only tier recall (the read side of the medulla)
+// =========================================================================
+//
+// The routing layer is the ONLY place that can compose ACROSS stores: a tool
+// handler holds a single `&mut SessionState` and structurally cannot read a
+// sibling brain. `serve_and_compose` dispatches the tool on the primary (routed)
+// brain, then — for the memory-recall tools only — folds in the other stores the
+// tier selector names, each row labeled with its `origin_brain` (MEDULLA-PRD §6).
+//
+// THE LEAK INVARIANT (MED-INV-1), made mechanical here: a brain X default beat
+// composes exactly X's own store + the medulla — no third store is ever read
+// unless the caller passes `tier:"all-brains"`. So a claim from brain Y can reach
+// X's default beat only if it lives in the medulla (promoted / doctrine-born).
+// Pull, never push.
+//
+// Lock discipline (route_and_run's contract): NEVER hold two session locks at
+// once. Each store is locked, queried, and released before the next is touched;
+// the primary lock is dropped before any sibling is read.
+
+/// Tools whose payloads carry a durable-memory feed that tier recall composes.
+/// `seek` folds into `results`; `north` into `memory`; `boot_memory` (list) into
+/// `entries`. Every other tool is served verbatim by the primary brain.
+fn is_tier_recall_tool(tool: &str) -> bool {
+    matches!(bare_tool_name(tool), "seek" | "north" | "boot_memory")
+}
+
+/// The memory tier a caller asked for (MEDULLA-PRD §5.2). Absent / unknown →
+/// the default beat (`project + medulla`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MemoryTier {
+    /// This brain's own store only.
+    Project,
+    /// The medulla (promoted/doctrine) store only.
+    Medulla,
+    /// Default: this brain's store + the medulla.
+    ProjectAndMedulla,
+    /// The explicit cross-project fan-out — every hosted store, labeled by origin.
+    AllBrains,
+}
+
+impl MemoryTier {
+    /// Read the `tier` argument off a `tools/call` request. Absent, empty, or
+    /// unrecognized → the default beat (never an error — an unknown tier must not
+    /// break recall, and must never silently widen past the default, §12 risk 1).
+    fn from_request(request: &JsonRpcRequest) -> MemoryTier {
+        let raw = request
+            .params
+            .get("arguments")
+            .and_then(|a| a.get("tier"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
+        match raw {
+            "project" => MemoryTier::Project,
+            "medulla" => MemoryTier::Medulla,
+            "all-brains" | "all_brains" => MemoryTier::AllBrains,
+            // "" | "project+medulla" | anything else → the safe default.
+            _ => MemoryTier::ProjectAndMedulla,
+        }
+    }
+}
+
+/// Serve `request` on `primary` (the routed brain), then compose the tier-selected
+/// memory feed from the other stores. `primary_is_project` is true when `primary`
+/// is a per-project brain (its own beat is `project`); false when it is the bound
+/// owner, which IS the medulla today (its own beat is already `project+medulla` by
+/// identity). Non-recall tools and the `project` tier are served verbatim.
+fn serve_and_compose(
+    app: &Arc<AppState>,
+    primary: Arc<Mutex<SessionState>>,
+    request: &JsonRpcRequest,
+    caller_root: Option<String>,
+    primary_is_project: bool,
+) -> JsonRpcResponse {
+    // Non-recall tools, or a non-`tools/call` method: serve verbatim, one lock.
+    let tool_name = if request.method == "tools/call" {
+        request.params.get("name").and_then(|v| v.as_str())
+    } else {
+        None
+    };
+    let Some(tool) = tool_name.filter(|t| is_tier_recall_tool(t)) else {
+        let mut state = primary.lock();
+        state.caller_root = caller_root;
+        return handle_mcp_method(&mut state, request);
+    };
+    let tier = MemoryTier::from_request(request);
+
+    // 1. PRIMARY dispatch — the routed brain's own answer (its full envelope). We
+    //    dispatch the tool directly to get the RAW payload (not the wrapped text),
+    //    so composing is a structured merge, not string surgery. The lock is
+    //    released before any sibling store is read (lock discipline).
+    let id = request.id.clone();
+    let (mut payload, primary_origin) = {
+        let mut state = primary.lock();
+        state.caller_root = caller_root.clone();
+        let args = request
+            .params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        // Mirror handle_mcp_method's per-call agent tracking (the read-only recall
+        // tools do not autotick the daemon, so nothing else here diverges).
+        if let Some(aid) = args.get("agent_id").and_then(|v| v.as_str()) {
+            state.track_agent(aid);
+        }
+        let origin = state.origin_brain();
+        match dispatch_tool(&mut state, bare_tool_name(tool), &args) {
+            Ok(v) => (v, origin),
+            // Tool-level failure: return it verbatim (no compose over an error).
+            Err(e) => return tool_error_response(id, e.to_string()),
+        }
+    };
+    // `tier:"project"` — the primary brain's own beat, nothing folded in.
+    if tier == MemoryTier::Project {
+        return tool_result_response(id, &payload);
+    }
+
+    // 2. Decide which sibling stores to read.
+    //    - the MEDULLA feed (app.session) is added for every non-project tier, but
+    //      only when the primary is NOT already the medulla (a project brain);
+    //    - `all-brains` additionally fans out over every hosted project brain.
+    let agent_id = request
+        .params
+        .get("arguments")
+        .and_then(|a| a.get("agent_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("tier-recall")
+        .to_string();
+    let query = tier_recall_query(tool, request);
+
+    let mut folded: Vec<serde_json::Value> = Vec::new();
+
+    let want_medulla = matches!(
+        tier,
+        MemoryTier::Medulla | MemoryTier::ProjectAndMedulla | MemoryTier::AllBrains
+    );
+    if want_medulla && primary_is_project {
+        // Read the medulla (the bound owner store). Its own claims are the shared
+        // doctrine feed every project beat gets (MED-INV-1's "+ medulla").
+        let medulla = app.session.clone();
+        folded.extend(store_recall_rows(
+            tool, &medulla, &agent_id, &query, "medulla",
+        ));
+    }
+
+    // `tier:"medulla"` — ONLY the medulla feed. When the primary is a PROJECT brain,
+    // drop its own project rows so only the folded medulla feed remains. When the
+    // primary already IS the medulla (the bound owner), its own rows ARE the medulla
+    // feed — keep them (nothing was folded, and stripping would return empty).
+    if tier == MemoryTier::Medulla && primary_is_project {
+        strip_memory_feed(&mut payload, tool);
+    }
+
+    if tier == MemoryTier::AllBrains {
+        // THE FAN-OUT. Every project brain on disk is resolved through the registry,
+        // which routes each warm-boot through the R15 eviction gate — so a wide
+        // fan-out can never pin more than the warm-brain cap (§C9.1). Each store's
+        // rows are labeled by its OWN origin brain (its project root). The primary
+        // brain is skipped (its rows are already in `payload`); the medulla was
+        // folded above when the primary is a project brain.
+        let primary_key = canonical_of(&primary_origin);
+        for (root, _facts, _dir) in app.project_brains.disk_roster() {
+            if canonical_of(&root) == primary_key {
+                continue; // already the primary's own rows
+            }
+            // resolve() bumps LRU + routes through insert_with_eviction: the warm
+            // map stays ≤ cap no matter how many roots this fan-out touches.
+            if let Some(brain) = app.project_brains.resolve(&root) {
+                let origin = { brain.lock().origin_brain() };
+                folded.extend(store_recall_rows(tool, &brain, &agent_id, &query, &origin));
+            }
+        }
+    }
+
+    // 3. Fold the sibling rows into the primary payload's memory feed, de-duped by
+    //    node id so a claim surfaced twice is carried once (the primary wins).
+    if !folded.is_empty() {
+        append_memory_rows(&mut payload, tool, folded);
+    }
+    // Honest label so a reader/agent knows the beat is cross-brain and how wide.
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(
+            "tier".into(),
+            serde_json::json!(match tier {
+                MemoryTier::Project => "project",
+                MemoryTier::Medulla => "medulla",
+                MemoryTier::ProjectAndMedulla => "project+medulla",
+                MemoryTier::AllBrains => "all-brains",
+            }),
+        );
+    }
+    tool_result_response(id, &payload)
+}
+
+/// Canonicalized form of a brain origin string, for identity comparison across
+/// path alias spellings. `medulla` (and any non-path origin) passes through.
+fn canonical_of(origin: &str) -> String {
+    if origin == "medulla" {
+        return origin.to_string();
+    }
+    crate::project_brains::ProjectBrainRegistry::canonical_key(origin)
+}
+
+/// The recall query for the folded feed: `seek`/`north` carry a `query`/`task`;
+/// `boot_memory` list has none (a broad, most-recent recall). Kept aligned with
+/// north's own light-recall query shape.
+fn tier_recall_query(tool: &str, request: &JsonRpcRequest) -> String {
+    let args = request.params.get("arguments");
+    let field = match bare_tool_name(tool) {
+        "seek" => "query",
+        "north" => "task",
+        _ => "",
+    };
+    args.and_then(|a| a.get(field))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.trim().is_empty())
+        // boot_memory (or an empty query) → a broad, most-recent memory recall.
+        .unwrap_or_else(|| "memory decision finding note claim".to_string())
+}
+
+/// Read a sibling store's memory feed in the shape the tool expects: `seek`/`north`
+/// fold L1GHT claims (via [`store_memory_rows`]); `boot_memory` folds boot-KV
+/// entries (via [`store_boot_rows`]) — same shape as the primary's own `entries`.
+fn store_recall_rows(
+    tool: &str,
+    brain: &Arc<Mutex<SessionState>>,
+    agent_id: &str,
+    query: &str,
+    origin_brain: &str,
+) -> Vec<serde_json::Value> {
+    match bare_tool_name(tool) {
+        "boot_memory" => store_boot_rows(brain, agent_id, origin_brain),
+        _ => store_memory_rows(brain, agent_id, query, origin_brain),
+    }
+}
+
+/// Read a sibling store's boot-memory KV entries (action=list), each labeled with
+/// `origin_brain` + `tier`. Same `{key, value, updated_at_ms, …}` shape the
+/// primary's own `entries` carry, so the fold is homogeneous.
+fn store_boot_rows(
+    brain: &Arc<Mutex<SessionState>>,
+    agent_id: &str,
+    origin_brain: &str,
+) -> Vec<serde_json::Value> {
+    let mut state = brain.lock();
+    let this_tier = if state.is_medulla_store() {
+        "medulla"
+    } else {
+        "project"
+    };
+    let list = crate::boot_memory_handlers::handle_boot_memory(
+        &mut state,
+        crate::boot_memory_handlers::BootMemoryInput {
+            agent_id: agent_id.to_string(),
+            action: "list".into(),
+            key: None,
+            value: None,
+            tags: Vec::new(),
+            source_refs: Vec::new(),
+        },
+    );
+    list.ok()
+        .and_then(|v| v.get("entries").and_then(|e| e.as_array()).cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|mut entry| {
+            if let Some(obj) = entry.as_object_mut() {
+                obj.insert("origin_brain".into(), serde_json::json!(origin_brain));
+                obj.insert("tier".into(), serde_json::json!(this_tier));
+            }
+            entry
+        })
+        .collect()
+}
+
+/// Run a LIGHT-tier recall over `brain`'s own store and return memory rows labeled
+/// with `origin_brain`. Reuses `seek` scoped to the `light::` id namespace (exactly
+/// north's mixed-graph-safe recall, §2.1) so code nodes never compete for the
+/// window; each hit becomes a `{claim, age_ms, source_agent, origin_brain, tier,
+/// node_id}` row. Empty when the store has no live L1GHT claims (honest absence).
+fn store_memory_rows(
+    brain: &Arc<Mutex<SessionState>>,
+    agent_id: &str,
+    query: &str,
+    origin_brain: &str,
+) -> Vec<serde_json::Value> {
+    const LIGHT_RECALL_SCOPE: &str = "light::";
+    let mut state = brain.lock();
+    let this_tier = if state.is_medulla_store() {
+        "medulla"
+    } else {
+        "project"
+    };
+    let out = crate::layer_handlers::handle_seek(
+        &mut state,
+        crate::protocol::layers::SeekInput {
+            query: query.to_string(),
+            agent_id: agent_id.to_string(),
+            top_k: 24,
+            scope: Some(LIGHT_RECALL_SCOPE.to_string()),
+            node_types: Vec::new(),
+            min_score: 0.1,
+            graph_rerank: true,
+            conformance_aware: true,
+            token_budget: None,
+        },
+    );
+    let now = now_ms();
+    let stale_after_ms: u64 = 30 * 24 * 60 * 60 * 1000;
+    let mut seen = std::collections::HashSet::new();
+    out.map(|o| o.results)
+        .unwrap_or_default()
+        .into_iter()
+        // A real memory row carries authorship provenance (a code node never does).
+        .filter(|r| r.source_agent.is_some() || r.authored_ms_ago.is_some())
+        .filter(|r| seen.insert(r.node_id.clone()))
+        .take(5)
+        .map(|r| {
+            let age_ms = r.authored_ms_ago;
+            let mut obj = serde_json::Map::new();
+            obj.insert("kind".into(), serde_json::json!("light"));
+            obj.insert("claim".into(), serde_json::json!(r.label));
+            if let Some(age) = age_ms {
+                obj.insert("age_ms".into(), serde_json::json!(age));
+                obj.insert("stale".into(), serde_json::json!(age > stale_after_ms));
+            }
+            obj.insert(
+                "source_agent".into(),
+                r.source_agent
+                    .map(serde_json::Value::String)
+                    .unwrap_or(serde_json::Value::Null),
+            );
+            // Provenance-in-recall: prefer the claim's OWN Origin-Brain stamp; fall
+            // back to the store's identity when the file predates the stamp.
+            let origin = r.origin_brain.unwrap_or_else(|| origin_brain.to_string());
+            obj.insert("origin_brain".into(), serde_json::json!(origin));
+            obj.insert("tier".into(), serde_json::json!(this_tier));
+            obj.insert("node_id".into(), serde_json::json!(r.node_id));
+            serde_json::Value::Object(obj)
+        })
+        .collect()
+}
+
+/// The payload key that holds a tool's memory feed.
+fn memory_feed_key(tool: &str) -> &'static str {
+    match bare_tool_name(tool) {
+        "seek" => "results",
+        "north" => "memory",
+        "boot_memory" => "entries",
+        _ => "memory",
+    }
+}
+
+/// Append folded sibling-store rows into the primary payload's memory feed,
+/// de-duped by `node_id` (the primary's own rows already present win).
+fn append_memory_rows(payload: &mut serde_json::Value, tool: &str, rows: Vec<serde_json::Value>) {
+    let key = memory_feed_key(tool);
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+    let existing = obj
+        .entry(key.to_string())
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+    let Some(arr) = existing.as_array_mut() else {
+        return;
+    };
+    // Identity is `node_id` for light rows, `key` for boot-KV rows.
+    let row_id = |r: &serde_json::Value| -> Option<String> {
+        r.get("node_id")
+            .and_then(|v| v.as_str())
+            .or_else(|| r.get("key").and_then(|v| v.as_str()))
+            .map(String::from)
+    };
+    let mut have: std::collections::HashSet<String> = arr.iter().filter_map(row_id).collect();
+    for row in rows {
+        if let Some(rid) = row_id(&row) {
+            if !have.insert(rid) {
+                continue; // already carried by the primary or an earlier store
+            }
+        }
+        arr.push(row);
+    }
+}
+
+/// Drop the primary brain's OWN memory feed (used by `tier:"medulla"`, which wants
+/// only the medulla's rows). Leaves the rest of the envelope intact.
+fn strip_memory_feed(payload: &mut serde_json::Value, tool: &str) {
+    let key = memory_feed_key(tool);
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(key.to_string(), serde_json::Value::Array(Vec::new()));
     }
 }
 

--- a/m1nd-mcp/src/protocol/layers.rs
+++ b/m1nd-mcp/src/protocol/layers.rs
@@ -88,6 +88,15 @@ pub struct SeekInput {
     pub token_budget: Option<usize>,
 }
 
+// NOTE (MEDULLA-PRD §5.2 · pull-not-push): the memory-tier selector `tier`
+// (`project` | `medulla` | `all-brains`, default `project+medulla`) is DELIBERATELY
+// not a `SeekInput` field. tier is a ROUTING concern — it chooses WHICH STORES the
+// memory beat reads, which `handle_seek` (searching the single store it is called on)
+// structurally cannot do. It is read from the raw tool arguments by the routing layer
+// (`mcp_http::tier_recall`), which fans out / composes across stores and labels each
+// hit with `origin_brain`. serde ignores the unknown field here, so the seek call
+// itself is untouched; the field is advertised in the hand-written seek JSON schema.
+
 /// Answer-free stop signal for goal-conditioned retrieval. It never claims to
 /// know the answer — only whether the returned context is likely *enough* to
 /// act on, whether more relevant context exists beyond what was returned, or
@@ -298,6 +307,12 @@ pub struct SeekResultEntry {
     /// `Source-Agent` frontmatter). Absent on code nodes and legacy memories.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_agent: Option<String>,
+    /// Provenance-in-recall (MEDULLA-PRD §6): which BRAIN this memory was born in
+    /// (the `Origin-Brain` frontmatter — a project root, or `medulla`). Absent on
+    /// code nodes and legacy memories with no `Origin-Brain` — rendered "unknown",
+    /// never faked (MED-INV-4).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin_brain: Option<String>,
     /// Connected nodes (callers, callees, importers).
     pub connections: Vec<SeekConnection>,
 }

--- a/m1nd-mcp/src/result_shaping.rs
+++ b/m1nd-mcp/src/result_shaping.rs
@@ -462,6 +462,7 @@ mod tests {
                 excerpt: None,
                 authored_ms_ago: None,
                 source_agent: None,
+                origin_brain: None,
                 connections: vec![SeekConnection {
                     node_id: "x".into(),
                     label: "x".into(),
@@ -486,6 +487,7 @@ mod tests {
                 excerpt: None,
                 authored_ms_ago: None,
                 source_agent: None,
+                origin_brain: None,
                 connections: vec![],
             },
         ];

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -59,6 +59,17 @@ age + author — absent, never faked, when unknown), a sufficiency signal, one \
 composes trust_selftest + orient + boot_memory + focus — reach for the pieces directly \
 only when you need just one.
 
+**Memory is PULL, never PUSH (the medulla law).** Your default recall beat carries exactly \
+TWO feeds: your own project brain's memory + the shared `medulla` (promoted/doctrine claims). \
+Another repo's private claim NEVER appears in your beat — it can only reach you if it was \
+promoted to the medulla. Every recall row is labeled with its `tier` (`project` | `medulla`) \
+and `origin_brain` (WHICH brain it came from), so you always know a claim's provenance. \
+Need to inspect across projects? Pass `tier` on `seek`/`north`/`boot_memory`: `project` (your \
+store only), `medulla` (doctrine only), `project+medulla` (the default), or `all-brains` — the \
+EXPLICIT cross-project fan-out that reads every hosted brain, each hit labeled by `origin_brain`. \
+`all-brains` is one argument away and never ambient; don't reach for it unless you actually need \
+another project's knowledge.
+
 ## 2. ACT ON VERDICTS — trust the calibration, don't override it
 
 Retrieval and prediction return a calibrated verdict; obey it:
@@ -444,7 +455,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "agent_id": { "type": "string", "description": "Calling agent identifier" },
                         "task": { "type": "string", "description": "Free-form description of the task you are about to start. The graph spread-activates on this text to find your starting context." },
                         "top_k": { "type": "integer", "default": 8, "description": "How many focus nodes to return (ranked by activation from the task)" },
-                        "scope": { "type": "string", "description": "Optional scope hint to bound orientation and trust binding" }
+                        "scope": { "type": "string", "description": "Optional scope hint to bound orientation and trust binding" },
+                        "tier": { "type": "string", "enum": ["project", "medulla", "project+medulla", "all-brains"], "description": "Memory-tier for the packet's recall beat (pull-not-push). Default project+medulla: this brain's own memory + the shared medulla (promoted/doctrine). 'all-brains' fans out over EVERY hosted brain, each memory row labeled origin_brain — the explicit cross-project inspection, never ambient. Another brain's claim reaches your default beat only if it was promoted to the medulla." }
                     },
                     "required": ["agent_id", "task"]
                 }
@@ -1051,7 +1063,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "node_types": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Filter by node type: function, class, struct, module, file" },
                         "min_score": { "type": "number", "default": 0.1, "description": "Minimum combined score threshold" },
                         "graph_rerank": { "type": "boolean", "default": true, "description": "Whether to run graph re-ranking on embedding candidates" },
-                        "token_budget": { "type": "integer", "minimum": 1, "description": "Optional approx context-token budget. m1nd keeps the highest graph-importance hits that fit, drops the rest, and returns a 'budget' block (estimate = chars/4, not exact tokenization)" }
+                        "token_budget": { "type": "integer", "minimum": 1, "description": "Optional approx context-token budget. m1nd keeps the highest graph-importance hits that fit, drops the rest, and returns a 'budget' block (estimate = chars/4, not exact tokenization)" },
+                        "tier": { "type": "string", "enum": ["project", "medulla", "project+medulla", "all-brains"], "description": "Memory-tier for cross-brain recall (pull-not-push). Default project+medulla: this brain's own memory + the shared medulla (promoted/doctrine). 'all-brains' fans out over EVERY hosted brain, each hit labeled origin_brain — the explicit cross-project inspection, never ambient. A claim from another brain only reaches your default beat if it was promoted to the medulla." }
                     },
                     "required": ["query", "agent_id"]
                 }
@@ -2144,7 +2157,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "key": { "type": "string", "description": "Canonical boot memory key" },
                         "value": { "description": "JSON value to persist for the boot memory entry" },
                         "tags": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Optional tags for organization" },
-                        "source_refs": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Optional source references backing this boot memory" }
+                        "source_refs": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Optional source references backing this boot memory" },
+                        "tier": { "type": "string", "enum": ["project", "medulla", "project+medulla", "all-brains"], "description": "For action=list: memory-tier for cross-brain recall (pull-not-push). Default project+medulla: this brain's own entries + the shared medulla. 'all-brains' fans out over every hosted brain, each entry labeled origin_brain — the explicit cross-project inspection, never ambient." }
                     },
                     "required": ["agent_id", "action"]
                 }
@@ -3065,7 +3079,15 @@ fn handle_north(
     //    sees the durable KV facts AND the memorized L1GHT claims for its task.
     let now = now_ms();
     let stale_after_ms: u64 = 30 * 24 * 60 * 60 * 1000; // 30 days
-                                                        // (a) boot_memory KV entries.
+                                                        // This store's own memory tier
+                                                        // (project brain vs medulla) — every
+                                                        // row from THIS store's beat carries it.
+    let own_beat_tier = if state.is_medulla_store() {
+        "medulla"
+    } else {
+        "project"
+    };
+    // (a) boot_memory KV entries.
     let boot_entries: Vec<serde_json::Value> = {
         let list = crate::boot_memory_handlers::handle_boot_memory(
             state,
@@ -3110,6 +3132,10 @@ fn handle_north(
                         if let Some(stale) = stale {
                             obj.insert("stale".into(), serde_json::json!(stale));
                         }
+                        // Tier label so a composed beat can tell project KV from
+                        // medulla KV (MEDULLA-PRD §10.4). boot KV has no per-row
+                        // origin brain; the tier is the store's own tier.
+                        obj.insert("tier".into(), serde_json::json!(own_beat_tier));
                         obj.insert(
                             "tags".into(),
                             entry.get("tags").cloned().unwrap_or(serde_json::json!([])),
@@ -3165,6 +3191,16 @@ fn handle_north(
         (r.source_agent.is_some() || r.authored_ms_ago.is_some())
             && !is_marker_fragment(&r.node_id, &r.label)
     };
+    // The tier this brain's OWN memory feed carries (MEDULLA-PRD §5.1 · §10.4): a
+    // routed project brain's own recall is `project`; the medulla/owner store's own
+    // recall is `medulla`. The cross-store compose (adding the medulla feed to a
+    // project beat, and the `all-brains` fan-out) is done by the routing layer AROUND
+    // north — here we only honestly label the single store north ran on.
+    let own_tier = if state.is_medulla_store() {
+        "medulla"
+    } else {
+        "project"
+    };
     let map_light = |r: &layers::SeekResultEntry| -> serde_json::Value {
         // age_ms is the authored age seek already computed (now − Created); absent
         // stays absent — never fabricated. staleness uses the same 30-day rule.
@@ -3183,6 +3219,13 @@ fn handle_north(
                 .map(serde_json::Value::String)
                 .unwrap_or(serde_json::Value::Null),
         );
+        // Provenance-in-recall (MEDULLA-PRD §6 · MED-INV-4): which brain the claim was
+        // born in + its tier. `origin_brain` is absent (unknown) on legacy files —
+        // rendered so, never faked. `tier` is this store's own tier (see above).
+        obj.insert("tier".into(), serde_json::json!(own_tier));
+        if let Some(origin) = &r.origin_brain {
+            obj.insert("origin_brain".into(), serde_json::json!(origin));
+        }
         if let Some(stale) = stale {
             obj.insert("stale".into(), serde_json::json!(stale));
         }

--- a/m1nd-mcp/tests/medulla_m5b_tier_recall.rs
+++ b/m1nd-mcp/tests/medulla_m5b_tier_recall.rs
@@ -1,0 +1,621 @@
+//! MEDULLA ladder R3 / slice M5b — pull-only tier recall (the read side of the
+//! medulla). Drives the REAL Streamable-HTTP routing (`handle_mcp_post`) in-process
+//! — the exact seam attach bridges hit — so the leak invariant is proven end-to-end,
+//! not unit-mocked.
+//!
+//! THE LAWS UNDER TEST (MEDULLA-PRD §3.2, §5, §10):
+//!   - MED-INV-1 (the no-leak law): a claim from brain Y NEVER surfaces in brain X's
+//!     DEFAULT beat unless its tier is medulla (promoted / doctrine-born). Pull, not
+//!     push, made mechanical.
+//!   - `tier:"all-brains"` DOES surface Y's claim in X's beat, labeled origin_brain=Y
+//!     — the explicit cross-project inspection, one argument away, never ambient.
+//!   - the default beat = project + medulla only; a medulla (doctrine-born) claim
+//!     surfaces cross-brain by default, tier-labeled.
+//!   - the `all-brains` fan-out warm-boots through the R15 eviction gate: a wide
+//!     fan-out can never pin more than the warm-brain cap (§C9.1).
+//!   - provenance-in-recall: every folded row carries origin_brain (MED-INV-4).
+//!
+//! RED before M5b: a `seek`/`north` had no tier fan-out, so `all-brains` could not
+//! surface Y's claim (no cross-brain path existed); and the medulla feed was not
+//! composed into a routed project brain's default beat. This file pins both the
+//! never-leak direction AND the must-surface-on-demand direction.
+#![cfg(feature = "serve")]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::http::HeaderMap;
+use parking_lot::Mutex;
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+use m1nd_mcp::http_server::{AppState, SseEvent};
+use m1nd_mcp::mcp_http::{handle_mcp_post, new_mcp_session_registry};
+use m1nd_mcp::project_brains::ProjectBrainRegistry;
+use m1nd_mcp::server::{tool_schemas, McpConfig, McpServer};
+
+// ---------------------------------------------------------------------------
+// Fixture repos — tiny, deterministic, DISTINCT sentinels per repo. Neutral
+// names only (no other-project names, no personal paths).
+// ---------------------------------------------------------------------------
+
+fn write_repo(root: &Path, tag: &str) {
+    std::fs::create_dir_all(root.join("src")).expect("mk repo src");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        format!("pub fn {tag}_probe() -> i64 {{ 42 }}\npub struct {tag}Widget {{ pub v: i64 }}\n"),
+    )
+    .expect("write lib.rs");
+    std::fs::write(root.join("Cargo.toml"), "[package]\nname=\"fx\"\n").expect("write toml");
+}
+
+struct Owner {
+    app: Arc<AppState>,
+}
+
+fn mk_owner_with_cap(runtime: &Path, cap: usize) -> Owner {
+    std::fs::create_dir_all(runtime).expect("mk runtime");
+    let config = McpConfig {
+        graph_source: runtime.join("graph_snapshot.json"),
+        plasticity_state: runtime.join("plasticity_state.json"),
+        runtime_dir: Some(runtime.to_path_buf()),
+        registry_dir: Some(runtime.join("registry")),
+        ..Default::default()
+    };
+    let server = McpServer::new(config).expect("boot owner");
+    let session = Arc::new(Mutex::new(server.into_session_state()));
+    let (event_tx, _rx) = broadcast::channel::<SseEvent>(64);
+    let tool_schemas_cache = tool_schemas()
+        .get("tools")
+        .cloned()
+        .unwrap_or(Value::Array(vec![]));
+    let project_brains = Arc::new(ProjectBrainRegistry::with_capacity(
+        runtime.join("project-brains"),
+        Some(runtime.join("registry")),
+        cap,
+    ));
+    Owner {
+        app: Arc::new(AppState {
+            session,
+            tool_schemas_cache,
+            event_tx,
+            event_log_path: None,
+            registry_dir: Some(runtime.join("registry")),
+            mcp_sessions: new_mcp_session_registry(),
+            project_brains,
+        }),
+    }
+}
+
+impl Owner {
+    async fn post(
+        &self,
+        session: Option<&str>,
+        caller_root: Option<&Path>,
+        body: Value,
+    ) -> (Value, Option<String>) {
+        let mut headers = HeaderMap::new();
+        if let Some(sid) = session {
+            headers.insert("mcp-session-id", sid.parse().unwrap());
+        }
+        if let Some(root) = caller_root {
+            headers.insert("m1nd-caller-root", root.to_string_lossy().parse().unwrap());
+        }
+        let resp = handle_mcp_post(
+            axum::extract::State(self.app.clone()),
+            headers,
+            Bytes::from(body.to_string()),
+        )
+        .await;
+        let minted = resp
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let parsed = serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null);
+        (parsed, minted)
+    }
+
+    async fn init_session(&self, caller_root: &Path) -> String {
+        let (_b, minted) = self
+            .post(
+                None,
+                Some(caller_root),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                    "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                        "clientInfo": {"name": "m5b-probe", "version": "0"}}
+                }),
+            )
+            .await;
+        minted.expect("initialize mints a session id")
+    }
+
+    /// tools/call → the tool's parsed JSON payload (content[0].text).
+    async fn tool(&self, sid: &str, caller_root: &Path, name: &str, args: Value) -> Value {
+        let (body, _) = self
+            .post(
+                Some(sid),
+                Some(caller_root),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": {"name": name, "arguments": args}
+                }),
+            )
+            .await;
+        let text = body["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("tool {name} returned no content text: {body}"));
+        serde_json::from_str(text)
+            .unwrap_or_else(|e| panic!("tool {name} content is not JSON ({e}): {text}"))
+    }
+
+    /// Bootstrap a project brain from `root` (one-call ingest); returns its sid.
+    async fn bootstrap(&self, root: &Path, agent: &str) -> String {
+        let sid = self.init_session(root).await;
+        let boot = self
+            .tool(
+                &sid,
+                root,
+                "ingest",
+                serde_json::json!({
+                    "path": root.to_string_lossy(),
+                    "project_root": root.to_string_lossy(),
+                    "agent_id": agent
+                }),
+            )
+            .await;
+        assert!(
+            boot["ingest"]["node_count"].as_u64().unwrap_or(0) > 0,
+            "bootstrap must ingest nodes: {boot}"
+        );
+        sid
+    }
+
+    /// Ingest the bound "dev" graph (a caller AT that root — classic single-brain).
+    async fn ingest_bound(&self, root: &Path) -> String {
+        let sid = self.init_session(root).await;
+        let ing = self
+            .tool(
+                &sid,
+                root,
+                "ingest",
+                serde_json::json!({"path": root.to_string_lossy(), "agent_id": "setup"}),
+            )
+            .await;
+        assert!(
+            ing["node_count"].as_u64().unwrap_or(0) > 0,
+            "bound ingest must produce nodes: {ing}"
+        );
+        sid
+    }
+
+    /// memorize a sentinel claim in the store the session is routed to.
+    async fn memorize(&self, sid: &str, caller_root: &Path, agent: &str, label: &str, text: &str) {
+        let out = self
+            .tool(
+                sid,
+                caller_root,
+                "memorize",
+                serde_json::json!({
+                    "agent_id": agent,
+                    "node_label": label,
+                    "claims": [{"label": label, "text": text, "confidence": "high"}]
+                }),
+            )
+            .await;
+        assert!(
+            out["refused"].is_null(),
+            "memorize for {label} must not be refused: {out}"
+        );
+        assert!(
+            out["ingested"].as_bool().unwrap_or(false)
+                || out["claims_written"].as_u64().unwrap_or(0) > 0,
+            "memorize for {label} must write a claim: {out}"
+        );
+    }
+
+    fn warm_len(&self) -> usize {
+        self.app.project_brains.warm_len()
+    }
+}
+
+/// The memory feed of a north packet.
+fn north_memory(north: &Value) -> Vec<Value> {
+    north["memory"].as_array().cloned().unwrap_or_default()
+}
+
+/// True when any row mentions `needle` — checks BOTH `claim` (north memory rows)
+/// and `label` (seek result rows), so the same helper works across surfaces.
+fn any_claim_mentions(rows: &[Value], needle: &str) -> bool {
+    rows.iter().any(|r| {
+        let claim = r["claim"].as_str().unwrap_or("");
+        let label = r["label"].as_str().unwrap_or("");
+        claim.contains(needle) || label.contains(needle)
+    })
+}
+
+/// The seek results array.
+fn seek_results(seek: &Value) -> Vec<Value> {
+    seek["results"].as_array().cloned().unwrap_or_default()
+}
+
+// ===========================================================================
+// (1) THE LEAK INVARIANT — a project claim NEVER leaks into another brain's
+//     default beat; but IS reachable on demand via all-brains, labeled by origin.
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn med_inv_1_project_claim_never_leaks_but_all_brains_surfaces_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let owner = mk_owner_with_cap(&tmp.path().join("runtime"), 4);
+
+    // Two project brains: X and Y (each its own store, its own graph).
+    let root_x = tmp.path().join("repo-x");
+    let root_y = tmp.path().join("repo-y");
+    write_repo(&root_x, "X");
+    write_repo(&root_y, "Y");
+    let sid_x = owner.bootstrap(&root_x, "agent-x").await;
+    let sid_y = owner.bootstrap(&root_y, "agent-y").await;
+
+    // Seed a DISTINCT sentinel claim in brain Y only.
+    let sentinel = "YellowbrickSentinelClaim";
+    owner
+        .memorize(
+            &sid_y,
+            &root_y,
+            "agent-y",
+            sentinel,
+            "a private finding in brain Y",
+        )
+        .await;
+
+    // --- THE NO-LEAK ASSERTION: brain X's DEFAULT beat NEVER carries Y's claim. ---
+    let north_x = owner
+        .tool(
+            &sid_x,
+            &root_x,
+            "north",
+            serde_json::json!({"agent_id": "agent-x", "task": format!("find {sentinel}")}),
+        )
+        .await;
+    let mem_x = north_memory(&north_x);
+    assert!(
+        !any_claim_mentions(&mem_x, sentinel),
+        "MED-INV-1 VIOLATED: brain Y's claim leaked into brain X's default north beat: {mem_x:?}"
+    );
+
+    // seek's default beat must not leak it either.
+    let seek_x = owner
+        .tool(
+            &sid_x,
+            &root_x,
+            "seek",
+            serde_json::json!({"agent_id": "agent-x", "query": sentinel}),
+        )
+        .await;
+    assert!(
+        !any_claim_mentions(&seek_results(&seek_x), sentinel),
+        "MED-INV-1 VIOLATED: brain Y's claim leaked into brain X's default seek: {}",
+        seek_x
+    );
+
+    // --- THE ON-DEMAND ASSERTION: tier=all-brains DOES surface Y's claim in X's
+    //     beat, labeled origin_brain = Y. ---
+    let north_all = owner
+        .tool(
+            &sid_x,
+            &root_x,
+            "north",
+            serde_json::json!({
+                "agent_id": "agent-x",
+                "task": format!("find {sentinel}"),
+                "tier": "all-brains"
+            }),
+        )
+        .await;
+    let mem_all = north_memory(&north_all);
+    let hit = mem_all
+        .iter()
+        .find(|r| {
+            r["claim"]
+                .as_str()
+                .map(|c| c.contains(sentinel))
+                .unwrap_or(false)
+        })
+        .unwrap_or_else(|| {
+            panic!("tier=all-brains MUST surface brain Y's claim in X's beat, got: {mem_all:?}")
+        });
+    let origin = hit["origin_brain"].as_str().unwrap_or_default();
+    assert!(
+        origin.contains("repo-y"),
+        "the all-brains hit must be LABELED with its origin brain (repo-y), got origin_brain={origin:?} in {hit}"
+    );
+    assert_eq!(
+        north_all["tier"].as_str(),
+        Some("all-brains"),
+        "the packet must honestly label its beat width"
+    );
+}
+
+// ===========================================================================
+// (2) THE MEDULLA FEED — a doctrine-born (medulla) claim SURFACES cross-brain in
+//     the DEFAULT beat; that is the ONLY cross-brain thing the default beat carries.
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn medulla_doctrine_claim_surfaces_in_a_project_default_beat() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let owner = mk_owner_with_cap(&tmp.path().join("runtime"), 4);
+
+    // The bound owner IS the medulla today. Ingest a tiny bound graph, then write a
+    // doctrine claim into the medulla store (a covered/owner session).
+    let bound = tmp.path().join("bound-repo");
+    write_repo(&bound, "Bound");
+    let sid_bound = owner.ingest_bound(&bound).await;
+    let doctrine = "DoctrineProofStandardClaim";
+    owner
+        .memorize(
+            &sid_bound,
+            &bound,
+            "maintainer",
+            doctrine,
+            "always prove before claiming",
+        )
+        .await;
+
+    // A project brain X, distinct store.
+    let root_x = tmp.path().join("repo-x");
+    write_repo(&root_x, "X");
+    let sid_x = owner.bootstrap(&root_x, "agent-x").await;
+
+    // X's DEFAULT beat must carry the medulla doctrine claim, tier-labeled medulla.
+    let north_x = owner
+        .tool(
+            &sid_x,
+            &root_x,
+            "north",
+            serde_json::json!({"agent_id": "agent-x", "task": format!("recall {doctrine}")}),
+        )
+        .await;
+    let mem_x = north_memory(&north_x);
+    let hit = mem_x
+        .iter()
+        .find(|r| {
+            r["claim"]
+                .as_str()
+                .map(|c| c.contains(doctrine))
+                .unwrap_or(false)
+        })
+        .unwrap_or_else(|| {
+            panic!("the medulla doctrine claim MUST surface in brain X's default beat: {mem_x:?}")
+        });
+    assert_eq!(
+        hit["tier"].as_str(),
+        Some("medulla"),
+        "the doctrine claim must be labeled tier=medulla, got: {hit}"
+    );
+    assert_eq!(
+        hit["origin_brain"].as_str(),
+        Some("medulla"),
+        "a doctrine-born claim's origin brain is medulla, got: {hit}"
+    );
+}
+
+// ===========================================================================
+// (3) DEFAULT UNCHANGED — tier absent behaves as project+medulla, and a lone brain
+//     (no medulla claims, no siblings) still sees its OWN claim. Pins the default.
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_beat_carries_own_claim_and_labels_tier_project() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let owner = mk_owner_with_cap(&tmp.path().join("runtime"), 4);
+
+    let root_x = tmp.path().join("repo-x");
+    write_repo(&root_x, "X");
+    let sid_x = owner.bootstrap(&root_x, "agent-x").await;
+    let own = "MyOwnProjectClaim";
+    owner
+        .memorize(&sid_x, &root_x, "agent-x", own, "a fact local to brain X")
+        .await;
+
+    // Default (no tier): X's own claim surfaces, labeled tier=project, origin=X.
+    let north_x = owner
+        .tool(
+            &sid_x,
+            &root_x,
+            "north",
+            serde_json::json!({"agent_id": "agent-x", "task": format!("recall {own}")}),
+        )
+        .await;
+    let mem = north_memory(&north_x);
+    let hit = mem
+        .iter()
+        .find(|r| {
+            r["claim"]
+                .as_str()
+                .map(|c| c.contains(own))
+                .unwrap_or(false)
+        })
+        .unwrap_or_else(|| panic!("brain X's own claim must surface in its own beat: {mem:?}"));
+    assert_eq!(
+        hit["tier"].as_str(),
+        Some("project"),
+        "own claim is tier=project: {hit}"
+    );
+    assert!(
+        hit["origin_brain"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("repo-x"),
+        "own claim's origin brain is X: {hit}"
+    );
+}
+
+// ===========================================================================
+// (4) ALL-BRAINS FAN-OUT ROUTES THROUGH EVICTION — a fan-out over MORE brains than
+//     the cap must never pin more than the cap in the warm map (§C9.1 · MED-INV-8).
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_brains_fanout_stays_within_the_eviction_cap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Cap 2 — a fan-out over 5 project brains must never hold more than 2 warm.
+    let cap = 2usize;
+    let owner = mk_owner_with_cap(&tmp.path().join("runtime"), cap);
+
+    // The caller lives in the bound owner (the medulla); it fans out over N project
+    // brains. Build N distinct project brains, each with a sentinel claim.
+    let bound = tmp.path().join("bound-repo");
+    write_repo(&bound, "Bound");
+    let sid_bound = owner.ingest_bound(&bound).await;
+
+    let n = 5usize;
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for i in 0..n {
+        let root = tmp.path().join(format!("repo-{i}"));
+        write_repo(&root, &format!("R{i}"));
+        let sid = owner.bootstrap(&root, &format!("agent-{i}")).await;
+        owner
+            .memorize(
+                &sid,
+                &root,
+                &format!("agent-{i}"),
+                &format!("FanoutSentinel{i}"),
+                "a claim in one of many brains",
+            )
+            .await;
+        roots.push(root);
+    }
+
+    // Bootstrapping already exercised the gate; assert the precondition holds.
+    assert!(
+        owner.warm_len() <= cap,
+        "precondition: warm map already within cap after bootstraps: {} > {cap}",
+        owner.warm_len()
+    );
+
+    // THE FAN-OUT: an all-brains north from the bound owner touches every store.
+    let north_all = owner
+        .tool(
+            &sid_bound,
+            &bound,
+            "north",
+            serde_json::json!({
+                "agent_id": "maintainer",
+                "task": "FanoutSentinel survey across all brains",
+                "tier": "all-brains"
+            }),
+        )
+        .await;
+
+    // THE EVICTION PROOF: after fanning out over N=5 brains with cap=2, the warm map
+    // is STILL within the cap — the fan-out warm-booted through the eviction gate.
+    assert!(
+        owner.warm_len() <= cap,
+        "all-brains fan-out over {n} brains pinned {} warm brains, exceeding cap {cap} — \
+         the fan-out did NOT route through the R15 eviction gate",
+        owner.warm_len()
+    );
+
+    // AND the fan-out actually reached across brains: at least a couple of distinct
+    // sentinels surfaced, each labeled by its origin brain (not one anonymous pile).
+    let mem = north_memory(&north_all);
+    let labeled_sentinels = mem
+        .iter()
+        .filter(|r| {
+            r["claim"]
+                .as_str()
+                .map(|c| c.contains("FanoutSentinel"))
+                .unwrap_or(false)
+                && r["origin_brain"].as_str().is_some()
+        })
+        .count();
+    assert!(
+        labeled_sentinels >= 2,
+        "all-brains must surface sentinels from multiple brains, each origin-labeled — saw {labeled_sentinels}: {mem:?}"
+    );
+}
+
+// ===========================================================================
+// (5) EXPLICIT `tier:"medulla"` — from a project brain, returns ONLY the medulla
+//     feed (the project's own claim is dropped); from the owner (which IS the
+//     medulla) it returns the medulla's own claim, not empty. Pins the selector.
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tier_medulla_selector_returns_only_doctrine_from_a_project_brain() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let owner = mk_owner_with_cap(&tmp.path().join("runtime"), 4);
+
+    // Doctrine in the medulla (bound owner), a private claim in project X.
+    let bound = tmp.path().join("bound-repo");
+    write_repo(&bound, "Bound");
+    let sid_bound = owner.ingest_bound(&bound).await;
+    let doctrine = "DoctrineOnlyClaim";
+    owner
+        .memorize(
+            &sid_bound,
+            &bound,
+            "maintainer",
+            doctrine,
+            "the shared rule",
+        )
+        .await;
+
+    let root_x = tmp.path().join("repo-x");
+    write_repo(&root_x, "X");
+    let sid_x = owner.bootstrap(&root_x, "agent-x").await;
+    let private = "XPrivateOnlyClaim";
+    owner
+        .memorize(&sid_x, &root_x, "agent-x", private, "a fact local to X")
+        .await;
+
+    // tier=medulla from X's session: the doctrine surfaces, X's own private claim
+    // does NOT (the project feed is dropped — only the medulla feed remains).
+    let seek_medulla = owner
+        .tool(
+            &sid_x,
+            &root_x,
+            "seek",
+            serde_json::json!({
+                "agent_id": "agent-x",
+                "query": "Claim",
+                "tier": "medulla"
+            }),
+        )
+        .await;
+    let rows = seek_results(&seek_medulla);
+    assert!(
+        any_claim_mentions(&rows, doctrine),
+        "tier=medulla must surface the doctrine claim: {rows:?}"
+    );
+    assert!(
+        !any_claim_mentions(&rows, private),
+        "tier=medulla must NOT surface the project's own private claim: {rows:?}"
+    );
+
+    // tier=medulla from the OWNER itself (which IS the medulla) must still return
+    // its own doctrine claim — not empty (the strip-then-nothing regression guard).
+    let seek_owner_medulla = owner
+        .tool(
+            &sid_bound,
+            &bound,
+            "seek",
+            serde_json::json!({
+                "agent_id": "maintainer",
+                "query": "Claim",
+                "tier": "medulla"
+            }),
+        )
+        .await;
+    assert!(
+        any_claim_mentions(&seek_results(&seek_owner_medulla), doctrine),
+        "tier=medulla on the owner (the medulla itself) must return its own claim, not empty: {seek_owner_medulla}"
+    );
+}

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -258,6 +258,8 @@ Quick pattern:
 
 Provenance and scope (MEDULLA M5a): every `memorize` is stamped with an `Origin-Brain` — the project root it was born in, or `medulla` for the owner's own doctrine store — so recall can always name WHICH brain a claim came from. If your session's root has no project brain, a `memorize` is REFUSED rather than written into the shared medulla store; the refusal carries the one-call bootstrap (`ingest project_root=<your repo>`). Run it once, then your memory lands project-private in your own brain.
 
+Pull, never push — tier-scoped recall (MEDULLA M5b): your default memory beat carries exactly TWO feeds — your own project brain's memory + the shared `medulla` (promoted/doctrine claims). Another repo's private claim NEVER surfaces in your beat; it can only reach you if it was promoted to the medulla. Every recall row is labeled with its `tier` (`project` | `medulla`) and `origin_brain`. To inspect across projects, pass `tier` on `seek`/`north`/`boot_memory`: `project` (your store only), `medulla` (doctrine only), `project+medulla` (the default — zero change for existing callers), or `all-brains` (the explicit fan-out over every hosted brain, each hit labeled by `origin_brain`, warm-boots routed through the eviction cap). `all-brains` is one argument away and never ambient — reach for it only when you genuinely need another project's knowledge.
+
 Caveat: `ingest mode:replace` wipes agent memory nodes. Use `mode:merge` when re-ingesting code to keep agent memory intact.
 
 ## Skip Conditions

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -118,6 +118,15 @@ this loop by default:
    silently written into the shared medulla); the refusal hands you the one-call
    bootstrap `ingest project_root=<your repo>` — run it, then memory lands
    project-private.
+8. Memory is pull, never push (the medulla law): your default recall beat carries
+   exactly your own project brain + the shared `medulla` (promoted/doctrine) — no
+   other repo's private claim ever reaches you unless it was promoted. Every recall
+   row is labeled `tier` (`project` | `medulla`) + `origin_brain`. To inspect
+   across projects, pass `tier` on `seek`/`north`/`boot_memory`: `project`,
+   `medulla`, `project+medulla` (default), or `all-brains` (the explicit fan-out
+   over every hosted brain, each hit origin-labeled). `all-brains` is one argument
+   away and never ambient — use it only when you truly need another project's
+   knowledge.
 
 This is the trained-agent behavior to preserve across hosts: m1nd is graph plus
 operating doctrine, not graph alone.


### PR DESCRIPTION
## Pull-only tier recall — the read side of the medulla (ladder R3 / MEDULLA M5b)

Builds on R2/M5a (storage split + Origin-Brain) and R15 (eviction gate). A routed brain X's default memory beat now composes exactly **two feeds — X's own store + the medulla (promoted/doctrine)** — and nothing else. Pull, never push.

### What landed
- **The `tier` argument** on `seek` / `north` / `boot_memory`: `project` | `medulla` | `project+medulla` (default — zero change for existing callers) | `all-brains`. Read from the raw tool args at the routing layer (serde ignores it on the seek call), so no internal call site changes.
- **The leak invariant (MED-INV-1), made mechanical:** a claim from brain Y reaches brain X's default beat ONLY if it is a medulla claim (promoted / doctrine-born). The default beat reads exactly two stores — a closed set.
- **`all-brains` fan-out:** the explicit cross-project inspection — reads every hosted brain, grouped and labeled by `origin_brain`, never ambient. Each store is resolved through the project-brain registry, so **every warm-boot routes through the R15 eviction gate**: a wide fan-out can never pin more than the warm-brain cap (§C9.1). Lock discipline held — the primary lock is dropped before any sibling is read.
- **Provenance in recall:** `Origin-Brain` flows frontmatter → `light:origin_brain:` graph tag → `SeekResultEntry.origin_brain` → every recall row, beside `tier`. Legacy files without the stamp render origin as unknown, never faked.

### Where it lives
Tier composition is at the HTTP routing seam (`mcp_http::serve_and_compose`) — the one place that can read across stores, since a tool handler holds a single session and cannot reach a sibling brain.

### Proof (RED-first — `m1nd-mcp/tests/medulla_m5b_tier_recall.rs`)
The leak permutation matrix over the real routing handler:
- seed a claim in brain Y → assert brain X's default `north` **and** `seek` NEVER carry it; assert `tier:"all-brains"` DOES, labeled `origin_brain: Y`.
- a medulla (doctrine-born) claim surfaces cross-brain in a project's default beat, tier-labeled `medulla`.
- the default beat labels rows `tier:project` / `origin_brain:X`.
- explicit `tier:"medulla"` returns only doctrine from a project brain, and the medulla's own claim (not empty) from the owner.
- **`all-brains` over 5 brains with cap 2 keeps the warm map ≤ cap** — the fan-out routed through eviction.

Each assertion was proven to fail without the implementation (temporary single-brain fallback → 4/5 RED).

### Gates
- `cargo test -p m1nd-mcp` green (557 lib + all integration incl. 5 new M5b + adapter tests).
- `cargo clippy --workspace --all-targets -D warnings` clean.
- `cargo fmt --all --check` clean.
- Battery all-pass + **no regression**: 38/38 pass, `m1nd_wins` 20 → 20 vs the base.

### Docs / agent surfaces (same PR, era-coherence)
MEDULLA §11 M5b and ORGANISM §C10 R3 marked shipped; the MCP instructions, the m1nd-first skill, and the universal agent pack all carry the pull-not-push tier-recall contract.

**Code-land only:** the live server was not migrated or restarted.