### PR TITLE
feat(seek): conformance_boost rerank — X-RAY steers attention (ladder R17)

### DIFF
--- a/docs/ORGANISM-PRD.md
+++ b/docs/ORGANISM-PRD.md
@@ -828,18 +828,28 @@ the 2H residue family (`[needs-backend §9.5.1/§4A.9]` card fields, per-brain `
 rides this rung. *RED:* letter#51's misattribution case.
 
 **R17 — the conformance_boost rerank (JOINT-J: X-RAY steers attention) — owner: the X-RAY/seek
-family; small, parallel.** *What:* grammar-4 conformance becomes the payoff axis it was designed to
-be — the manifesto stops being a report and steers what loads. Inject an additive `conformance_boost`
-term into the shared `handle_seek` rerank (BEDROCK **+0.20**, EROSION **−0.30**); because `focus` is a
-thin layer over `handle_seek`, the same term boosts seek and focus at once. It **composes** with the
-two terms already in that rerank — trust × tremor (damping, multiplicative) × conformance (additive) —
-the one place intent-vs-reality feeds attention. *State:* shipped-partial (DESIGNED, X360 §5.5 —
-P1 malus-only leapfrog: EROSION down-ranking first). *Precondition (LANDED):* the centrality-vs-semantic
-balance of this rerank was corrected first — the `graph_activation` term is now gated by node relevance
-so a high-PageRank/low-similarity hub can't ride pure centrality to the top; R17 adds `conformance_boost`
-on top of that corrected base. *RED:* a rerank fixture — a BEDROCK node
-out-ranks its pre-boost position and an EROSION node drops, with the composition against trust/tremor
-pinned so no term silently dominates.
+family; small, parallel. [SHIPPED 2026-07-05]** *What:* grammar-4 conformance becomes the payoff axis it
+was designed to be — the manifesto stops being a report and steers what loads. An additive
+`conformance_boost` term rides the shared `handle_seek` rerank (BEDROCK **+0.20**, EROSION **−0.30**);
+because `focus` is a thin layer over `handle_seek`, the same term boosts seek and focus at once. It
+**composes** with the two terms already in that rerank — trust × tremor (damping, multiplicative) ×
+conformance (additive) — the one place intent-vs-reality feeds attention. *What landed:* the additive
+term + full plumbing (constants, `resolve_node_conformance`, `SeekInput.conformance_aware`,
+`SeekOutput.conformance` summary + erosion-in-result-set drift note) was implemented on `main` in
+`8244c48`; this rung composed it onto the **corrected base** (below) and pinned the composition with a
+RED→GREEN proof + a battery no-regression. Both the BEDROCK up-boost (+0.20) and the EROSION malus
+(−0.30) ship — the P1 malus-only leapfrog is superseded (up-boost is live and proven). *Precondition
+(LANDED):* the centrality-vs-semantic balance of this rerank was corrected first (#278) — the
+`graph_activation` term is now gated by node relevance so a high-PageRank/low-similarity hub can't ride
+pure centrality to the top; `conformance_boost` sits on that corrected base. *RED→GREEN (PROVEN):* a
+synthetic rerank fixture — with the term OFF, a BEDROCK node and an EROSION node rank by base score only;
+with it ON, the BEDROCK node out-ranks its pre-boost position (+0.20) and the EROSION node drops (−0.30).
+Composition pinned: a BEDROCK-but-semantically-irrelevant node still can't ride the boost above the
+relevant pool (base relevance + the activation gate gate it), the exact per-node delta equals
+`boost × heuristic_factor` (trust × tremor still composes, never dominated), and absence/opt-out stays
+byte-identical. Battery: `m1nd_wins` unchanged (20/20, 38/38 pass) before vs after. *Residue:* X360 §5.5
+P3 (freshness-aware `Unprovable` downgrade) + P4 (calibration surface for the three constants) remain
+deferred — see the X360 §5.5 note.
 
 **R16 — SOUL: the PRD, then slices — LAST.** Bound by §C8.6's seven constraints; designed against
 a working medulla (R2–R4 landed). If the SOUL-PRD lands on main before this constitution, its row

--- a/docs/X360-RUNTIME-PRD.md
+++ b/docs/X360-RUNTIME-PRD.md
@@ -667,6 +667,23 @@ flowchart TD
 
 ### 5.5 Seek Integration (manifesto / X-RAY as an attention gradient)
 
+> **[SHIPPED 2026-07-05 — ORGANISM ladder R17.]** The additive `conformance_boost` term is live in the
+> shared `handle_seek` rerank (`layer_handlers.rs`): `combined = (base_score + conformance_boost).max(0.0)
+> * heuristic_factor`, with `CONFORMANCE_BEDROCK_BOOST = +0.20` and `CONFORMANCE_EROSION_MALUS = -0.30`.
+> `focus` rides the same rerank, so both are conformance-aware. Grammar-4 state is sourced verbatim from
+> `resolve_node_conformance()` (`xray_handlers.rs`, the same `erosion_source_set`/`exercised_set`
+> predicates the gate uses — no second evaluator): a `grounded_in`/test-exercised node → `Bedrock`, a
+> layer/forbid-violating cross-module source → `ErosionCandidate`, else neutral (boost 0.0). Absence /
+> opt-out (`conformance_aware=false` or no resolved manifesto) is byte-identical to the pre-conformance
+> path (zero-cost by absence). Both P1 (EROSION malus) **and** P2 (BEDROCK up-boost) shipped — the
+> P1-only leapfrog is superseded. The R17 rung added the RED→GREEN composition proof
+> (`conformance_boost_composes_bedrock_up_erosion_down_no_term_dominates`) — BEDROCK rises, EROSION drops,
+> a semantically-irrelevant BEDROCK node cannot ride the boost above the relevant pool, and the exact
+> per-node delta equals `boost × heuristic_factor` (trust × tremor still composes) — plus a battery
+> no-regression (`m1nd_wins` unchanged). **Deferred (honest residue):** P3 (freshness-aware
+> `Bedrock`→`Unprovable` downgrade via `cross_verify(evidence_freshness)`) and P4 (lifting the three
+> boost constants into `SessionState`/config for measured calibration) are NOT yet implemented.
+
 **Goal / one-liner.** Make declared architectural intent *shape what the agent loads*: BEDROCK-conforming context gets an additive attention up-boost, EROSION context a malus, and every conformance-relevant drop is named honestly in the existing `budget` accounting. This is the payoff axis: the manifesto stops being a report and starts steering attention. **It wires into the shared `handle_seek` rerank (`layer_handlers.rs:75`). Both `seek` and the shipped `focus` verb (PR #157 — a thin layer that calls `handle_seek`) ride this rerank, so injecting the conformance term here boosts attention for both at once.**
 
 **Problem & non-goals.**

--- a/docs/wiki/src/api-reference/exploration.md
+++ b/docs/wiki/src/api-reference/exploration.md
@@ -26,12 +26,13 @@ Unlike `activate` (which propagates signal through edges), `seek` scores every n
 ### Scoring Formula
 
 ```
-relevance = max(embedding_similarity, keyword_match, trigram)
-combined  = keyword_match * 0.4
-          + embedding_similarity * 0.3
-          + graph_activation * activation_gate(relevance) * 0.2
-          + trigram * 0.1
-          + path/anchor biases
+relevance  = max(embedding_similarity, keyword_match, trigram)
+base_score = keyword_match * 0.4
+           + embedding_similarity * 0.3
+           + graph_activation * activation_gate(relevance) * 0.2
+           + trigram * 0.1
+           + path/anchor biases
+combined   = (base_score + conformance_boost).max(0.0) * (trust_factor * tremor_factor)
 ```
 
 `embedding_similarity` is the query↔node cosine (static local embeddings; falls back to the
@@ -44,6 +45,18 @@ semantically-irrelevant hub from riding pure centrality to the top and drowning 
 centrality remains a full-strength co-ranker and tie-breaker, it just no longer acts alone.
 
 The combined base is then damped multiplicatively by trust × tremor heuristics before ranking.
+
+**Conformance composes as an additive term (X-RAY steers attention).** When an X-RAY manifesto
+resolves for the workspace and `conformance_aware` is on (the default), each node's grammar-4 state
+adds a separate `conformance_boost` to `base_score` **before** the trust × tremor damping: a BEDROCK
+node (proven/grounded) gets **+0.20**, an EROSION source (a layer/forbid-violating cross-module source)
+gets **−0.30**, and everything else is neutral (0.0). Because the term is *additive*, conformance can
+*raise* a proven node's attention, not only damp a suspect one — and because it composes with (rather
+than replaces) relevance and the multiplicative damping, **no single term dominates**: a BEDROCK but
+semantically-irrelevant node still cannot ride the boost above genuinely relevant results. Conformance
+only re-orders within the relevance-cleared pool; it never drops a node. With no manifesto or with
+`conformance_aware=false`, every boost is 0.0 and ranking is byte-identical to the base formula above.
+`focus` rides the same rerank, so it is conformance-aware too.
 
 ### Example Request
 

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -11105,6 +11105,15 @@ mod tests {
         query: &str,
         conformance_aware: bool,
     ) -> crate::protocol::layers::SeekOutput {
+        run_seek_conformance_ranked(state, query, conformance_aware, true)
+    }
+
+    fn run_seek_conformance_ranked(
+        state: &mut SessionState,
+        query: &str,
+        conformance_aware: bool,
+        graph_rerank: bool,
+    ) -> crate::protocol::layers::SeekOutput {
         handle_seek(
             state,
             SeekInput {
@@ -11114,7 +11123,7 @@ mod tests {
                 scope: None,
                 node_types: vec![],
                 min_score: 0.0,
-                graph_rerank: true,
+                graph_rerank,
                 conformance_aware,
                 token_budget: None,
             },
@@ -11535,6 +11544,392 @@ mod tests {
             hub_rank, 0,
             "a node that is both central and relevant must rank first \
              (hub_rank={hub_rank})"
+        );
+    }
+
+    /// A multi-token query for the conformance-composition fixture. Every scored
+    /// node carries a subset of these tags; the count of matched tags is the only
+    /// relevance lever between them (same isolation trick as the rerank-balance
+    /// graph: relevance lives in TAGS, labels stay opaque).
+    const CONFORMANCE_COMPOSITION_QUERY: &str =
+        "parse tokenize evaluate serialize deserialize validate normalize \
+         canonicalize interpolate marshal";
+
+    /// Build ONE synthetic graph that isolates the R17 conformance-composition
+    /// contract. All scored nodes share the opaque `zzznode_` label prefix, so the
+    /// matched-tag count is the sole relevance lever. Tag counts are chosen so the
+    /// fixed +0.20 boost crosses exactly one relevance step but never the whole
+    /// relevance ladder:
+    ///
+    ///   * `plain`    — 8 matched tags, NEUTRAL conformance. The pivot the bedrock
+    ///     node's up-boost must cross.
+    ///   * `bedrock`  — 7 matched tags (one step BELOW `plain` on base score), made
+    ///     BEDROCK by an incoming `grounded_in` edge. The +0.20 boost must lift it
+    ///     ABOVE its pre-boost position (past `plain`).
+    ///   * `eroded`   — 8 matched tags in `modA`, made an EROSION source by a
+    ///     layer-violating `modA -> modB` import. The -0.30 malus must drop it
+    ///     below its pre-boost position.
+    ///   * `far_hi`   — 9 matched tags, NEUTRAL conformance. A strongly-relevant
+    ///     node used only to anchor the top of the relevance-cleared pool.
+    ///   * `off_topic_bedrock` — 1 matched tag (near-zero relevance) but BEDROCK.
+    ///     The dominance pin: +0.20 must NOT let a semantically-irrelevant BEDROCK
+    ///     node ride to the top of the relevant pool. No single term dominates.
+    ///
+    /// A `layer_order ["modA","modB"]` manifesto on disk makes `modA -> modB` the
+    /// layer-axis divergence; every other node lives in `modB`/`modC`/`proof` so
+    /// only `eroded` is flagged. `grounded_in` edges (never `imports`/`depends_on`)
+    /// create the two BEDROCK nodes without tripping the erosion rule.
+    fn build_conformance_composition_graph(root: &std::path::Path) -> SessionState {
+        let runtime_dir = root.join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut graph = Graph::new();
+
+        // Distinct query tokens, sliced by count to set relevance.
+        let tags7 = &[
+            "parse",
+            "tokenize",
+            "evaluate",
+            "serialize",
+            "deserialize",
+            "validate",
+            "normalize",
+        ];
+        let tags8 = &[
+            "parse",
+            "tokenize",
+            "evaluate",
+            "serialize",
+            "deserialize",
+            "validate",
+            "normalize",
+            "canonicalize",
+        ];
+        let tags9 = &[
+            "parse",
+            "tokenize",
+            "evaluate",
+            "serialize",
+            "deserialize",
+            "validate",
+            "normalize",
+            "canonicalize",
+            "interpolate",
+        ];
+        let lo = &["marshal"];
+
+        let bedrock = graph
+            .add_node(
+                "file::modB/bedrock.rs",
+                "zzznode_bedrock",
+                NodeType::Function,
+                tags7,
+                0.0,
+                0.0,
+            )
+            .expect("add bedrock");
+        let _plain = graph
+            .add_node(
+                "file::modB/plain.rs",
+                "zzznode_plain",
+                NodeType::Function,
+                tags8,
+                0.0,
+                0.0,
+            )
+            .expect("add plain");
+        let eroded = graph
+            .add_node(
+                "file::modA/eroded.rs",
+                "zzznode_eroded",
+                NodeType::Function,
+                tags8,
+                0.0,
+                0.0,
+            )
+            .expect("add eroded");
+        let modb_import = graph
+            .add_node(
+                "file::modB/imported.rs",
+                "zzznode_imported",
+                NodeType::Function,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add imported");
+        let _far_hi = graph
+            .add_node(
+                "file::modB/far_hi.rs",
+                "zzznode_farhi",
+                NodeType::Function,
+                tags9,
+                0.0,
+                0.0,
+            )
+            .expect("add far_hi");
+        let off_topic_bedrock = graph
+            .add_node(
+                "file::modC/off_topic.rs",
+                "zzznode_offtopic",
+                NodeType::Function,
+                lo,
+                0.0,
+                0.0,
+            )
+            .expect("add off_topic_bedrock");
+
+        // Proof-source nodes (in a `proof` module) that ground the two BEDROCK
+        // nodes via `grounded_in`. A `grounded_in` edge marks its TARGET as
+        // exercised → BEDROCK, and is not an `imports`/`depends_on` relation, so it
+        // never trips the erosion rule.
+        let proof_a = graph
+            .add_node(
+                "file::proof/proof_a.rs",
+                "proof_a",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add proof_a");
+        let proof_b = graph
+            .add_node(
+                "file::proof/proof_b.rs",
+                "proof_b",
+                NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("add proof_b");
+
+        let grounded = |g: &mut Graph, s: m1nd_core::types::NodeId, t: m1nd_core::types::NodeId| {
+            g.add_edge(
+                s,
+                t,
+                "grounded_in",
+                FiniteF32::new(1.0),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.5),
+            )
+            .expect("grounded_in edge");
+        };
+        grounded(&mut graph, proof_a, bedrock);
+        grounded(&mut graph, proof_b, off_topic_bedrock);
+
+        // The layer-violating boundary edge: modA -> modB import makes `eroded`
+        // an erosion source under the `["modA","modB"]` layer_order.
+        graph
+            .add_edge(
+                eroded,
+                modb_import,
+                "imports",
+                FiniteF32::new(1.0),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(0.5),
+            )
+            .expect("edge eroded->imported");
+        graph.finalize().expect("finalize");
+
+        std::fs::write(
+            root.join("xray.manifest.json"),
+            br#"{"ratified": true, "layer_order": ["modA", "modB"]}"#,
+        )
+        .expect("write manifest");
+
+        let mut state =
+            SessionState::initialize(graph, &config, DomainConfig::code()).expect("init session");
+        state.ingest_roots = vec![root.to_string_lossy().to_string()];
+        state.workspace_root = Some(root.to_string_lossy().to_string());
+        state
+    }
+
+    /// R17 ladder — the conformance_boost composition proof (JOINT-J: X-RAY steers
+    /// attention). Grammar-4 conformance (BEDROCK/EROSION) becomes an ADDITIVE term
+    /// in the shared `handle_seek` rerank, composing with the trust×tremor damping
+    /// and the base relevance + activation gate. Proven RED→GREEN on ONE fixture:
+    ///
+    ///   RED  (conformance_aware=false): the BEDROCK node and the EROSION node rank
+    ///        by BASE SCORE only — the bedrock node sits just below its neutral
+    ///        `plain` neighbor, the eroded node sits among its relevance peers.
+    ///   GREEN(conformance_aware=true):  the +0.20 boost lifts the bedrock node
+    ///        ABOVE its pre-boost position (past `plain`), and the -0.30 malus drops
+    ///        the eroded node BELOW its pre-boost position.
+    ///
+    /// The composition is PINNED so no single term dominates:
+    ///   * a BEDROCK-but-semantically-irrelevant node (`off_topic_bedrock`) still
+    ///     cannot ride +0.20 to the top — the genuinely-relevant nodes outrank it
+    ///     in BOTH runs (base relevance + the activation gate still gate it);
+    ///   * the highest-relevance neutral node (`far_hi`) stays first in both runs
+    ///     (conformance re-orders WITHIN the relevance-cleared pool, never over it).
+    #[test]
+    fn conformance_boost_composes_bedrock_up_erosion_down_no_term_dominates() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut state = build_conformance_composition_graph(temp.path());
+
+        // `graph_rerank=false` removes the PageRank prior from `base_score`, so
+        // matched-tag relevance is the SOLE base lever between the scored nodes —
+        // the `grounded_in` edges that make the BEDROCK nodes don't leak in as
+        // centrality. This isolates the conformance term as the only mover between
+        // the RED and GREEN runs.
+        // RED: the base ranking, conformance term OFF.
+        let base =
+            run_seek_conformance_ranked(&mut state, CONFORMANCE_COMPOSITION_QUERY, false, false);
+        // GREEN: the same graph + manifesto, conformance term ON.
+        let boosted =
+            run_seek_conformance_ranked(&mut state, CONFORMANCE_COMPOSITION_QUERY, true, false);
+
+        assert!(
+            base.conformance.is_none(),
+            "conformance_aware=false must carry no summary"
+        );
+        assert!(
+            boosted.conformance.is_some(),
+            "conformance_aware=true with a manifesto must carry a summary"
+        );
+
+        let pos = |o: &crate::protocol::layers::SeekOutput, id: &str| {
+            rank_of(o, id).unwrap_or_else(|| panic!("{id} present in results"))
+        };
+
+        // --- Fixture sanity: the RED base ranking is what the proof assumes. ---
+        // The bedrock node ranks BELOW its neutral peer on base score alone, so the
+        // up-boost has a real position to cross.
+        let base_bedrock = pos(&base, "file::modB/bedrock.rs");
+        let base_plain = pos(&base, "file::modB/plain.rs");
+        assert!(
+            base_bedrock > base_plain,
+            "fixture invalid: on base score the bedrock node must sit BELOW plain \
+             (bedrock={base_bedrock}, plain={base_plain})"
+        );
+
+        // --- RED baseline: the off-topic BEDROCK node is near-zero relevance and
+        // already ranks below every genuinely-relevant node with the term OFF. ---
+        let base_offtopic = pos(&base, "file::modC/off_topic.rs");
+        let base_farhi = pos(&base, "file::modB/far_hi.rs");
+        let base_eroded = pos(&base, "file::modA/eroded.rs");
+        assert!(
+            base_farhi < base_offtopic
+                && base_plain < base_offtopic
+                && base_bedrock < base_offtopic
+                && base_eroded < base_offtopic,
+            "fixture invalid: off-topic node must start below the relevant pool \
+             (farhi={base_farhi}, plain={base_plain}, bedrock={base_bedrock}, \
+             eroded={base_eroded}, offtopic={base_offtopic})"
+        );
+
+        // --- GREEN: BEDROCK rises, EROSION drops. ---
+        let boosted_bedrock = pos(&boosted, "file::modB/bedrock.rs");
+        let boosted_plain = pos(&boosted, "file::modB/plain.rs");
+        assert!(
+            boosted_bedrock < base_bedrock,
+            "the +0.20 boost must lift the BEDROCK node above its pre-boost position \
+             (before={base_bedrock}, after={boosted_bedrock})"
+        );
+        assert!(
+            boosted_bedrock < boosted_plain,
+            "the boosted BEDROCK node must now out-rank its neutral peer \
+             (bedrock={boosted_bedrock}, plain={boosted_plain})"
+        );
+
+        let boosted_eroded = pos(&boosted, "file::modA/eroded.rs");
+        assert!(
+            boosted_eroded > base_eroded,
+            "the -0.30 malus must drop the EROSION node below its pre-boost position \
+             (before={base_eroded}, after={boosted_eroded})"
+        );
+
+        // --- The composition pin: no single term dominates. ---
+        // (1) A BEDROCK-but-semantically-irrelevant node cannot ride +0.20 over the
+        // genuinely-relevant, non-eroded nodes: base relevance + the activation gate
+        // still gate it. (`eroded` is excluded here — its -0.30 malus can legitimately
+        // sink it past an off-topic node; that is the malus working, not the boost
+        // dominating.)
+        let boosted_offtopic = pos(&boosted, "file::modC/off_topic.rs");
+        let boosted_farhi = pos(&boosted, "file::modB/far_hi.rs");
+        assert!(
+            boosted_farhi < boosted_offtopic
+                && boosted_plain < boosted_offtopic
+                && boosted_bedrock < boosted_offtopic,
+            "a semantically-irrelevant BEDROCK node must NOT ride the boost above the \
+             relevant pool (farhi={boosted_farhi}, plain={boosted_plain}, \
+             bedrock={boosted_bedrock}, offtopic={boosted_offtopic})"
+        );
+        // (2) The strongest-relevance node leads the RED base ranking, and after the
+        // conformance term it stays first among the NEUTRAL nodes (plain) — the boost
+        // only lets a genuinely-relevant BEDROCK node cross a neutral peer, it does
+        // not re-order the neutral pool among itself.
+        assert_eq!(
+            base_farhi, 0,
+            "the strongest-relevance node ranks first on base score"
+        );
+        assert!(
+            boosted_farhi < boosted_plain,
+            "the strongest-relevance neutral node still leads its neutral peer after \
+             the conformance term (farhi={boosted_farhi}, plain={boosted_plain})"
+        );
+
+        // --- Trust/tremor still compose: the damping factor is untouched and
+        // still applied on top of the additive term (combined = (base+boost)*factor).
+        // With no trust/tremor history in this fixture every factor is 1.0, so the
+        // additive term is the visible mover — but it rides THROUGH the multiplier,
+        // not instead of it: the score equals (base + boost) exactly here.
+        let factor_of = |o: &crate::protocol::layers::SeekOutput, id: &str| {
+            o.results
+                .iter()
+                .find(|r| r.node_id == id)
+                .and_then(|r| r.heuristic_signals.as_ref())
+                .map(|h| h.heuristic_factor)
+        };
+        let score_of = |o: &crate::protocol::layers::SeekOutput, id: &str| {
+            o.results
+                .iter()
+                .find(|r| r.node_id == id)
+                .map(|r| r.score)
+                .unwrap_or_else(|| panic!("{id} present"))
+        };
+        // The multiplicative trust×tremor damping still composes ON TOP of the
+        // additive term: `combined = (base + boost) * heuristic_factor`. With no
+        // trust/tremor history the factor sits in the L2 dead-band right around the
+        // identity (~0.99) — present and near-neutral, never dominating and never
+        // absent. That it is NOT exactly 1.0 is the point: the damping term is real.
+        let bedrock_factor =
+            factor_of(&boosted, "file::modB/bedrock.rs").expect("heuristic signals present");
+        assert!(
+            (0.95..=1.05).contains(&bedrock_factor),
+            "the multiplicative heuristic_factor must remain a near-identity co-term \
+             in the composition, not vanish or dominate (factor={bedrock_factor})"
+        );
+        // Exact composition through the factor: the ONLY delta between RED and GREEN
+        // is the additive constant scaled by the (shared) damping factor —
+        // +0.20*factor for BEDROCK, -0.30*factor for EROSION — proving the term is a
+        // bounded, inspectable additive nudge riding THROUGH the multiplier, not an
+        // opaque re-weighting. (`combined = (base + boost) * factor`.)
+        let bedrock_delta =
+            score_of(&boosted, "file::modB/bedrock.rs") - score_of(&base, "file::modB/bedrock.rs");
+        assert!(
+            (bedrock_delta - super::CONFORMANCE_BEDROCK_BOOST * bedrock_factor).abs() < 1e-3,
+            "BEDROCK score must rise by exactly +{}*factor (delta={bedrock_delta}, \
+             factor={bedrock_factor})",
+            super::CONFORMANCE_BEDROCK_BOOST
+        );
+        let eroded_factor =
+            factor_of(&boosted, "file::modA/eroded.rs").expect("heuristic signals present");
+        let eroded_delta =
+            score_of(&boosted, "file::modA/eroded.rs") - score_of(&base, "file::modA/eroded.rs");
+        assert!(
+            (eroded_delta - super::CONFORMANCE_EROSION_MALUS * eroded_factor).abs() < 1e-3,
+            "EROSION score must fall by exactly {}*factor (delta={eroded_delta}, \
+             factor={eroded_factor})",
+            super::CONFORMANCE_EROSION_MALUS
         );
     }
 


### PR DESCRIPTION
## What

Grammar-4 X-RAY conformance becomes an **additive term** in the shared `handle_seek` rerank — the one place declared architectural intent feeds attention. Because `focus` is a thin layer over `handle_seek`, a single injection point makes both `seek` and `focus` conformance-aware.

```
combined = (base_score + conformance_boost).max(0.0) * (trust_factor * tremor_factor)
```

- `CONFORMANCE_BEDROCK_BOOST = +0.20` — proven/grounded (BEDROCK) nodes get an up-boost.
- `CONFORMANCE_EROSION_MALUS = -0.30` — layer/forbid-violating cross-module sources (EROSION) get a malus.
- everything else neutral (0.0).

Grammar-4 state is sourced verbatim from `resolve_node_conformance()` — the same `erosion_source_set` / `exercised_set` predicates the gate uses, so seek and the gate can never disagree (no second evaluator). Conformance is **additive**; the trust × tremor damping stays **multiplicative**. With no manifesto or `conformance_aware=false`, every boost is 0.0 and ranking is byte-identical to the base formula.

## Composition proof (RED → GREEN)

New synthetic-fixture test `conformance_boost_composes_bedrock_up_erosion_down_no_term_dominates`:

- **RED** (conformance off): a BEDROCK node and an EROSION node rank by base score only.
- **GREEN** (on): the BEDROCK node out-ranks its pre-boost position (+0.20); the EROSION node drops (−0.30).
- **No term dominates:** a BEDROCK-but-semantically-irrelevant node still cannot ride the boost above the relevant pool — base relevance + the activation gate keep it down. The exact per-node delta equals `boost × heuristic_factor`, so trust × tremor still composes and is never dominated. Absence / opt-out stays byte-identical.

RED-first verified: neutering both constants to `0.0` makes the up-boost assertion fail (`before=3, after=3`), so the test genuinely exercises the feature.

## Battery — no regression (same rerank)

Head-to-head battery over the repo, before (`origin/main`) vs after:

| | n_queries | m1nd_pass | m1nd_wins | tie | grep_wins |
|---|---|---|---|---|---|
| before | 38 | 38 (100%) | **20** | 18 | 0 |
| after  | 38 | 38 (100%) | **20** | 18 | 0 |

`m1nd_wins` unchanged.

## Gates

- `cargo test -p m1nd-mcp` — green (all targets)
- `cargo clippy --workspace --all-targets -D warnings` — clean
- `cargo fmt --all --check` — clean

## Docs

- ORGANISM §C10 R17 marked `[SHIPPED]`.
- X360 §5.5 SHIPPED note; P3 (freshness-aware `Unprovable` downgrade) and P4 (calibration surface for the three constants) noted as deferred residue.
- Seek scoring-formula wiki now shows the additive conformance term + composition contract.