### PR TITLE
build(m1nd-ui): add ESLint 9 flat config and clear the lint backlog

### DIFF
--- a/m1nd-ui/eslint.config.js
+++ b/m1nd-ui/eslint.config.js
@@ -1,0 +1,31 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+
+// Flat config (ESLint 9). Vite + React + TypeScript, syntax-only linting
+// (no type-aware rules) to keep it fast and dependency-light.
+export default tseslint.config(
+  // Replaces .eslintignore — build output and deps are never linted.
+  { ignores: ['dist', 'node_modules'] },
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      reactHooks.configs['recommended-latest'],
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.browser,
+    },
+    rules: {
+      // Fast Refresh is a dev-only concern; a few modules here legitimately
+      // co-locate a helper/registry with components (e.g. lib/icons/registry.tsx).
+      // Keep it as a signal, not a lint failure.
+      'react-refresh/only-export-components': 'warn',
+    },
+  },
+)

--- a/m1nd-ui/package-lock.json
+++ b/m1nd-ui/package-lock.json
@@ -16,6 +16,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/dagre": "^0.7.52",
         "@types/node": "^22.20.0",
         "@types/react": "^18.3.18",
@@ -23,10 +24,14 @@
         "@vitejs/plugin-react": "^6.0.3",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.21.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.7.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.23.0",
         "typescript": "~5.7.0",
+        "typescript-eslint": "^8.62.1",
         "vite": "^8.1.0"
       }
     },
@@ -626,6 +631,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
@@ -1202,6 +1220,288 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1979,6 +2279,29 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -2251,9 +2574,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3426,6 +3749,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3643,6 +3979,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3702,6 +4051,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/m1nd-ui/package.json
+++ b/m1nd-ui/package.json
@@ -22,6 +22,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@types/dagre": "^0.7.52",
     "@types/node": "^22.20.0",
     "@types/react": "^18.3.18",
@@ -29,10 +30,14 @@
     "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.21.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.5.3",
+    "globals": "^17.7.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.23.0",
     "typescript": "~5.7.0",
+    "typescript-eslint": "^8.62.1",
     "vite": "^8.1.0"
   }
 }

--- a/m1nd-ui/src/components/ActivationReplay.tsx
+++ b/m1nd-ui/src/components/ActivationReplay.tsx
@@ -186,7 +186,7 @@ const ActivationReplay = React.memo(function ActivationReplay({ onBack }: Activa
       if (!isReplaying) return;
       if (e.code === 'Space') {
         e.preventDefault();
-        isPlaying ? pause() : play();
+        if (isPlaying) pause(); else play();
       }
       if (e.code === 'ArrowRight') { e.preventDefault(); nextFrame(); }
       if (e.code === 'ArrowLeft')  { e.preventDefault(); prevFrame(); }

--- a/m1nd-ui/src/components/GraphCanvas.tsx
+++ b/m1nd-ui/src/components/GraphCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback } from 'react';
 import {
   ReactFlow,
   Background,
@@ -19,7 +19,7 @@ import StructuralHoleNode from './nodes/StructuralHoleNode';
 import WeightedEdge from './edges/WeightedEdge';
 import GhostEdge from './edges/GhostEdge';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/* eslint-disable @typescript-eslint/no-explicit-any -- @xyflow/react's NodeTypes/EdgeTypes maps reject our concrete node/edge component signatures; casting is the documented workaround */
 const nodeTypes: NodeTypes = {
   file: FileNode as any,
   class: ClassNode as any,
@@ -27,11 +27,11 @@ const nodeTypes: NodeTypes = {
   structuralHole: StructuralHoleNode as any,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const edgeTypes: EdgeTypes = {
   weighted: WeightedEdge as any,
   ghost: GhostEdge as any,
 };
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 // Canvas-level Error Boundary (FM-FE-056)
 class CanvasErrorBoundary extends React.Component<
@@ -79,9 +79,8 @@ interface GraphCanvasProps {
   onEdgeContextMenu?: (edgeId: string, position: { x: number; y: number }) => void;
 }
 
-export default function GraphCanvas({ onNodeSelect, onNodeContextMenu, onEdgeContextMenu }: GraphCanvasProps) {
-  const { nodes, edges, showMinimap, setNodes, setEdges, selectNode, clearGraph } = useGraphStore();
-  const lastQueryRef = useRef<{ tool: string; query: string } | null>(null);
+export default function GraphCanvas({ onNodeSelect, onNodeContextMenu }: GraphCanvasProps) {
+  const { nodes, edges, showMinimap, setNodes, selectNode, clearGraph } = useGraphStore();
 
   const onNodeClick: NodeMouseHandler = useCallback((_event, node) => {
     selectNode(node.id);

--- a/m1nd-ui/src/components/InstancesPanel.tsx
+++ b/m1nd-ui/src/components/InstancesPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { api, ApiError } from '../api/client';
-import type { InstanceListResponse, InstanceRegistryEntry, InstanceSelfResponse } from '../types';
+import type { InstanceRegistryEntry, InstanceSelfResponse } from '../types';
 
 interface InstancesPanelProps {
   isOpen: boolean;

--- a/m1nd-ui/src/components/hall/BrainPalette.tsx
+++ b/m1nd-ui/src/components/hall/BrainPalette.tsx
@@ -20,7 +20,6 @@ import {
   brainDisplayName,
   lastSeenPhrase,
   entryBaseUrl,
-  isProjectBrain,
   canOpenBrainInPlace,
 } from '../../lib/hallSemantics';
 

--- a/m1nd-ui/src/components/hall/HallView.tsx
+++ b/m1nd-ui/src/components/hall/HallView.tsx
@@ -22,7 +22,6 @@ import {
   brainDisplayName,
   brainProjectPath,
   isProjectBrain,
-  canOpenBrainInPlace,
 } from '../../lib/hallSemantics';
 import { canonRootForCompare } from '../../lib/viewedBrain';
 import { useCardV2Data } from '../../hooks/useCardV2Data';
@@ -59,7 +58,6 @@ function errorDetail(error: unknown, fallback: string): string {
 
 export default function HallView({
   onExit,
-  onOpenBound,
   onOpenBrain,
   onBootstrap,
   restSelector,

--- a/m1nd-ui/src/components/hall/delete-flow.test.tsx
+++ b/m1nd-ui/src/components/hall/delete-flow.test.tsx
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ForgetStepView, canFireDelete, liveRefusalLine, type ForgetStep } from './ForgetRuntimeFlow';
+import { ForgetStepView, canFireDelete, liveRefusalLine } from './ForgetRuntimeFlow';
 import { brainDisplayName, nameMatches } from '../../lib/hallSemantics';
 import type { InstanceListResponse } from '../../types';
 

--- a/m1nd-ui/src/components/preflight/preflight-card.test.tsx
+++ b/m1nd-ui/src/components/preflight/preflight-card.test.tsx
@@ -38,7 +38,6 @@ const decode = (s: string) =>
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"');
-const visibleText = (el: React.ReactElement) => decode(html(el).replace(/<[^>]+>/g, ' '));
 
 // ── The card mounts and names what's about to be touched ──────────────────────
 test('the card renders its dialog shell + the seeded target', () => {

--- a/m1nd-ui/src/components/tree/LivingTree.tsx
+++ b/m1nd-ui/src/components/tree/LivingTree.tsx
@@ -179,7 +179,6 @@ export default function LivingTree({ viewedBrain = BOUND_VIEW, onIngest }: Livin
   useEffect(() => {
     setLayers(null);
     setStalePaths(new Set());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [root]);
 
   // Switching the viewed brain (§4A.9) resets the tree's local view: a different

--- a/m1nd-ui/src/components/tree/TreeDrawer.tsx
+++ b/m1nd-ui/src/components/tree/TreeDrawer.tsx
@@ -91,6 +91,7 @@ export default function TreeDrawer({ row, band, onClose, onCheckBeforeEditing }:
     return () => {
       mounted = false;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the selected row's id; refetch only when it changes
   }, [row?.externalId]);
 
   if (!row) {

--- a/m1nd-ui/src/lib/hallSemantics.ts
+++ b/m1nd-ui/src/lib/hallSemantics.ts
@@ -11,7 +11,6 @@
  * INV-10: every value here traces to an owner-reported field; absence is
  * absence, never an invented number.
  */
-import type { InstanceRegistryEntry, InstanceSelfResponse } from '../types';
 
 // ── Liveness band (PRD §4A.3 card anatomy: the liveness dot) ──────────────────
 // sage = live · unfired grey = dormant · ochre = stale heartbeat · brick = hard

--- a/m1nd-ui/src/stores/toastStore.ts
+++ b/m1nd-ui/src/stores/toastStore.ts
@@ -16,7 +16,7 @@ interface ToastStore {
 
 let toastCounter = 0;
 
-export const useToastStore = create<ToastStore>((set, get) => ({
+export const useToastStore = create<ToastStore>((set) => ({
   toasts: [],
 
   addToast: (message, detail, type = 'info') => {


### PR DESCRIPTION
## What

`m1nd-ui`'s `npm run lint` (`eslint . --ext ts,tsx`) crashed: ESLint 9 requires a flat config and none existed in the package. This adds a minimal Vite + React + TypeScript `eslint.config.js` and clears the backlog it surfaced. Pre-existing and repo-wide — unrelated to any feature branch.

## Config

- `eslint.config.js` (flat, ESLint 9): `@eslint/js` + `typescript-eslint` recommended (syntax-only, no type-aware pass, to stay fast), plus `react-hooks` and `react-refresh`. Ignores `dist/` and `node_modules/`.
- devDeps pinned to the ESLint 9 line — `typescript-eslint` 8.62.1, `@eslint/js` 9.39.4, `eslint-plugin-react-hooks` 5.2.0, `eslint-plugin-react-refresh` 0.5.3, `globals` 17. ESLint stays at **9.39.4**; no major bump (npm `latest` would have pulled ESLint 10).

## The 28 problems → 0 errors

- Removed dead imports/vars (`no-unused-vars`) across several files.
- Scoped the `@xyflow/react` `as any` casts under one justified block-disable (the two prior line-disables were misplaced and inert).
- Rewrote an expression-statement ternary as `if/else`.
- Annotated the intentional `exhaustive-deps` keying in `TreeDrawer`; dropped a stale disable in `LivingTree`.
- Downgraded `react-refresh/only-export-components` to `warn` (dev-only Fast Refresh concern; e.g. `lib/icons/registry.tsx` legitimately co-locates a registry with components).

No rule was blanket-disabled; `@typescript-eslint/no-explicit-any` stays an error.

## Verification

- `npm run lint` → **0 errors** (5 `react-refresh` warnings)
- `npm run build` → green
- `npm test` → **232 pass / 0 fail**
- soft-proof lints (`violet`, `icon`) left untouched and green

The embedded `dist/` (tracked for `rust-embed`) is intentionally **not** regenerated here: this is a lint/tooling change with no functional UI impact. Regenerate it in a separate `build(...)` commit if wanted.
