### PR TITLE
scan/reconcile resolve the code root — a hosted brain's store dir is never the repo

### DIFF
--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -979,14 +979,25 @@ impl SessionState {
     /// arm on brain identity (the mission_post brain guard) use THIS, so a bare
     /// session never refuses over plumbing.
     pub fn code_root_display_name(&self) -> Option<String> {
+        self.code_root_path().map(|root| basename_of(&root))
+    }
+
+    /// The PATH of the real code root (the same cases 1-2 as
+    /// [`code_root_display_name`]): a non-sidecar ingest root, else a workspace
+    /// that is a .git repo. `None` on plumbing — a hosted brain's raw
+    /// `workspace_root` is its STORE dir (where memory sidecars live), so the
+    /// repo-file-list surfaces (reconcile, skeleton_candidate) MUST use this,
+    /// never `workspace_root` directly: the first virgin-repo scan listed the
+    /// brain's `.light.md` memories as the repo because of exactly that.
+    pub fn code_root_path(&self) -> Option<String> {
         for root in &self.ingest_roots {
             if !is_memory_sidecar(root) && std::path::Path::new(root).is_dir() {
-                return Some(basename_of(root));
+                return Some(root.clone());
             }
         }
         if let Some(ws) = self.workspace_root.as_deref() {
             if !is_memory_sidecar(ws) && std::path::Path::new(ws).join(".git").exists() {
-                return Some(basename_of(ws));
+                return Some(ws.to_string());
             }
         }
         None

--- a/m1nd-mcp/src/system_blocks_handlers.rs
+++ b/m1nd-mcp/src/system_blocks_handlers.rs
@@ -197,13 +197,13 @@ pub fn handle_skeleton_candidate(
         }
     })?;
     let root = state
-        .workspace_root
-        .as_ref()
+        .code_root_path()
         .ok_or_else(|| M1ndError::InvalidParams {
             tool: TOOL.to_string(),
-            detail: "no workspace root is bound to this brain — skeleton_candidate needs a repo file list".to_string(),
-        })?
-        .clone();
+            detail: "no CODE root is bound to this brain — skeleton_candidate needs the repo \
+                 (a hosted brain's raw workspace is its store dir, never scanned)"
+                .to_string(),
+        })?;
     let file_list =
         system_blocks::repo_file_list(Path::new(&root)).map_err(|e| seed_err(TOOL, e))?;
     let source_commit = git_head_commit(Path::new(&root)).unwrap_or_default();
@@ -384,14 +384,14 @@ pub fn handle_system_blocks_reconcile(
         Some(list) => list,
         None => {
             let root = state
-                .workspace_root
-                .as_ref()
+                .code_root_path()
                 .ok_or_else(|| M1ndError::InvalidParams {
                     tool: TOOL.to_string(),
-                    detail: "no workspace root is bound to this brain — pass file_list explicitly"
+                    detail: "no CODE root is bound to this brain — pass file_list explicitly \
+                         (a hosted brain's raw workspace is its store dir, never scanned)"
                         .to_string(),
                 })?;
-            system_blocks::repo_file_list(Path::new(root)).map_err(|e| seed_err(TOOL, e))?
+            system_blocks::repo_file_list(Path::new(&root)).map_err(|e| seed_err(TOOL, e))?
         }
     };
     let (store, report) = reconcile_in_dir(&dir, input.expected_store_version, &file_list)
@@ -565,6 +565,70 @@ fn iso8601_from_ms(ms: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn scan_and_reconcile_use_the_code_root_never_the_store_dir() {
+        // The first virgin-repo scan listed the brain's .light.md memories as the
+        // repo: a hosted brain's raw workspace_root is its STORE dir. The handlers
+        // must resolve the CODE root (a real ingest root) instead.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("real-repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo");
+        std::fs::write(repo.join("src/lib.rs"), "pub fn x() {}\n").expect("file");
+        let store_dir = temp.path().join("brain-store/agent-memory");
+        std::fs::create_dir_all(&store_dir).expect("store");
+        std::fs::write(store_dir.join("doctrine.light.md"), "memory\n").expect("mem");
+
+        let config = crate::server::McpConfig {
+            graph_source: temp.path().join("g.json"),
+            plasticity_state: temp.path().join("p.json"),
+            runtime_dir: Some(temp.path().join("rt")),
+            ..crate::server::McpConfig::default()
+        };
+        let mut state = crate::session::SessionState::initialize(
+            m1nd_core::graph::Graph::new(),
+            &config,
+            m1nd_core::domain::DomainConfig::code(),
+        )
+        .expect("init");
+        // The hosted-brain shape: workspace points at the STORE dir; the real repo
+        // is an ingest root.
+        state.workspace_root = Some(store_dir.to_string_lossy().to_string());
+        state.ingest_roots = vec![repo.to_string_lossy().to_string()];
+
+        assert_eq!(
+            state.code_root_path().as_deref(),
+            Some(repo.to_string_lossy().as_ref()),
+            "the code root is the ingest root, never the store dir"
+        );
+
+        let out = handle_skeleton_candidate(
+            &mut state,
+            SkeletonCandidateInput {
+                agent_id: Some("t".to_string()),
+                expected_store_version: None,
+                review_limit: None,
+                naming: None,
+            },
+        )
+        .expect("scan runs against the real repo");
+        let members: Vec<String> = out["candidate_seed"]["blocks"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .flat_map(|b| b["membership"].as_array().cloned().into_iter().flatten())
+            .filter_map(|m| m["path"].as_str().map(str::to_string))
+            .collect();
+        assert!(
+            members.iter().all(|p| !p.contains(".light.md")),
+            "no memory sidecar file may enter a candidate: {members:?}"
+        );
+        assert!(
+            members.iter().any(|p| p.contains("lib.rs")),
+            "the real repo's files are the candidate: {members:?}"
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
The first virgin-repo scan (the F0c baptism) proposed twelve blocks — every one a `.light.md` memory file from the brain's own store: a hosted brain's raw `workspace_root` is its STORE dir, and both `skeleton_candidate` and `system_blocks_reconcile` fed it to `repo_file_list`. The candidate honestly confessed (`coverage_ratio 0.0` everywhere — no member had a graph node). Both handlers now resolve `code_root_path()` (a real non-sidecar ingest root, else a .git workspace, else an honest refusal), and the regression test pins the exact shape. 722/722.