### PR TITLE
fix(mailbox): make expand_home test OS-separator-agnostic (Windows CI)

### DIFF
--- a/m1nd-mcp/src/mailbox.rs
+++ b/m1nd-mcp/src/mailbox.rs
@@ -1060,12 +1060,15 @@ mod tests {
     fn expand_home_and_strip_parenthetical() {
         // Use the pure core with an explicit home — mutating the process-global
         // HOME here would poison every other parallel test that resolves ~/.m1nd.
-        let home = Some(PathBuf::from("/path/to/home"));
+        let home_path = PathBuf::from("/path/to/home");
+        let home = Some(home_path.clone());
+        // Expected via join() too, so the OS path separator matches (Windows: `\`).
+        let expected = home_path.join("repo-b").to_string_lossy().to_string();
+        assert_eq!(expand_home_with("~/repo-b", home.clone()), expected);
         assert_eq!(
-            expand_home_with("~/repo-b", home.clone()),
-            "/path/to/home/repo-b"
+            expand_home_with("~", home.clone()),
+            home_path.to_string_lossy()
         );
-        assert_eq!(expand_home_with("~", home.clone()), "/path/to/home");
         assert_eq!(expand_home_with("repo-b", home), "repo-b");
         assert_eq!(strip_parenthetical("repo-a (worktree x)"), "repo-a");
         assert_eq!(strip_parenthetical("repo-a"), "repo-a");


### PR DESCRIPTION
The `expand_home_and_strip_parenthetical` unit test (landed in #287) hard-coded a forward-slash expectation (`/path/to/home/repo-b`), but `expand_home_with` builds the path via `PathBuf::join`, which yields a backslash on Windows. The test passed on macOS/Linux but **failed the Windows CI test leg** (Windows Test is not a required check, so #287 still merged — this restores it to green).

Fix: build the expected value with `join()`/`to_string_lossy()` too, so the assertion matches the platform separator on every OS. No production behavior change — test-only.

Verified locally: `cargo test -p m1nd-mcp --lib mailbox` green, `cargo fmt --all --check` clean.