### PR TITLE
chore: update stale tool-count literals in MCP server docstrings

### DIFF
--- a/m1nd-ingest/src/cross_file.rs
+++ b/m1nd-ingest/src/cross_file.rs
@@ -1497,9 +1497,9 @@ impl RustModuleIndex {
         };
 
         // Parent = everything before the last slash
-        let parent_path = match canonical.rfind('/') {
-            Some(idx) => &canonical[..idx],
-            None => return None, // already at root, no super
+        let parent_path = {
+            let idx = canonical.rfind('/')?;
+            &canonical[..idx]
         };
 
         // Try "parent_path" directly (for mod.rs case) or "parent_path.rs"

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -6271,8 +6271,8 @@ fn l7_prefix_graph_nodes(
                 let causal = source.csr.causal_strengths[edge_pos].get();
                 let inhibitory = source.csr.inhibitory[edge_pos];
 
-                let new_src_id = format!("{}::{}", repo_name, &source_ext_ids[src_idx]);
-                let new_tgt_id = format!("{}::{}", repo_name, &source_ext_ids[tgt_node.as_usize()]);
+                let new_src_id = format!("{}::{}", repo_name, source_ext_ids[src_idx]);
+                let new_tgt_id = format!("{}::{}", repo_name, source_ext_ids[tgt_node.as_usize()]);
 
                 if let (Some(src), Some(tgt)) = (
                     target.resolve_id(&new_src_id),
@@ -6292,8 +6292,8 @@ fn l7_prefix_graph_nodes(
         }
     } else {
         for edge in &source.csr.pending_edges {
-            let new_src_id = format!("{}::{}", repo_name, &source_ext_ids[edge.source.as_usize()]);
-            let new_tgt_id = format!("{}::{}", repo_name, &source_ext_ids[edge.target.as_usize()]);
+            let new_src_id = format!("{}::{}", repo_name, source_ext_ids[edge.source.as_usize()]);
+            let new_tgt_id = format!("{}::{}", repo_name, source_ext_ids[edge.target.as_usize()]);
             if let (Some(src), Some(tgt)) = (
                 target.resolve_id(&new_src_id),
                 target.resolve_id(&new_tgt_id),

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -366,7 +366,7 @@ struct DaemonRuntimeControl {
 // Tool tier gate
 // ---------------------------------------------------------------------------
 
-/// The curated ESSENTIAL tool set (~25 tools) advertised by default.
+/// The curated ESSENTIAL tool set (42 tools) advertised by default.
 ///
 /// These are the high-frequency tools agents need for orientation, trust, and
 /// everyday graph queries. All other tools are "advanced" and are hidden from
@@ -421,8 +421,8 @@ pub const ESSENTIAL_TOOLS: &[&str] = &[
 
 /// Returns the active tool tier based on the `M1ND_TOOL_TIER` env var.
 ///
-/// - Unset or `essential` (case-insensitive) → `"essential"` (curated ~25)
-/// - `full` (case-insensitive) → `"full"` (all 102 tools)
+/// - Unset or `essential` (case-insensitive) → `"essential"` (curated 42)
+/// - `full` (case-insensitive) → `"full"` (all 118 tools)
 /// - Any unrecognized value → defaults to `"essential"`
 pub fn active_tool_tier() -> &'static str {
     match std::env::var("M1ND_TOOL_TIER")
@@ -463,7 +463,7 @@ pub fn proof_gate_enabled() -> bool {
 }
 
 /// Returns ALL registered MCP tool schemas regardless of tier.
-/// Use this when you always need the full 102-tool registry (e.g., health
+/// Use this when you always need the full 118-tool registry (e.g., health
 /// contract counts, internal tests that verify advanced tool registration).
 pub fn all_tool_schemas() -> serde_json::Value {
     all_tool_schemas_inner()
@@ -503,7 +503,7 @@ pub fn tool_schemas_for_tier(tier: &str) -> serde_json::Value {
     serde_json::json!({ "tools": filtered })
 }
 
-/// Internal: the complete static tool registry (all 102 tools). Never filtered.
+/// Internal: the complete static tool registry (all 118 tools). Never filtered.
 fn all_tool_schemas_inner() -> serde_json::Value {
     serde_json::json!({
         "tools": [

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -3315,8 +3315,8 @@ pub fn handle_health(state: &mut SessionState, _input: HealthInput) -> M1ndResul
             "full_registry_tool_count": full_registry_tool_count,
             // advertised_tool_count: what tools/list currently exposes (tier-dependent)
             "advertised_tool_count": advertised_tool_count,
-            // tool_tier: "essential" (default, ~25 tools) or "full" (all tools).
-            // Set M1ND_TOOL_TIER=full to expose all 102 tools in tools/list.
+            // tool_tier: "essential" (default, 42 tools) or "full" (all tools).
+            // Set M1ND_TOOL_TIER=full to expose all 118 tools in tools/list.
             // Hidden tools remain callable via tools/call dispatch at all times.
             "tool_tier": tool_tier,
             "required_agent_trust_tools": AGENT_TRUST_REQUIRED_TOOLS,


### PR DESCRIPTION
Updated the stale tool-count literals in the MCP server docstrings to reflect the actual counts from the tool registry.

*   Updated "curated ~25 tools" to "curated 42 tools" in `m1nd-mcp/src/server.rs` and `m1nd-mcp/src/tools.rs`.
*   Updated "all 102 tools" to "all 118 tools" in `m1nd-mcp/src/server.rs` and `m1nd-mcp/src/tools.rs`.
*   Fixed clippy warnings in `m1nd-ingest/src/cross_file.rs` (replaced `match` with `?` operator) and `m1nd-mcp/src/layer_handlers.rs` (removed redundant reference in `format!` argument) to ensure pipeline compliance.

Author commits as Max Kle1nz <kleinz@cosmophonix.com>.

---
*PR created automatically by Jules for task [9233617611211685867](https://jules.google.com/task/9233617611211685867) started by @maxkle1nz*