### PR TITLE
fix(test): hall_brains_listing display_name guard is separator-agnostic (Windows CI, for real)

### DIFF
--- a/m1nd-mcp/tests/hall_brains_listing.rs
+++ b/m1nd-mcp/tests/hall_brains_listing.rs
@@ -188,6 +188,56 @@ fn canon(p: &Path) -> String {
         .to_string()
 }
 
+/// The repo basename of a filesystem root, separator-agnostic — the SAME thing
+/// production's `session::basename_of` computes for `display_name`. Splits on
+/// BOTH '/' and '\\' (tolerating trailing separators) so a Windows backslash
+/// `project_root` ("C:\\...\\project-repo") yields "project-repo" here exactly as
+/// it does in the production listing, instead of the whole path. This is why the
+/// prior fix (#275 fixed production `basename_of`) did not un-red Windows CI: the
+/// naming-guard test recomputed the expected basename with '/'-only splitting,
+/// so on Windows `expected` was the entire path and the assertion failed.
+fn repo_basename(root: &str) -> &str {
+    let is_sep = |c: char| c == '/' || c == '\\';
+    root.trim_end_matches(is_sep)
+        .rsplit(is_sep)
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(root)
+}
+
+#[test]
+fn repo_basename_is_separator_agnostic() {
+    // POSIX separators (Unix CI / the macOS dev box).
+    assert_eq!(
+        repo_basename("/private/tmp/xyz/project-repo"),
+        "project-repo"
+    );
+    assert_eq!(
+        repo_basename("/private/tmp/xyz/project-repo/"),
+        "project-repo"
+    );
+    // Windows backslash separators — the chronic red CI case. On a Unix box the
+    // std::path::Path basename of a backslash string is the whole string (there
+    // is no '\\' separator off-Windows), so the guard MUST split on '\\' itself.
+    // This pins the exact input shape that broke #279/#280 without needing a
+    // Windows runner to observe the failure.
+    assert_eq!(
+        repo_basename(r"C:\Users\RUNNER~1\AppData\Local\Temp\xyz\project-repo"),
+        "project-repo",
+        "a Windows project_root must yield the repo basename, not the whole path"
+    );
+    assert_eq!(
+        repo_basename(r"C:\Users\RUNNER~1\AppData\Local\Temp\xyz\project-repo\"),
+        "project-repo",
+        "trailing backslash tolerated"
+    );
+    // Mixed separators (a POSIX-rooted temp with a backslash tail, or vice versa).
+    assert_eq!(
+        repo_basename(r"/private/tmp/xyz\project-repo"),
+        "project-repo"
+    );
+}
+
 /// An owner whose bound graph is `bound-repo`, plus a hosted `project-repo`
 /// brain bootstrapped through the one-call `ingest {project_root}` path.
 async fn owner_with_two_brains(tmp: &Path) -> (Owner, PathBuf, PathBuf) {
@@ -382,12 +432,12 @@ async fn no_display_name_is_a_runtime_or_agent_memory_name() {
                 "display_name is a fingerprint store-dir hash, not a project name: {b}"
             );
             // And the name must actually be the basename of the project_root.
+            // Compute `expected` separator-agnostically (the SAME rule production
+            // uses for display_name) so a Windows backslash project_root yields
+            // the repo basename here too — otherwise this guard reds Windows CI
+            // while production is correct (the trap #279 fell into).
             let root = b["project_root"].as_str().unwrap();
-            let expected = root
-                .trim_end_matches('/')
-                .rsplit('/')
-                .next()
-                .unwrap_or(root);
+            let expected = repo_basename(root);
             assert_eq!(
                 name, expected,
                 "display_name must be the project_root basename: {b}"


### PR DESCRIPTION
## The chronic red Windows check, diagnosed for real

`m1nd-mcp/tests/hall_brains_listing.rs::no_display_name_is_a_runtime_or_agent_memory_name` has failed on `windows-latest` repeatedly. #279 shipped claiming a fix; it still failed on the next run. This PR finds why and fixes the actual cause.

### Root cause the prior fix missed

The naming guard's final assertion recomputed the expected `project_root` basename **inline**, splitting on `/` only:

```rust
let expected = root.trim_end_matches('/').rsplit('/').next().unwrap_or(root);
assert_eq!(name, expected, "display_name must be the project_root basename");
```

On Windows the tempdir `project_root` is a backslash path (`C:\...\project-repo`). Splitting on `/` finds no separator, so `expected` becomes the **entire path**. Meanwhile the value under test — the production `display_name` — is correctly just the folder name (`project-repo`), because production `basename_of()` was already made separator-agnostic. So the guard asserted `"project-repo" == "C:\\...\\project-repo"` and went red **while the production code was correct**.

The earlier fix repaired production `basename_of()` (split on both `/` and `\`) but never touched this test's private inline recomputation. The code under test was green; the test's own expectation was still Unix-only. That is why a fix "landed" and the check stayed red.

### The fix (minimal, cross-platform correct)

Replace the inline `/`-only split with a `repo_basename` helper that mirrors production exactly (splits on both `/` and `\`, tolerates trailing separators), and add `repo_basename_is_separator_agnostic` pinning a Windows-shaped backslash input on any OS:

```
C:\Users\RUNNER~1\AppData\Local\Temp\xyz\project-repo  ->  project-repo
```

Because a Unix `std::path::Path` treats a backslash string as one component, the helper splits on `\` itself — so the exact failure shape is exercised on the macOS/Linux runners too, no Windows runner required to observe red->green.

The guard's intent is unchanged: a `display_name` is never a runtime dir name, `agent-memory`, a hex store-dir fingerprint, or empty, and must equal the `project_root` basename.

### Proof

- `cargo test -p m1nd-mcp` (default features; matches the Windows CI job) — 31 suites, 0 failed, incl. the target test and the new backslash unit
- `cargo clippy -p m1nd-mcp --features serve --tests -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Standalone separator proof: old `/`-only logic returns the whole backslash path (red vs production `project-repo`); new logic returns `project-repo` (green); POSIX behavior unchanged