### PR TITLE
fix: hardening wave 1 — bind gate, restart trio, learn validation, recall order, in_flight fate

### DIFF
--- a/docs/UML-ORGANISM.md
+++ b/docs/UML-ORGANISM.md
@@ -111,7 +111,7 @@ These cross every system; no sheet may invent a fifth word for any of them.
 Severity order: security > data-loss > correctness > fragility > honesty/cleanup. Each entry carries its home sheet; fixes land RED-first or not at all.
 
 ### SECURITY
-1. **Unauthenticated network mutation surface.** `--serve` on `0.0.0.0` exposes graph mutation to the LAN with only a stderr warning, no refusal, no auth. *(routing-reception)*
+1. **Unauthenticated network mutation surface.** `--serve` on `0.0.0.0` exposes graph mutation to the LAN with only a stderr warning, no refusal, no auth. *(routing-reception)* — **CLOSED** (hardening wave 1): a non-loopback bind is now REFUSED at startup unless `--allow-remote` is passed (with the flag, a strong unauthenticated-exposure warning remains). Residual: token auth remains future work — the flag only makes remote exposure a deliberate opt-in, it does not authenticate callers.
 
 ### DATA-LOSS
 2. **M5a migration cluster** *(medulla; fix in flight at atlas time)*: apply overwrites same-named destination claims with no destination-side backup; rollback reconstructs "moved" by scanning the whole destination store and deletes pre-existing claims; `count_conserved` is cardinality-only (passes through content loss); rollback is destructive-first (no snapshot); `ingest_roots.json` never restored; apply leaves the destination brain unregistered (orphan store, no `project_brain.json`); no live-owner guard (keepalive resurrection raced an offline apply in the field); the runtime's code graph lives at the medulla root, so memory-only migration yields a hybrid.
@@ -120,12 +120,12 @@ Severity order: security > data-loss > correctness > fragility > honesty/cleanup
 
 ### CORRECTNESS
 5. **The seek trust envelope can never reach `act`:** its `envelope` calibration signal has no production writer (only a test helper) — structurally capped at `reverify`. *(trust-calibration)*
-6. **`handle_learn` catch-all maps any non-{wrong,partial} feedback to `record_defect`** — mislabeled feedback silently accrues defects against innocent nodes. *(trust-calibration)*
+6. **`handle_learn` catch-all maps any non-{wrong,partial} feedback to `record_defect`** — mislabeled feedback silently accrues defects against innocent nodes. *(trust-calibration)* — **CLOSED** (hardening wave 1): the feedback verb is validated up front (exactly `correct|wrong|partial`); any other value returns `InvalidParams` before any mutation, so a typo can no longer record a defect.
 7. **HeapEngine re-expansion:** once a node enters the Bloom visited-set, a later STRONGER signal cannot update it — order-dependent activation loss. *(graph-core)*
 8. **Perspective is single-viewpoint:** route family hardcoded `Structural` at both call sites; lens/`route_families` are no-ops. *(perspective)*
-9. **Mailbox `in_flight` fate is dead code:** `in_flight_ids` has no producer, yet every surface counts it inside "open". *(mailbox)*
-10. **North freshest-first inversion:** the broad L1GHT fallback sorts `Option<u64>` ascending, so `None` (undated legacy) outranks every dated claim — oldest-first where freshest-first is promised. *(spine-north)*
-11. **Restart reload trio is field-hazardous:** kickstart matches EVERY label containing "m1nd" (fleet-wide SIGKILL from one swap), runs even when codesign failed (re-execs an unsigned binary → OS-level kill loop), and label parsing breaks on labels with spaces. *(cli-operator; review-confirmed)*
+9. **Mailbox `in_flight` fate is dead code:** `in_flight_ids` has no producer, yet every surface counts it inside "open". *(mailbox)* — **CLOSED** (hardening wave 1): `in_flight_ids` now has a natural reply-graph producer — a `triage`/receipt answer CLOSES an id (`fired_clay`), a non-receipt reference PICKS IT UP without closing (`in_flight`); closed takes precedence.
+10. **North freshest-first inversion:** the broad L1GHT fallback sorts `Option<u64>` ascending, so `None` (undated legacy) outranks every dated claim — oldest-first where freshest-first is promised. *(spine-north)* — **CLOSED** (hardening wave 1): the fallback now sorts on `(authored_ms_ago.is_none(), authored_ms_ago)` — dated claims first (freshest within them), undated claims trail.
+11. **Restart reload trio is field-hazardous:** kickstart matches EVERY label containing "m1nd" (fleet-wide SIGKILL from one swap), runs even when codesign failed (re-execs an unsigned binary → OS-level kill loop), and label parsing breaks on labels with spaces. *(cli-operator; review-confirmed)* — **CLOSED** (hardening wave 1): kickstart resolves each candidate label's managed program via `launchctl print` and kicks ONLY the one matching the installed target (fail-closed on an undiscoverable path); a failed darwin codesign skips the reload; label parsing takes columns 3..end so spaced labels survive.
 
 ### FRAGILITY
 12. **Medulla fold is HTTP-only:** a stdio caller's `north.memory` silently lacks the medulla feed — the pull law realized on one transport. *(spine-north / routing)*

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -27,9 +27,20 @@ pub struct Cli {
     #[arg(long, default_value = "1337")]
     pub port: u16,
 
-    /// Bind address override (default: 127.0.0.1). Use 0.0.0.0 for network access.
+    /// Bind address override (default: 127.0.0.1). A non-loopback bind (e.g.
+    /// 0.0.0.0 or a concrete LAN IP) exposes graph mutation to the network and is
+    /// REFUSED at startup unless `--allow-remote` is also given — there is no
+    /// authentication yet, so an unguarded remote bind must be an explicit,
+    /// deliberate opt-in, never the default.
     #[arg(long, default_value = "127.0.0.1")]
     pub bind: String,
+
+    /// Explicitly allow binding the HTTP server to a non-loopback address.
+    /// Without this flag a non-loopback `--bind` is refused at startup (there is
+    /// no auth: an open bind would expose graph mutation to the LAN). With it the
+    /// bind proceeds and a strong unauthenticated-exposure warning is printed.
+    #[arg(long)]
+    pub allow_remote: bool,
 
     /// Serve frontend from disk instead of embedded (dev mode)
     #[arg(long)]

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -393,22 +393,68 @@ pub fn spawn_background(
     })
 }
 
+/// Pure network-exposure decision (no I/O, no exit) so it is unit-testable in
+/// both directions. Returns `Err(one_line_error)` when the process MUST refuse to
+/// start, `Ok(warning)` otherwise — `Some(warning)` when the bind is remote and
+/// allowed (a strong exposure warning to print), `None` when it is loopback.
+///
+/// The rule: a bind that does NOT resolve to a loopback address exposes graph
+/// mutation to the network, and there is no authentication yet — so it is refused
+/// unless `allow_remote` is set. This is stricter than a literal `== "0.0.0.0"`
+/// check: `0.0.0.0`, `::`, and any concrete LAN IP (e.g. `192.168.1.10`) are all
+/// non-loopback and all gated. A hostname that does not parse as an IP is treated
+/// as potentially remote (fail-closed) and requires the flag too.
+fn remote_bind_verdict(bind: &str, allow_remote: bool) -> Result<Option<String>, String> {
+    use std::net::IpAddr;
+
+    let is_loopback = bind
+        .trim()
+        .parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false);
+
+    if is_loopback {
+        return Ok(None);
+    }
+
+    if allow_remote {
+        Ok(Some(format!(
+            "[m1nd-mcp] WARNING: Binding to a non-loopback address ({bind}) exposes the server to the network. \
+             No authentication is configured — anyone who can reach this address can read AND MUTATE the graph. \
+             Proceeding only because --allow-remote was given."
+        )))
+    } else {
+        Err(format!(
+            "[m1nd-mcp] REFUSING to bind to non-loopback address {bind}: this exposes graph mutation to the \
+             network and no authentication is configured. Re-run with --allow-remote to opt in explicitly, or \
+             bind to a loopback address (the default 127.0.0.1). Token auth is not yet implemented."
+        ))
+    }
+}
+
 /// Start the HTTP server (and optionally stdio).
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     config: McpConfig,
     port: u16,
     bind: String,
+    allow_remote: bool,
     dev_mode: bool,
     auto_open: bool,
     also_stdio: bool,
     event_log: Option<String>,
     watch_events: Option<String>,
 ) {
-    // Warn about network exposure
-    if bind == "0.0.0.0" {
-        eprintln!("[m1nd-mcp] WARNING: Binding to 0.0.0.0 exposes the server to the network.");
-        eprintln!("[m1nd-mcp] WARNING: No authentication is configured. Anyone on the network can access the API.");
+    // Network-exposure gate: a non-loopback bind is REFUSED unless --allow-remote
+    // is set (no auth yet — see `remote_bind_verdict`). A refusal exits before any
+    // graph load, engine build, or lease is taken.
+    match remote_bind_verdict(&bind, allow_remote) {
+        Ok(Some(warning)) => eprintln!("{warning}"),
+        Ok(None) => {}
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(2);
+        }
     }
 
     // 1. Create McpServer to load graph + build engines
@@ -2267,6 +2313,65 @@ mod tests {
         assert_eq!(changed.data["event"], "memorize");
         assert_eq!(changed.data["agent_id"], "agent-b");
         assert_eq!(changed.data["timestamp_ms"], 1234);
+    }
+
+    // ---- Network-exposure bind gate (SECURITY #1) --------------------------
+
+    #[test]
+    fn loopback_bind_needs_no_flag_and_no_warning() {
+        // 127.0.0.1 and ::1 are loopback → allowed with no flag, no warning.
+        assert_eq!(remote_bind_verdict("127.0.0.1", false), Ok(None));
+        assert_eq!(remote_bind_verdict("::1", false), Ok(None));
+        // Whitespace is tolerated.
+        assert_eq!(remote_bind_verdict("  127.0.0.1  ", false), Ok(None));
+    }
+
+    #[test]
+    fn wildcard_bind_is_refused_without_the_flag() {
+        // The regression this closes: `0.0.0.0` used to bind with only a stderr
+        // warning. It must now be a hard refusal (Err) unless opted in.
+        let verdict = remote_bind_verdict("0.0.0.0", false);
+        let msg = verdict.expect_err("0.0.0.0 without --allow-remote must refuse");
+        assert!(msg.contains("REFUSING"), "got: {msg}");
+        assert!(
+            msg.contains("--allow-remote"),
+            "must name the opt-in: {msg}"
+        );
+        // `::` (IPv6 wildcard) is refused the same way.
+        assert!(remote_bind_verdict("::", false).is_err());
+    }
+
+    #[test]
+    fn concrete_lan_ip_is_refused_without_the_flag() {
+        // Stricter than a literal `== "0.0.0.0"`: any non-loopback address, incl.
+        // a concrete LAN IP, is gated.
+        assert!(remote_bind_verdict("192.168.1.10", false).is_err());
+        assert!(remote_bind_verdict("10.0.0.5", false).is_err());
+        // A non-IP hostname is fail-closed (treated as potentially remote).
+        assert!(remote_bind_verdict("example.local", false).is_err());
+    }
+
+    #[test]
+    fn remote_bind_is_allowed_with_the_flag_but_warns() {
+        // With the explicit opt-in the bind proceeds, returning the strong
+        // unauthenticated-exposure warning to print.
+        let verdict = remote_bind_verdict("0.0.0.0", true);
+        let warning = verdict
+            .expect("--allow-remote must not refuse")
+            .expect("a remote bind must carry a warning");
+        assert!(warning.contains("WARNING"), "got: {warning}");
+        assert!(
+            warning.contains("--allow-remote"),
+            "warning should note the opt-in: {warning}"
+        );
+        // A concrete LAN IP with the flag is likewise allowed + warned.
+        assert!(remote_bind_verdict("192.168.1.10", true).unwrap().is_some());
+    }
+
+    #[test]
+    fn loopback_bind_ignores_the_flag() {
+        // The flag is a no-op for loopback — still no warning.
+        assert_eq!(remote_bind_verdict("127.0.0.1", true), Ok(None));
     }
 
     #[test]

--- a/m1nd-mcp/src/mailbox.rs
+++ b/m1nd-mcp/src/mailbox.rs
@@ -359,15 +359,16 @@ pub fn read_letters(path: &Path) -> M1ndResult<Vec<Letter>> {
 /// Derive the fate of every letter in a set from the reply graph (§C2.2). One
 /// pass builds the answered-set from all `answers[]`; then each letter's fate is:
 ///   - `external` if its class marks it as about a non-m1nd tool,
-///   - `fired_clay` if any letter answers it,
-///   - `in_flight` if a non-closing letter references it (reserved: today a
-///     reference IS an answer, so this arises only when a letter is referenced
-///     but no receipt has closed it — modeled via `in_flight_refs`),
+///   - `fired_clay` if a receipt closed it (its id is in `answered`),
+///   - `in_flight` if a non-receipt letter references it without closing it
+///     (its id is in `in_flight_ids` — picked up, fix in flight),
 ///   - `wet_ink` otherwise.
 ///
 /// `external_ids` is the set of letter ids judged external (about a non-m1nd
-/// tool). `in_flight_ids` is the set referenced-but-not-closed. This keeps the
-/// derivation pure and testable; [`fates_for`] composes the default policy.
+/// tool). `answered` is the receipt-closed set ([`answered_set`]); `in_flight_ids`
+/// is the referenced-but-not-closed set ([`in_flight_set`]) — closed takes
+/// precedence. This keeps the derivation pure and testable; [`view_letters`]
+/// composes the default policy.
 pub fn derive_fate(
     id: &str,
     answered: &BTreeSet<String>,
@@ -386,13 +387,51 @@ pub fn derive_fate(
     Fate::WetInk
 }
 
-/// The answered-set: every id that appears in some letter's `answers[]` — those
-/// letters are `fired_clay` (a receipt closed them).
+/// The `triage`/receipt class — a letter whose `answers[]` CLOSE the ids they
+/// reference (flip them to `fired_clay`). A letter of any other class that
+/// references an id is a non-closing pickup (→ `in_flight`), per grammar 3.
+pub const CLASS_TRIAGE: &str = "triage";
+
+/// Whether a letter is a receipt — i.e. its `answers[]` close the referenced
+/// letters. Today the receipt class is exactly `triage`; the distribution
+/// receipt writer files under it (§9.2).
+fn is_receipt(letter: &Letter) -> bool {
+    letter.class.eq_ignore_ascii_case(CLASS_TRIAGE)
+}
+
+/// The closed-set: every id CLOSED by a receipt — an id that appears in the
+/// `answers[]` of at least one `triage`/receipt letter. Only these are
+/// `fired_clay`; an id referenced solely by non-receipt letters is a pickup that
+/// has not closed (see [`in_flight_set`]).
 pub fn answered_set(letters: &[Letter]) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     for l in letters {
+        if !is_receipt(l) {
+            continue;
+        }
         for a in &l.answers {
             out.insert(a.clone());
+        }
+    }
+    out
+}
+
+/// The in-flight set (grammar 3, MED-INV-9): every id that is REFERENCED by some
+/// letter's `answers[]` but NOT closed by any receipt — "picked up, fix in
+/// flight". This is the natural producer the reply graph always supported: a
+/// non-receipt letter that names an earlier id has acknowledged it without
+/// closing it. `closed` is [`answered_set`] (the receipt-closed ids), which take
+/// precedence — an id both picked up and later closed reads as `fired_clay`.
+pub fn in_flight_set(letters: &[Letter], closed: &BTreeSet<String>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for l in letters {
+        if is_receipt(l) {
+            continue;
+        }
+        for a in &l.answers {
+            if !closed.contains(a) {
+                out.insert(a.clone());
+            }
         }
     }
     out
@@ -677,11 +716,12 @@ fn view_letters(letters: &[Letter], foreign_tools: &BTreeSet<String>) -> Vec<Swe
         .filter(|l| is_external(l, foreign_tools))
         .map(|l| l.id.clone())
         .collect();
-    // Today a reference IS a closing answer (no separate "picked up but open"
-    // signal in the spool schema), so `in_flight_ids` is empty by default — a
-    // referenced letter is `fired_clay`. The InFlight fate is derivable the moment
-    // a non-closing reference class appears; the derivation is ready for it.
-    let in_flight_ids: BTreeSet<String> = BTreeSet::new();
+    // Natural in_flight derivation from the reply graph: a receipt (`triage`)
+    // letter's answers CLOSE their ids (→ fired_clay, in `answered`); a
+    // non-receipt letter that references an id has PICKED IT UP without closing
+    // it (→ in_flight). `answered` (receipt-closed) takes precedence over
+    // in_flight, so an id closed after a pickup reads as fired_clay.
+    let in_flight_ids: BTreeSet<String> = in_flight_set(letters, &answered);
 
     letters
         .iter()
@@ -1397,6 +1437,77 @@ mod tests {
         // The receipt's answered_by wiring: L1 is answered_by the receipt.
         let l1_view = viewed.iter().find(|l| l.id == l1_id).unwrap();
         assert_eq!(l1_view.answered_by, vec![receipt_view.id.clone()]);
+    }
+
+    #[test]
+    fn non_receipt_reference_derives_in_flight_not_fired_clay() {
+        // Regression (mailbox #9 — in_flight dead code): a NON-receipt letter that
+        // references an earlier id has picked it up WITHOUT closing it. That id
+        // must derive `in_flight`, not `fired_clay` (which is a receipt's job) and
+        // not `wet_ink`. Before the producer, `in_flight_ids` was hardcoded empty,
+        // so this letter was mis-rendered as `fired_clay`.
+        let l1 = line(
+            serde_json::json!({"ts":"t1","agent":"a","repo":"repo-a","tool":"seek","class":"bug","what":"the original bug"}),
+        );
+        let l1_id = letter_id(&l1);
+        // A working (non-receipt) letter that references L1 — "I picked this up".
+        let pickup = line(
+            serde_json::json!({"ts":"t2","agent":"b","repo":"repo-a","tool":"seek","class":"bug","what":"looking into it","answers":[l1_id]}),
+        );
+
+        let letters: Vec<Letter> = [l1.clone(), pickup]
+            .iter()
+            .filter_map(|s| parse_letter(s))
+            .collect();
+        let viewed = view_letters(&letters, &BTreeSet::new());
+
+        let l1_view = viewed.iter().find(|l| l.id == l1_id).unwrap();
+        assert_eq!(
+            l1_view.state, "in_flight",
+            "a non-receipt pickup must make the referenced letter in_flight, got {}",
+            l1_view.state
+        );
+
+        // And in_flight still counts toward the open ("abertas") total — the
+        // same rule every surface uses (wet_ink + in_flight).
+        let in_flight_count = viewed.iter().filter(|l| l.state == "in_flight").count();
+        assert_eq!(
+            in_flight_count, 1,
+            "exactly one picked-up letter is in_flight"
+        );
+        let open = viewed
+            .iter()
+            .filter(|l| l.state == "wet_ink" || l.state == "in_flight")
+            .count();
+        assert!(open >= 1, "in_flight must count toward open, got {open}");
+    }
+
+    #[test]
+    fn receipt_close_wins_over_a_prior_pickup() {
+        // If a letter is first picked up (non-receipt reference) and LATER closed
+        // by a receipt, `fired_clay` wins over `in_flight` — closed is closed.
+        let l1 = line(
+            serde_json::json!({"ts":"t1","agent":"a","repo":"repo-a","tool":"seek","class":"bug","what":"bug"}),
+        );
+        let l1_id = letter_id(&l1);
+        let pickup = line(
+            serde_json::json!({"ts":"t2","agent":"b","repo":"repo-a","tool":"seek","class":"bug","what":"on it","answers":[l1_id]}),
+        );
+        let receipt = line(
+            serde_json::json!({"ts":"t3","agent":"triage","repo":"repo-a","tool":"triage","class":"triage","what":"fixed","answers":[l1_id]}),
+        );
+
+        let letters: Vec<Letter> = [l1, pickup, receipt]
+            .iter()
+            .filter_map(|s| parse_letter(s))
+            .collect();
+        let viewed = view_letters(&letters, &BTreeSet::new());
+        let l1_view = viewed.iter().find(|l| l.id == l1_id).unwrap();
+        assert_eq!(
+            l1_view.state, "fired_clay",
+            "a receipt close wins over a prior pickup, got {}",
+            l1_view.state
+        );
     }
 
     // --- external excluded from the "abertas" count -------------------------

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -711,6 +711,7 @@ async fn main() {
                 config,
                 cli.port,
                 cli.bind,
+                cli.allow_remote,
                 cli.dev,
                 cli.open,
                 cli.stdio,

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -3161,6 +3161,17 @@ fn handle_orient(
 ///     when the graph can't answer yet.
 ///   - `honest_gaps` names what m1nd does NOT yet know for this task.
 ///
+/// Freshest-first ordering key for the broad (non-task-scoped) L1GHT recall
+/// fallback. `authored_ms_ago` is an AGE (now − Created), so a smaller value is
+/// fresher and an absent value is an UNKNOWN age (undated legacy claim). The key
+/// `(is_none, age)` sorts dated claims ahead of undated ones (`false` < `true`)
+/// and, within the dated claims, ascending age = freshest first. A plain
+/// `sort_by_key(|r| r.authored_ms_ago)` is inverted, because Rust orders
+/// `None < Some(_)`, which would float every undated claim to the front.
+fn light_recall_freshness_key(authored_ms_ago: Option<u64>) -> (bool, Option<u64>) {
+    (authored_ms_ago.is_none(), authored_ms_ago)
+}
+
 /// Read-only safe: every composed handler is read-only (`trust_selftest`,
 /// `orient`→`activate`, `boot_memory action=list`, `focus`→`seek` all route
 /// through read-only-safe paths).
@@ -3440,8 +3451,11 @@ fn handle_north(
             // a cold agent still sees that institutional memory EXISTS (honest: this is
             // "memory exists, not necessarily about your task", surfaced most-recent).
             hits = seek_light("memory decision finding note claim", 24);
-            // Prefer the freshest few when the recall is not task-scoped.
-            hits.sort_by_key(|r| r.authored_ms_ago);
+            // Prefer the freshest few when the recall is not task-scoped. See
+            // `light_recall_freshness_key`: dated claims first, freshest within
+            // them, undated (unknown-age) claims last — NOT the inverted
+            // `None`-first order a bare `sort_by_key(authored_ms_ago)` gives.
+            hits.sort_by_key(|r| light_recall_freshness_key(r.authored_ms_ago));
         }
         // De-dup by node_id (a memory can surface under both label and evidence path)
         // and cap at light_limit.
@@ -5584,9 +5598,9 @@ impl McpServer {
 #[cfg(test)]
 mod tests {
     use super::{
-        all_tool_schemas, background_tick_if_due, daemon_wait_duration_ms, run_daemon_tick,
-        should_autotick_daemon, tool_schemas, tool_schemas_for_tier, DaemonRuntimeControl,
-        McpServer, ESSENTIAL_TOOLS,
+        all_tool_schemas, background_tick_if_due, daemon_wait_duration_ms,
+        light_recall_freshness_key, run_daemon_tick, should_autotick_daemon, tool_schemas,
+        tool_schemas_for_tier, DaemonRuntimeControl, McpServer, ESSENTIAL_TOOLS,
     };
     use crate::server::McpConfig;
     use crate::session::SessionState;
@@ -8909,5 +8923,49 @@ mod tests {
         if let Err(panic) = result {
             std::panic::resume_unwind(panic);
         }
+    }
+
+    // ---- Broad L1GHT recall freshest-first ordering (spine-north #10) --------
+
+    #[test]
+    fn broad_light_recall_sorts_dated_claims_before_undated_freshest_first() {
+        // Regression: the broad (non-task-scoped) memory fallback sorted
+        // `Option<u64>` ages with a bare key, and Rust orders `None < Some(_)`, so
+        // an UNDATED legacy claim outranked every dated one — oldest/unknown-first
+        // where freshest-first is promised.
+        //
+        // Fixture mirrors seek hits by (label, authored_ms_ago); smaller age =
+        // fresher. Expected freshest-first order: fresh(1h) → old(30d) → undated.
+        let fresh_ms = 60 * 60 * 1000u64; // 1 hour old
+        let old_ms = 30 * 24 * 60 * 60 * 1000u64; // 30 days old
+        let mut hits: Vec<(&str, Option<u64>)> = vec![
+            ("undated-legacy", None),
+            ("old-dated", Some(old_ms)),
+            ("fresh-dated", Some(fresh_ms)),
+        ];
+
+        hits.sort_by_key(|(_, age)| light_recall_freshness_key(*age));
+
+        let order: Vec<&str> = hits.iter().map(|(label, _)| *label).collect();
+        assert_eq!(
+            order,
+            vec!["fresh-dated", "old-dated", "undated-legacy"],
+            "dated claims must lead (freshest first); undated must trail"
+        );
+
+        // Guard against the specific inversion: the undated claim must NOT be
+        // first, and the bare-key order (which WOULD put it first) must differ.
+        assert_ne!(order.first(), Some(&"undated-legacy"));
+        let mut bare = [
+            ("undated-legacy", None::<u64>),
+            ("old-dated", Some(old_ms)),
+            ("fresh-dated", Some(fresh_ms)),
+        ];
+        bare.sort_by_key(|(_, age)| *age); // the OLD, inverted key
+        assert_eq!(
+            bare.first().map(|(l, _)| *l),
+            Some("undated-legacy"),
+            "sanity: the bare key really does float the undated claim to the front"
+        );
     }
 }

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -2734,6 +2734,23 @@ pub fn handle_drift(state: &mut SessionState, input: DriftInput) -> M1ndResult<s
 /// Handle m1nd.learn (03-MCP Section 2.10).
 /// Replaces: targeted edge strengthen/weaken bypass of Hebbian cycle
 pub fn handle_learn(state: &mut SessionState, input: LearnInput) -> M1ndResult<serde_json::Value> {
+    // Validate the feedback verb BEFORE any mutation. Exactly `correct | wrong |
+    // partial` are meaningful; any other value (a typo like "corect", a stray
+    // "neutral") must be refused, never silently mapped. The old catch-alls sent
+    // an unrecognized verb to `record_defect`, accruing a defect against innocent
+    // nodes, and to the edge path's "treat as correct" fallback — both wrong.
+    match input.feedback.as_str() {
+        "correct" | "wrong" | "partial" => {}
+        other => {
+            return Err(m1nd_core::error::M1ndError::InvalidParams {
+                tool: "learn".into(),
+                detail: format!(
+                    "unknown feedback '{other}': expected one of correct | wrong | partial"
+                ),
+            });
+        }
+    }
+
     let mut graph = state.graph.write();
 
     let mut seen_nodes = HashSet::new();
@@ -2832,15 +2849,12 @@ pub fn handle_learn(state: &mut SessionState, input: LearnInput) -> M1ndResult<s
                 }
                 (s_pairs, w_pairs)
             }
-            _ => {
-                // Unrecognized feedback — fall back to treating as "correct"
-                let mut pairs = Vec::new();
-                for i in 0..expanded.len() {
-                    for j in (i + 1)..expanded.len() {
-                        pairs.push((expanded[i], expanded[j]));
-                    }
-                }
-                (pairs, Vec::new())
+            other => {
+                // Unreachable: `input.feedback` was validated to be one of
+                // correct | wrong | partial at the top of this function. This arm
+                // exists only so a future variant is a loud panic in tests, never
+                // a silent "treat as correct".
+                unreachable!("unvalidated learn feedback reached edge match: {other}")
             }
         };
 
@@ -2958,7 +2972,11 @@ pub fn handle_learn(state: &mut SessionState, input: LearnInput) -> M1ndResult<s
         match input.feedback.as_str() {
             "wrong" => state.trust_ledger.record_false_alarm(external_id, now),
             "partial" => state.trust_ledger.record_partial(external_id, now),
-            _ => state.trust_ledger.record_defect(external_id, now),
+            // Only "correct" remains (validated at the top). A defect is recorded
+            // ONLY for an explicit "wrong"/"partial"; a typo can no longer reach
+            // `record_defect` and accuse an innocent node.
+            "correct" => state.trust_ledger.record_defect(external_id, now),
+            other => unreachable!("unvalidated learn feedback reached ledger match: {other}"),
         }
 
         let weight_delta = node_weight_deltas.get(node).copied().unwrap_or(0.0);
@@ -4616,6 +4634,70 @@ mod tests {
         state.ingest_roots = vec![root.to_string_lossy().to_string()];
         state.workspace_root = Some(root.to_string_lossy().to_string());
         (state, "file::hub.rs".to_string())
+    }
+
+    #[test]
+    fn learn_rejects_typo_feedback_without_accusing_a_defect() {
+        // Regression (trust-calibration ledger #6): a mislabeled feedback verb —
+        // here the typo "corect" — used to fall through the catch-all and call
+        // `record_defect` against the named node, silently accruing a defect on an
+        // innocent node. It must now be a clean InvalidParams refusal that mutates
+        // NOTHING in the trust ledger.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (mut state, hub_id) = build_star_graph(temp.path(), 3);
+
+        assert_eq!(
+            state.trust_ledger.external_ids().count(),
+            0,
+            "ledger starts empty"
+        );
+
+        let result = super::handle_learn(
+            &mut state,
+            crate::protocol::LearnInput {
+                query: "did the hub change?".into(),
+                agent_id: "test".into(),
+                feedback: "corect".into(), // typo of "correct"
+                node_ids: vec![hub_id.clone()],
+                strength: crate::protocol::default_feedback_strength(),
+            },
+        );
+
+        let err = result.expect_err("a typo feedback must be refused, not silently mapped");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("corect") && msg.contains("correct") && msg.contains("partial"),
+            "the refusal must name the bad value and list the valid ones, got: {msg}"
+        );
+
+        // The load-bearing guarantee: NO defect (and no entry at all) was recorded
+        // against the node for the typo.
+        assert_eq!(
+            state.trust_ledger.external_ids().count(),
+            0,
+            "a refused typo must not create any trust-ledger entry"
+        );
+    }
+
+    #[test]
+    fn learn_accepts_the_three_valid_feedback_verbs() {
+        // The complement: the exact set correct | wrong | partial is accepted (a
+        // guard that the up-front validation did not over-reject).
+        for verb in ["correct", "wrong", "partial"] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let (mut state, hub_id) = build_star_graph(temp.path(), 3);
+            let out = super::handle_learn(
+                &mut state,
+                crate::protocol::LearnInput {
+                    query: "q".into(),
+                    agent_id: "test".into(),
+                    feedback: verb.into(),
+                    node_ids: vec![hub_id],
+                    strength: crate::protocol::default_feedback_strength(),
+                },
+            );
+            assert!(out.is_ok(), "'{verb}' must be accepted, got {out:?}");
+        }
     }
 
     #[test]

--- a/m1nd-mcp/tests/remote_bind_refusal.rs
+++ b/m1nd-mcp/tests/remote_bind_refusal.rs
@@ -1,0 +1,47 @@
+//! End-to-end proof of the network-exposure bind gate (SECURITY #1).
+//!
+//! `--serve --bind <non-loopback>` WITHOUT `--allow-remote` must make the process
+//! REFUSE TO START — exit nonzero with a one-line refusal on stderr, BEFORE the
+//! HTTP listener is created, before the graph loads, before any lease is taken.
+//! An unguarded remote bind would expose graph mutation to the LAN with no auth,
+//! so it must be a deliberate opt-in, never a mere warning.
+//!
+//! We spawn the real built binary because only a spawned process can prove
+//! `std::process::exit` actually fired. The refusal path binds NO port (it exits
+//! first), so this test never opens a network listener — and it uses the loopback
+//! default for everything else, never the maintainer's real runtime or port 1338.
+
+use std::process::Command;
+
+/// Path to the compiled binary under test. Cargo sets `CARGO_BIN_EXE_<name>`
+/// for integration tests automatically.
+const BIN: &str = env!("CARGO_BIN_EXE_m1nd-mcp");
+
+#[test]
+fn serve_wildcard_bind_without_allow_remote_refuses_to_start() {
+    let output = Command::new(BIN)
+        .arg("--serve")
+        .arg("--bind")
+        .arg("0.0.0.0")
+        // Keep the refusal path cheap and hermetic — it exits before any of this
+        // matters, but set read-only so a regression that slips past the gate
+        // cannot touch the developer's real runtime.
+        .env("M1ND_READ_ONLY", "1")
+        .output()
+        .expect("spawn m1nd-mcp");
+
+    assert!(
+        !output.status.success(),
+        "non-loopback bind without --allow-remote must exit nonzero, got {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("REFUSING"),
+        "expected refusal line on stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--allow-remote"),
+        "refusal should name the opt-in flag, got: {stderr}"
+    );
+}

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -2653,38 +2653,112 @@ function codesignAdHoc(targetBinary) {
   };
 }
 
-// The launchd service label managing a target, discovered GENERICALLY from
-// `launchctl list` — never a hardcoded personal label. `launchctl list` prints
-// `PID\tSTATUS\tLABEL` lines; we take the m1nd-owned labels (a label naming
-// m1nd), so a reload targets whatever the operator actually installed. Returns
-// the matching labels (possibly several); empty when launchctl is absent or no
-// m1nd service is loaded (then restart keeps its kill -TERM fallback).
-function managedLaunchdLabels() {
+// Parse the LABEL out of one `launchctl list` line. The format is
+// `PID\tSTATUS\tLABEL`, and a launchd label MAY contain whitespace, so the label
+// is everything from the third column on — `.split(/\s+/).slice(2).join(" ")`,
+// NOT `.pop()` (which would keep only the last space-separated token of a label
+// with spaces). Returns "" for a header/blank/malformed line.
+function parseLaunchctlLabel(line) {
+  const parts = String(line || "").trim().split(/\s+/);
+  if (parts.length < 3) return "";
+  return parts.slice(2).join(" ");
+}
+
+// Candidate m1nd-named labels from `launchctl list` (a label naming m1nd). These
+// are only CANDIDATES: the fleet may run several m1nd services (worktrees, other
+// installs), and a swap must reload ONLY the one whose managed binary is the
+// target just installed — see `launchdLabelManagesTarget`. Returns [] when
+// launchctl is absent / no m1nd service is loaded (restart keeps its kill -TERM
+// fallback).
+function candidateLaunchdLabels() {
   if (process.platform !== "darwin") return [];
   const result = runCommand("launchctl", ["list"]);
   if (!result.ok) return [];
   return result.stdout
     .split(/\r?\n/)
-    .map((line) => line.trim())
+    .map(parseLaunchctlLabel)
     .filter(Boolean)
-    .map((line) => line.split(/\s+/).pop() || "")
     .filter((label) => /m1nd/i.test(label));
 }
 
-// Reload a managed launchd service so it re-execs the just-installed binary.
-// `launchctl kickstart -k gui/<uid>/<label>` stops (SIGKILL) then restarts the
-// service under the caller's GUI domain — the reliable "reload now" the plain
-// kill -TERM could miss (KeepAlive races, the TERM never reaching the service).
-// Returns one result per label kicked; empty when no m1nd label is loaded.
-function kickstartManagedServices() {
+// The program path a launchd label manages, from `launchctl print gui/<uid>/<label>`.
+// The print output has a `program = /path/to/bin` line (and/or a `program-arguments`
+// array whose first entry is the executable). Returns the resolved path or null
+// when it cannot be determined (absent tool, unreadable output).
+function launchdLabelProgramPath(uid, label) {
+  const result = runCommand("launchctl", ["print", `gui/${uid}/${label}`]);
+  if (!result.ok) return null;
+  return parseLaunchctlProgramPath(result.stdout);
+}
+
+// Pure parse of a `launchctl print` block → the managed executable path. Prefers
+// the explicit `program = …`; falls back to the first `program-arguments` entry.
+// Returns null when neither is present.
+function parseLaunchctlProgramPath(printOutput) {
+  const text = String(printOutput || "");
+  const program = text.match(/^\s*program\s*=\s*(.+?)\s*$/m);
+  if (program && program[1]) return program[1].trim();
+  // program-arguments = {\n\t\t0 => /path/to/exe\n ... }
+  const firstArg = text.match(/program-arguments\s*=\s*\{[^}]*?\b0\s*=>\s*(.+?)\s*$/m);
+  if (firstArg && firstArg[1]) return firstArg[1].trim();
+  return null;
+}
+
+// Whether a launchd label's managed program IS the target binary just installed.
+// Pure + path-normalized so `/var`→`/private/var` aliases and trailing separators
+// do not cause a false miss (or, worse, a false MATCH that SIGKILLs an unrelated
+// m1nd service). A null/empty program path is NOT a match (fail-closed): an
+// undiscoverable program must never be kicked.
+function launchdLabelManagesTarget(programPath, targetBinary) {
+  if (!programPath || !targetBinary) return false;
+  const norm = (p) => {
+    try {
+      return fs.realpathSync(p);
+    } catch (_) {
+      return path.resolve(String(p));
+    }
+  };
+  return norm(programPath) === norm(targetBinary);
+}
+
+// Reload the managed launchd service that runs the JUST-INSTALLED binary so it
+// re-execs it. `launchctl kickstart -k gui/<uid>/<label>` stops (SIGKILL) then
+// restarts the service — the reliable "reload now" the plain kill -TERM could
+// miss (KeepAlive races, the TERM never reaching the service).
+//
+// SCOPE (field hazard fix): only labels whose managed program path equals
+// `targetBinary` are kicked. The old code kicked EVERY label containing "m1nd",
+// so one swap SIGKILLed the whole fleet (worktrees, other installs). Each
+// candidate is resolved via `launchctl print` and compared to the target;
+// non-matches are recorded as skipped, never kicked. Returns one result per
+// candidate (kicked or skipped); empty when no m1nd label is loaded.
+function kickstartManagedServices(targetBinary) {
   const uid = typeof process.getuid === "function" ? process.getuid() : null;
   if (uid === null) return [];
-  const labels = managedLaunchdLabels();
+  const labels = candidateLaunchdLabels();
   return labels.map((label) => {
     const domain = `gui/${uid}/${label}`;
+    const programPath = launchdLabelProgramPath(uid, label);
+    if (!launchdLabelManagesTarget(programPath, targetBinary)) {
+      // A candidate that does NOT manage the target is left untouched — kicking
+      // it would SIGKILL an unrelated m1nd service.
+      return { label, domain, skipped: true, reason: "program path does not match target", program_path: programPath || null };
+    }
     const result = runCommand("launchctl", ["kickstart", "-k", domain]);
-    return { label, domain, ok: result.ok, status: result.status, stderr: (result.stderr || "").trim() || undefined };
+    return { label, domain, ok: result.ok, status: result.status, program_path: programPath, stderr: (result.stderr || "").trim() || undefined };
   });
+}
+
+// Whether the reload (kickstart) may proceed after an install. On darwin a
+// re-exec of an UNSIGNED binary is killed by the OS (OS_REASON_CODESIGNING), so
+// if the ad-hoc codesign was attempted and FAILED, kickstarting would drive the
+// service into a kill/respawn loop — refuse it and tell the operator to sign
+// first. Non-darwin, or a successful/needless codesign, allows the reload.
+// `codesign` is the `codesignAdHoc` result (or null when none was attempted).
+function shouldKickstartAfterInstall(platform, codesign) {
+  if (platform !== "darwin") return true;
+  if (codesign && codesign.attempted && !codesign.ok) return false;
+  return true;
 }
 
 function restart(args) {
@@ -2783,20 +2857,34 @@ function restart(args) {
   if (yes && killRequested) {
     // On macOS a m1nd daemon is a launchd-managed service: a plain kill -TERM can
     // race KeepAlive or never reach the service, so the OLD binary keeps running
-    // after the swap. Kickstart any managed m1nd service FIRST — it stops then
-    // re-execs the just-installed binary reliably. kill -TERM stays as the
+    // after the swap. Kickstart the managed service that runs the JUST-INSTALLED
+    // binary FIRST — it stops then re-execs it reliably. kill -TERM stays as the
     // fallback (and covers non-launchd processes + non-macOS hosts).
-    const kicked = kickstartManagedServices();
-    if (kicked.length > 0) {
-      result.actions.kickstarted_services = kicked;
-      const failedKicks = kicked.filter((k) => !k.ok);
-      if (failedKicks.length > 0) {
-        result.next_actions.push(
-          `Some managed m1nd launchd services did not reload (${failedKicks.map((k) => k.label).join(", ")}); check 'launchctl print ${failedKicks[0].domain}'.`
-        );
+    //
+    // codesign gate: if the ad-hoc codesign was attempted and FAILED, the
+    // installed binary is unsigned and re-execing it would be killed by the OS
+    // (OS_REASON_CODESIGNING) — an endless kill/respawn loop. Do NOT kickstart in
+    // that case; leave the (old, signed) service running and tell the operator to
+    // sign first. kill -TERM is likewise skipped so we don't drop the daemon onto
+    // the unsigned binary via KeepAlive.
+    if (!shouldKickstartAfterInstall(process.platform, result.actions.codesign)) {
+      result.actions.kickstart_skipped = "codesign failed — not re-execing an unsigned binary";
+      result.next_actions.push(
+        `Skipped reloading launchd services: the installed binary at ${targetBinary} is unsigned (codesign failed) and macOS would kill it on re-exec. Sign it (codesign --force --sign - ${targetBinary}), then re-run.`
+      );
+    } else {
+      const kicked = kickstartManagedServices(targetBinary);
+      if (kicked.length > 0) {
+        result.actions.kickstarted_services = kicked;
+        const failedKicks = kicked.filter((k) => !k.skipped && !k.ok);
+        if (failedKicks.length > 0) {
+          result.next_actions.push(
+            `Some managed m1nd launchd services did not reload (${failedKicks.map((k) => k.label).join(", ")}); check 'launchctl print ${failedKicks[0].domain}'.`
+          );
+        }
       }
+      result.actions.stopped_processes = stopRuntimeProcesses(processes);
     }
-    result.actions.stopped_processes = stopRuntimeProcesses(processes);
     const failedStops = result.actions.stopped_processes.filter((processInfo) => !processInfo.ok);
     if (failedStops.length > 0) {
       result.next_actions.push("Some visible m1nd-mcp processes did not stop; restart the host session or OS if the process state is uninterruptible.");
@@ -3146,4 +3234,8 @@ module.exports = {
   githubReleaseAssetName,
   versionFromText,
   compareSemver,
+  parseLaunchctlLabel,
+  parseLaunchctlProgramPath,
+  launchdLabelManagesTarget,
+  shouldKickstartAfterInstall,
 };

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -21,6 +21,10 @@ const {
   restart,
   runtimeBinaryName,
   selfUpdate,
+  parseLaunchctlLabel,
+  parseLaunchctlProgramPath,
+  launchdLabelManagesTarget,
+  shouldKickstartAfterInstall,
 } = require("../lib/cli");
 const { classifyScopeBinding } = require("../lib/agent-cli");
 
@@ -1574,6 +1578,123 @@ function homeForTest() {
   assert(
     !plan.next_actions.some((action) => action.includes("DRY RUN — nothing was installed")),
     "with no installable source, the loud install-swap line must be absent"
+  );
+}
+
+// --- restart reload trio hardening (cli-operator #11) ---------------------
+
+// (c) label parsing: `launchctl list` is `PID\tSTATUS\tLABEL`, and a label MAY
+// contain whitespace. The label is columns 3..end, not the last token.
+{
+  assert.strictEqual(
+    parseLaunchctlLabel("1234\t0\tcom.kle1nz.m1nd-serve"),
+    "com.kle1nz.m1nd-serve",
+    "a normal label parses whole"
+  );
+  assert.strictEqual(
+    parseLaunchctlLabel("1234\t0\tcom.example.m1nd service with spaces"),
+    "com.example.m1nd service with spaces",
+    "a label WITH SPACES must survive intact (the .pop() bug kept only 'spaces')"
+  );
+  assert.strictEqual(
+    parseLaunchctlLabel("-\t0\tcom.example.m1nd.idle"),
+    "com.example.m1nd.idle",
+    "a '-' PID column still yields the full label"
+  );
+  assert.strictEqual(parseLaunchctlLabel("PID\tStatus\tLabel"), "Label", "header parses by shape");
+  assert.strictEqual(parseLaunchctlLabel(""), "", "a blank line yields no label");
+  assert.strictEqual(parseLaunchctlLabel("only two"), "", "a malformed <3-column line yields no label");
+}
+
+// program-path parsing from `launchctl print` — both the `program = …` form and
+// the `program-arguments` array first-entry fallback.
+{
+  const withProgram = [
+    "com.example.m1nd = {",
+    "\tactive count = 1",
+    "\tprogram = /Users/x/.m1nd/bin/m1nd-mcp",
+    "\targuments = {",
+    "\t}",
+    "}",
+  ].join("\n");
+  assert.strictEqual(
+    parseLaunchctlProgramPath(withProgram),
+    "/Users/x/.m1nd/bin/m1nd-mcp",
+    "the explicit program line is preferred"
+  );
+
+  const withArgsOnly = [
+    "com.example.m1nd = {",
+    "\tprogram-arguments = {",
+    "\t\t0 => /opt/m1nd/bin/m1nd-mcp",
+    "\t\t1 => --serve",
+    "\t}",
+    "}",
+  ].join("\n");
+  assert.strictEqual(
+    parseLaunchctlProgramPath(withArgsOnly),
+    "/opt/m1nd/bin/m1nd-mcp",
+    "falls back to the first program-argument"
+  );
+
+  assert.strictEqual(parseLaunchctlProgramPath("no program here"), null, "no program → null");
+}
+
+// (a) kickstart-scope: a label is kicked ONLY when its managed program IS the
+// target binary. A different m1nd install must NOT match (that was the fleet-wide
+// SIGKILL bug). A null program path is fail-closed (never a match).
+{
+  const tmp = mkTmpDir();
+  const target = path.join(tmp, "m1nd-mcp");
+  fs.writeFileSync(target, "#!/bin/sh\n");
+  const other = path.join(tmp, "other-m1nd-mcp");
+  fs.writeFileSync(other, "#!/bin/sh\n");
+
+  assert.strictEqual(
+    launchdLabelManagesTarget(target, target),
+    true,
+    "the exact target program matches"
+  );
+  assert.strictEqual(
+    launchdLabelManagesTarget(other, target),
+    false,
+    "a DIFFERENT m1nd binary must NOT match — no fleet-wide kick"
+  );
+  assert.strictEqual(
+    launchdLabelManagesTarget(null, target),
+    false,
+    "an undiscoverable program path is fail-closed (never kicked)"
+  );
+  assert.strictEqual(
+    launchdLabelManagesTarget("", target),
+    false,
+    "an empty program path is fail-closed"
+  );
+}
+
+// (b) codesign-gate: after an install, a FAILED darwin codesign must block the
+// kickstart (re-execing an unsigned binary → OS kill loop). Everything else
+// proceeds.
+{
+  assert.strictEqual(
+    shouldKickstartAfterInstall("darwin", { attempted: true, ok: false }),
+    false,
+    "darwin + codesign FAILED must NOT kickstart"
+  );
+  assert.strictEqual(
+    shouldKickstartAfterInstall("darwin", { attempted: true, ok: true }),
+    true,
+    "darwin + codesign ok proceeds"
+  );
+  assert.strictEqual(
+    shouldKickstartAfterInstall("darwin", null),
+    true,
+    "darwin + no codesign attempted proceeds (e.g. no install this run)"
+  );
+  assert.strictEqual(
+    shouldKickstartAfterInstall("linux", { attempted: true, ok: false }),
+    true,
+    "non-darwin ignores codesign entirely"
   );
 }
 

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -1587,8 +1587,8 @@ function homeForTest() {
 // contain whitespace. The label is columns 3..end, not the last token.
 {
   assert.strictEqual(
-    parseLaunchctlLabel("1234\t0\tcom.kle1nz.m1nd-serve"),
-    "com.kle1nz.m1nd-serve",
+    parseLaunchctlLabel("1234\t0\tcom.example.m1nd-serve"),
+    "com.example.m1nd-serve",
     "a normal label parses whole"
   );
   assert.strictEqual(


### PR DESCRIPTION
Closes five gap-ledger items (docs/UML-ORGANISM.md §5), each RED-first.

- **[security] Non-loopback bind refused without `--allow-remote`** — default is loopback; binding `0.0.0.0`/`::`/a LAN IP now fail-closes before the listener opens unless the flag is passed (strong warning when it is). Token auth remains future work — the flag makes remote exposure deliberate, not authenticated.
- **[correctness] restart reload trio** (npm) — kickstart now targets ONLY the launchd service whose managed program is the installed binary (no more fleet-wide SIGKILL); a failed ad-hoc codesign blocks the re-exec (no unsigned crash-loop); label parsing survives spaces.
- **[correctness] `learn` rejects unknown feedback** — a typo verb returns InvalidParams instead of silently accruing a defect on an innocent node.
- **[correctness] freshest-first recall** — broad L1GHT recall now orders dated claims first (freshest first), undated last, instead of floating undated legacy to the top.
- **[correctness] mailbox `in_flight` derived** — implemented the natural reply-graph derivation (a non-receipt reference picks an id up = in_flight; a receipt closes it = fired_clay), retiring the dead-code fate that was miscounted in "open".

`cargo test --workspace` 1320 passed / 0 failed · clippy `-D warnings` clean · fmt clean · npm `node --test` pass. Fixtures environment-neutral.