### PR TITLE
fix(medulla-migrate): require an explicit destination brain, never the ambient binding

### DIFF
--- a/docs/MEDULLA-PRD.md
+++ b/docs/MEDULLA-PRD.md
@@ -180,6 +180,8 @@ Today's shared `agent-memory/` (25 claims, live-enumerated at migration time —
 
 **Gates (mechanized, inherited from M4 + tightened):** `count(baseline) == count(project-active) + count(medulla-active)`; every claim `seek`-able at exactly one live tier; `.history/` holds every superseded original; **the ghost-pointer sweep** — `ingest_roots.json` entries pointing at deleted `.light.md` files (live example: `tokenvalidator.light.md`, §2.2c) are pruned, and per-file memorize entries collapse into the one dir root. Rollback: supersession is non-destructive; reactivate from `.history/`.
 
+**Destination is explicit, never ambient (`apply`/`rollback`):** the runner (`--medulla-migrate`) takes the destination project brain as an explicit `--migrate-project-root <repo>` argument — the brain repo-facts move into and whose root is stamped as `Origin-Brain`. It is **never derived from the ambient session binding**: a second agent that had bound the owner to an unrelated repo once caused `apply` to move legacy memories into the wrong brain's store — a silent cross-brain contamination (MED-INV-1) — so `apply`/`rollback` now refuse without the flag, and `plan` flags an ambient fallback as unsafe in its JSON (`destination_source`). `apply` is also idempotent: a re-run over an already-migrated store (nothing to move or stamp) returns `already_migrated` and writes no fresh backup, never reporting a phantom count-conservation failure. (Field bug 2026-07-05.)
+
 ---
 
 ## 5. Pull-not-push recall — the tier argument

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -127,6 +127,18 @@ pub struct Cli {
     /// intended for the maintainer, never an agent (the CODE-LAND-ONLY posture).
     #[arg(long, value_name = "plan|apply|rollback")]
     pub medulla_migrate: Option<MedullaMigrateMode>,
+
+    /// The destination project brain for `--medulla-migrate`, named EXPLICITLY
+    /// as a repo root path — the brain that repo-fact claims move into and whose
+    /// root is stamped as their `Origin-Brain`. It is NEVER derived from the
+    /// ambient session binding: a second agent that bound the owner to an
+    /// unrelated repo once caused the migration to move legacy memories into the
+    /// wrong brain's store (field bug 2026-07-05). REQUIRED for `apply` (and for
+    /// `rollback`, which must locate the same store); recommended for `plan`,
+    /// which otherwise falls back to the ambient binding and loudly flags that
+    /// destination as unsafe in its JSON.
+    #[arg(long, value_name = "PATH")]
+    pub migrate_project_root: Option<String>,
 }
 
 /// The verb for `--medulla-migrate` (MEDULLA-PRD §4.2). No default: the flag

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -327,7 +327,11 @@ fn run_inbox_sweep(config: McpConfig, no_distribute: bool) {
 /// (mutates the store); `rollback` restores the medulla store from its most recent
 /// `apply` backup. Operator convenience — OFF the MCP surface, offline, no server
 /// transport.
-fn run_medulla_migrate(config: McpConfig, mode: m1nd_mcp::cli::MedullaMigrateMode) {
+fn run_medulla_migrate(
+    config: McpConfig,
+    mode: m1nd_mcp::cli::MedullaMigrateMode,
+    migrate_project_root: Option<String>,
+) {
     use m1nd_mcp::cli::MedullaMigrateMode;
     use m1nd_mcp::medulla_migration::MedullaMigration;
     use m1nd_mcp::project_brains::{ProjectBrainRegistry, PROJECT_BRAINS_DIR};
@@ -343,12 +347,50 @@ fn run_medulla_migrate(config: McpConfig, mode: m1nd_mcp::cli::MedullaMigrateMod
     let runtime_root = state.runtime_root.clone();
 
     // The medulla store IS the owner runtime root's `agent-memory/` (the tier is
-    // the directory, §4.1 — no move). The project brain's store is the m1nd repo's
-    // per-project `agent-memory/` under `project-brains/<fingerprint>/`. The origin
-    // stamped on moved claims is the m1nd repo root itself.
+    // the directory, §4.1 — no move). The project brain's store is the destination
+    // repo's per-project `agent-memory/` under `project-brains/<fingerprint>/`.
+    //
+    // The destination repo MUST be named explicitly (`--migrate-project-root`), and
+    // is NEVER derived from the ambient session binding: a second agent that bound
+    // the owner to an unrelated repo once caused the migration to move legacy
+    // memories into the wrong brain's store, a silent cross-brain contamination
+    // (field bug 2026-07-05, MED-INV-1). `apply`/`rollback` therefore REQUIRE the
+    // flag; `plan` may fall back to the ambient binding but flags it as unsafe.
     let medulla_dir = runtime_root.join("agent-memory");
     let ingest_roots_path = runtime_root.join("ingest_roots.json");
-    let project_origin = state.project_root_display().unwrap_or_default();
+
+    // Resolve the destination origin + whether it was explicit. For `apply` and
+    // `rollback` an absent flag is a hard refusal (exit != 0) — the store must
+    // never be mutated against a destination guessed from the environment.
+    let (project_origin, destination_source) = match (&migrate_project_root, mode) {
+        (Some(root), _) => (root.clone(), "explicit"),
+        (None, MedullaMigrateMode::Apply | MedullaMigrateMode::Rollback) => {
+            eprintln!(
+                "[m1nd-mcp][medulla_migrate] {} requires --migrate-project-root <repo>: the \
+                 destination brain must be named explicitly, never derived from the ambient \
+                 session binding (field bug 2026-07-05)",
+                match mode {
+                    MedullaMigrateMode::Apply => "apply",
+                    MedullaMigrateMode::Rollback => "rollback",
+                    MedullaMigrateMode::Plan => unreachable!(),
+                }
+            );
+            std::process::exit(2);
+        }
+        (None, MedullaMigrateMode::Plan) => {
+            eprintln!(
+                "[m1nd-mcp][medulla_migrate] WARNING: no --migrate-project-root given; plan \
+                 falls back to the ambient session binding, which is UNSAFE as a destination \
+                 (field bug 2026-07-05). Pass --migrate-project-root <repo> to target a brain \
+                 explicitly."
+            );
+            (
+                state.project_root_display().unwrap_or_default(),
+                "ambient-binding (unsafe — pass --migrate-project-root)",
+            )
+        }
+    };
+
     let registry = ProjectBrainRegistry::new(runtime_root.join(PROJECT_BRAINS_DIR), None);
     let project_dir = registry
         .store_dir_for(&ProjectBrainRegistry::canonical_key(&project_origin))
@@ -423,6 +465,7 @@ fn run_medulla_migrate(config: McpConfig, mode: m1nd_mcp::cli::MedullaMigrateMod
         "medulla_dir": medulla_dir.to_string_lossy(),
         "project_dir": project_dir.to_string_lossy(),
         "project_origin": project_origin,
+        "destination_source": destination_source,
         "plan": payload,
     });
     println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
@@ -652,7 +695,7 @@ async fn main() {
     // pure dry-run; `apply`/`rollback` mutate the store (CODE-LAND-ONLY posture —
     // for the maintainer, never an agent). Runs BEFORE --serve/stdio.
     if let Some(mode) = cli.medulla_migrate {
-        run_medulla_migrate(config, mode);
+        run_medulla_migrate(config, mode, cli.migrate_project_root);
         return;
     }
 

--- a/m1nd-mcp/src/medulla_migration.rs
+++ b/m1nd-mcp/src/medulla_migration.rs
@@ -401,6 +401,31 @@ impl MedullaMigration {
     /// AFTER the moves, the caller should `rollback` immediately.
     pub fn apply(&self) -> M1ndResult<MigrationReceipt> {
         let plan = self.plan()?;
+
+        // Idempotency guard (field bug 2026-07-05): a store with no repo fact to
+        // move AND nothing left to stamp is already migrated. Re-running `apply`
+        // must NOT write a fresh (empty) backup nor re-report a phantom
+        // count-conservation failure — never degrade an already-migrated store.
+        // "Nothing to do" = no Project-bound claim and every staying claim already
+        // carries its `Origin-Brain`.
+        let nothing_to_move = plan.project_count == 0;
+        let nothing_to_stamp = plan.claims.iter().all(|c| c.has_origin_brain);
+        if nothing_to_move && nothing_to_stamp {
+            let medulla_after = self.live_claims()?.len();
+            let project_after = count_project_claims(&self.project_dir);
+            return Ok(MigrationReceipt {
+                backup_dir: String::new(),
+                moved_to_project: 0,
+                stamped_medulla: 0,
+                ghosts_pruned: 0,
+                baseline_count: plan.baseline_count,
+                medulla_after,
+                project_after,
+                count_conserved: true,
+                already_migrated: true,
+            });
+        }
+
         let backup_dir = self.backup()?;
 
         std::fs::create_dir_all(&self.project_dir).map_err(M1ndError::Io)?;
@@ -442,18 +467,7 @@ impl MedullaMigration {
         // Count-conservation gate: the live medulla + project stores together must
         // hold exactly the baseline count.
         let medulla_after = self.live_claims()?.len();
-        let project_after = std::fs::read_dir(&self.project_dir)
-            .map(|e| {
-                e.flatten()
-                    .filter(|d| {
-                        d.path()
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .is_some_and(|n| !n.starts_with('.') && n.ends_with(".light.md"))
-                    })
-                    .count()
-            })
-            .unwrap_or(0);
+        let project_after = count_project_claims(&self.project_dir);
         let count_conserved = plan.baseline_count == medulla_after + project_after;
 
         Ok(MigrationReceipt {
@@ -465,6 +479,7 @@ impl MedullaMigration {
             medulla_after,
             project_after,
             count_conserved,
+            already_migrated: false,
         })
     }
 
@@ -521,6 +536,29 @@ pub struct MigrationReceipt {
     pub project_after: usize,
     /// The count-conservation gate: `baseline == medulla_after + project_after`.
     pub count_conserved: bool,
+    /// True when the store was already migrated (nothing to move, nothing to
+    /// stamp): `apply` short-circuited BEFORE any backup or mutation. A
+    /// re-invocation of a done migration never degrades the store (field bug
+    /// 2026-07-05). On the normal executing path this is `false`.
+    #[serde(default)]
+    pub already_migrated: bool,
+}
+
+/// Count the LIVE `.light.md` claims in a project store (skip dot-dirs/backups),
+/// shared by `apply`'s count-conservation gate and its already-migrated guard.
+fn count_project_claims(project_dir: &Path) -> usize {
+    std::fs::read_dir(project_dir)
+        .map(|e| {
+            e.flatten()
+                .filter(|d| {
+                    d.path()
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| !n.starts_with('.') && n.ends_with(".light.md"))
+                })
+                .count()
+        })
+        .unwrap_or(0)
 }
 
 /// Insert an `Origin-Brain: <value>` frontmatter line into a `.light.md` if it
@@ -933,6 +971,75 @@ mod tests {
         assert!(
             roots.contains(&s.medulla.to_string_lossy().to_string()),
             "the dir root survives"
+        );
+    }
+
+    /// Idempotency guard (field bug 2026-07-05): a SECOND `apply` over a store
+    /// with nothing left to move or stamp reports `already_migrated` with zero
+    /// moves and an empty backup path — it never writes a fresh (empty) backup nor
+    /// reports a phantom count-conservation failure.
+    #[test]
+    fn apply_is_idempotent_on_already_migrated_store() {
+        let s = scratch();
+        write_claim(
+            &s.medulla,
+            "sliceship.light.md",
+            &light_doc(
+                "SliceShip",
+                "closer",
+                "shipped.\n\n[⍂ entity: SliceShip]\n[𝔻 evidence: m1nd-mcp/src/x.rs]\n",
+            ),
+        );
+        write_claim(
+            &s.medulla,
+            "maxpref.light.md",
+            &light_doc(
+                "MaxPref",
+                "orch",
+                "maintainer doctrine.\n\n[⍂ entity: MaxPref]\n",
+            ),
+        );
+        std::fs::write(
+            &s.roots,
+            serde_json::to_string_pretty(&vec![s.medulla.to_string_lossy().to_string()]).unwrap(),
+        )
+        .unwrap();
+
+        let mig = MedullaMigration::new(&s.medulla, &s.project, &s.roots, "/path/to/repo");
+        let first = mig.apply().expect("first apply");
+        assert!(!first.already_migrated, "first apply actually migrates");
+        assert_eq!(first.moved_to_project, 1);
+
+        // Drop the first (legitimate) backup so the assertion isolates run 2.
+        for e in std::fs::read_dir(&s.medulla).unwrap().flatten() {
+            if e.file_name().to_string_lossy().starts_with(BACKUP_PREFIX) {
+                std::fs::remove_dir_all(e.path()).unwrap();
+            }
+        }
+
+        let second = mig.apply().expect("second apply");
+        assert!(
+            second.already_migrated,
+            "a re-applied migration reports already_migrated"
+        );
+        assert_eq!(second.moved_to_project, 0, "nothing moved the second time");
+        assert!(
+            second.count_conserved,
+            "already-migrated must not report a count-conservation failure"
+        );
+        assert!(
+            second.backup_dir.is_empty(),
+            "already-migrated writes no backup, got: {}",
+            second.backup_dir
+        );
+        let backups: Vec<_> = std::fs::read_dir(&s.medulla)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with(BACKUP_PREFIX))
+            .collect();
+        assert!(
+            backups.is_empty(),
+            "no fresh backup dir on the second apply"
         );
     }
 

--- a/m1nd-mcp/tests/medulla_migrate_cli.rs
+++ b/m1nd-mcp/tests/medulla_migrate_cli.rs
@@ -149,3 +149,237 @@ fn medulla_migrate_requires_an_explicit_subcommand() {
     let (code2, _o2, _e2) = run(&["--medulla-migrate", "frobnicate"], &runtime_dir);
     assert_ne!(code2, 0, "an unknown subcommand value must be rejected");
 }
+
+/// Seed a runtime whose AMBIENT session binding resolves to `ambient_repo`: the
+/// owner's `ingest_roots.json` points at that repo, so a boot picks it up as the
+/// bound project. This reproduces the field condition (2026-07-05) where a second
+/// agent on another host had bound the owner to an unrelated repo, and the migrate
+/// derived its destination brain from that ambient binding — moving m1nd's legacy
+/// memories into the wrong brain's store (a MED-INV-1 cross-brain contamination).
+fn seed_runtime_bound_to(runtime_dir: &Path, ambient_repo: &Path) {
+    let medulla = runtime_dir.join("agent-memory");
+    std::fs::create_dir_all(&medulla).expect("mk medulla store");
+    std::fs::create_dir_all(ambient_repo).expect("mk ambient repo dir");
+    // The owner boots its bound project root from ingest_roots.json next to the
+    // graph (session::load_ingest_roots). Point it at the ambient repo.
+    std::fs::write(
+        runtime_dir.join("ingest_roots.json"),
+        serde_json::to_string_pretty(&vec![ambient_repo.to_string_lossy().to_string()]).unwrap(),
+    )
+    .expect("write ingest_roots.json");
+    // One code-anchored repo fact to move + one doctrine claim that stays.
+    std::fs::write(
+        medulla.join("sliceship.light.md"),
+        light_doc(
+            "SliceShip",
+            "closer",
+            "shipped.\n\n[⍂ entity: SliceShip]\n[𝔻 evidence: m1nd-mcp/src/server.rs]\n",
+        ),
+    )
+    .expect("write repo-fact claim");
+    std::fs::write(
+        medulla.join("doctrine.light.md"),
+        light_doc(
+            "Doctrine",
+            "orchestrator",
+            "The maintainer prefers pt-BR replies always.\n\n[⍂ entity: Doctrine]\n",
+        ),
+    )
+    .expect("write doctrine claim");
+}
+
+/// Recursively collect the `.light.md` file names living under a `project-brains/`
+/// tree, so the test can prove WHERE the moved claim landed without recomputing
+/// the private fingerprint-hashing scheme.
+fn light_files_under(dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                out.extend(light_files_under(&p));
+            } else if p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".light.md"))
+            {
+                out.push(p.to_string_lossy().to_string());
+            }
+        }
+    }
+    out
+}
+
+/// RED (field bug 2026-07-05): `--medulla-migrate apply` WITHOUT an explicit
+/// destination must refuse and exit non-zero. Deriving the destination brain from
+/// the ambient session binding silently moved m1nd's legacy memories into another
+/// repo's brain. `apply` must never touch the store without an explicit target.
+#[test]
+fn apply_without_explicit_project_root_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    let ambient_repo = tmp.path().join("repo-alpha");
+    seed_runtime_bound_to(&runtime_dir, &ambient_repo);
+
+    let (code, stdout, stderr) = run(&["--medulla-migrate", "apply"], &runtime_dir);
+    assert_ne!(
+        code, 0,
+        "apply with no --migrate-project-root must exit non-zero; stdout:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("--migrate-project-root"),
+        "the refusal must name the required flag; stderr:\n{stderr}"
+    );
+
+    // It refused BEFORE mutating: no backup dir, no claim moved anywhere.
+    let medulla = runtime_dir.join("agent-memory");
+    let backups: Vec<_> = std::fs::read_dir(&medulla)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".m5a-backup-"))
+        .collect();
+    assert!(backups.is_empty(), "a refused apply writes no backup dir");
+    assert!(
+        medulla.join("sliceship.light.md").exists(),
+        "a refused apply leaves the medulla store untouched"
+    );
+    let moved = light_files_under(&runtime_dir.join("project-brains"));
+    assert!(
+        moved.is_empty(),
+        "a refused apply moves nothing into any project brain, found: {moved:?}"
+    );
+}
+
+/// RED (the heart of the bug): `apply` must derive its destination brain from the
+/// EXPLICIT `--migrate-project-root`, IGNORING the ambient session binding. Here
+/// the owner is bound to `repo-alpha` (ingest_roots.json) but we migrate to
+/// `repo-beta`. The repo fact must land in repo-beta's brain and stamp
+/// `Origin-Brain: <repo-beta>` — never repo-alpha's.
+#[test]
+fn apply_uses_explicit_target_and_ignores_ambient_binding() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    let ambient_repo = tmp.path().join("repo-alpha"); // the WRONG ambient binding
+    let target_repo = tmp.path().join("repo-beta"); // the explicit destination
+    seed_runtime_bound_to(&runtime_dir, &ambient_repo);
+    std::fs::create_dir_all(&target_repo).expect("mk target repo dir");
+
+    let (code, stdout, stderr) = run(
+        &[
+            "--medulla-migrate",
+            "apply",
+            "--migrate-project-root",
+            &target_repo.to_string_lossy(),
+        ],
+        &runtime_dir,
+    );
+    assert_eq!(
+        code, 0,
+        "apply with an explicit target must succeed; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+
+    let out: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be JSON, got {e}:\n{stdout}"));
+    let project_origin = out["project_origin"].as_str().unwrap_or_default();
+    assert_eq!(
+        project_origin,
+        target_repo.to_string_lossy(),
+        "project_origin must be the EXPLICIT target, not the ambient binding"
+    );
+    assert!(
+        !project_origin.contains("repo-alpha"),
+        "the ambient binding (repo-alpha) must NOT be the destination; got {project_origin}"
+    );
+
+    // The moved claim landed in repo-beta's brain, and its Origin-Brain stamp is
+    // repo-beta — proving the ambient binding was ignored end to end.
+    let moved = light_files_under(&runtime_dir.join("project-brains"));
+    let sliceship: Vec<_> = moved
+        .iter()
+        .filter(|p| p.ends_with("sliceship.light.md"))
+        .collect();
+    assert_eq!(
+        sliceship.len(),
+        1,
+        "the repo fact moved into exactly one project brain, found: {moved:?}"
+    );
+    let moved_text = std::fs::read_to_string(sliceship[0]).unwrap();
+    assert!(
+        moved_text.contains(&format!("Origin-Brain: {}", target_repo.to_string_lossy())),
+        "the moved claim is stamped with the explicit target origin, got:\n{moved_text}"
+    );
+    assert!(
+        !moved_text.contains("Origin-Brain: ") || !moved_text.contains("repo-alpha"),
+        "the moved claim must NOT be stamped with the ambient binding"
+    );
+}
+
+/// RED (field bug 2026-07-05, idempotency): running `apply` a SECOND time over an
+/// already-migrated store (every claim moved or stamped, nothing left to do) must
+/// report `already_migrated` with `moved: 0` and `count_conserved != false`,
+/// WITHOUT writing a fresh (empty) backup or degrading the store. In the field the
+/// second invocation reported `count_conserved: false` and created an empty backup.
+#[test]
+fn apply_is_idempotent_on_an_already_migrated_store() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    let target_repo = tmp.path().join("repo-beta");
+    seed_runtime_bound_to(&runtime_dir, &tmp.path().join("repo-alpha"));
+    std::fs::create_dir_all(&target_repo).expect("mk target repo dir");
+    let medulla = runtime_dir.join("agent-memory");
+
+    let args = [
+        "--medulla-migrate",
+        "apply",
+        "--migrate-project-root",
+        target_repo.to_str().unwrap(),
+    ];
+
+    // First apply: migrates (moves the repo fact, stamps the doctrine, backs up).
+    let (code1, stdout1, stderr1) = run(&args, &runtime_dir);
+    assert_eq!(code1, 0, "first apply must succeed; stderr:\n{stderr1}");
+    let out1: serde_json::Value = serde_json::from_str(stdout1.trim()).expect("json1");
+    assert_eq!(
+        out1["plan"]["already_migrated"], false,
+        "the first apply actually migrates, got:\n{stdout1}"
+    );
+    // Clear the (legitimate) first backup so the assertion below isolates the
+    // SECOND run's behavior.
+    for e in std::fs::read_dir(&medulla).unwrap().flatten() {
+        if e.file_name().to_string_lossy().starts_with(".m5a-backup-") {
+            std::fs::remove_dir_all(e.path()).unwrap();
+        }
+    }
+
+    // Second apply over the now-migrated store: nothing to move, nothing to stamp.
+    let (code2, stdout2, stderr2) = run(&args, &runtime_dir);
+    assert_eq!(
+        code2, 0,
+        "second apply over an already-migrated store must exit 0; stderr:\n{stderr2}\nstdout:\n{stdout2}"
+    );
+    let out2: serde_json::Value = serde_json::from_str(stdout2.trim())
+        .unwrap_or_else(|e| panic!("stdout must be JSON, got {e}:\n{stdout2}"));
+    assert_eq!(
+        out2["plan"]["already_migrated"], true,
+        "a second apply with nothing to do reports already_migrated; got:\n{stdout2}"
+    );
+    assert_eq!(
+        out2["plan"]["moved_to_project"], 0,
+        "already-migrated apply moved zero claims"
+    );
+    assert_ne!(
+        out2["plan"]["count_conserved"], false,
+        "already-migrated apply must not report count_conserved:false (the field regression)"
+    );
+
+    // The essential guard: the SECOND run wrote NO fresh backup dir.
+    let backups: Vec<_> = std::fs::read_dir(&medulla)
+        .unwrap()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().starts_with(".m5a-backup-"))
+        .collect();
+    assert!(
+        backups.is_empty(),
+        "an already-migrated apply writes no backup dir, found: {backups:?}"
+    );
+}


### PR DESCRIPTION
## The bug (field-proven cross-brain contamination — MED-INV-1)

`--medulla-migrate apply` derived its destination brain from the ambient session binding (`state.project_root_display()`). When the owner was bound to a different repo — e.g. a second agent working from elsewhere — `apply` silently moved a store's legacy repo-fact memories into the **wrong** brain. It was also non-idempotent: a second `apply` over an already-migrated store reported `count_conserved: false` and wrote an empty backup.

## The fix
1. **Explicit destination, never ambient** — new `--migrate-project-root <PATH>` flag. `apply`/`rollback` **refuse with exit 2** when it's absent; the destination is derived from the path, and the ambient binding is ignored entirely. `plan` may fall back to ambient but warns and stamps `destination_source: "ambient-binding (unsafe)"`.
2. **Idempotency guard** — `apply` short-circuits before any backup or mutation when there is nothing to move and nothing to stamp, returning `already_migrated: true` (`moved: 0`, `count_conserved: true`).

## Proof
RED-first: the new CLI tests fail on the parent commit exactly as the bug predicts (refusal test showed `apply` succeeding off the ambient binding). After the fix, `apply_uses_explicit_target_and_ignores_ambient_binding` seeds a runtime bound to one repo and proves the moved claim lands in the *explicitly named* brain, stamped with its origin. Idempotency covered by a module test.

`cargo test --workspace` green · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo fmt --check` clean. MEDULLA-PRD §4.2 documents the explicit-destination rule.