### PR TITLE
tray: the mission tray is an in-flow column, never a fixed overlay

### DIFF
--- a/m1nd-ui/src/App.tsx
+++ b/m1nd-ui/src/App.tsx
@@ -532,17 +532,21 @@ export default function App() {
           ) : (
             <LivingTree viewedBrain={viewedBrain} onIngest={() => setIngestOpen(true)} />
           )}
-        </div>
 
-        {/* The MISSION TRAY (F2.5 §3) — fixed on every working surface, outside the
-            surface switch. Not on the Threshold (no brain yet → no missions to track). */}
-        {surface != null && surface !== 'threshold' && (
-          <MissionTrayLive
-            viewedBrain={viewedBrain}
-            enabled={backendReachable}
-            onOpenBlock={onOpenBlock}
-          />
-        )}
+          {/* The MISSION TRAY (F2.5 §3) — on every working surface, outside the
+              surface switch but INSIDE the shell row: an in-flow right column, so
+              expanding it makes room instead of painting over the surface (the
+              fixed-overlay tray click-blocked the block panel / tree drawer —
+              field bug 2026-07-10). Not on the Threshold (no brain yet → no
+              missions to track). */}
+          {surface != null && surface !== 'threshold' && (
+            <MissionTrayLive
+              viewedBrain={viewedBrain}
+              enabled={backendReachable}
+              onOpenBlock={onOpenBlock}
+            />
+          )}
+        </div>
 
         {/* The 3-beat orientation (§4A.2) — only after a fresh bootstrap, never returns. */}
         {orienting && surface === 'tree' && typeof window !== 'undefined' && (

--- a/m1nd-ui/src/components/tray/MissionTray.tsx
+++ b/m1nd-ui/src/components/tray/MissionTray.tsx
@@ -1,11 +1,13 @@
 /*
- * MissionTray — the fixed write-mode surface (HUMAN-VIEW-V2 F2.5 §3). A right-edge
- * tray, collapsible, present on EVERY surface (mounted in the App shell, outside the
- * surface switch). Collapsed: a thin vertical strip with per-phase counts. Expanded
- * (~320px): the mission cards, `failed` PINNED atop (§3c), read-only over letters
- * (§3e). This component is pure/presentational — the App wires `useMissions` + the
- * localStorage dismiss/expand state (MissionTrayLive) — so the honesty at the pixel
- * boundary is unit-provable with a captured-fixture SSR render.
+ * MissionTray — the persistent write-mode surface (HUMAN-VIEW-V2 F2.5 §3). A
+ * right-edge tray, collapsible, present on EVERY surface (mounted in the App shell,
+ * outside the surface switch, INSIDE the shell's flex row — an in-flow column, never
+ * a fixed overlay, so it can never paint over or click-block the surface beside it).
+ * Collapsed: a thin vertical strip with per-phase counts. Expanded (~320px): the
+ * mission cards, `failed` PINNED atop (§3c), read-only over letters (§3e). This
+ * component is pure/presentational — the App wires `useMissions` + the localStorage
+ * dismiss/expand state (MissionTrayLive) — so the honesty at the pixel boundary is
+ * unit-provable with a captured-fixture SSR render.
  *
  * Degraded states are honest, never a broken shell: a pre-F2.5a owner (no
  * `kind=mission` read) says "mission letters need an updated owner"; a read error
@@ -62,12 +64,15 @@ export default function MissionTray({
   );
 
   // Collapsed — the thin vertical strip with per-phase counts (§3a).
+  // Layout law: the tray is an IN-FLOW flex child of the shell row (never a fixed
+  // overlay) — sibling surfaces keep their full width and stay clickable; the tray
+  // can never paint over the block panel / tree drawer (field bug 2026-07-10).
   if (!expanded) {
     return (
       <div
         data-role="mission-tray"
         data-expanded="false"
-        className="fixed top-12 right-0 bottom-0 z-30 w-9 flex flex-col items-center border-l border-hairline bg-porcelain/95 py-2 gap-2"
+        className="w-9 shrink-0 flex flex-col items-center border-l border-hairline bg-porcelain py-2 gap-2"
       >
         <button
           type="button"
@@ -99,12 +104,14 @@ export default function MissionTray({
     );
   }
 
-  // Expanded — the mission cards (~320px).
+  // Expanded — the mission cards (~320px). Same layout law as the strip: in-flow,
+  // solid ground (the old `bg-porcelain/97` was not a real token — it compiled to
+  // NO background, so the tray painted transparent over the surface beneath).
   return (
     <div
       data-role="mission-tray"
       data-expanded="true"
-      className="fixed top-12 right-0 bottom-0 z-30 w-80 flex flex-col border-l border-hairline bg-porcelain/97 shadow-card"
+      className="w-80 shrink-0 flex flex-col border-l border-hairline bg-porcelain"
     >
       <div className="flex items-center gap-2 px-3 py-2 border-b border-ink/10 shrink-0">
         <span className="text-sm font-semibold text-ink">Missions</span>

--- a/m1nd-ui/src/components/tray/mission-tray.test.tsx
+++ b/m1nd-ui/src/components/tray/mission-tray.test.tsx
@@ -148,3 +148,35 @@ test('COPY LAW: the tray never says proven/done/correct', () => {
   assert.doesNotMatch(t, /\bdone\b/i);
   assert.doesNotMatch(t, /\bcorrect\b/i);
 });
+
+// ── Layout law (field bug 2026-07-10) ─────────────────────────────────────────
+// The tray is an IN-FLOW flex column of the shell row, never a fixed overlay: a
+// fixed tray painted over (and click-blocked) the map's block panel and the
+// tree's drawer, and its `/97` alpha compiled to NO background (transparent
+// text soup). Pinned here at the class boundary; the geometry is browser-proven.
+
+function rootClasses(out: string): string {
+  const m = out.match(/data-role="mission-tray"[^>]*class="([^"]*)"/);
+  assert.ok(m, 'the tray root carries a class list');
+  return m![1];
+}
+
+test('LAYOUT LAW: the expanded tray is in-flow (no fixed/z overlay) on solid ground', () => {
+  const cls = rootClasses(tray());
+  assert.doesNotMatch(cls, /\bfixed\b/, 'never position:fixed — it must make room, not paint over');
+  assert.doesNotMatch(cls, /\bz-\d/, 'no z-index war with the surface beside it');
+  assert.match(cls, /\bshrink-0\b/, 'a rigid flex column');
+  assert.match(cls, /\bw-80\b/, 'the ~320px card column');
+  assert.match(cls, /\bbg-porcelain\b/, 'solid ground');
+  assert.doesNotMatch(cls, /bg-porcelain\/\d+/, 'no alpha ground — /97 compiled to no background at all');
+});
+
+test('LAYOUT LAW: the collapsed strip is in-flow (no fixed/z overlay) on solid ground', () => {
+  const cls = rootClasses(tray({ expanded: false }));
+  assert.doesNotMatch(cls, /\bfixed\b/);
+  assert.doesNotMatch(cls, /\bz-\d/);
+  assert.match(cls, /\bshrink-0\b/);
+  assert.match(cls, /\bw-9\b/, 'the thin strip');
+  assert.match(cls, /\bbg-porcelain\b/);
+  assert.doesNotMatch(cls, /bg-porcelain\/\d+/);
+});


### PR DESCRIPTION
Owner-reported (screenshot, 1680×930): with missions in the tray, three layers fought over the right corner — the expanded tray painted OVER and click-blocked the block-selection panel, and tooltips stacked on top of the tray header.

Root cause: the tray was a `fixed top-12 right-0 z-30` overlay (with an alpha background that compiled to none). The law this PR pins: **the tray is an in-flow flex child of the shell row — it makes room, it never paints over.** Expanded = a `w-80 shrink-0` column on solid ground; collapsed = a `w-9` strip; the mission list scrolls inside it; the block panel is a disjoint sibling.

Proof (live browser against the served owner, 20 real missions): numeric non-overlap via getBoundingClientRect at 1680×930 AND 1280×800, expanded AND collapsed — **overlap 0px in all four**, tray always `position:static`/`z-index:auto`; expanding SHIFTS the block panel left (makes room); `elementFromPoint` at the panel's stolen corner now returns the panel; internal list scroll proven (scrollHeight 2189 > clientHeight). Two LAYOUT LAW tests pin the invariant (no `fixed`, no `z-` on either tray root); right-corner sweep found modals/backdrops legit and tooltips native.

Declared, untouched: `useSSE.ts` hardcodes `localhost:1337` for the dev EventSource (harmless console noise in dev; REST mailbox path is what the tray reads) — pre-existing, out of scope.

Gates: 435/435 UI tests · tsc clean · no new console.log · no-leak clean.