### PR TITLE
naming: size the owner batch budget to a real CLI runner

### DIFF
--- a/m1nd-mcp/src/naming_runner.rs
+++ b/m1nd-mcp/src/naming_runner.rs
@@ -47,10 +47,19 @@ pub const PACKET_MEMBER_PATHS_CAP: usize = 40;
 /// How many top symbols a naming packet materializes.
 pub const PACKET_SYMBOLS_CAP: usize = 12;
 
+/// The instruction serialized into every naming packet (§2c: the response is ONE
+/// JSON line, schema-gated and sanitized on both sides).
+pub const PACKET_INSTRUCTION: &str = "Name this code block from the data in this JSON. Reply with EXACTLY one line of JSON and nothing else: {\"name\":\"...\",\"purpose\":\"...\"} — name is a short human module name (max 40 chars), purpose is one plain-text line (max 120 chars). No markdown, no URLs, no paths, no extra keys, no surrounding text.";
+
 /// One block's naming packet (§2a): what the runner sees — member list + dominant
 /// kinds + top symbols, NO file bodies. Built by the scan from data it already has.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct BlockNamingPacket {
+    /// The task instruction, serialized INTO every packet so a generic LLM-backed
+    /// runner works out of the box — field-proven necessary: a real CLI runner
+    /// receiving bare data (no task, no format) wandered past its timeout on
+    /// every live call. A non-LLM runner may ignore it.
+    pub instruction: String,
     pub block_id: String,
     /// The honest total member count (the list below may be capped).
     pub member_count: usize,
@@ -1010,6 +1019,7 @@ mod tests {
         let (port, daemon) = spawn_fake_daemon("HTTP/1.1 200 OK", body, "s3cr3t");
 
         let packets = vec![BlockNamingPacket {
+            instruction: PACKET_INSTRUCTION.to_string(),
             block_id: "sb_a".to_string(),
             member_count: 1,
             member_paths: vec!["src/a.rs".to_string()],
@@ -1083,6 +1093,7 @@ mod tests {
 
     fn packet_for(block_id: &str) -> BlockNamingPacket {
         BlockNamingPacket {
+            instruction: PACKET_INSTRUCTION.to_string(),
             block_id: block_id.to_string(),
             member_count: 1,
             member_paths: vec![format!("src/{block_id}.rs")],

--- a/m1nd-mcp/src/naming_runner.rs
+++ b/m1nd-mcp/src/naming_runner.rs
@@ -441,13 +441,17 @@ pub struct ScanNamingOutcome {
     pub transport_error: Option<String>,
 }
 
-/// The owner-side wait budget for one whole `/name` batch: headroom over the
-/// daemon's default 20s-per-block at parallelism 4, capped under the tool
+/// The owner-side wait budget for one whole `/name` batch, capped under the tool
 /// dispatch timeout so a slow runner degrades to the honest heuristic fallback
-/// instead of killing the scan.
+/// instead of killing the scan. Field-measured: a real CLI-backed naming runner
+/// takes ~50s per call (process startup dominates), and the daemon's per-block
+/// timeout is operator-configurable up to that scale — a 25s-per-wave budget cut
+/// live batches mid-read (EAGAIN at the exact budget) while the daemon was still
+/// legitimately working. One wave now gets the full sub-dispatch window; larger
+/// batches keep the same cap and surface the partial result honestly.
 fn scan_naming_timeout(block_count: usize) -> Duration {
     let waves = block_count.div_ceil(4).max(1) as u64;
-    Duration::from_secs((10 + 25 * waves).min(90))
+    Duration::from_secs((10 + 95 * waves).min(110))
 }
 
 /// Run the whole §2a scan-path naming attempt: try each announced daemon port in

--- a/m1nd-mcp/src/skeleton_scan.rs
+++ b/m1nd-mcp/src/skeleton_scan.rs
@@ -433,6 +433,7 @@ pub fn scan_skeleton(input: SkeletonScanInput, options: SkeletonScanOptions) -> 
             .take(crate::naming_runner::PACKET_SYMBOLS_CAP)
             .collect();
         naming_packets.push(crate::naming_runner::BlockNamingPacket {
+            instruction: crate::naming_runner::PACKET_INSTRUCTION.to_string(),
             block_id: block_id.clone(),
             member_count: group.members.len(),
             member_paths: group
@@ -654,6 +655,7 @@ pub(crate) fn naming_packet_for_store_block(
     kind_pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
 
     crate::naming_runner::BlockNamingPacket {
+        instruction: crate::naming_runner::PACKET_INSTRUCTION.to_string(),
         block_id: block.block_id.clone(),
         member_count: member_paths_full.len(),
         member_paths: member_paths_full


### PR DESCRIPTION
First live-fire finding: the owner's `/name` batch budget (10+25s per wave, cap 90) was sized to the daemon's 20s default, but a real CLI-backed naming runner measures ~50s per call (startup dominates) and the daemon's per-block timeout is operator-configurable to that scale. The owner cut the socket read at the exact budget (EAGAIN → a false `no_naming_runner`) while the daemon was still working. One wave now gets the full sub-dispatch window (10+95s, cap 110 under the 120s tool timeout); larger batches keep the cap and surface partial results honestly. Verified live after the fix: two production-monorepo blocks runner-named end-to-end.