### PR TITLE
era-coherence: every agent-facing surface teaches the write laws

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,32 @@ unless m1nd is served at a reachable address.
 
 Every agent is a sensor: if m1nd misbehaves during a mission, append one JSON line to the
 field-report spool (see `CLAUDE.md`) — report, never fix mid-mission.
+
+## The two write laws — reception governs WRITES (read before any m1nd write)
+
+One owner (`:1338`) hosts many per-project brains and routes each request to the brain that
+covers the caller's repo. Two laws keep one agent's work out of another repo's brain. Ignore
+them and you corrupt shared state — a real incident: a foreign skeleton once overwrote a
+bound brain because the writer never checked which brain it was talking to.
+
+1. **No WRITE under a reception mismatch.** A m1nd response may carry a `reception` block;
+   `reception.match == "caller_root_mismatch"` means the brain currently serving you does
+   NOT cover your repo. A read under mismatch is a warning (don't trust retrieval for this
+   repo). A **write** under mismatch is prohibited by doctrine — every write verb
+   (`memorize`, `skeleton_candidate`, `candidate_edit`, `system_blocks_seed_import` /
+   `_ratify` / `_reconcile`, `mission_post`) would land in the WRONG brain. The one correct
+   gesture BEFORE any write: `ingest project_root=<your repo root>` — a single call
+   creates/resolves YOUR brain, ingests it, binds the session, and returns its north in the
+   same response; from then on your root routes to your brain automatically. Then write.
+   (The mechanical write-refusal is landing; the doctrine holds now.)
+2. **No twin brains.** Minting a brain for a root that is the PARENT, CHILD, or WORKTREE of
+   an existing brain is refused with a teaching error (`overlap_parent` / `overlap_child` /
+   `overlap_worktree`) that names the conflict and the two ways forward: bind to the existing
+   brain (`ingest project_root=<existing>`), or pass `allow_overlap:true` only when you know
+   exactly why. It holds on BOTH doors — the MCP wire and REST `POST /api/tools/ingest` route
+   through one guarded core. A burst worktree does NOT get its own brain; bind to the main
+   repo's. This stops one repo growing two brains (double ingest cost, memories fragmented).
+
+Editing the block map (the skeleton) is one atomic verb, `candidate_edit`, and it refuses on
+a ratified skeleton (candidate-only). **Ratifying a skeleton is a human-only gesture — no
+agent ratifies, ever.** The hand proposes; the human signs.

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -48,6 +48,17 @@ your root routes to YOUR brain automatically, including brand-new sessions. Abse
 `reception` = your root matches the brain serving you (silent bind is legal only on a \
 match, TT-INV-12).
 
+**Reception governs WRITES, not just reads.** A read under `caller_root_mismatch` is a \
+warning; a WRITE under it is PROHIBITED by doctrine — `memorize`, `skeleton_candidate`, \
+`candidate_edit`, `system_blocks_seed_import`/`_ratify`/`_reconcile`, and `mission_post` would \
+each land in the WRONG brain (this is exactly how a foreign skeleton once overwrote a bound \
+brain). Run the one bootstrap `ingest project_root=<your repo root>` FIRST, then write. That \
+bootstrap is OVERLAP-GUARDED: minting a brain for a root that is the PARENT, CHILD, or WORKTREE \
+of an existing brain is refused (`overlap_parent`/`overlap_child`/`overlap_worktree`) with the \
+two ways forward — bind to the existing brain (`ingest project_root=<existing>`), or pass \
+`allow_overlap:true` only when you know exactly why. It holds on BOTH seams (the MCP wire and \
+REST `POST /api/tools/ingest`); a burst worktree does NOT get its own brain.
+
 ## 1. PRE-ORIENT — never start cold
 
 Call `north(task)` FIRST, before reading or editing anything. One round-trip returns: \
@@ -175,6 +186,23 @@ against code/git/runtime → update durable claims via `memorize` (with `soul_so
 the ONE write door) → prune stale NEVER silently (every removal named, git keeps the text) → \
 re-check → carry the receipt in the PR body. WHO VERIFIES THE CURATOR (§C8.4): its report must \
 pass `soul_check {verify_curator_report: <report>}` run by a DIFFERENT agent — grader ≠ author.
+
+## 6. THE WRITE SURFACE — the candidate map & missions (RATIFY IS HUMAN)
+
+Two write surfaces beyond `memorize`, both candidate/human-gated by design. THE CANDIDATE MAP: \
+`skeleton_candidate` scans a repo into a CANDIDATE block map (with `naming:\"auto\"` + a live \
+naming-runner it is born NAMED — the zero-touch default); `candidate_edit` is the ONE verb that \
+edits it — six typed ops (rename/merge/split/move_member/resolve_seam/assign_unmapped) in ONE \
+atomic OCC batch under `expected_store_version` (one bad op persists NOTHING), and it REFUSES on a \
+ratified skeleton (candidate-only). `candidate_lease` is advisory (TTL, reclaimable) and NEVER \
+blocks the owner. RATIFY IS EXCLUSIVELY HUMAN — no agent ratifies a skeleton, ever, and an \
+untouched raw-heuristic block cannot be ratified; the hand proposes (even a whole-candidate \
+curation mission edits via `candidate_edit`), the human signs. THE MISSION LETTER: `mission_post` \
+records one mission's live state as `m1nd-mission-letter-v0` — `brain_ref` is the brain's DISPLAY \
+NAME (the basename of its root, never an absolute path; a wrong one is refused `brain_mismatch`), \
+`block_id` must name a real block in the bound skeleton (else `unknown_block`; a legitimate \
+smoke/probe letter sets `synthetic:true`), and a letter is STATE, never evidence: it never colors a \
+block — only `receipt_import` does — and `landed` is reserved for a confirmed imported receipt.
 
 ## SECONDARY VERBS (one line each)
 

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -45,8 +45,13 @@ this loop by default:
    `project_root=<your repo root>` creates a per-project brain inside the served
    owner, ingests your repo, binds your session, and returns its north packet —
    thereafter every call from your root routes to YOUR brain automatically.
-   Absent/null `reception` = your root matches the brain serving you. An empty
-   memory beat is NOT proof of an empty store: the packet carries
+   Reception governs WRITES, not just reads: a read under mismatch is a warning,
+   but a WRITE under mismatch is PROHIBITED by doctrine — any write verb
+   (`memorize`, `skeleton_candidate`, `candidate_edit`, `system_blocks_*`,
+   `mission_post`) would land in the WRONG brain. That is exactly how a foreign
+   skeleton once overwrote a bound brain. Run the one bootstrap `ingest` FIRST,
+   then write. Absent/null `reception` = your root matches the brain serving you.
+   An empty memory beat is NOT proof of an empty store: the packet carries
    `memory_exists: N` (the on-disk claim count) plus an honest note when recall
    found no task-relevant match over a non-empty store — never conclude "no
    memory" without checking the stamp; widen the task text or `seek` the store
@@ -91,6 +96,41 @@ this loop by default:
 
 This is the `m1nd-trained` behavior measured in internal bug-hunt rounds: graph
 plus operating doctrine, not graph alone.
+
+## The Write Surface — bootstrap, the map, and missions
+
+Retrieval is forgiving; writing is not. Four things to know before any write:
+
+1. **Write only into the brain that covers you** (the reception law, above). A
+   write under `caller_root_mismatch` corrupts the wrong store. The one-call
+   `ingest project_root=<your repo root>` bootstrap is the gate — it creates or
+   resolves your brain, binds the session, returns north; then write.
+2. **No twin brains.** Minting a brain for a root that is the PARENT, CHILD, or
+   WORKTREE of an existing brain is REFUSED with a teaching error
+   (`overlap_parent` / `overlap_child` / `overlap_worktree`) naming the conflict
+   and two ways forward: bind to the existing brain, or pass `allow_overlap:true`
+   only when you know exactly why. It holds on both seams (MCP wire and REST
+   `POST /api/tools/ingest`). A burst worktree does NOT earn its own brain — bind
+   to the main repo's. One repo, one brain, so memories don't fragment.
+3. **The candidate map is edited by one verb.** `skeleton_candidate` scans a repo
+   into a candidate block map (with `naming:"auto"` and a live naming-runner it is
+   born NAMED — the zero-touch default). `candidate_edit` is the single write verb
+   over it: six typed ops (`rename` / `merge` / `split` / `move_member` /
+   `resolve_seam` / `assign_unmapped`), one atomic OCC batch under
+   `expected_store_version` (one bad op persists NOTHING). It refuses on a ratified
+   skeleton (candidate-only); `candidate_lease` is advisory (TTL, reclaimable) and
+   NEVER blocks. **Ratify is EXCLUSIVELY human** — no agent ratifies a skeleton,
+   ever, and an untouched raw-heuristic block cannot be ratified. The hand
+   proposes; the human signs.
+4. **A mission is a letter.** `mission_post` records one mission's state as an
+   `m1nd-mission-letter-v0`; `brain_ref` is the brain's DISPLAY NAME (the basename
+   of its root, never an absolute path) and a letter naming another brain is
+   refused (`brain_mismatch`); `block_id` must name a real block in the bound
+   skeleton (or the skeleton id itself for a whole-skeleton mission), else
+   `unknown_block` — a genuinely synthetic smoke/probe letter sets
+   `synthetic:true` as the declared escape. A letter is STATE, never evidence: it
+   never colors a block; only `receipt_import` does, and `landed` is reserved for a
+   confirmed imported receipt.
 
 ## Scope Binding Taxonomy
 

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -43,6 +43,9 @@ measured high-signal pattern starts by never starting cold:
    served owner, ingests your repo, binds your session, and returns its north
    packet — thereafter every call from your root routes to YOUR brain
    automatically. Absent/null = your root matches the brain serving you.
+   Reception governs WRITES too, not only reads: a read under mismatch is a
+   warning, a WRITE under mismatch is prohibited (see Write-Mode Laws below) —
+   bootstrap first, then write.
 2. If `north` returns `needs_ingest` (empty/unbound graph), `ingest` the repo,
    then `north` again. `needs_ingest` is a REAL answer, not a failure.
 3. Act on verdicts, do not override them (see below).
@@ -76,6 +79,108 @@ Verdict semantics — trust the calibration:
 
 Internal bug-hunt rounds call this `m1nd-trained`: graph plus operating
 doctrine. A visible MCP surface without this loop is only `m1nd-basic`.
+
+## Write-Mode Laws — reception governs writes, one repo means one brain
+
+The served owner hosts many per-project brains and routes each request to the
+brain that covers the caller's repo (`M1nd-Caller-Root` ↔ `covers_root`).
+Retrieval under a wrong binding is a recoverable annoyance; a WRITE under a wrong
+binding is corruption of shared state. A real incident set this law: a foreign
+repo's skeleton was written into a bound brain because the writer never checked
+which brain answered it. Two laws:
+
+- **Law 1 — no write under a reception mismatch.** When a response carries
+  `reception.match == "caller_root_mismatch"`, the brain serving you does NOT
+  cover your repo. Reads are a warning; **writes are prohibited by doctrine** —
+  `memorize`, `skeleton_candidate`, `candidate_edit`, `system_blocks_seed_import`
+  / `_ratify` / `_reconcile`, and `mission_post` would each land in the WRONG
+  brain. The single correct gesture BEFORE any write: `ingest
+  project_root=<your repo root>` — one call classifies the root (overlap-guarded,
+  Law 2), creates or warm-resolves your brain, ingests it, binds the session
+  sticky, and returns north in the same response. Then write. The `memorize`
+  refusal (a write from a root with no project brain is refused, never dropped
+  into the shared medulla, and hands you this exact bootstrap) is the one already
+  mechanical instance; the doctrine generalizes it to every write verb, and the
+  broader mechanical refusal is landing. If you ever catch a miswrite, that is
+  `class:"memory_misdelivery"` / `kind:"wrong_store_write"` in the field spool.
+- **Law 2 — no twin brains (the overlap guard, both seams, LIVE).** Before
+  minting a NEW project brain, the bootstrap classifies the root against every
+  existing brain (warm map ∪ on-disk roster) into one of three overlap classes
+  and refuses with a teaching error naming the conflict and two ways forward:
+  - `overlap_child` — the new root is INSIDE an existing brain's root.
+  - `overlap_parent` — an existing brain's root is INSIDE the new root (the
+    mother-folder trap that would re-ingest the child repo from above).
+  - `overlap_worktree` — the new root is a git worktree (`.git` is a gitdir file
+    under `<main>/.git/worktrees/`) whose main repo already has a brain.
+  The two ways forward: (a) bind to the existing brain (`ingest
+  project_root=<existing>`), or (b) pass `allow_overlap:true` to mint a separate
+  brain anyway — only when you know exactly why. The exact-same root is warm-reuse
+  (never an overlap). This holds on BOTH doors: the MCP wire (`ingest` with a
+  non-empty `project_root` is a bootstrap directive → `run_bootstrap`) and the
+  REST `POST /api/tools/ingest` route both call one seam-shared guarded core, so a
+  REST caller gets the same refusal as an HTTP 400. A burst worktree does NOT earn
+  its own brain — bind to the main repo's. (Separately, bootstrap never SHADOWS
+  the bound dev graph: a `project_root` the bound graph already covers is refused.)
+
+Not yet built (do not rely on it): `skeleton_coherence`, a vital sign that makes
+a brain flag loudly when it is wearing a skeleton from a foreign repo. Until it
+lands, Law 1 is the doctrine that prevents the miswrite.
+
+## The Candidate Map and Mission Letters (F11 + F2.5 write mode)
+
+The block map (the skeleton) and the mission layer are the two write surfaces
+beyond `memorize`. Both are candidate/human-gated by design.
+
+**The candidate map (F11).** `skeleton_candidate` scans a repo into a CANDIDATE
+block map; with `naming:"auto"` and a live naming-runner the map is born NAMED
+(the zero-touch default — read the map, stamp it). One verb edits it:
+
+```json
+candidate_edit {"agent_id":"...","expected_store_version":7,"ops":[
+  {"op":"rename","block_id":"sb_x","name":"Auth","purpose":"..."},
+  {"op":"merge","into":"sb_x","block_ids":["sb_y","sb_z"]},
+  {"op":"split","block_id":"sb_x","by":{"paths":[["a/**"],["b/**"]]}},
+  {"op":"move_member","path":"src/hook.ts","from":"sb_x","to":"sb_y"},
+  {"op":"resolve_seam","path":"src/shared.ts","resolution":"primary:sb_y"},
+  {"op":"assign_unmapped","path":"scripts/x.sh","block_id":"sb_x"}
+]}
+```
+
+Signed behavior: one ATOMIC OCC batch under `expected_store_version` validated
+preflight-on-a-clone (one invalid op → the whole batch persists NOTHING, its
+index named); it REFUSES on a ratified skeleton (`skeleton_not_candidate` —
+candidate-only). Provenance per touch: `named_by` is `runner` | `owner` |
+`heuristic`. `candidate_lease {acquire|release|refresh, agent_id, ttl_secs}` is
+ADVISORY — TTL-bounded, expired-is-reclaimable, and it NEVER blocks the owner (a
+dead agent must not trap the candidate). **Ratify is EXCLUSIVELY human.** No agent
+ratifies a skeleton, ever — and `system_blocks_ratify` REJECTS any block still on
+a raw untouched heuristic label (`needs_owner_naming`). The heavy case (a large
+monorepo candidate) has a one-gesture escape: a CURATION MISSION where a hand
+edits the whole candidate through the SAME `candidate_edit` verb — the human
+reviews the polished result and ratifies. The hand proposes; the human signs.
+`candidate_naming` is the screen's HTTP-only route, not an MCP loop verb.
+
+**The mission letter (F2.5).** A mission's live state is one
+`m1nd-mission-letter-v0`, posted with `mission_post` (WRITE, deny-listed on
+read-only owners):
+
+- `brain_ref` is the brain's DISPLAY NAME — the basename of its project root,
+  case-sensitive — never an absolute path, and never the skeleton id's slug. A
+  letter naming a different brain is refused (`brain_mismatch`); this killed the
+  reconnect-collapsed mis-route that silently posted into the bound brain's box.
+- `block_id` must name a real block in the DISPATCHING brain's skeleton, else
+  `unknown_block`. A whole-skeleton mission (e.g. the F11 curation dispatch)
+  anchors at the store's skeleton id, which validates like a block. A legitimately
+  synthetic letter (a smoke test or warm-pool probe) sets `synthetic:true` (the
+  declared escape) and skips the guard — never a silent pass.
+- A letter is STATE, not evidence: it NEVER changes a block's color; only
+  `receipt_import` does (the anti-poison law). `landed` is RESERVED for a
+  confirmed imported receipt — a green gate without an imported receipt is
+  `merge_wait` ("gate green — receipt not landed"), never `landed`.
+- Ordering is causal: each mission's letters form a hash chain (`mission_seq` +1,
+  `prev_letter_id`); a stale head is refused (`stale_head`, CAS on the head
+  pointer). Runnerd emits the `executing`→`merge_wait` letters but holds NO
+  `receipt_import` permission — the human lands from the tray.
 
 ## Scope Binding Taxonomy
 
@@ -440,6 +545,12 @@ one graph:
   header is the caller identity reception verifies (`M1nd-Caller-Root` ↔
   `covers_root`); a mismatch returns the degraded reception, not a fabricated
   orientation.
+- Runner daemon: `m1nd-runnerd` (its own port, `1339`, launchd) is the ONLY
+  spawner — the owner never spawns. It runs a mission packet in an isolated
+  worktree-per-mission and posts letters from `executing` onward, but holds NO
+  `receipt_import` permission (the human lands from the tray). Capabilities are
+  pinned owner-side (`runners.toml`); the announce proves liveness only and can
+  never grant or widen a capability.
 
 A freshly-landed verb appears ONLY after the owner is rebuilt and kickstarted —
 a live verb needs the served owner restarted (`m1nd restart --source

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -27,7 +27,10 @@ graph does NOT cover your current repo — do not trust retrieval for it; read
 `project_root=<your repo root>` creates a per-project brain inside the served
 owner, ingests your repo, binds your session, and returns its north packet —
 thereafter every call from your root routes to YOUR brain automatically.
-Absent/null `reception` = your root matches the brain serving you.
+Absent/null `reception` = your root matches the brain serving you. Reception
+governs WRITES, not just reads: a read under mismatch is a warning, but a WRITE
+under mismatch is PROHIBITED — see Write-Mode Laws below; bootstrap first, write
+after.
 
 Drop to the trust-only sub-checks when the binding looks degraded and you need
 just the trust verdict:
@@ -167,6 +170,43 @@ this loop by default:
 
 This is the trained-agent behavior to preserve across hosts: m1nd is graph plus
 operating doctrine, not graph alone.
+
+## Write-Mode Laws — reception governs writes
+
+The served owner hosts many per-project brains and routes each request to the
+brain that covers the caller's repo. Retrieval under a wrong binding is
+recoverable; a WRITE under a wrong binding corrupts shared state. A real incident
+set these laws — a foreign repo's skeleton was written into a bound brain because
+the writer never checked which brain answered it.
+
+1. **No write under a reception mismatch.** When a response carries
+   `reception.match == "caller_root_mismatch"`, the brain serving you does NOT
+   cover your repo. Reads are a warning; **writes are prohibited** — `memorize`,
+   `skeleton_candidate`, `candidate_edit`, `system_blocks_seed_import` / `_ratify`
+   / `_reconcile`, and `mission_post` would each land in the WRONG brain. The one
+   correct gesture BEFORE any write: `ingest project_root=<your repo root>` — one
+   call creates/resolves your brain, ingests it, binds the session, and returns
+   north. Then write. (The `memorize` refusal — a write from a root with no
+   project brain is refused, never silently dropped into the shared medulla, and
+   hands you this bootstrap — is the one already-mechanical instance.)
+2. **No twin brains.** Minting a brain for a root that is the PARENT, CHILD, or
+   WORKTREE of an existing brain is refused with a teaching error
+   (`overlap_parent` / `overlap_child` / `overlap_worktree`) naming the conflict
+   and two ways forward: bind to the existing brain (`ingest
+   project_root=<existing>`), or pass `allow_overlap:true` only when you know
+   exactly why. It holds on both seams (MCP wire and REST `POST
+   /api/tools/ingest`). A burst worktree does NOT earn its own brain — bind to the
+   main repo's.
+
+**The write surface, briefly.** The block map (skeleton) is edited by one atomic
+verb, `candidate_edit` (six typed ops under `expected_store_version`; refuses on a
+ratified skeleton — candidate-only); `candidate_lease` is advisory and never
+blocks. **Ratify is EXCLUSIVELY human — no agent ratifies a skeleton, ever.** A
+mission is a letter (`mission_post`): `brain_ref` is the brain's display name (the
+basename of its root, never an absolute path; a wrong one is `brain_mismatch`),
+`block_id` must name a real block (else `unknown_block`; a smoke/probe letter sets
+`synthetic:true`), and a letter is STATE, never evidence — it never colors a
+block, only `receipt_import` does.
 
 ## Mission Control (not the default loop)
 


### PR DESCRIPTION
Owner-ordered sweep after the bound-contamination incident: an agent wrote a foreign skeleton into the served bound brain because no surface it reads taught the law. Audit found ALL agent-facing surfaces at era zero — no F11, no overlap guard, no write doctrine anywhere.

Five atomic commits bring the era to every surface an agent reads:
- **M1ND_INSTRUCTIONS** (the MCP initialize text — the one every agent receives): section 0 gains the write law (reception mismatch governs WRITES: bind before writing) + the overlap guard; new section 6 "THE WRITE SURFACE — RATIFY IS HUMAN" teaches the candidate verbs' contract and the one invariant that never bends.
- **skills/m1nd-first, skills/m1nd-operator, skills/m1nd-universal-agent-pack, AGENTS.md**: the two write laws, the F11 candidate-editing contract (OCC batch, advisory lease, provenance, the o6 gate), mission-letter rules (§1f brain_ref, §1g anchors, synthetic escape), field telemetry, serve/attach era.

Honesty rules held: `skeleton_coherence` framed as not-yet-built; the general write-refusal taught as doctrine with the mechanical enforcement landing (memorize's refusal named as the existing instance); no unverifiable specifics; incident worded generically.

Gates: 781 m1nd-mcp tests green (the instructions-pinning test stayed green — additions only) · fmt clean · Agent Docs Gate PASS · no-leak clean.