### PR TITLE
mission_post refuses a mis-routed brain_ref — the silent wrong-box trap dies

### DIFF
--- a/m1nd-mcp/src/mission_letter_handlers.rs
+++ b/m1nd-mcp/src/mission_letter_handlers.rs
@@ -58,6 +58,27 @@ fn mission_err(err: MissionLetterError) -> M1ndError {
 /// line — reusing the mailbox append/dedup. A stale head returns `stale_head` and
 /// nothing is appended; an identical replay dedups (idempotent).
 pub fn handle_mission_post(state: &mut SessionState, input: MissionPostInput) -> M1ndResult<Value> {
+    // The brain guard (field-hardening, proposed by the first external hand agent
+    // after living the trap): a letter whose `brain_ref` does not name the brain
+    // THIS session is bound to would land silently in the WRONG box — the exact
+    // mis-route that hit both the hand agent and the tray on day one. Refuse
+    // honestly instead. `brain_ref` matches the bound brain's display name (the
+    // §4A.9 echo identity). A medulla-bound session (no code root) has no display
+    // and accepts any ref — the memory-only box is an explicit fallback, not a
+    // mis-route.
+    if let Some(bound) = state.code_root_display_name() {
+        if input.letter.brain_ref != bound {
+            return Err(M1ndError::InvalidParams {
+                tool: "mission_post".to_string(),
+                detail: format!(
+                    "brain_mismatch: the letter names brain_ref '{}' but this session is bound \
+                     to '{}' — bind to the right brain (ingest project_root=<its root>) or fix \
+                     the letter; nothing was appended",
+                    input.letter.brain_ref, bound
+                ),
+            });
+        }
+    }
     let box_path = mission_box_path(state);
     let outcome = mission_letter::post_mission_letter(&box_path, &input.agent_id, &input.letter)
         .map_err(mission_err)?;

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -6020,6 +6020,57 @@ mod tests {
     }
 
     #[test]
+    fn mission_post_refuses_a_brain_ref_that_is_not_the_bound_brain() {
+        // The brain guard: a session bound to a real code root refuses a letter
+        // naming a DIFFERENT brain_ref — the silent mis-route becomes an honest
+        // refusal. A matching ref posts; the medulla fallback (no root) stays
+        // permissive (covered by the end-to-end test above, whose state has no
+        // bound root).
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("project-a");
+        std::fs::create_dir_all(repo.join(".git")).expect("repo dir with .git");
+        state.workspace_root = Some(repo.to_string_lossy().to_string());
+
+        let letter = serde_json::json!({
+            "schema": "m1nd-mission-letter-v0",
+            "mission_id": "msn_0123456789ab",
+            "mission_seq": 1,
+            "block_id": "sb_x",
+            "brain_ref": "some-other-brain",
+            "seat": "hand",
+            "capability": "build-runner",
+            "phase": "judging",
+            "packet_ref": "sha256:abc",
+            "tokens_total": 0,
+            "started_at": "2026-07-09T00:00:00Z",
+            "updated_at": "2026-07-09T00:00:00Z",
+        });
+        let err = super::dispatch_tool(
+            &mut state,
+            "mission_post",
+            &serde_json::json!({"agent_id": "t", "letter": letter}),
+        )
+        .expect_err("a mismatched brain_ref must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("brain_mismatch"), "got: {msg}");
+        assert!(
+            msg.contains("project-a"),
+            "the refusal names the bound brain: {msg}"
+        );
+
+        // The same letter naming the BOUND brain posts cleanly.
+        let mut ok_letter = letter;
+        ok_letter["brain_ref"] = serde_json::json!("project-a");
+        let out = super::dispatch_tool(
+            &mut state,
+            "mission_post",
+            &serde_json::json!({"agent_id": "t", "letter": ok_letter}),
+        )
+        .expect("a matching brain_ref posts");
+        assert_eq!(out["mission_seq"], 1);
+    }
+
+    #[test]
     fn mission_post_is_wired_end_to_end_with_head_cas() {
         let (_temp, mut state) = build_state();
 

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -973,6 +973,25 @@ impl SessionState {
         self.project_root_display().map(|root| basename_of(&root))
     }
 
+    /// The display name ONLY when it comes from a REAL code root (resolver cases
+    /// 1-2: an ingest root or a repo workspace) — `None` on the plumbing
+    /// fallbacks (cases 3-4), where the "display" is a runtime dir. Guards that
+    /// arm on brain identity (the mission_post brain guard) use THIS, so a bare
+    /// session never refuses over plumbing.
+    pub fn code_root_display_name(&self) -> Option<String> {
+        for root in &self.ingest_roots {
+            if !is_memory_sidecar(root) && std::path::Path::new(root).is_dir() {
+                return Some(basename_of(root));
+            }
+        }
+        if let Some(ws) = self.workspace_root.as_deref() {
+            if !is_memory_sidecar(ws) && std::path::Path::new(ws).join(".git").exists() {
+                return Some(basename_of(ws));
+            }
+        }
+        None
+    }
+
     /// True when THIS store is the medulla — the owner's own memory-of-doctrine
     /// store, not a per-project brain (MEDULLA-PRD §4.1: the tier IS the directory).
     ///


### PR DESCRIPTION
Field-hardening proposed by the external hand agent after the mis-route hit twice in one day (its mission chains landed in an unrelated brain's box; the tray showed a mission whose map could not open). `mission_post` now refuses with an honest `brain_mismatch` naming both sides when the letter's `brain_ref` is not the brain the session is bound to. The guard arms only on a REAL code root (new `code_root_display_name`: an ingest root or a .git workspace) — bare/medulla-bound sessions stay permissive (the memory-only box is an explicit fallback, not a mis-route). Tests: the refusal + the matching post + the plumbing-display case; suite 713/713.