### PR TITLE
Close-out burst: medulla migration CLI, honest restart, mailbox abstain, and the Case-Intelligence PRD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ scratchpad/*
 # with local paths) live here but are NOT published with the product.
 docs/internal/
 .github/wiki/VERIFICATION_REPORT.md
+
+# Local agent-session tooling and throwaway harnesses — never published.
+/.claude/
+/CLAUDE.md
+m1nd-ingest/examples/xray_ingest.rs

--- a/docs/CASE-INTELLIGENCE-PRD.md
+++ b/docs/CASE-INTELLIGENCE-PRD.md
@@ -1,0 +1,234 @@
+# Case Intelligence — PRD
+
+**The mailbox learns to think · fingerprints, cases, absence sentinels, claim-vs-measure, and the abandonment signal — five organs, one law: a case is an overlay, never an axis**
+
+> **Status:** OFFICIAL — maintainer-directed design, 2026-07-05. **UNBUILT** — code-confirmed: `grep -rE 'case_id|CaseId|fingerprint|absence_sentinel|abandonment' m1nd-mcp/src m1nd-core/src` returns zero engine hits at HEAD. This is the §C10 **R11** rung of the organism ladder — the last unclimbed rung, "the homeless organ" (JOINT-K): it spans mailbox, calibration, delegation, and soul, so no earlier sub-PRD could own it. Per the ladder's own doctrine it is **PRD-first, then slices**; shipping this document closes the rung, and §9 names the implementation slices it opens.
+> **Provenance:** design seat, single-seat. Every `file:line` anchor was re-verified in the working tree at `origin/main` @ `5ebec83` (the commit that landed R13, closing the ladder's code rungs). **The symbol is the contract, the line is a hint — re-anchor at implementation start** (a mailbox-resolver fix and a migration CLI are in flight in the same area).
+> **Ground includes a LIVE PROBE (2026-07-05):** the first real `--inbox-sweep` ever run against the maintainer's spool (66 letters), plus a census of that corpus (§2.3). The probe both proved the substrate's invariants (spool untouched · idempotent re-run `appended: 0` · consent-deferred `.gitignore`) and produced this PRD's RED state: **recurrence is real, and the system cannot see it** (§2.4). One friction letter about the sweep itself was filed during the probe — the corpus grew by one *while being probed*, which is the mailbox working as designed.
+> **Sisters, same organism:** the mailbox substrate this PRD overlays — `docs/MEDULLA-PRD.md` (§9 letters, boxes, misdelivery). The receipt shape it borrows — `docs/SOUL-PRD.md` (§6.1 the freshness receipt). The claim-vs-measure precedent it generalizes — `docs/NEXTGEN-AGENT-PRD.md` §O.12 (`outcomes.jsonl`). The constitution it obeys — `docs/ORGANISM-PRD.md` §C2.2 (the one law), §C6 (verb budget), Grammar 3 (letter fates).
+
+---
+
+## 1. Thesis — the founding insight
+
+> **The problem, stated:** a letter is a witness; a case is a trial. Today the mailbox remembers every signal and understands none of them. Three letters about the same defect are three strangers standing in the same room — the grouping happens in an orchestrator's head, or nowhere.
+
+The corpus proves this is not hypothetical. During the construction era, one defect (the pre-orient verb returning an empty memory beat over a non-empty store — the false-absence bug, later fixed as ladder R0) generated **three independent honesty-class letters from three different sessions**. The third witness's author, having no mechanical way to declare the repetition, wrote *"REINCIDENCE of the L52 class"* **in free prose inside the letter body**. The recurrence was real, was noticed, and was recorded — in the one place no machine can read it. That sentence is this PRD's founding artifact: an agent hand-simulating the organ this document designs.
+
+Decompressed into the five organs, each mechanizing a judgment the maintainer or an orchestrator currently performs by hand:
+
+1. **FINGERPRINT** — a stable `(tool_family + symptom_kind)` identity for a recurring problem, so "this again" becomes a computable fact instead of a prose remark. *Confusion is telemetry* made mechanical.
+2. **CASES** — N letters → 1 root cause → 1 fix → linked receipts. The grouping the orchestrator does in their head at triage time, made a derived, recomputable overlay.
+3. **ABSENCE SENTINELS** — a fixed case earns a standing battery assertion that the symptom **stays absent after restart**. The post-deploy *permanence diff* made mechanical: silence stops being assumed and starts being asserted.
+4. **CLAIM-VS-MEASURE** — every honesty-class letter is a labeled pair (what m1nd claimed, what reality showed). Today those pairs rot as prose; audited, they are the calibration corpus the trust machinery is starving for.
+5. **THE ABANDONMENT SIGNAL** — an agent that hit an error and silently stopped using m1nd is the most damning honesty datum the system can collect, and today it is invisible. Mechanized (where a session boundary is actually observable — §4.5 is honest about where that is), it becomes the corpus's one **auto-generated** calibration ground truth (the JOINT-D seam made real).
+
+And the one law that disciplines all five (§3): **case intelligence is a grouping overlay, never a third axis.** No new stored state on letters, no fifth fate, no new grammar. Delete every case artifact and not one letter loses a byte.
+
+---
+
+## 2. Today, probed — the current-state truth (2026-07-05)
+
+### 2.1 The substrate that exists (and this design composes — reuse-first)
+
+| Mechanism | Where (verified @ `5ebec83`) | What it gives case intelligence |
+|---|---|---|
+| **Letter model** | `m1nd-mcp/src/mailbox.rs:62` (`Letter`), `:75` (doc classes `friction\|bug\|triage\|honesty\|win`) | The witness record: `ts`, `agent`, `repo`, `tool`, `class`, `what`, `expected`, stable content-id (sha256[0..12]), `answers[]` reply graph. Free-form `class` field — the fingerprint's `kind` follows the same open-field-closed-vocabulary pattern. |
+| **Derived fates** | `mailbox.rs` `derive_fate` — `wet_ink \| in_flight \| fired_clay \| external`, receipt `disposition: fixed \| declined \| moot` | The axis cases overlay. Fates are derived from `answers[]`, never stored — the exact discipline the case overlay inherits. |
+| **A closed kind vocabulary, already shipped** | `mailbox.rs:108-125` — `memory_misdelivery` kinds `leak \| false_absence \| wrong_store_write \| misattribution \| vanished` | The proof that a typed symptom taxonomy works in this codebase, and the seed of the fingerprint vocabulary (§4.1): `false_absence` is already both a misdelivery kind and the model case's root class. |
+| **Counts-only rendering** | `mailbox.rs:614-624` (`SweepResult.misdelivery`), `:887-895` (`doctor` confusion block) | The honesty style: `doctor` renders confusion as **counts per week, never an uncalibrated score**. Every case-intelligence surface inherits this (CASE-INV-6). |
+| **Boxes + sweep** | `mailbox.rs:160-173` (`BoxTarget`), `main.rs:227+` (`run_inbox_sweep`) | The distribution substrate (per-project boxes, medulla box, pending). Fingerprinting is a sweep-time computation — no new process, no new door. |
+| **`learn`** | `tools.rs:2736` (`handle_learn`) — `correct \| wrong \| partial`, Hebbian on the graph | The measure half of claim-vs-measure at edge granularity; case receipts cite `learn` events as evidence. |
+| **Trust ledger** | `m1nd-core/src/trust.rs` — `TrustEntry` defect/false-alarm/partial counts + timestamps | The per-node memory of being wrong. Cases aggregate the same events at *problem* granularity — same data, one level up. |
+| **`outcomes.jsonl`** | `delegation_handlers.rs:~1419-1439` (row schema), `:1617` (`append_outcome_row`) | The shipped claim-vs-measure precedent: delegate PREDICTS a touch-set, debrief MEASURES the real one, one JSONL row per grading. §4.4 generalizes exactly this pattern. |
+| **Calibration** | `m1nd-core/src/calibration.rs` — split-conformal, `CalibrationTable` keyed by signal | The consumer. Its own header admits co-change is "the first and currently only calibrated signal" — case intelligence exists to feed it labeled rows from the field. |
+| **Soul receipt** | `m1nd-mcp/src/soul_handlers.rs` — one-line count-honest receipt | The receipt shape (`checked <date> @<sha> — N fresh · M stale`) that case receipts and the sentinel report reuse verbatim in spirit: dated, sha-anchored, counts only. |
+| **Per-brain session counters** | R14 — `attached_sessions`, `query_count`, `calibration_armed` partitioned by `bound_project_root` | The only session substrate that exists today. §4.5's honest dependency analysis starts from what these counters can and cannot witness. |
+
+### 2.2 What does NOT exist (grep-proven)
+
+No fingerprint computation, no case derivation, no sentinel runner, no generalized claim audit, no abandonment detection. There is also **no engine-minted letter**: every letter in the corpus was appended by an agent. The write door for the engine speaking into its own mailbox (§4.1's escalation letter, §4.5's abandonment letter) is new — small, but new, and named in the budget (§7).
+
+### 2.3 The corpus census — the live probe's numbers
+
+The maintainer's spool at probe time: **66 letters**. By class: 25 friction · 15 triage · 10 honesty · 8 bug · 8 win. By tool, the leader by a wide margin is the pre-orient verb: **16 letters** name it (11 as `north`, 5 as `north (memory beat)` — note the free-text suffix variance, which is exactly why §4.1 normalizes `tool_family` before matching). The first real sweep distributed 17 letters into per-project boxes and the medulla box, proved idempotence (`appended: 0` on re-run), left the spool byte-identical — and left the **majority of the corpus pending under bare repo names**, a resolver gap caught by the probe itself, filed as a friction letter, with a fix in flight. The probe audits the prober: working as designed.
+
+### 2.4 The RED state — recurrence is real and invisible
+
+A naive experiment against the census: fingerprint every letter as `(tool, first-6-words-of-symptom)`. Result: **zero recurrences detected** across 66 letters. Yet the corpus demonstrably contains at least one three-witness recurrence (the false-absence trilogy — three honesty letters, three sessions, one root cause, one eventual fix at ladder R0) plus a hand-written *"REINCIDENCE"* annotation proving an agent SAW the repetition the machine could not.
+
+The lesson is the design: **free text does not fingerprint.** Recurrence in this corpus lives at the granularity of `(tool_family + symptom_kind)` where `kind` is a closed vocabulary — the same lesson `memory_misdelivery` already encodes for its five kinds. Raw-text matching under-groups (three phrasings of one bug look like three bugs); anything fuzzier over-groups (a junk drawer). A closed vocabulary with an honest "no kind → no fingerprint" refusal is the only shape that neither lies in either direction. That refusal is CASE-INV-2.
+
+### 2.4.1 The seams, enumerated
+
+1. **Recurrence invisible** — the trilogy took an orchestrator's memory to connect; the third witness hand-wrote the link.
+2. **Fixes prove presence-of-green, never absence-of-symptom.** R0 landed with a RED→green battery case — but nothing PERIODICALLY re-asserts "the false-absence symptom is still absent on the live owner after every restart." The permanence diff is still a human habit.
+3. **Claim-vs-measure exists for exactly one verb pair** (delegate/debrief). The 10 honesty letters — each one a labeled (claim, reality) pair about `north`, envelopes, freshness — feed nothing.
+4. **Abandonment is silent.** The counters (R14) can say a session queried 3 times and stopped; nothing asks *why*, and no letter is minted.
+
+---
+
+## 3. The one law — a case is an overlay (constitutional, adopted verbatim)
+
+From `docs/ORGANISM-PRD.md` §C2.2:
+
+> **Case intelligence is a grouping overlay, never a third axis:** a `case` is a set of letter ids plus one receipt (`case_id`/`fingerprint` fields), layered over fates (→ the Case-Intelligence PRD, §C10 R11).
+
+Operationalized as four hard rules this PRD may not weaken:
+
+1. **Member letters are never touched.** A letter gains no case field, no flag, no rewrite when it joins a case. Membership is derived: `case(fp) = { letters whose computed fingerprint == fp } ∪ { the receipt that names fp }`.
+2. **The only stored case artifacts are two fields ON THE RECEIPT** — `fingerprint` (the identity) and optionally `case_id` (an alias for it) — plus the receipt's existing `answers[]` links. A receipt is already a letter; no new record type exists.
+3. **Fates gain no fifth word.** A case has no fate of its own; it *renders* the fates of its members (a case whose receipt is `fired_clay·fixed` and whose sentinel is green is displayed "closed·guarded" — display vocabulary, never storage).
+4. **Recomputability is the test.** Delete every fingerprint cache and every derived view: re-running the sweep over the untouched spool+boxes reconstructs every case bit-identically. If any information would be lost, that information is stored in the wrong place.
+
+---
+
+## 4. The five organs
+
+### 4.1 FINGERPRINT — the stable identity of a recurring problem
+
+**Identity:** `fingerprint = (tool_family, symptom_kind)`, rendered `fp:<tool_family>/<kind>` (e.g. `fp:north/false_absence`).
+
+- **`tool_family`** — the letter's `tool` field, normalized: lowercase, strip any parenthesized suffix (`north (memory beat)` → `north`), trim. The census (§2.3) shows suffix variance is the dominant noise; nothing smarter is warranted or permitted (no fuzzy matching across families — CASE-INV-2).
+- **`symptom_kind`** — a **closed vocabulary**, seeded from the corpus and from the shipped `memory_misdelivery` precedent:
+
+| kind | one-line definition (corpus-grounded) |
+|---|---|
+| `false_absence` | said "nothing here" over a store that provably held content (the model case) |
+| `stale_claim` | served a claim whose evidence had moved underneath it |
+| `overclaimed_verdict` | said `act`/fresh/closed where reality was weaker (honesty-class core) |
+| `wrong_route` | answered from / wrote to the wrong brain, box, or store |
+| `scope_escape` | retrieval or action crossed a declared boundary |
+| `silent_drop` | accepted input and lost it without an error or a receipt |
+| `crash` | process/verb died (panics, codesigning rejections, transport deaths) |
+| `ux_confusion` | a surface made a human or agent misread state (labels, counts, phrasing) |
+
+- **Who assigns `kind`:** the letter author, via a new OPTIONAL `kind` field on the letter (same open-field pattern as `class`; the write transport is unchanged). The sweep may **conservatively backfill** kinds for legacy letters only where a deterministic rule fires (e.g. class `honesty` + tool `north` + "memory" and an emptiness token in `what` → `false_absence`); anything short of a rule match gets **no fingerprint**. There is deliberately no `other` bucket: a junk drawer is where taxonomies go to lie (CASE-INV-2).
+- **Where it computes:** inside the existing sweep (`run_inbox_sweep`), read-only over spool+boxes; recurrence counts land in `SweepResult` beside `misdelivery` and render in `doctor` — counts only.
+
+**Auto-escalation on the 2nd recurrence.** When a fingerprint's witness count reaches 2, the sweep mints **one** escalation letter into the affected project's box: class `triage`, `kind` mirrored from the fingerprint, `what` naming the fingerprint and its witness letter ids, authored as the engine (§4.6). Exactly once per fingerprint (dedup by fingerprint id in the escalation letter's content — the content-id dedup the boxes already enforce makes double-minting structurally impossible; CASE-INV-3). At 2, not 3: the corpus shows the second witness is where a human first says "again" — the trilogy's REINCIDENCE annotation appeared on witness #2's successor because nothing had flagged witness #2.
+
+### 4.2 CASES — N letters → 1 root cause → 1 fix → linked receipts
+
+A case is **born by a receipt, never by a letter count.** When someone (agent or maintainer) answers the witnesses with a receipt letter — `answers: [ids…]`, `disposition: fixed|declined|moot` — and stamps it `fingerprint: fp:<…>`, the case exists. From that moment:
+
+- **Membership is derived** (law §3): every letter whose computed fingerprint matches, plus every letter the receipt explicitly `answers`. The explicit list handles pre-taxonomy letters that a backfill rule can't reach: the receipt's author is the human-judgment escape hatch, and their judgment is *recorded in the receipt*, not smeared onto members.
+- **The case receipt speaks the soul receipt's dialect** (dated, sha-anchored, counts-honest): `case fp:north/false_absence — 3 witnesses · fixed @<sha> · sentinel: <probe>`. One line, renderable everywhere a letter renders today (doctor, the mailbox UI's fate-line), no new UI surface required in v0.
+- **A case never closes letters.** Members keep their own fates; the mailbox UI already renders reply-graph state, and a case is just a lens over it. Where a display groups by case, the group label uses display vocabulary (`open` / `answered` / `closed·guarded`) computed from member fates + sentinel state, stored nowhere.
+
+### 4.3 ABSENCE SENTINELS — the permanence diff made mechanical
+
+**A fixed case earns a standing assertion that its symptom stays gone.**
+
+- **Shape:** the fixing receipt MAY carry `sentinel: { probe: "<command or battery case id>", expect: "absent" }`. The probe is the same command family the repo's battery already speaks (a battery case id, or a one-line runnable probe against the served owner).
+- **Runner:** `--sentinel-sweep` (same offline CLI pattern as `--inbox-sweep`): collect every sentinel from every box's receipts, run each probe, report `sentinels: N guarded · M green · K RED` — and a RED sentinel **mints a letter** into the case's box (class `bug`, kind mirrored, `what`: "sentinel regression: <fp> resurfaced"), which — because the fingerprint already has a receipt — is *witness N+1 of an existing case*, not a new orphan. Regression re-opens the story exactly where its history lives.
+- **When it runs:** by hand, at battery time, and naturally after restarts (the post-restart diff — the moment silence is least trustworthy). It is a read-only prober; it never mutates stores.
+- **Bound:** a sentinel exists only on a `disposition: fixed` receipt (CASE-INV-4). Declined/moot cases guard nothing — there is nothing to keep absent.
+
+The model case, concretely: the false-absence receipt would carry `sentinel: { probe: "north over the seeded non-empty fixture asserts memory_exists ≥ 1 or a non-empty beat", expect: "absent(false_absence)" }` — the exact battery case R0 landed with, promoted from "ran once at merge" to "stands guard forever".
+
+### 4.4 CLAIM-VS-MEASURE — the audit, generalized from the one place it already works
+
+The delegation layer already does this end-to-end: predict (packet) → measure (debrief) → one `outcomes.jsonl` row → derived counts, calibration-gated tuning at N ≥ 30. R11 generalizes the PATTERN, not the plumbing:
+
+- **The labeled pair already exists in the wild:** every honesty-class letter IS `(claim m1nd made, reality observed)` — the census holds 10. What's missing is structure: the `kind` field (§4.1) supplies the claim taxonomy; the fingerprint supplies grouping.
+- **S3 adds one export:** the sweep renders, per `(tool_family, kind)`, the honest counts — `claimed-right / claimed-wrong / unresolved` — from honesty letters and their receipts, into a `claims` block beside `misdelivery` in `SweepResult` + `doctor`. Counts only, forever (CASE-INV-6): the delegation layer's own rule ("no quality number prints anywhere" until calibrated) binds here verbatim.
+- **The calibration hand-off is a file, not a promise:** rows shaped for `CalibrationTable` (signal = the tool_family's verdict channel, label = the letter's measured truth) appended to a `field-labels.jsonl` beside `outcomes.jsonl` — the same one-row-per-event JSONL discipline. Whether any signal ever consumes them is that signal's calibration decision at its own N-threshold; this PRD only guarantees the rows stop rotting as prose.
+
+### 4.5 THE ABANDONMENT SIGNAL — the crown, held honestly
+
+**Definition:** an agent that received an error / wrong answer / hard abstain from m1nd and then **stopped using m1nd within the same working session** — not a complaint, a *silent walk-away*. It is the purest honesty datum: unprompted, behavioral, and negative (nobody files a letter about the tool they just stopped trusting — that is exactly why it must be auto-generated, JOINT-D).
+
+**What m1nd can actually see (the honest dependency analysis):**
+
+| Substrate | Can it witness abandonment? |
+|---|---|
+| Per-brain counters (R14: `attached_sessions`, `query_count`) | Volume only. Can show "3 calls then silence", cannot distinguish *finished the task happily* from *walked away angry*. |
+| The MCP transport | Sees its own calls only. A session that keeps working via other tools after dropping m1nd is invisible from inside m1nd. |
+| **The ambient hook wave (ladder R12 — Stop/session-end hooks)** | **The only honest witness.** A session-end hook can observe: m1nd was called early, an error/abstain/`learn(wrong)` occurred, zero m1nd calls followed, and the session demonstrably continued (the Stop event itself proves the session outlived the walk-away). |
+
+**Decision:** abandonment detection is **S4 and depends on the ambient wave**. When the Stop-hook path exists, the rule is mechanical and conservative: `(error|wrong|hard-abstain observed) ∧ (zero m1nd calls afterward) ∧ (session continued to a Stop)` → mint ONE letter, class `honesty`, `kind: overclaimed_verdict` or the error's own kind, engine-authored, citing the last verb + the failing call's shape (never the conversation — m1nd sees its own traffic only). Exactly-once per session (dedup by session id in content). Until the hook exists, the organism does not pretend: a `learn(wrong)`-with-no-follow-up heuristic was considered and REJECTED as a proxy — it cannot see whether the session continued, so it would mint accusations from silence. §10 carries this as the named gap.
+
+### 4.6 The engine-minted letter — one new write path, tightly caged
+
+§4.1 (escalation), §4.3 (sentinel regression), and §4.5 (abandonment) all need the engine to speak into its own mailbox. One shared mechanism, three callers:
+
+- `agent` field: `"m1nd:engine"` — a reserved authorship namespace that no real agent uses; provenance is unmistakable and auditable (the same etiquette-by-provenance promote already practices; CASE-INV-5).
+- Same transport as everyone else: append to the target box (never the spool — engine letters are born *distributed*, they have no distribution question), content-id dedup applies, MED-INV-9/10 untouched.
+- Engine letters never impersonate, never editorialize (template bodies with ids and counts, no adjectives), and are themselves fingerprintable — the system's own speech is subject to the same audit as everyone else's.
+
+---
+
+## 5. The verb surface — zero new verbs (v0 decision, Budget Law)
+
+The soul earned two verbs because it introduced a first-class TYPE. A case is an overlay on an existing type, and the constitution's verb budget (§C6) prices every new verb against the packet. Decision: **v0 ships no new MCP verb.**
+
+- **Compute** lives in the sweep (`--inbox-sweep` gains fingerprint/recurrence; `--sentinel-sweep` is a CLI flag, not a verb).
+- **Read** lives where mailbox reading already lives: `doctor` (counts + top recurrent fingerprints + case one-liners), the mailbox HTTP route / UI fate-line (case lens, display-only), and the letters themselves.
+- **Write** is the receipt author stamping two fields — `memorize`/append paths unchanged.
+- If field pressure ever demands a `cases` read verb, that is an S-slice behind measured demand (letters asking for it), not a v0 guess.
+
+---
+
+## 6. CASE-INV — the honesty invariants (additive; TT-INV/MED-INV bind here unweakened)
+
+1. **CASE-INV-1 (overlay-only):** cases are derived; deleting every case artifact loses zero letter bytes; recompute reconstructs bit-identically (§3.4).
+2. **CASE-INV-2 (no junk drawer):** no `kind` → no fingerprint → no case membership by computation. There is no `other`. Backfill only by deterministic rule; the receipt's explicit `answers[]` is the sole judgment channel, and it is signed.
+3. **CASE-INV-3 (escalation exactly-once):** one escalation letter per fingerprint, ever — enforced structurally by content-id dedup, not by memory.
+4. **CASE-INV-4 (sentinels guard fixes):** a sentinel exists only on a `disposition: fixed` receipt; a RED sentinel mints a witness into the existing case, never a new orphan.
+5. **CASE-INV-5 (engine provenance):** engine-minted letters author as `m1nd:engine`, template-bodied, dedup-caged, never impersonating an agent — and never minted from unobservable silence (§4.5's rejection of the proxy).
+6. **CASE-INV-6 (counts only):** every case-intelligence surface renders counts and receipts; no uncalibrated score, rate-without-denominator, or health adjective, anywhere, ever.
+7. **CASE-INV-7 (substrate inviolate):** the spool is never truncated (MED-INV-9); pending never re-routes to the medulla (MED-INV-10); boxes append-only with dedup. Case intelligence reads; only §4.6's caged writer writes.
+
+---
+
+## 7. Budget conformance — everything new, priced
+
+| Addition | Kind | Cost |
+|---|---|---|
+| `kind` field on letters | optional field, open write shape | zero to existing writers |
+| `fingerprint`/`case_id` + `sentinel` on receipts | optional fields on an existing letter shape | zero to non-participants |
+| fingerprint/recurrence/claims in `SweepResult` + `doctor` | extension of existing render | counts only, no packet impact |
+| `--sentinel-sweep` | CLI flag (offline, read-only prober + caged writer) | no verb, no packet |
+| engine-minted letters | one new write path, §4.6 caged | bounded: template + dedup |
+| `field-labels.jsonl` | one JSONL beside `outcomes.jsonl` | append-only rows |
+| new MCP verbs | — | **none** |
+| north-packet change | — | **none in v0** (a case headline in the packet is an S-slice behind the same sufficiency gating as everything else in §C1.3) |
+
+---
+
+## 8. The closed loop, traced end-to-end (the payoff)
+
+The model case, replayed as if R11 had existed during the construction era:
+
+1. Session A files a witness: `north` returned an empty memory beat over a bound, non-empty store → letter, class `honesty`, `kind: false_absence`. Fingerprint `fp:north/false_absence`, count 1. Nothing escalates — one witness is an anecdote.
+2. Session B (different day, different phrasing) files witness 2. The sweep computes count 2 → **mints the escalation letter** into the project box: "fp:north/false_absence — 2 witnesses: <id>, <id>". No human memory required; the *"REINCIDENCE"* prose annotation never needs to exist.
+3. Triage reads one escalation letter instead of re-deriving the link; the confirmed defect becomes a RED battery case BEFORE the fix (the repo's standing triage law, now with the witnesses pre-assembled).
+4. The fix lands. The receipt answers all witnesses: `disposition: fixed`, `fingerprint: fp:north/false_absence`, `sentinel: {probe: <the RED case, now guarding>, expect: absent}`. **The case now exists** — derived, one line: `case fp:north/false_absence — 3 witnesses · fixed @<sha> · guarded`.
+5. Every future `--sentinel-sweep` (notably post-restart) re-asserts absence. If the symptom resurfaces in any future rebuild, the RED sentinel mints witness 4 *into the same case* — history intact, no orphan, no re-diagnosis from zero.
+6. The three honesty letters export as labeled rows to `field-labels.jsonl`; when the pre-orient verdict channel reaches its calibration N, the field corpus is sitting there, structured, waiting.
+7. When the ambient wave lands, the walk-away that today costs a user silently becomes witness 0 of the next case — filed by the engine before any human notices the frustration.
+
+One signal, one identity, one trial, one guard, one labeled row — and the next cold session inherits all of it by reading one line.
+
+---
+
+## 9. Slice plan — proof-grown, PRD-first honored
+
+Each slice lands with a battery case RED on the REAL corpus (or a faithful synthetic replay of it) before the code.
+
+- **S0 — fingerprint in the sweep (read-only).** `tool_family` normalization + the kind vocabulary + optional `kind` on letters + conservative backfill rules + recurrence counts in `SweepResult`/`doctor`. **Seed battery (RED today):** replaying the census corpus groups the false-absence trilogy under one fingerprint (today: zero groupings, §2.4); the two tool-suffix variants of the pre-orient verb normalize to one family; a kindless letter earns NO fingerprint.
+- **S1 — escalation + the case overlay.** Engine-minted escalation at count 2 (exactly-once, §4.6 writer); `fingerprint`/`case_id` on receipts; case derivation + the one-line case receipt in `doctor` and the mailbox surfaces. **Battery:** corpus replay mints exactly ONE escalation for the trilogy (at witness 2, not 3); the receipt derives the full case; deleting derived artifacts + recompute is bit-identical (CASE-INV-1 proven, not asserted).
+- **S2 — absence sentinels.** `sentinel` on fixed receipts; `--sentinel-sweep` runner; RED-sentinel mints a witness into the existing case. **Battery:** the model case's sentinel runs green against the fixed engine; a deliberately re-broken fixture turns it RED and the minted letter lands in the same case.
+- **S3 — claim-vs-measure export.** The `claims` counts block + `field-labels.jsonl` rows from honesty letters + receipts. **Battery:** the census's honesty letters produce exactly the expected labeled rows; counts render with denominators; no score appears anywhere (a grep gate, like the UI's air-gap grep).
+- **S4 — abandonment `[depends: the ambient wave — hard dependency, not a preference]`.** The Stop-hook rule (§4.5), engine-minted honesty letters, exactly-once per session. **Battery:** a synthetic session transcript (error → silence → Stop) mints one letter; the same transcript without the Stop (session died with m1nd's error as the last event) mints NOTHING — the no-accusation-from-silence rule proven.
+
+---
+
+## 10. Known problems & honest gaps
+
+- **S4 is gated on infrastructure that does not exist yet** (the ambient Stop-hook wave). The crown organ ships last, and the interim proxy was rejected on honesty grounds (§4.5) — abandonment stays invisible until it can be witnessed truthfully. This is a scope admission, not a schedule promise.
+- **The kind vocabulary will be wrong somewhere.** Eight kinds cover the 66-letter census; the first uncoverable letter will arrive. The governance is the taxonomy's own precedent: extending the closed vocabulary is a PRD-amendment-grade change (a new word in a grammar), never an ad-hoc string — and the pressure signal is mechanical: kindless letters accumulating in `doctor`'s counts.
+- **Backfill rules can misfile history.** They are deliberately narrow (deterministic, corpus-derived); a misfiled legacy letter is correctable by a receipt's explicit `answers[]`, and the derived overlay means re-filing is always a recompute, never a migration.
+- **The bare-name pending gap** (§2.3, fix in flight at PRD time) means per-project boxes under-populate until resolved; fingerprinting over spool+boxes together is unaffected, but per-box case rendering inherits whatever the resolver misses.
+- **Engine speech is a new trust surface.** §4.6's cage (reserved author, templates, dedup, observable-facts-only) is designed to keep the engine's mailbox voice as auditable as any agent's — the first engine letter that editorializes or double-mints is itself a `bug`-class letter against `m1nd:engine`, and the system audits itself with its own machinery.

--- a/docs/ORGANISM-PRD.md
+++ b/docs/ORGANISM-PRD.md
@@ -896,7 +896,10 @@ card golden against two REAL captured packets (`preflight_north.json` warm + `pr
 green; violet-lint + icon-lint green; `tsc` clean; `vite build` green with the dist air-gap grep at
 zero external resource loads; dist regenerated + embedded (rust-embed).
 
-**R11 — the CASE-INTELLIGENCE PRD (the homeless organ, JOINT-K — PRD first, then slices).**
+**R11 — the CASE-INTELLIGENCE PRD (the homeless organ, JOINT-K — PRD first, then slices) —
+[PRD SHIPPED 2026-07-05 → `docs/CASE-INTELLIGENCE-PRD.md`: five organs under the §C2.2 overlay
+law, CASE-INV 1–7, slices S0–S4 defined there (S4 honestly gated on the ambient wave); shipping
+the PRD closes this rung].**
 After R8 (needs stable letter ids + `answers[]`). Scope, from the sealed doctrine: fingerprint
 (tool+symptom) with auto-escalation on 2nd recurrence · cases (N letters → 1 root cause → 1 fix →
 linked receipts) as the §C2.2 grouping overlay · absence sentinels in the battery (post-restart

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -2,13 +2,17 @@
 
 > Read this first. Single source of truth for any chat / subagent / parallel
 > session working on m1nd, so we don't re-derive state or contradict each other.
-> Last checkpoint: 2026-07-05 (**checkpoint 10 — THE DESIGN ERA CLOSES, THE CONSTRUCTION ERA
-> OPENS**). Six PRDs on `main` now form a single organism, capped by the **ORGANISM constitution**
-> (one spine · four grammars · one ritual · one cross-PRD build ladder R0–R17, adversarially
-> verified). The blueprints are done; the build order is fixed; the first three rungs shipped
-> (R0/R1/R5, #275). This is the capstone that closes the design era and hands the next agent a
-> ladder to climb — not another vision to write. Prior checkpoints (9 → 7) are summarized in
-> **Prior Eras** below; their full text lives in git history.
+> Last checkpoint: 2026-07-05 (**checkpoint 11 — THE LADDER IS CLIMBED, the close-out burst**).
+> The entire ORGANISM ladder R0–R17 is landed on `main` and live on the served owner: medulla
+> storage/tiers/promotion (R2/R3/R4), delegation (R6/R7), the per-project mailbox + UI (R8/R9),
+> Pre-Flight (R10), reconnect-rebind (R13), per-brain counters (R14), eviction (R15), the soul
+> (R16), seek-rerank conformance (R17) — and R11's deliverable, `docs/CASE-INTELLIGENCE-PRD.md`,
+> shipped as the last rung's PRD (its implementation slices S0–S4 are the next construction seed).
+> The close-out burst also wired the M5a migration CLI (`--medulla-migrate plan|apply|rollback`),
+> made `restart --binary` honest (loud dry-run + codesign + kickstart), fixed the mailbox roster's
+> duplicate-basename misrouting to the honest abstain, ran the first real `--inbox-sweep`
+> (idempotence proven live), and brought `skills/` to the serve-attach/medulla/delegation/soul era.
+> Prior checkpoints (10 → 7) are summarized in **Prior Eras** below; full text in git history.
 
 ## North Star
 m1nd = operational intelligence for coding agents. The bar: genuinely BEAT plain

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -113,4 +113,31 @@ pub struct Cli {
     /// spool + boxes (a pure, read-only view).
     #[arg(long)]
     pub no_distribute: bool,
+
+    /// One-shot MEDULLA storage-split migration (MEDULLA-PRD §4.2, slice M5a).
+    /// Takes one required verb (no default):
+    ///   `plan`     — print the dry-run plan JSON (enumerate + classify + the
+    ///                count-conservation gate) WITHOUT mutating anything;
+    ///   `apply`    — backup-first, then move repo-fact claims into the project
+    ///                brain store, stamp `Origin-Brain`, prune ghost ingest-root
+    ///                pointers, and verify count-conservation; prints the receipt;
+    ///   `rollback` — restore the medulla store from the most recent backup.
+    /// Derives every path from the runtime root exactly like `--inbox-sweep`,
+    /// runs offline, prints JSON, and exits. `apply`/`rollback` mutate the store —
+    /// intended for the maintainer, never an agent (the CODE-LAND-ONLY posture).
+    #[arg(long, value_name = "plan|apply|rollback")]
+    pub medulla_migrate: Option<MedullaMigrateMode>,
+}
+
+/// The verb for `--medulla-migrate` (MEDULLA-PRD §4.2). No default: the flag
+/// requires one of these values, so a bare `--medulla-migrate` is a usage error.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[value(rename_all = "lower")]
+pub enum MedullaMigrateMode {
+    /// Pure dry-run: print the plan, mutate nothing (§11 M5a default).
+    Plan,
+    /// The gated executor: backup-first split + stamp + prune (mutates).
+    Apply,
+    /// Restore the medulla store from the most recent backup (mutates).
+    Rollback,
 }

--- a/m1nd-mcp/src/mailbox.rs
+++ b/m1nd-mcp/src/mailbox.rs
@@ -834,30 +834,62 @@ pub fn project_basename(root: &str) -> String {
 /// registry `disk_roster` + the bound root). `worktree_base` is the project whose
 /// worktrees are `<base>-*`. A root whose dir is absent is still listed as an
 /// UNREACHABLE box (named by the sweep), never dropped.
+///
+/// A bare `repo` name resolves against `known_repos` by normalized basename, so a
+/// name that maps to a SINGLE root routes cleanly. When a basename maps to more
+/// than one DISTINCT root (two brains sharing a basename in different parents),
+/// the name is left OUT of `known_repos` — a bare letter for it abstains to
+/// `Pending` rather than being silently routed into whichever root won a
+/// first-wins race. This mirrors `covering_brain`'s unique/abstain law: exactly
+/// one match resolves, zero-or-more-than-one is honest doubt, never a guess. Every
+/// distinct root is still listed as a named `KnownBox` (the sweep surfaces it).
 pub fn boxes_from_roots(
     project_roots: &[String],
     worktree_base: &str,
 ) -> (BTreeMap<String, PathBuf>, Vec<KnownBox>) {
-    let mut known: BTreeMap<String, PathBuf> = BTreeMap::new();
+    // Group the DISTINCT dirs each normalized name resolves to. A repeated exact
+    // (name, dir) pair is the same brain seen twice (roster + bound root) — one
+    // distinct dir, so it still resolves; two DIFFERENT dirs is the ambiguity.
+    let mut dirs_by_name: BTreeMap<String, BTreeSet<PathBuf>> = BTreeMap::new();
     let mut boxes: Vec<KnownBox> = Vec::new();
-    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut seen_box: BTreeSet<(String, PathBuf)> = BTreeSet::new();
 
     for root in project_roots {
         let dir = PathBuf::from(root.trim());
         let name = normalize_repo(root, worktree_base);
-        if name.is_empty() || !seen.insert(name.clone()) {
+        if name.is_empty() {
             continue;
         }
         let reachable = dir.is_dir();
         if reachable {
-            known.insert(name.clone(), dir.clone());
+            dirs_by_name
+                .entry(name.clone())
+                .or_default()
+                .insert(dir.clone());
         }
-        boxes.push(KnownBox {
-            label: name,
-            path: box_path_for_repo(&dir),
-            reachable,
-        });
+        // One named box per distinct (name, dir): every root stays visible, but a
+        // dir listed twice is not duplicated in the sweep.
+        if seen_box.insert((name.clone(), dir.clone())) {
+            boxes.push(KnownBox {
+                label: name,
+                path: box_path_for_repo(&dir),
+                reachable,
+            });
+        }
     }
+
+    // Only names with exactly ONE distinct reachable dir are resolvable; an
+    // ambiguous basename is dropped so a bare letter for it stays Pending.
+    let known: BTreeMap<String, PathBuf> = dirs_by_name
+        .into_iter()
+        .filter_map(
+            |(name, dirs)| match dirs.into_iter().collect::<Vec<_>>().as_slice() {
+                [only] => Some((name, only.clone())),
+                _ => None,
+            },
+        )
+        .collect();
+
     (known, boxes)
 }
 
@@ -1497,5 +1529,90 @@ mod tests {
         assert_eq!(id1, id2, "trailing newline does not change the id");
         assert_eq!(id1.len(), 12, "id is the 12-hex-char sha256 prefix");
         assert!(id1.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    // --- bare repo names resolve against the roster by unique basename --------
+    //
+    // The first real sweep left most letters pending: a letter whose `repo` is a
+    // bare name (or a worktree variant of it) must resolve to the roster brain
+    // whose bound_project_root basename matches UNIQUELY — even when that brain is
+    // NOT the bound worktree_base. Mirrors covering_brain's unique/abstain law:
+    // exactly one match resolves; zero or >1 stays Pending (honest, never a guess).
+
+    #[test]
+    fn bare_name_resolves_against_unique_roster_basename() {
+        let s = Scratch::new("bare-name");
+        let runtime = s.path("runtime");
+        std::fs::create_dir_all(&runtime).unwrap();
+        // A roster brain bound deep under an unrelated path; only its basename
+        // ("repo-alpha") matches the bare letter. worktree_base is a DIFFERENT
+        // project, so the collapse rule alone cannot save the bare name.
+        let repo_alpha = mk_repo(&s, "place").join("repo-alpha");
+        std::fs::create_dir_all(&repo_alpha).unwrap();
+
+        let roots = vec![repo_alpha.to_string_lossy().to_string()];
+        let (known, _boxes) = boxes_from_roots(&roots, "some-bound-project");
+
+        // Bare name → resolves to the unique roster brain.
+        let bare: Letter =
+            serde_json::from_str(r#"{"repo":"repo-alpha","tool":"x","class":"bug"}"#).unwrap();
+        assert_eq!(
+            resolve_box(&bare, &runtime, "some-bound-project", &known),
+            BoxTarget::Project(repo_alpha.clone()),
+            "a bare name resolves to the roster brain whose basename matches uniquely"
+        );
+
+        // Worktree/annotation variant of the same bare name → same resolution.
+        let variant: Letter = serde_json::from_str(
+            r#"{"repo":"repo-alpha (worktree repo-alpha-x)","tool":"x","class":"bug"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_box(&variant, &runtime, "some-bound-project", &known),
+            BoxTarget::Project(repo_alpha),
+            "a parenthetical worktree variant collapses to the same bare name and resolves"
+        );
+    }
+
+    #[test]
+    fn ambiguous_basename_abstains_to_pending_never_guesses() {
+        let s = Scratch::new("ambiguous-basename");
+        let runtime = s.path("runtime");
+        std::fs::create_dir_all(&runtime).unwrap();
+        // TWO distinct roster roots that share the basename "repo-alpha".
+        let a1 = mk_repo(&s, "place1").join("repo-alpha");
+        let a2 = mk_repo(&s, "place2").join("repo-alpha");
+        std::fs::create_dir_all(&a1).unwrap();
+        std::fs::create_dir_all(&a2).unwrap();
+
+        let roots = vec![
+            a1.to_string_lossy().to_string(),
+            a2.to_string_lossy().to_string(),
+        ];
+        let (known, boxes) = boxes_from_roots(&roots, "bound");
+
+        // The ambiguous basename must NOT be a resolvable known repo (a guess
+        // would silently misroute every "repo-alpha" letter into whichever root
+        // won a first-wins race).
+        assert!(
+            !known.contains_key("repo-alpha"),
+            "an ambiguous basename must not resolve to a single root: {known:?}"
+        );
+
+        // A bare "repo-alpha" letter therefore stays Pending — honest, not a guess.
+        let bare: Letter =
+            serde_json::from_str(r#"{"repo":"repo-alpha","tool":"x","class":"bug"}"#).unwrap();
+        assert_eq!(
+            resolve_box(&bare, &runtime, "bound", &known),
+            BoxTarget::Pending("repo-alpha".to_string()),
+            "an ambiguous bare name abstains to Pending (0-or->1 → never chute)"
+        );
+
+        // Both ambiguous roots are still NAMED as boxes (visible, never silently
+        // dropped) — the sweep surfaces them, it just cannot route a bare name.
+        assert!(
+            boxes.iter().filter(|b| b.label == "repo-alpha").count() >= 1,
+            "the ambiguous roots remain visible as named boxes"
+        );
     }
 }

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -319,6 +319,134 @@ fn run_inbox_sweep(config: McpConfig, no_distribute: bool) {
     let _: BTreeMap<String, PathBuf> = known; // keep the type explicit for clarity
 }
 
+/// One-shot MEDULLA storage-split migration (MEDULLA-PRD §4.2, slice M5a). Boots a
+/// `SessionState` to recover the canonical runtime root + the bound project root,
+/// derives the two store dirs + `ingest_roots.json` from them exactly like
+/// `run_inbox_sweep` does, then runs the requested verb and prints JSON. `plan` is
+/// the pure dry-run (mutates nothing); `apply` is the gated backup-first split
+/// (mutates the store); `rollback` restores the medulla store from its most recent
+/// `apply` backup. Operator convenience — OFF the MCP surface, offline, no server
+/// transport.
+fn run_medulla_migrate(config: McpConfig, mode: m1nd_mcp::cli::MedullaMigrateMode) {
+    use m1nd_mcp::cli::MedullaMigrateMode;
+    use m1nd_mcp::medulla_migration::MedullaMigration;
+    use m1nd_mcp::project_brains::{ProjectBrainRegistry, PROJECT_BRAINS_DIR};
+
+    let server = match McpServer::new(config) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[m1nd-mcp][medulla_migrate] failed to boot session: {e}");
+            std::process::exit(1);
+        }
+    };
+    let state = server.into_session_state();
+    let runtime_root = state.runtime_root.clone();
+
+    // The medulla store IS the owner runtime root's `agent-memory/` (the tier is
+    // the directory, §4.1 — no move). The project brain's store is the m1nd repo's
+    // per-project `agent-memory/` under `project-brains/<fingerprint>/`. The origin
+    // stamped on moved claims is the m1nd repo root itself.
+    let medulla_dir = runtime_root.join("agent-memory");
+    let ingest_roots_path = runtime_root.join("ingest_roots.json");
+    let project_origin = state.project_root_display().unwrap_or_default();
+    let registry = ProjectBrainRegistry::new(runtime_root.join(PROJECT_BRAINS_DIR), None);
+    let project_dir = registry
+        .store_dir_for(&ProjectBrainRegistry::canonical_key(&project_origin))
+        .join("agent-memory");
+
+    let mig = MedullaMigration::new(
+        &medulla_dir,
+        &project_dir,
+        &ingest_roots_path,
+        project_origin.clone(),
+    );
+
+    let (mode_str, payload) = match mode {
+        MedullaMigrateMode::Plan => match mig.plan() {
+            Ok(plan) => ("plan", serde_json::to_value(&plan).unwrap_or_default()),
+            Err(e) => {
+                eprintln!("[m1nd-mcp][medulla_migrate] plan failed: {e}");
+                std::process::exit(1);
+            }
+        },
+        MedullaMigrateMode::Apply => match mig.apply() {
+            Ok(receipt) => ("apply", serde_json::to_value(&receipt).unwrap_or_default()),
+            Err(e) => {
+                eprintln!("[m1nd-mcp][medulla_migrate] apply failed: {e}");
+                std::process::exit(1);
+            }
+        },
+        MedullaMigrateMode::Rollback => {
+            // Find the most recent `.m5a-backup-*` dir written by a prior apply.
+            let backup = match most_recent_backup(&medulla_dir) {
+                Some(b) => b,
+                None => {
+                    eprintln!(
+                        "[m1nd-mcp][medulla_migrate] rollback: no backup found under {}",
+                        medulla_dir.display()
+                    );
+                    std::process::exit(1);
+                }
+            };
+            // The moved files are those now present in the project store — remove
+            // them so the project store returns to its pre-migration contents.
+            let moved: Vec<String> = std::fs::read_dir(&project_dir)
+                .map(|entries| {
+                    entries
+                        .flatten()
+                        .filter_map(|e| {
+                            let name = e.file_name().to_string_lossy().to_string();
+                            (!name.starts_with('.') && name.ends_with(".light.md")).then_some(name)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            match mig.rollback(&backup.to_string_lossy(), &moved) {
+                Ok(()) => (
+                    "rollback",
+                    serde_json::json!({
+                        "restored_from": backup.to_string_lossy(),
+                        "removed_from_project": moved,
+                    }),
+                ),
+                Err(e) => {
+                    eprintln!("[m1nd-mcp][medulla_migrate] rollback failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+    };
+
+    let out = serde_json::json!({
+        "schema": "m1nd-medulla-migrate-v0",
+        "mode": mode_str,
+        "medulla_dir": medulla_dir.to_string_lossy(),
+        "project_dir": project_dir.to_string_lossy(),
+        "project_origin": project_origin,
+        "plan": payload,
+    });
+    println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+}
+
+/// The most recent `.m5a-backup-<ms>` dir under a medulla store, if any. The
+/// suffix is `now_ms()` at `apply` time, so lexical max over the numeric suffix
+/// is the newest backup (the rollback anchor).
+fn most_recent_backup(medulla_dir: &std::path::Path) -> Option<PathBuf> {
+    const PREFIX: &str = ".m5a-backup-";
+    std::fs::read_dir(medulla_dir)
+        .ok()?
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            let name = path.file_name()?.to_str()?.to_string();
+            let suffix = name.strip_prefix(PREFIX)?;
+            let stamp: u128 = suffix.parse().ok()?;
+            path.is_dir().then_some((stamp, path))
+        })
+        .max_by_key(|(stamp, _)| *stamp)
+        .map(|(_, path)| path)
+}
+
 async fn run_stdio_server(config: McpConfig, event_log: Option<String>, no_gui: bool, _port: u16) {
     if event_log.is_some() {
         eprintln!(
@@ -515,6 +643,16 @@ async fn main() {
     // never boots a server transport.
     if cli.inbox_sweep {
         run_inbox_sweep(config, cli.no_distribute);
+        return;
+    }
+
+    // --medulla-migrate plan|apply|rollback: the one-shot MEDULLA storage-split
+    // migration (MEDULLA-PRD §4.2, slice M5a). Derives every path from the runtime
+    // root like --inbox-sweep, runs offline, prints JSON, and exits. `plan` is a
+    // pure dry-run; `apply`/`rollback` mutate the store (CODE-LAND-ONLY posture —
+    // for the maintainer, never an agent). Runs BEFORE --serve/stdio.
+    if let Some(mode) = cli.medulla_migrate {
+        run_medulla_migrate(config, mode);
         return;
     }
 

--- a/m1nd-mcp/src/medulla_migration.rs
+++ b/m1nd-mcp/src/medulla_migration.rs
@@ -172,6 +172,38 @@ impl MedullaMigration {
     fn classify(text: &str) -> (Destination, String) {
         let lower = text.to_ascii_lowercase();
 
+        // STRONGEST signal of all: transversal doctrine the maintainer curates for
+        // EVERY project, not one repo's fact. It stays on the medulla even when it
+        // cites evidence paths — a doctrine note routinely anchors to the docs that
+        // prove it, so the code-evidence heuristic below would otherwise misfile it
+        // into a single brain (closeout field letter, 2026-07-05). These markers are
+        // deliberately UNAMBIGUOUS about cross-project reach (and bilingual, since the
+        // maintainer writes doctrine in pt-BR too) so a plain repo fact never matches.
+        const HARD_DOCTRINE_MARKERS: &[&str] = &[
+            "doctrine",
+            "doutrina",
+            "cross-project",
+            "transversal",
+            "universal across",
+            "across any project",
+            "every m1nd caller",
+            "every agent",
+            "todo agente",
+            "founder decision",
+            "sealed by max",
+            "product vocabulary",
+            "maintainer preference",
+        ];
+        if let Some(hit) = HARD_DOCTRINE_MARKERS.iter().find(|m| lower.contains(*m)) {
+            return (
+                Destination::Medulla,
+                format!(
+                    "cross-project doctrine: mentions '{hit}' — stays on the medulla \
+                     even though it cites evidence"
+                ),
+            );
+        }
+
         // Strongest project signal: the claim anchors to code evidence.
         let has_code_evidence = text.lines().any(|l| {
             let t = l.trim();
@@ -623,6 +655,32 @@ mod tests {
 
     fn write_claim(dir: &Path, file: &str, contents: &str) {
         std::fs::write(dir.join(file), contents).expect("write claim");
+    }
+
+    /// RED (closeout field letter, 2026-07-05): a cross-project doctrine note
+    /// routinely cites the docs that prove it, so it carries a `[𝔻 evidence:]`
+    /// marker. The code-evidence heuristic must NOT pull such a claim into one
+    /// repo's brain — the transversal-doctrine signal wins over the code anchor,
+    /// and it must fire on the maintainer's bilingual wording ("Doutrina").
+    #[test]
+    fn cross_project_doctrine_with_evidence_stays_on_the_medulla() {
+        let doctrine = "# SixMoves\nDoutrina destilada: every agent applies the six \
+             analytical moves across any project.\n\n[𝔻 evidence: docs/HUMAN-LAYER-PRD.md]\n";
+        assert_eq!(
+            MedullaMigration::classify(doctrine).0,
+            Destination::Medulla,
+            "transversal doctrine that cites evidence must stay medulla"
+        );
+
+        // The guard must stay narrow: a genuine repo fact that cites code
+        // evidence still routes to the project brain.
+        let repo_fact = "# SliceShip\nThe reception slice shipped on main.\n\n\
+             [𝔻 evidence: m1nd-mcp/src/server.rs]\n";
+        assert_eq!(
+            MedullaMigration::classify(repo_fact).0,
+            Destination::Project,
+            "a repo fact with code evidence still moves to the project brain"
+        );
     }
 
     /// RED framing (M5a acceptance): a store with mixed claims, zero

--- a/m1nd-mcp/tests/medulla_migrate_cli.rs
+++ b/m1nd-mcp/tests/medulla_migrate_cli.rs
@@ -1,0 +1,151 @@
+//! MEDULLA slice M5a — the CLI wiring for the storage-split migration.
+//!
+//! `medulla_migration.rs` ships `MedullaMigration::{plan, apply, rollback}` fully
+//! built + battery-proven, but with ZERO callers outside its own tests (the
+//! CODE-LAND-ONLY posture — the module builds and proves the migration, it never
+//! ran it). This test drives the operator seam that makes it reachable:
+//!
+//!   m1nd-mcp --medulla-migrate plan --runtime-dir <runtime>
+//!
+//! `plan` is the pure dry-run (§11 M5a default): it enumerates + classifies the
+//! medulla `agent-memory/` store and prints the plan JSON, mutating NOTHING. The
+//! test spawns the REAL binary against a synthetic runtime fixture (never the
+//! developer's live `~/.m1nd`) and asserts the plan keys + the count-conservation
+//! gate — the faithful seam, because the flag lives in the process entry point
+//! (`cli.rs` + `main.rs`), which only the binary exercises.
+//!
+//! RED on `main`: the flag does not exist, so clap exits non-zero with an
+//! "unexpected argument" error and prints no plan JSON. GREEN with the wiring:
+//! stdout is the `m1nd-medulla-migrate-v0` plan payload.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Path to the compiled binary under test (Cargo sets `CARGO_BIN_EXE_<name>`).
+const BIN: &str = env!("CARGO_BIN_EXE_m1nd-mcp");
+
+/// A minimal `.light.md` with the given frontmatter + body (mirrors the module's
+/// own fixture shape).
+fn light_doc(node: &str, source_agent: &str, body: &str) -> String {
+    format!(
+        "---\nProtocol: L1GHT/1.0\nNode: {node}\nState: authored\nCreated: 1700000000000\nSource-Agent: {source_agent}\n---\n\n# {node}\n\n## {node}\n\n{body}\n"
+    )
+}
+
+/// Run the binary with the given args + a synthetic runtime dir. Returns
+/// (status_code, stdout, stderr). Isolated: a private registry dir + no GUI so it
+/// never touches the developer's real runtime.
+fn run(args: &[&str], runtime_dir: &Path) -> (i32, String, String) {
+    let out = Command::new(BIN)
+        .args(args)
+        .arg("--runtime-dir")
+        .arg(runtime_dir)
+        .arg("--no-gui")
+        .env("M1ND_REGISTRY_DIR", runtime_dir.join("registry"))
+        .env("M1ND_NO_GUI", "1")
+        .output()
+        .expect("spawn m1nd-mcp");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn medulla_migrate_plan_prints_the_dry_run_plan_and_mutates_nothing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    let medulla = runtime_dir.join("agent-memory");
+    std::fs::create_dir_all(&medulla).expect("mk medulla store");
+
+    // A code-anchored repo fact (→ Project) and a doctrine claim (→ Medulla),
+    // neither carrying an Origin-Brain line (the RED framing of M5a).
+    std::fs::write(
+        medulla.join("sliceship.light.md"),
+        light_doc(
+            "SliceShip",
+            "closer",
+            "shipped.\n\n[⍂ entity: SliceShip]\n[𝔻 evidence: m1nd-mcp/src/server.rs]\n",
+        ),
+    )
+    .expect("write repo-fact claim");
+    std::fs::write(
+        medulla.join("doctrine.light.md"),
+        light_doc(
+            "Doctrine",
+            "orchestrator",
+            "The maintainer prefers pt-BR replies always.\n\n[⍂ entity: Doctrine]\n",
+        ),
+    )
+    .expect("write doctrine claim");
+
+    // Snapshot the store bytes BEFORE the plan runs — plan must be pure-read.
+    let before = std::fs::read_to_string(medulla.join("sliceship.light.md")).unwrap();
+
+    let (code, stdout, stderr) = run(&["--medulla-migrate", "plan"], &runtime_dir);
+    assert_eq!(
+        code, 0,
+        "`--medulla-migrate plan` must exit 0; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+
+    let plan: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be the plan JSON, got parse error {e}:\n{stdout}"));
+
+    assert_eq!(
+        plan["schema"], "m1nd-medulla-migrate-v0",
+        "the migrate payload carries its schema tag"
+    );
+    assert_eq!(plan["mode"], "plan", "mode echoes the requested subcommand");
+    let p = &plan["plan"];
+    assert_eq!(p["baseline_count"], 2, "two live claims in the store");
+    assert_eq!(
+        p["project_count"], 1,
+        "the code-anchored fact routes to project"
+    );
+    assert_eq!(
+        p["medulla_count"], 1,
+        "the doctrine claim stays on the medulla"
+    );
+    assert_eq!(
+        p["count_conserved"], true,
+        "the count-conservation gate holds (baseline == project + medulla)"
+    );
+    assert!(
+        p["claims"].as_array().map(|a| a.len()) == Some(2),
+        "one row per claim, got: {}",
+        p["claims"]
+    );
+
+    // PURE-READ: the store is byte-identical after the plan.
+    let after = std::fs::read_to_string(medulla.join("sliceship.light.md")).unwrap();
+    assert_eq!(
+        before, after,
+        "plan is a dry-run — it must not mutate the store"
+    );
+    // apply's backup dirs never get created by a plan.
+    let backups: Vec<_> = std::fs::read_dir(&medulla)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".m5a-backup-"))
+        .collect();
+    assert!(backups.is_empty(), "plan writes no backup dir");
+}
+
+#[test]
+fn medulla_migrate_requires_an_explicit_subcommand() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(runtime_dir.join("agent-memory")).expect("mk store");
+
+    // No value → clap error (the flag takes a required value; no default).
+    let (code, _stdout, _stderr) = run(&["--medulla-migrate"], &runtime_dir);
+    assert_ne!(
+        code, 0,
+        "a bare --medulla-migrate with no value must be a usage error"
+    );
+
+    // An unknown value → rejected (only plan|apply|rollback are legal).
+    let (code2, _o2, _e2) = run(&["--medulla-migrate", "frobnicate"], &runtime_dir);
+    assert_ne!(code2, 0, "an unknown subcommand value must be rejected");
+}

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -2631,6 +2631,62 @@ function installRuntimeBinary(sourceBinary, targetBinary) {
   fs.renameSync(tempTarget, targetBinary);
 }
 
+// Ad-hoc codesign a freshly-installed binary on macOS. A binary written by a
+// plain file copy inherits no signature, and Gatekeeper kills the unsigned
+// replacement with OS_REASON_CODESIGNING the moment launchd re-execs it — the
+// swap "succeeds" but the daemon never comes back. `codesign --sign -` applies
+// an ad-hoc signature that satisfies the local policy. Returns a small result
+// object; a MISSING codesign tool is a warning, never fatal (Linux/Windows and
+// stripped-down macOS have no codesign — the install still stands).
+function codesignAdHoc(targetBinary) {
+  const result = runCommand("codesign", ["--force", "--sign", "-", targetBinary]);
+  if (result.error && /ENOENT/.test(result.error)) {
+    return { attempted: true, ok: false, missing: true, error: result.error };
+  }
+  return {
+    attempted: true,
+    ok: result.ok,
+    missing: false,
+    status: result.status,
+    error: result.error,
+    stderr: (result.stderr || "").trim() || undefined,
+  };
+}
+
+// The launchd service label managing a target, discovered GENERICALLY from
+// `launchctl list` — never a hardcoded personal label. `launchctl list` prints
+// `PID\tSTATUS\tLABEL` lines; we take the m1nd-owned labels (a label naming
+// m1nd), so a reload targets whatever the operator actually installed. Returns
+// the matching labels (possibly several); empty when launchctl is absent or no
+// m1nd service is loaded (then restart keeps its kill -TERM fallback).
+function managedLaunchdLabels() {
+  if (process.platform !== "darwin") return [];
+  const result = runCommand("launchctl", ["list"]);
+  if (!result.ok) return [];
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/).pop() || "")
+    .filter((label) => /m1nd/i.test(label));
+}
+
+// Reload a managed launchd service so it re-execs the just-installed binary.
+// `launchctl kickstart -k gui/<uid>/<label>` stops (SIGKILL) then restarts the
+// service under the caller's GUI domain — the reliable "reload now" the plain
+// kill -TERM could miss (KeepAlive races, the TERM never reaching the service).
+// Returns one result per label kicked; empty when no m1nd label is loaded.
+function kickstartManagedServices() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (uid === null) return [];
+  const labels = managedLaunchdLabels();
+  return labels.map((label) => {
+    const domain = `gui/${uid}/${label}`;
+    const result = runCommand("launchctl", ["kickstart", "-k", domain]);
+    return { label, domain, ok: result.ok, status: result.status, stderr: (result.stderr || "").trim() || undefined };
+  });
+}
+
 function restart(args) {
   const sourceDir = path.resolve(args.source || args["build-from"] || process.cwd());
   const targetBinary = path.resolve(args.binary || defaultRuntimePath());
@@ -2695,6 +2751,21 @@ function restart(args) {
         installRuntimeBinary(builtBinary, targetBinary);
         result.actions.install = { ok: true, source: builtBinary, target: targetBinary };
         result.actions.installed = true;
+        // macOS: an unsigned copy is killed by Gatekeeper (OS_REASON_CODESIGNING)
+        // the moment launchd re-execs it. Ad-hoc sign the installed binary so the
+        // swap actually survives. A missing codesign tool is a loud warning, not
+        // a failure — the install still stands.
+        if (process.platform === "darwin") {
+          const sign = codesignAdHoc(targetBinary);
+          result.actions.codesign = sign;
+          if (!sign.ok) {
+            result.next_actions.push(
+              sign.missing
+                ? `codesign not found — the installed binary at ${targetBinary} is UNSIGNED and macOS may kill it (OS_REASON_CODESIGNING); sign it before relying on the swap.`
+                : `codesign failed for ${targetBinary}; the binary may be unsigned and killed by macOS on launch — sign it manually before relying on the swap.`
+            );
+          }
+        }
       } catch (error) {
         result.actions.install = {
           ok: false,
@@ -2710,6 +2781,21 @@ function restart(args) {
   }
 
   if (yes && killRequested) {
+    // On macOS a m1nd daemon is a launchd-managed service: a plain kill -TERM can
+    // race KeepAlive or never reach the service, so the OLD binary keeps running
+    // after the swap. Kickstart any managed m1nd service FIRST — it stops then
+    // re-execs the just-installed binary reliably. kill -TERM stays as the
+    // fallback (and covers non-launchd processes + non-macOS hosts).
+    const kicked = kickstartManagedServices();
+    if (kicked.length > 0) {
+      result.actions.kickstarted_services = kicked;
+      const failedKicks = kicked.filter((k) => !k.ok);
+      if (failedKicks.length > 0) {
+        result.next_actions.push(
+          `Some managed m1nd launchd services did not reload (${failedKicks.map((k) => k.label).join(", ")}); check 'launchctl print ${failedKicks[0].domain}'.`
+        );
+      }
+    }
     result.actions.stopped_processes = stopRuntimeProcesses(processes);
     const failedStops = result.actions.stopped_processes.filter((processInfo) => !processInfo.ok);
     if (failedStops.length > 0) {
@@ -2720,6 +2806,13 @@ function restart(args) {
   result.after_version = runtimeVersion(targetBinary);
 
   if (!yes) {
+    // LOUD dry-run honesty (field bug): without --yes NOTHING is installed, yet
+    // the version line reads X -> X and looks like a completed swap. When a
+    // source IS installable, say so plainly and name the target, so the dry-run
+    // can never be mistaken for the real thing.
+    if (buildable && !args["no-install"]) {
+      result.next_actions.push(`DRY RUN — nothing was installed; re-run with --yes to swap ${targetBinary}.`);
+    }
     result.next_actions.push("Re-run with --yes to build/install/stop processes, or add --no-build/--no-install/--no-kill to narrow the repair.");
   }
   result.next_actions.push("Restart or rebind the MCP host/client so it launches the installed binary.");

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -1534,4 +1534,47 @@ function homeForTest() {
   return process.env.M1ND_TEST_HOME || os.homedir();
 }
 
+// === restart --binary honesty (dry-run loudness) =========================
+// Field bug: `restart --binary <target>` WITHOUT --yes is a silent dry-run —
+// the operator reads "version: X -> X", assumes the swap happened, and nothing
+// was installed. When a source IS installable, the plan must say so LOUDLY,
+// naming the exact target, so the dry-run can never be mistaken for a swap.
+{
+  const repoRoot = path.resolve(__dirname, "..", "..");
+  const target = path.join(mkTmpDir(), "m1nd-mcp");
+  const plan = restart({
+    source: repoRoot, // the m1nd checkout — sourceLooksBuildable() is true here
+    binary: target,
+    "no-kill": true, // do not touch real processes during the test
+  });
+  assert.strictEqual(plan.dry_run, true, "no --yes → dry run");
+  assert.strictEqual(plan.source_buildable, true, "the m1nd checkout is buildable");
+  assert(
+    plan.next_actions.some(
+      (action) =>
+        action.includes("DRY RUN") &&
+        action.includes("nothing was installed") &&
+        action.includes(target)
+    ),
+    `dry-run plan must loudly say nothing was installed and name the target ${target}; got:\n` +
+      plan.next_actions.map((a) => `  - ${a}`).join("\n")
+  );
+}
+
+// When there is NO installable source, the loud dry-run install line must NOT
+// appear (there was nothing to install — the honesty cuts both ways).
+{
+  const target = path.join(mkTmpDir(), "m1nd-mcp");
+  const plan = restart({
+    source: mkTmpDir(), // an empty dir — not a buildable m1nd checkout
+    binary: target,
+    "no-kill": true,
+  });
+  assert.strictEqual(plan.source_buildable, false, "an empty dir is not buildable");
+  assert(
+    !plan.next_actions.some((action) => action.includes("DRY RUN — nothing was installed")),
+    "with no installable source, the loud install-swap line must be absent"
+  );
+}
+
 console.log("npm cli tests ok");

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -45,7 +45,12 @@ this loop by default:
    `project_root=<your repo root>` creates a per-project brain inside the served
    owner, ingests your repo, binds your session, and returns its north packet —
    thereafter every call from your root routes to YOUR brain automatically.
-   Absent/null `reception` = your root matches the brain serving you.
+   Absent/null `reception` = your root matches the brain serving you. An empty
+   memory beat is NOT proof of an empty store: the packet carries
+   `memory_exists: N` (the on-disk claim count) plus an honest note when recall
+   found no task-relevant match over a non-empty store — never conclude "no
+   memory" without checking the stamp; widen the task text or `seek` the store
+   directly instead.
 2. If trust is degraded or retrieval comes back `blocked`/empty unexpectedly,
    drop to the recovery path: follow `recovery_playbook` before interpreting
    absence. `wrong_workspace_binding` means rebind, intentional ingest, or real
@@ -78,6 +83,11 @@ this loop by default:
    memory-delivery fault is `class:"memory_misdelivery"`. Letters distribute
    LOCALLY into per-project boxes (`<repo>/.m1nd/inbox.jsonl`) + a medulla box;
    triage is `m1nd-mcp --inbox-sweep` / `GET /api/inbox_sweep` (CLI/REST, not MCP).
+8. Near a PR or merge, price the handoff: `soul_check` verifies a repo's soul
+   (`docs/PATHOS.md`) claim-by-claim and returns a one-line freshness receipt
+   ("N fresh · M stale · declared intact, checked <date> @<sha>") — the line a
+   cold context reads to know how much to trust the handoff; `soul_read` pulls
+   the verified body. Details under Compounding Memory below.
 
 This is the `m1nd-trained` behavior measured in internal bug-hunt rounds: graph
 plus operating doctrine, not graph alone.
@@ -104,38 +114,26 @@ Do not loop on `seek`/`activate` when the binding is nested or file-level. Eithe
 upgrade the binding to the intended repo root, or explicitly switch to direct
 files/tests and record `m1nd_usage_mode=partial_scope_orientation`.
 
-## Mission Control v0
+## Mission Control (not the default loop)
 
-When the live runtime exposes `mission_start`, use Mission Control for broad
-reviews, bug hunts, risky refactors, or any task where agents tend to loop,
-over-trust graph evidence, or lose phase discipline.
+The default loop is `north` → verbs → `memorize`, NOT a mission. Reserve
+`mission_*` for `SubagentStop` and for the rare turn where a mission is
+genuinely open (a subagent whose whole job was one scoped mission). It is NOT
+the default `Stop` path, and NOT how ordinary reviews or bug hunts run — for
+those, orient with `north`, prove directly, and close with `memorize`
+(`Stop → cross_verify(evidence_freshness) → memorize(claims, evidence)`
+directly; `memorize` needs no `mission_id`).
 
-Minimal mission loop:
-
-1. `mission_start` with the intended repo, task, mode, budget, and risk.
-2. Record meaningful actions with `mission_event` when the tool exists, or feed
-   the latest action back as `last_event` to `mission_next`.
-3. Take the starter move or ask `mission_next` for exactly one next move.
-4. Obey `do_not` unless you record a dissent event with a concrete reason.
-5. Use `mission_verify` before turning a conclusion into final output.
-6. Use `mission_handoff` when another agent or future session may resume.
-7. Use `mission_close` to produce a proof packet with verified claims, rejected
-   claims, gaps, event digest, budget use, and non-claims.
-
-Important evidence rule: a direct event does not prove every later claim. A
-claim should reference the direct proof explicitly, for example
-`event:evt_1`, `file_read:path:line`, `test_run:name`, or `runtime_probe:id`.
-
-Mission Control does not replace source reads, tests, compiler/runtime output,
-or host recovery. Its most important behavior is
-`switch_to_direct_proof`: after graph orientation, it can tell you to stop
-calling `seek`/`activate` and prove the claim directly.
-
-Bug-hunt calibration: a verified finding does not mean the hunt is done. If
-`mission_next` asks for a `direct_sweep`, do one negative-space sweep over
-public contracts/docs, boundary values, error paths, async/concurrency behavior,
-and helper/exported APIs, then record the event as `coverage_sweep`,
-`boundary_sweep`, or `edge_case_sweep` before closing.
+When a mission IS open: `mission_start` (repo, task, mode, budget, risk) →
+record actions with `mission_event` (or feed `last_event` to `mission_next` for
+exactly one next move) → obey `do_not` unless you log a dissent event →
+`mission_verify` before final output → `mission_handoff` for a resumable
+session → `mission_close` for the proof packet. A direct event does not prove
+every later claim: a claim references its direct proof explicitly
+(`event:evt_1`, `file_read:path:line`, `test_run:name`, `runtime_probe:id`).
+Its most important behavior is `switch_to_direct_proof` — after graph
+orientation it can tell you to stop calling `seek`/`activate` and prove the
+claim directly.
 
 ## Short-Audit Route
 

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: m1nd-operator
-description: Use when the user mentions m1nd or when repo investigation, search, review, docs/spec work, or risky change prep should go through m1nd first before grep, glob, or manual file reads. Covers m1nd-first routing, L1GHT and universal document ingestion, risky edit preparation, document-to-code binding, multi-agent coordination, trails/continuity, daemon alerts, and refreshing the live m1nd tool surface from the local m1nd-mcp binary.
+description: Use when the user mentions m1nd or when repo investigation, search, review, docs/spec work, or risky change prep should go through m1nd first before grep, glob, or manual file reads. Covers m1nd-first routing, L1GHT and universal document ingestion, risky edit preparation, document-to-code binding, the served owner + --attach bridge transport, the delegation layer (delegate/debrief packets), medulla tiers and audited promotion, soul freshness receipts, trails/continuity, and daemon alerts.
 ---
 
 # m1nd Operator
@@ -99,14 +99,17 @@ nested/file-level binding when the task is repo-wide. Upgrade the binding once,
 run an isolated `--workspace-root /target/repo` probe, or switch to direct
 source/test proof and record `m1nd_usage_mode=partial_scope_orientation`.
 
-## Mission Control v0
+## Mission Control (not the default loop)
 
-Use Mission Control when the task needs an agent operating loop rather than
-another retrieval call: broad reviews, bug hunts, refactors, release checks, or
-long investigations where agents may repeat searches, drift phases, or turn
-graph hints into premature conclusions.
+Mission Control is NOT the default operating loop and NOT how ordinary reviews,
+bug hunts, or refactors run. The default is `north` → verbs → `memorize`; the
+composable close is `Stop → cross_verify(evidence_freshness) → memorize(claims,
+evidence)` DIRECTLY — `memorize` takes free-form structured claims with evidence
+paths and needs NO `mission_id`. Reserve `mission_*` for `SubagentStop` and for
+the rare turn where a mission is genuinely open (a subagent whose entire job was
+one scoped mission); it is never the default `Stop` path.
 
-The mission loop is deliberately small:
+When a mission IS open, the loop is deliberately small:
 
 1. `mission_start` creates the repo-scoped mission, route, budget envelope,
    starter moves, and non-claims.
@@ -125,18 +128,10 @@ The mission loop is deliberately small:
 
 Evidence rule: a direct mission event only proves a claim when the claim's
 `evidence_refs` names the event id or direct source/test/runtime proof. Do not
-let one direct read bless unrelated graph-only claims.
-
-Operational rule: when `mission_next` says to switch to direct proof, stop
-spending graph budget unless you record a dissent event. Mission Control is not
-a host repair tool, graph correctness proof, or autonomous multi-agent
-orchestrator.
-
-Bug-hunt rule: do not close only because one finding is verified. When
-`mission_next` returns `direct_sweep`, perform one negative-space sweep over
-public contracts/docs, boundary values, error paths, async/concurrency behavior,
-and helper/exported APIs. Feed it back as `coverage_sweep`, `boundary_sweep`, or
-`edge_case_sweep` before closing.
+let one direct read bless unrelated graph-only claims. When `mission_next` says
+to switch to direct proof, stop spending graph budget unless you record a
+dissent event. Mission Control is not a host repair tool, graph correctness
+proof, or autonomous multi-agent orchestrator.
 
 ## Short-Audit Route
 
@@ -430,6 +425,134 @@ The mailbox (MEDULLA §9.2, slice M7b): the spool is the ONE write slot; letters
 
 Caveat: `ingest mode:replace` wipes light memory nodes. Prefer `mode:merge` when re-ingesting code to preserve agent memory.
 
+## Serve/attach era — transport truth
+
+The runtime is a served OWNER plus thin bridges, not one process per host. A
+single served owner (default port `1338`) holds the live graph; hosts and probes
+ATTACH to it — there is no exclusive lease in attach mode, so many bridges share
+one graph:
+
+- Host bridge: `m1nd-mcp --attach http://127.0.0.1:1338` speaks stdio MCP to the
+  host and forwards every frame to the owner's `POST /mcp`, relaying the owner's
+  server→client push notifications back. It loads NO graph and takes NO lease.
+- Direct probe: `POST /mcp` with header `M1nd-Caller-Root: /abs/repo/root` — the
+  header is the caller identity reception verifies (`M1nd-Caller-Root` ↔
+  `covers_root`); a mismatch returns the degraded reception, not a fabricated
+  orientation.
+
+A freshly-landed verb appears ONLY after the owner is rebuilt and kickstarted —
+a live verb needs the served owner restarted (`m1nd restart --source
+/path/to/m1nd --yes` for a dev checkout, then reload the managed service). Bridges
+opened AFTER an owner restart re-recover on their own; a long-lived bridge from
+BEFORE the restart must reconnect (restart the host session). A persistent
+"failed to connect" means the owner is down — bring it back, do not thrash. If
+the tools drop mid-session, the owner was restarted underneath you: reconnect,
+do not conclude m1nd is broken.
+
+## Delegation Layer
+
+Spawning a subagent? Compose the RETRIEVAL half of its spec in ONE read-only
+call instead of hand-writing context.
+
+`delegate {agent_id, task}` returns a packet whose core is `prompt_markdown` you
+APPEND verbatim to your brief. It carries:
+
+- `mission.binding` — the NAMED brain the child must land on. This is the SAME
+  datum reception verifies (`M1nd-Caller-Root` ↔ `covers_root`), so the child
+  VERIFIES it landed (silent on a match) rather than choosing — the child law.
+- a LABELED memory slice — each row is `- [tier] claim — origin · author, age`,
+  `tier` ∈ `project | medulla`, so the child inherits doctrine-vs-project-fact,
+  not a flat blob. The slice is your DEFAULT beat (project task-relevant claims +
+  the medulla doctrine the domain touches) — never `all-brains`, never another
+  project's private claim.
+- ranked anchors, a staleness header, known static dependents, and an explicit
+  "what m1nd could NOT determine → your duties" section. Read the appendix law:
+  your text wins on WHAT-TO-DO, the packet wins on WHAT-IS, the packet outranks
+  assumption only.
+
+`delegate` abstains HONESTLY — `needs_ingest` (empty graph), `unscopable` (the
+task activates no coherent subgraph), `seeds_unresolvable` (every seed fails) —
+always with evidence + a `next_move`, never a bare no. It is PROJECT-TIER: no
+`all-brains` fan-out, and no predict/trust/tremor/xray enrichment yet; each
+omission is stated in `non_claims`, never hidden.
+
+When the subagent returns, `debrief {agent_id, delegation_id, outcome,
+diff|touched_paths, findings}` grades its real diff against the packet and TEACHES
+the graph — the ONLY mutation, through `memorize`/`learn`. It classifies each
+touched path (`in_scope | expected_change | dependent_contact | unpredicted`)
+with a worst-of verdict that carries fence existence ("stayed — no ratified
+boundaries existed"), memorizes the subagent's findings under the SUBAGENT's id
+and any map-miss lessons under YOURS (a clean run memorizes nothing), and appends
+one `outcomes.jsonl` row stamped `outcome_unverified` unless you attach
+`evidence`. Conformance grades PATHS, never code quality — it never says
+merge-safe. Every debrief deposits memory the next `delegate` surfaces, so
+skipping it wastes knowledge.
+
+Subagent report protocol (what the child returns to you): a one-line header
+`[m1nd dlg_<id>] landed <brain> · <N> anchors · <M> memory` (or the abstain +
+its `next_move`), a `DEVIATIONS:` block naming every touched path outside the
+packet's predicted set with a one-line why, and a `FINDINGS:` block of durable
+claims (each with an `evidence` path) — the exact input your `debrief` grades.
+
+## Promotion — the audited crossing
+
+`memorize` is ALWAYS project-private; a finding does NOT become shared doctrine
+by being written. The manual crossing, deliberately and rarely:
+
+```json
+promote {"brain": "<project_root>", "claim": "<slug>", "reason": "<one line>"}
+```
+
+It COPIES a verified claim UP into the medulla with the full readable chain
+(`Origin-Brain`, `Origin-Claim`, `Promoted-By`, `Promotion-Reason`); the project
+original stays in place stamped `Promoted-To` — promotion ELEVATES, never moves.
+Gates it enforces for you: only `State: verified` (or a founder claim) may
+promote (C8.3); a secret or a conflict-marker is refused at the hygiene floor
+(the medulla is the most-read store); a promoted claim's code evidence is
+origin-qualified so freshness delegates back to its home brain, or the claim is
+marked `evidence_unverifiable` (C8.2 — a medulla claim never reads fresher than
+it can prove). Etiquette: promotion is an ORCHESTRATOR act — a maker PROPOSES
+("candidate for promotion" is just a claim it memorizes), the orchestrator
+executes. Any id CAN call it (not a security boundary), but every promotion is
+auditably attributed by `Promoted-By`, so do not promote an unverified hunch.
+DEMOTE by `learn wrong` on the MEDULLA copy (or supersede it with a `moved_to:`
+medulla `memorize`) — this never touches the project witness (un-share, never
+destroy). The verb is served at the routed HTTP door; a fresh live verb needs
+the served owner rebuilt/kickstarted.
+
+## Memory Honesty and the Soul Receipt
+
+An empty memory beat is NOT proof of an empty store. `north` (and the recall
+surfaces) stamp `memory_exists: N` — the on-disk L1GHT claim count — plus an
+honest note when recall found no task-relevant match over a non-empty store.
+Never conclude "no memory": if `memory_exists > 0` while the beat is empty, the
+store simply held no task-relevant match — widen the task text, raise
+`top_k`/`token_budget`, or `seek` the store directly.
+
+Near a PR or doc-gate, price the handoff before trusting it. `soul_check` parses
+a repo's soul (`docs/PATHOS.md`) into anchored CLAIMS, classifies each
+(`path | line-hint | symbol | git | consistency | receipt | runtime | declared`),
+verifies per class, and returns the honesty report plus a one-line FRESHNESS
+RECEIPT:
+
+```text
+N fresh · M stale · K receipt-priced, checked <date> @<sha>
+```
+
+That line is what a cold context reads to know how much to trust the handoff.
+THE TWO TISSUES hold: verifiable tissue (Current State / Access Map / Known
+Problems) is machine-checkable; DECLARED tissue (North Star / Doctrine / taste /
+why-we-work-this-way) is UNPROVABLE-but-curated and NEVER fake-verified — the
+system knowing what it cannot verify IS the honesty. `soul_read` pulls the body
+(whole or one section) — the explicit pull, never ambient. THE CURATOR is a
+near-PR WORKFLOW (agent judgment on a deterministic substrate): sweep with
+`soul_check` → verify against code/git/runtime → update durable claims via
+`memorize {soul_source: "<path>#<section>"}` (the ONE write door) → prune stale
+NEVER silently (every removal named + where it went; git keeps the text) →
+re-check → carry the receipt in the PR body. Who verifies the curator (§C8.4):
+its report must pass `soul_check {verify_curator_report: <report>}` run by a
+DIFFERENT agent — grader ≠ author.
+
 ## Read These References
 
 - `references/routing-playbooks.md`
@@ -454,8 +577,22 @@ m1nd agent recover --repo /path/to/repo --from wrong_workspace_binding --json
 m1nd agent doctor --repo /path/to/repo --json
 ```
 
-The bundled probe script remains available from this skill directory for
-low-level MCP calls and compatibility:
+In the serve/attach era, the cheapest live probe is a direct HTTP call to the
+served owner — no isolated runtime, no lease, and it exercises the SAME graph the
+hosts see:
+
+```bash
+# Probe the served owner directly (identity via the caller-root header).
+curl -s http://127.0.0.1:1338/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'M1nd-Caller-Root: /path/to/repo' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"north","arguments":{"agent_id":"probe","task":"orient"}}}'
+```
+
+The bundled probe script remains a valid FALLBACK from this skill directory for
+low-level MCP calls, older binaries, and no-owner situations (it launches its own
+isolated runtime):
 
 ```bash
 python3 scripts/probe_m1nd.py tools

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -167,13 +167,16 @@ this loop by default:
 This is the trained-agent behavior to preserve across hosts: m1nd is graph plus
 operating doctrine, not graph alone.
 
-## Mission Control v0
+## Mission Control (not the default loop)
 
-If the live runtime exposes `mission_start`, use Mission Control for broad
-reviews, bug hunts, risky refactors, releases, or any task where the agent may
-loop, drift phases, or over-trust graph evidence.
+Mission Control is NOT the default loop. The default is `north` → verbs →
+`memorize` (the composable close is `Stop → cross_verify(evidence_freshness) →
+memorize(claims, evidence)` directly; `memorize` needs no `mission_id`). Reserve
+`mission_*` for `SubagentStop` and the rare turn where a mission is genuinely
+open — it is never the default `Stop` path, and not how ordinary reviews or bug
+hunts run.
 
-Minimal loop:
+When a mission IS open, the loop is small:
 
 1. Call `mission_start` with `agent_id`, `repo`, `task`, `mode`, `budget`, and
    `risk`.


### PR DESCRIPTION
## Close-out burst — the medulla migration path, an honest restart, a mailbox abstain, and the Case-Intelligence PRD

Wraps the construction era's remaining loose ends into one reviewed set. Every change is RED-first (a failing test before the fix) and no runtime memory was mutated — the live migration is a separate, operator-witnessed step.

### Features & fixes
- **`--medulla-migrate plan|apply|rollback`** — wires the M5a storage-split migration that existed only as a library module (no caller). `plan` is a pure dry-run; `apply` is backup-first with a count-conserving gate; `rollback` restores byte-for-byte from the newest backup. Mirrors the `--inbox-sweep` offline-CLI shape.
- **`--medulla-migrate` classifier keeps cross-project doctrine on the medulla** — the code-evidence heuristic used to win before any doctrine check, so a transversal doctrine note that anchors to the docs proving it was misfiled into a single project's brain. A narrow, bilingual hard-doctrine guard now runs first; a plain repo fact with code evidence still routes to the project brain.
- **`restart --binary` is honest and actually reloads** — without `--yes` it now prints a loud dry-run line instead of silently installing nothing; with `--yes` on macOS it ad-hoc-codesigns the freshly built binary and `launchctl kickstart`s the managed service (label discovered generically, never hardcoded), with `kill -TERM` kept as fallback.
- **Mailbox resolves bare names against the roster with an honest abstain** — a duplicate basename across two roster brains used to silently first-win-misroute every bare-named letter into one of them; it now resolves only on a unique basename and abstains (stays pending) on ambiguity. Bare names and worktree variants that map to a single brain still resolve.

### Docs
- **`docs/CASE-INTELLIGENCE-PRD.md`** — the last ladder rung (R11) as a PRD-first deliverable: five organs (fingerprint, cases, absence sentinels, claim-vs-measure, the abandonment signal) under one overlay law — a case never becomes a stored axis — with seven invariants and slices S0–S4 (S4 honestly gated on the ambient wave). Stamped closed in the constitution; PATHOS to checkpoint 11.
- **`skills/`** — the m1nd-first and m1nd-operator docs brought to the served-owner/attach transport, per-project brains, the medulla tiers and audited promotion, the delegation layer, and the soul freshness receipt; Mission Control demoted from the default loop to its real home.

### Proof
- `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; npm `node --test` green.
- The migration CLI's `plan` was run read-only against the live store: it triages every claim one row apiece, count-conserving, mutating nothing. No `apply` was run here.
