### PR TITLE
registry: a brain's instance entry is stable — opening a brain never duplicates its card

### DIFF
--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -241,10 +241,44 @@ impl InstanceHandle {
     /// can tell an owner-hosted per-project brain apart from the bound dev graph.
     /// The bound/dev owner never calls this, so its entry keeps `brain_kind:
     /// None`.
+    ///
+    /// STABLE-ID re-key (the "duplicate workspace" field bug): `acquire` mints an
+    /// EPHEMERAL instance id (pid + clock + a per-process nonce) that changes on
+    /// every boot. For a long-lived owner that is harmless (its dead-pid entry is
+    /// GC'd on restart), but a hosted brain warm-boots repeatedly WITHIN one live
+    /// owner (the eviction gate drops a brain's handle without `release`, so its
+    /// `instances/<id>.json` lingers under a still-live pid, and the next resolve
+    /// mints a NEW ephemeral id) — so the Hall listed one card PER boot. A brain
+    /// entry therefore takes a DETERMINISTIC id, `inst_<hash(workspace+runtime)>`,
+    /// stable across every warm-boot of the same store, so the boot UPSERTS the
+    /// SAME file instead of minting a duplicate. Attachers never reach here
+    /// (`ReadOnly` never calls `set_brain_kind`), so the N-attacher design keeps
+    /// its ephemeral, per-attacher ids untouched.
     pub fn set_brain_kind(&self, brain_kind: &str) -> M1ndResult<()> {
         let mut inner = self.inner.lock();
         inner.entry.brain_kind = Some(brain_kind.to_string());
-        persist_handle_inner(&inner)
+
+        let stable_id =
+            stable_brain_instance_id(&inner.entry.workspace_root, &inner.entry.runtime_root);
+        if inner.entry.instance_id != stable_id {
+            // Drop the ephemeral-id file this handle wrote at `acquire`; the brain
+            // is re-keyed onto its stable id (an atomic upsert-by-filename from
+            // here on — the warm-boot rewrites this one file, never a new one).
+            let ephemeral_path = inner.entry_path.clone();
+            inner.entry.instance_id = stable_id.clone();
+            inner.entry_path = inner
+                .registry_root
+                .join(INSTANCE_DIR_NAME)
+                .join(format!("{stable_id}.json"));
+            if ephemeral_path != inner.entry_path {
+                let _ = fs::remove_file(&ephemeral_path);
+            }
+        }
+        // Write the (re-keyed) entry + refresh the lease, THEN reconcile away any
+        // stale duplicates of THIS store left by earlier ephemeral-id boots.
+        persist_handle_inner(&inner)?;
+        reconcile_brain_duplicates(&inner);
+        Ok(())
     }
 
     pub fn mark_heartbeat(&self) -> M1ndResult<()> {
@@ -533,6 +567,56 @@ fn persist_handle_inner(inner: &InstanceHandleInner) -> M1ndResult<()> {
     Ok(())
 }
 
+/// Reconcile the `instances/` dir after a brain re-keys onto its stable id: drop
+/// every OTHER entry for the SAME `(workspace_root, runtime_root)` store — the
+/// duplicate cards earlier ephemeral-id boots minted for this exact brain. This
+/// is what lets the inheritance of pre-fix duplicates die on the next boot of
+/// each brain, instead of lingering forever under a still-live owner pid (which
+/// the dead-pid boot GC can never reap).
+///
+/// A live `read_only` attacher is NEVER a duplicate — N attachers coexist with
+/// one brain by design (a foreign process attached to the same store is not a
+/// twin), so it is preserved; everything else that shares this store's exact
+/// roots is a stale twin and is removed. Only same-store entries are candidates —
+/// a different brain (different roots) is never inspected. Best-effort: a
+/// corrupt/foreign entry that fails to parse is skipped, never force-deleted; the
+/// survivor's own (stable-id) entry is skipped by path. One process-table read is
+/// shared across the sweep via a single `LivePids` snapshot.
+fn reconcile_brain_duplicates(keep: &InstanceHandleInner) {
+    let dir = keep.registry_root.join(INSTANCE_DIR_NAME);
+    let read = match fs::read_dir(&dir) {
+        Ok(read) => read,
+        Err(_) => return,
+    };
+    let live = LivePids::snapshot();
+    for item in read.flatten() {
+        let path = item.path();
+        if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        // Never remove the survivor's own (stable-id) entry.
+        if path == keep.entry_path {
+            continue;
+        }
+        let entry: InstanceRegistryEntry = match read_json(&path) {
+            Ok(entry) => entry,
+            Err(_) => continue, // corrupt/foreign → skip, never delete
+        };
+        // Only entries for the SAME store are candidates for removal.
+        if entry.workspace_root != keep.entry.workspace_root
+            || entry.runtime_root != keep.entry.runtime_root
+        {
+            continue;
+        }
+        // A live read_only attacher shares the store by design — not a duplicate.
+        if InstanceMode::from_str(&entry.mode) == InstanceMode::ReadOnly && live.is_live(entry.pid)
+        {
+            continue;
+        }
+        let _ = fs::remove_file(&path);
+    }
+}
+
 /// Monotonic per-process nonce so that two instances acquired in the same
 /// process for the same (workspace, runtime) within a single millisecond clock
 /// tick never collide on `instance_id`. The pid already disambiguates across
@@ -549,6 +633,21 @@ fn generate_instance_id(workspace_root: &Path, runtime_root: &Path, now_ms: u64)
     INSTANCE_SEQ
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         .hash(&mut hasher);
+    format!("inst_{:x}", hasher.finish())
+}
+
+/// Deterministic instance id for a BRAIN entry (project/medulla): a pure function
+/// of `(workspace_root, runtime_root)`, stable across every warm-boot of the same
+/// store so the boot UPSERTS one `instances/<id>.json` instead of minting a new
+/// file each time (the duplicate-card field bug — see [`InstanceHandle::set_brain_kind`]).
+/// Reuses the module's `DefaultHasher` string-hashing scheme (the same one
+/// [`generate_instance_id`]/[`fingerprint_path`] use — mother rule, one scheme),
+/// dropping only the pid/clock/seq nonce that makes `generate_instance_id`
+/// ephemeral by construction.
+fn stable_brain_instance_id(workspace_root: &str, runtime_root: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    workspace_root.hash(&mut hasher);
+    runtime_root.hash(&mut hasher);
     format!("inst_{:x}", hasher.finish())
 }
 
@@ -1209,5 +1308,216 @@ mod tests {
         }
         assert!(live_entry_path.exists());
         assert!(live_lease_path.exists());
+    }
+
+    // ── STABLE BRAIN ID + reconcile (the "duplicate workspace" field bug) ────────
+    // Field repro (reproduced twice on-screen 2026-07-11): clicking "Open brain"
+    // on a dormant project brain DUPLICATED its Hall card. Root cause: a brain
+    // warm-boot minted a NEW ephemeral `instances/<id>.json` each time (the
+    // eviction gate drops a brain's handle without `release`, so its entry lingers
+    // under the still-live owner pid, which the dead-pid GC can never reap). The
+    // fix: a brain entry (`set_brain_kind` project/medulla) takes a DETERMINISTIC
+    // id, so the warm-boot UPSERTS one file, and a reconcile sweeps the stale twins
+    // earlier ephemeral boots left behind.
+
+    /// How many `instances/*.json` entries the registry holds.
+    fn count_instance_files(registry: &Path) -> usize {
+        fs::read_dir(registry.join(INSTANCE_DIR_NAME))
+            .map(|rd| {
+                rd.flatten()
+                    .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    /// The project-brain store shape: workspace_root == runtime_root == the store
+    /// dir (mirrors `project_brains::boot_store`, whose `runtime_dir` IS the store
+    /// and whose inferred workspace_root falls back to that same store dir).
+    fn brain_store(temp: &Path, name: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let store = temp.join("project-brains").join(name);
+        fs::create_dir_all(&store).unwrap();
+        let graph = store.join("graph_snapshot.json");
+        let plasticity = store.join("plasticity_state.json");
+        (store, graph, plasticity)
+    }
+
+    /// A second warm-boot of the SAME brain re-registers onto the SAME stable id
+    /// and UPSERTS the one file — never a duplicate — and the second boot's content
+    /// wins (proving it rewrote, not stacked). This is the exact "open twice = one
+    /// card" proof at the registry layer.
+    #[test]
+    fn brain_reregister_upserts_one_stable_entry() {
+        let temp = tempdir().unwrap();
+        let registry = temp.path().join("registry");
+        let (store, graph, plasticity) = brain_store(temp.path(), "fingerprintA");
+
+        // Boot 1: acquire (ephemeral id) → stamp brain kind (re-key to stable).
+        let stable_id = {
+            let h1 = InstanceHandle::acquire(&store, &store, &graph, &plasticity, Some(&registry))
+                .unwrap();
+            h1.set_brain_kind("project").unwrap();
+            let id = h1.summary().instance_id;
+            assert_eq!(
+                count_instance_files(&registry),
+                1,
+                "boot 1 writes one entry"
+            );
+            id
+            // h1 dropped WITHOUT release — its stable-id entry lingers on disk,
+            // exactly like an eviction-orphaned brain handle.
+        };
+
+        // Boot 2 (a warm-boot of the SAME store): a fresh handle, a distinguishable
+        // endpoint, then the brain-kind stamp that re-keys onto the SAME stable id.
+        let h2 =
+            InstanceHandle::acquire(&store, &store, &graph, &plasticity, Some(&registry)).unwrap();
+        h2.set_running_endpoint("127.0.0.1".into(), 4321).unwrap();
+        h2.set_brain_kind("project").unwrap();
+
+        assert_eq!(
+            h2.summary().instance_id,
+            stable_id,
+            "the same store re-registers onto the SAME stable id across boots"
+        );
+        assert_eq!(
+            count_instance_files(&registry),
+            1,
+            "a warm-boot UPSERTS the one file — never a duplicate card"
+        );
+        // The single surviving entry carries boot 2's content (the upsert rewrote it).
+        let entry_path = registry
+            .join(INSTANCE_DIR_NAME)
+            .join(format!("{stable_id}.json"));
+        let on_disk: InstanceRegistryEntry = read_json(&entry_path).unwrap();
+        assert_eq!(on_disk.instance_id, stable_id);
+        assert_eq!(on_disk.port, Some(4321), "boot 2's content won the upsert");
+        assert_eq!(on_disk.brain_kind.as_deref(), Some("project"));
+    }
+
+    /// A stale ephemeral twin of the SAME store — the inheritance an earlier
+    /// ephemeral-id boot left behind, still under a LIVE owner pid (the exact case
+    /// the dead-pid GC can never reap) — is reconciled away on the next brain
+    /// registration.
+    #[test]
+    fn brain_reregister_reconciles_stale_ephemeral_twin() {
+        let temp = tempdir().unwrap();
+        let registry = temp.path().join("registry");
+        let (store, graph, plasticity) = brain_store(temp.path(), "fingerprintA");
+
+        let brain =
+            InstanceHandle::acquire(&store, &store, &graph, &plasticity, Some(&registry)).unwrap();
+        brain.set_brain_kind("project").unwrap();
+        let stable_id = brain.summary().instance_id;
+
+        // Plant a pre-fix duplicate: same (workspace_root, runtime_root), a DIFFERENT
+        // (ephemeral) id, mode read_write, under THIS live process pid — so only the
+        // reconcile (not the dead-pid GC) can ever remove it.
+        let mut twin = brain.summary();
+        twin.instance_id = "inst_stale_ephemeral_twin".into();
+        twin.pid = std::process::id();
+        let twin_path = registry
+            .join(INSTANCE_DIR_NAME)
+            .join("inst_stale_ephemeral_twin.json");
+        save_json_atomic(&twin_path, &twin).unwrap();
+        assert_eq!(count_instance_files(&registry), 2, "the twin is planted");
+
+        // Re-register the brain → the reconcile sweeps the same-store twin.
+        brain.set_brain_kind("project").unwrap();
+
+        assert_eq!(
+            count_instance_files(&registry),
+            1,
+            "the stale ephemeral twin is reconciled away on re-register"
+        );
+        assert!(!twin_path.exists(), "the twin entry file is gone");
+        assert!(
+            registry
+                .join(INSTANCE_DIR_NAME)
+                .join(format!("{stable_id}.json"))
+                .exists(),
+            "the brain's own stable entry survives the reconcile"
+        );
+    }
+
+    /// The reconcile NEVER removes a live read_only attacher of the same store — N
+    /// attachers coexist with one brain by design. Re-registering the brain leaves
+    /// the two attacher entries intact (1 brain + 2 attachers = 3 entries).
+    #[test]
+    fn set_brain_kind_preserves_live_readonly_attachers() {
+        let temp = tempdir().unwrap();
+        let registry = temp.path().join("registry");
+        let (store, graph, plasticity) = brain_store(temp.path(), "fingerprintA");
+
+        let brain =
+            InstanceHandle::acquire(&store, &store, &graph, &plasticity, Some(&registry)).unwrap();
+        brain.set_brain_kind("project").unwrap();
+
+        // Two ReadOnly attachers to the SAME store (they never call set_brain_kind,
+        // so they keep their distinct ephemeral ids — the N-attacher design).
+        let _ro_a = InstanceHandle::acquire_with_mode(
+            &store,
+            &store,
+            &graph,
+            &plasticity,
+            Some(&registry),
+            InstanceMode::ReadOnly,
+        )
+        .unwrap();
+        let _ro_b = InstanceHandle::acquire_with_mode(
+            &store,
+            &store,
+            &graph,
+            &plasticity,
+            Some(&registry),
+            InstanceMode::ReadOnly,
+        )
+        .unwrap();
+        assert_eq!(count_instance_files(&registry), 3, "brain + 2 attachers");
+
+        // Re-register the brain → the reconcile must LEAVE the live attachers.
+        brain.set_brain_kind("project").unwrap();
+        assert_eq!(
+            count_instance_files(&registry),
+            3,
+            "live read_only attachers are never reconciled away (N-attacher design)"
+        );
+        let read_only = list_instances(Some(&registry))
+            .unwrap()
+            .into_iter()
+            .filter(|e| e.mode == "read_only")
+            .count();
+        assert_eq!(read_only, 2, "both attacher entries still discoverable");
+    }
+
+    /// Two DIFFERENT brains (distinct stores) each get their own stable entry — the
+    /// reconcile of one store never touches another. Different workspaces → two
+    /// entries.
+    #[test]
+    fn distinct_stores_get_distinct_stable_brain_entries() {
+        let temp = tempdir().unwrap();
+        let registry = temp.path().join("registry");
+        let (store_a, graph_a, plasticity_a) = brain_store(temp.path(), "fingerprintA");
+        let (store_b, graph_b, plasticity_b) = brain_store(temp.path(), "fingerprintB");
+
+        let a =
+            InstanceHandle::acquire(&store_a, &store_a, &graph_a, &plasticity_a, Some(&registry))
+                .unwrap();
+        a.set_brain_kind("project").unwrap();
+        let b =
+            InstanceHandle::acquire(&store_b, &store_b, &graph_b, &plasticity_b, Some(&registry))
+                .unwrap();
+        b.set_brain_kind("project").unwrap();
+
+        assert_eq!(
+            count_instance_files(&registry),
+            2,
+            "two distinct stores keep two distinct entries"
+        );
+        assert_ne!(
+            a.summary().instance_id,
+            b.summary().instance_id,
+            "distinct stores hash to distinct stable ids"
+        );
     }
 }

--- a/m1nd-ui/src/components/hall/BrainCard.tsx
+++ b/m1nd-ui/src/components/hall/BrainCard.tsx
@@ -48,6 +48,13 @@ export interface BrainCardProps {
    */
   viewing?: boolean;
   /**
+   * The GENUINE duplicate-workspace signal, derived by `groupBrainCards`: ≥2
+   * DISTINCT workspace_root strings collapsed onto this one card. Raises the calm
+   * "duplicate workspace" chip. The ephemeral-id duplicate bug (identical strings)
+   * collapses silently and never sets this — so the chip means a real conflict.
+   */
+  duplicateWorkspace?: boolean;
+  /**
    * Card-v2 GOLD fields (§4A.3.1) — rendered ONLY for the OPEN/bound brain (the
    * TODAY column). A hosted brain passes none and shows them absent-honest.
    */
@@ -71,6 +78,7 @@ export default function BrainCard({
   knownEdgeCount,
   selected,
   viewing = false,
+  duplicateWorkspace = false,
   gold = null,
   onReread,
   onCalibrate,
@@ -92,7 +100,12 @@ export default function BrainCard({
   const counts = resolvedBrainCounts(entry, { nodeCount: knownNodeCount, edgeCount: knownEdgeCount });
   const isProject = isProjectBrain(entry);
   const freshnessMs = brainFreshnessMs(entry);
-  const conflicts = visibleConflicts(entry);
+  // `visibleConflicts` strips the raw backend `duplicate_workspace` (ambiguous —
+  // the ephemeral-id bug set it on every dup). The Hall's grouping re-adds it ONLY
+  // when it is genuine (≥2 distinct roots collapsed onto this card).
+  const conflicts = duplicateWorkspace
+    ? [...visibleConflicts(entry), 'duplicate_workspace']
+    : visibleConflicts(entry);
   const name = brainDisplayName(entry);
   const projectPath = brainProjectPath(entry);
   // §4A.9: a hosted project brain opens IN THE TREE when the owner advertises the

--- a/m1nd-ui/src/components/hall/HallView.tsx
+++ b/m1nd-ui/src/components/hall/HallView.tsx
@@ -22,6 +22,7 @@ import {
   brainDisplayName,
   brainProjectPath,
   isProjectBrain,
+  groupBrainCards,
 } from '../../lib/hallSemantics';
 import { canonRootForCompare } from '../../lib/viewedBrain';
 import { useCardV2Data } from '../../hooks/useCardV2Data';
@@ -97,9 +98,14 @@ export default function HallView({
   useLiveRefresh({ onRefresh: onLive, enabled: true });
 
   const selfId = self?.instance.instance_id ?? null;
+  // Defense in depth (§4A.3): collapse duplicate registry entries to ONE card per
+  // workspace. The backend stable-id fix removes duplicates at the source; this
+  // guarantees the Hall never renders the "N identical cards" symptom regardless
+  // of what the owner reports (freshest per workspace wins; order preserved).
+  const cards = useMemo(() => groupBrainCards(instances), [instances]);
   const selected = useMemo(
-    () => instances.find((e) => e.instance_id === selectedId) ?? null,
-    [instances, selectedId],
+    () => cards.find((c) => c.entry.instance_id === selectedId)?.entry ?? null,
+    [cards, selectedId],
   );
 
   // Card-v2 GOLD/DEPTH for the OPEN/bound brain (§4A.3.1). On-demand only — the
@@ -185,19 +191,19 @@ export default function HallView({
         else onExit?.();
         return;
       }
-      if (instances.length === 0) return;
-      const idx = instances.findIndex((x) => x.instance_id === selectedId);
+      if (cards.length === 0) return;
+      const idx = cards.findIndex((x) => x.entry.instance_id === selectedId);
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        const next = instances[Math.min(idx + 1, instances.length - 1)] ?? instances[0];
-        setSelectedId(next.instance_id);
+        const next = cards[Math.min(idx + 1, cards.length - 1)] ?? cards[0];
+        setSelectedId(next.entry.instance_id);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        const prev = instances[Math.max(idx - 1, 0)] ?? instances[0];
-        setSelectedId(prev.instance_id);
+        const prev = cards[Math.max(idx - 1, 0)] ?? cards[0];
+        setSelectedId(prev.entry.instance_id);
       }
     },
-    [instances, selectedId, selected, onExit],
+    [cards, selectedId, selected, onExit],
   );
 
   return (
@@ -208,7 +214,7 @@ export default function HallView({
           <div>
             <h1 className="text-lg text-ink font-semibold">Your brains</h1>
             <p className="text-xs text-ink-soft mt-0.5">
-              Every map m1nd holds for you. {instances.length} {instances.length === 1 ? 'brain' : 'brains'}.
+              Every map m1nd holds for you. {cards.length} {cards.length === 1 ? 'brain' : 'brains'}.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -252,7 +258,8 @@ export default function HallView({
             </div>
           )}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {instances.map((entry) => {
+            {cards.map((group) => {
+              const entry = group.entry;
               const isSelf = entry.instance_id === selfId;
               // The viewing chip marks the ONE brain the tree is currently on
               // (§4A.8), now that per-brain Open (2H) lets it be a hosted brain.
@@ -272,6 +279,7 @@ export default function HallView({
                   knownEdgeCount={isSelf && self ? self.graph_state.edge_count : null}
                   selected={entry.instance_id === selectedId}
                   viewing={viewing}
+                  duplicateWorkspace={group.duplicateWorkspace}
                   // Card-v2 GOLD renders on the OPEN/bound brain only (§4A.3.1);
                   // hosted brains pass null → the fields are absent-honest.
                   gold={isSelf ? { g1: v2.g1, g2: v2.g2, g3: v2.g3, g4: v2.g4 } : null}
@@ -284,7 +292,7 @@ export default function HallView({
               );
             })}
           </div>
-          {instances.length === 0 && !error && (
+          {cards.length === 0 && !error && (
             <div className="rounded-xl border border-ink/10 bg-bone/50 px-6 py-10 text-center text-sm text-ink-soft">
               No brains yet — read your first repo to begin.
             </div>

--- a/m1nd-ui/src/components/hall/hall-render.test.tsx
+++ b/m1nd-ui/src/components/hall/hall-render.test.tsx
@@ -382,6 +382,32 @@ test('project card carries NO lock/instance badge (locks are an owner concept)',
   assert.equal((out.match(/data-role="conflict-chip"/g) ?? []).length, 0, 'no conflict chips on the project card');
 });
 
+// ── The duplicate-workspace badge is GROUP-DERIVED, never the raw backend flag ──
+// The ephemeral-id field bug set `duplicate_workspace` on every warm-boot dup, so
+// the raw flag is ambiguous and stripped (visibleConflicts). The Hall's grouping
+// re-adds it via the `duplicateWorkspace` prop ONLY for a genuine collision.
+test('§4A.3: the raw backend duplicate_workspace conflict never renders a chip on its own', () => {
+  // Even a bound entry carrying the raw conflict shows NO duplicate chip — the
+  // grouping owns that signal now, not the ambiguous backend field.
+  const withRaw = { ...bound, conflicts: ['duplicate_workspace'] };
+  const out = html(<BrainCard entry={withRaw} isSelf selected={false} onSelect={noop} onOpen={noop} />);
+  assert.doesNotMatch(out, /duplicate workspace/i, 'the raw flag alone renders no chip');
+  assert.equal((out.match(/data-role="conflict-chip"/g) ?? []).length, 0, 'no chip from the raw flag');
+});
+
+test('§4A.3: the GENUINE duplicate-workspace badge shows when the group flags it', () => {
+  // A project brain (locks stripped) with the group-derived duplicateWorkspace
+  // flag renders exactly one calm "duplicate workspace" chip.
+  const out = html(
+    <BrainCard entry={project} isSelf={false} duplicateWorkspace selected={false} onSelect={noop} onOpen={noop} />,
+  );
+  assert.match(out, /duplicate workspace/i, 'the genuine badge renders');
+  assert.equal((out.match(/data-role="conflict-chip"/g) ?? []).length, 1, 'exactly the one genuine chip');
+  // A card without the flag wears none.
+  const clean = html(<BrainCard entry={project} isSelf={false} selected={false} onSelect={noop} onOpen={noop} />);
+  assert.doesNotMatch(clean, /duplicate workspace/i, 'no flag → no chip');
+});
+
 test('project card wears a calm live dot, not a stale/failure dot from instance status', () => {
   // The fixture project entry has status:"stale" (an instance field) — it must
   // NOT drive the project card's dot to the stale band.

--- a/m1nd-ui/src/lib/hallSemantics.test.ts
+++ b/m1nd-ui/src/lib/hallSemantics.test.ts
@@ -27,8 +27,9 @@ import {
   brainFreshnessMs,
   restBrainSelectorSupported,
   canOpenBrainInPlace,
+  groupBrainCards,
 } from './hallSemantics';
-import type { InstanceListResponse, InstanceSelfResponse } from '../types';
+import type { InstanceListResponse, InstanceSelfResponse, InstanceRegistryEntry } from '../types';
 
 const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__');
 const load = <T>(name: string): T => JSON.parse(readFileSync(join(FIX, name), 'utf8'));
@@ -81,14 +82,58 @@ test('resolvedBrainCounts: a project brain uses its OWN entry counts, others use
   assert.equal(bc.edgeCount, 99);
 });
 
-test('visibleConflicts: lock/runtime conflicts are filtered out for a project brain', () => {
+test('visibleConflicts: lock/runtime + the ambiguous duplicate_workspace are stripped', () => {
   // The fixture project entry has a stale_lock conflict → hidden for kind=project.
   assert.ok(project.conflicts.includes('stale_lock'));
   assert.deepEqual(visibleConflicts(project), []);
-  // A NON-lock conflict on a project brain would still show.
-  assert.deepEqual(visibleConflicts({ brain_kind: 'project', conflicts: ['duplicate_workspace'] }), ['duplicate_workspace']);
-  // A real owner keeps all its conflicts.
+  // duplicate_workspace is NO LONGER read raw here: the backend set it on every
+  // ephemeral-id duplicate (N identical cards). The Hall now DERIVES the genuine
+  // badge when it groups cards (groupBrainCards), so the ambiguous raw flag is
+  // stripped in BOTH classes — a project brain AND a real owner.
+  assert.deepEqual(visibleConflicts({ brain_kind: 'project', conflicts: ['duplicate_workspace'] }), []);
+  assert.deepEqual(visibleConflicts({ brain_kind: null, conflicts: ['duplicate_workspace'] }), []);
+  // A real owner keeps its OTHER (non-duplicate) conflicts.
   assert.deepEqual(visibleConflicts({ brain_kind: null, conflicts: ['stale_lock', 'shared_runtime'] }), ['stale_lock', 'shared_runtime']);
+});
+
+// ── Card grouping: one card per workspace (defense in depth; §4A.3) ───────────
+test('groupBrainCards: 2 distinct workspaces render 2 cards; identical strings collapse to 1', () => {
+  // The real fixture has a bound + a hosted project brain — DISTINCT workspace
+  // roots → two cards, neither a genuine duplicate.
+  const two = groupBrainCards(list.instances);
+  assert.equal(two.length, 2, 'two distinct workspaces → two cards');
+  assert.ok(two.every((c) => c.duplicateWorkspace === false), 'distinct roots are not duplicates');
+
+  // Three entries for the SAME workspace (the ephemeral-id field bug: identical
+  // workspace_root, different instance_ids) collapse to ONE card, silently.
+  const dup = (id: string): InstanceRegistryEntry => ({ ...project, instance_id: id });
+  const three = groupBrainCards([dup('inst_a'), dup('inst_b'), dup('inst_c')]);
+  assert.equal(three.length, 1, 'three identical-workspace entries → one card');
+  assert.equal(three[0].duplicateWorkspace, false, 'identical strings are NOT a genuine duplicate');
+});
+
+test('groupBrainCards: the FIRST (freshest) entry per workspace wins, order preserved', () => {
+  // Registry order IS recency (freshest-first) — the first entry per workspace is
+  // kept, never re-sorted (R4/INV-10).
+  const mk = (id: string, ws: string): InstanceRegistryEntry => ({ ...project, instance_id: id, workspace_root: ws });
+  const cards = groupBrainCards([
+    mk('inst_fresh', '/rt/a'),
+    mk('inst_stale', '/rt/a'),
+    mk('inst_other', '/rt/b'),
+  ]);
+  assert.equal(cards.length, 2, 'two workspaces → two cards');
+  assert.equal(cards[0].entry.instance_id, 'inst_fresh', 'the freshest (first) entry wins its card');
+  assert.deepEqual(cards.map((c) => c.entry.workspace_root), ['/rt/a', '/rt/b'], 'first-appearance order preserved');
+});
+
+test('groupBrainCards: the genuine duplicate badge fires only when DISTINCT roots collapse', () => {
+  // Two textually DIFFERENT workspace_root strings that canonicalize to the same
+  // place (here: a trailing slash) — the rare real "duplicate workspace" conflict.
+  const a: InstanceRegistryEntry = { ...project, instance_id: 'inst_a', workspace_root: '/rt/repo' };
+  const b: InstanceRegistryEntry = { ...project, instance_id: 'inst_b', workspace_root: '/rt/repo/' };
+  const cards = groupBrainCards([a, b]);
+  assert.equal(cards.length, 1, 'two roots for the same place → one card');
+  assert.equal(cards[0].duplicateWorkspace, true, 'distinct root strings → the genuine duplicate badge');
 });
 
 test('brainFreshnessMs: a project brain uses last_activity_ms, others the heartbeat', () => {

--- a/m1nd-ui/src/lib/hallSemantics.ts
+++ b/m1nd-ui/src/lib/hallSemantics.ts
@@ -11,6 +11,8 @@
  * INV-10: every value here traces to an owner-reported field; absence is
  * absence, never an invented number.
  */
+import type { InstanceRegistryEntry } from '../types';
+import { canonRootForCompare } from './viewedBrain';
 
 // ── Liveness band (PRD §4A.3 card anatomy: the liveness dot) ──────────────────
 // sage = live · unfired grey = dormant · ochre = stale heartbeat · brick = hard
@@ -265,8 +267,16 @@ export function brainFreshnessMs(entry: {
  * brain never wears a "stale lock" it cannot own.
  */
 export function visibleConflicts(entry: { brain_kind?: string | null; conflicts: string[] }): string[] {
-  if (!isProjectBrain(entry)) return entry.conflicts;
-  return entry.conflicts.filter((c) => !/lock|runtime/i.test(c));
+  // `duplicate_workspace` is NO LONGER read from the raw backend conflict. The
+  // server marks it whenever two entries merely SHARE a workspace_root — which the
+  // ephemeral-id duplicate bug tripped on every warm-boot (N identical cards, all
+  // wearing "duplicate workspace"). The Hall now DERIVES that signal itself when
+  // it groups cards (`groupBrainCards`), raising it ONLY when two DISTINCT root
+  // strings collapse to one card (the genuine, rare case). So it is stripped here.
+  const conflicts = entry.conflicts.filter((c) => !/duplicate.?workspace/i.test(c));
+  if (!isProjectBrain(entry)) return conflicts;
+  // Lock/instance conflicts are OWNER-process concepts — never a project brain's.
+  return conflicts.filter((c) => !/lock|runtime/i.test(c));
 }
 
 // ── Implementation class → the RECEIPT line (PRD §4A.8, INV-14) ───────────────
@@ -338,4 +348,58 @@ export function ownerLanding(input: {
   if (input.brainCount <= 0) return 'threshold';
   if (input.hasLocalHistory) return 'tree';
   return 'hall';
+}
+
+// ── Card grouping: one card per workspace (defense in depth; §4A.3) ───────────
+// The instance-registry stable-id fix stops a brain minting a duplicate entry per
+// warm-boot at the SOURCE. This is the Hall's second layer: even if duplicate
+// entries reach it (a pre-fix owner, a race), it renders ONE card per workspace,
+// so the "N identical cards" symptom can never surface. The genuine
+// "duplicate workspace" badge survives ONLY when two DISTINCT root strings
+// canonicalize to the same card — the rare real conflict.
+
+export interface HallBrainGroup {
+  /** The freshest entry for this workspace — the one card's data source. */
+  entry: InstanceRegistryEntry;
+  /**
+   * True ONLY when ≥2 DISTINCT `workspace_root` strings canonicalize to this one
+   * card — the genuine "duplicate workspace" conflict. Identical-string duplicates
+   * (the ephemeral-id field bug) collapse SILENTLY with this false.
+   */
+  duplicateWorkspace: boolean;
+}
+
+/**
+ * Collapse registry entries into one card per workspace. Entries are keyed by
+ * their canonicalized `workspace_root`; within a key the FRESHEST wins. The list
+ * arrives freshest-first (registry order IS recency — bound-first, then
+ * heartbeat-descending), so the FIRST entry seen per key is the freshest and is
+ * kept, never re-sorted (R4 / INV-10). Overall card order is preserved
+ * (first-appearance order of each workspace), so the bound brain stays on top.
+ *
+ * The genuine `duplicateWorkspace` flag is raised only when a group merged ≥2
+ * DISTINCT `workspace_root` strings — two textually different roots pointing at
+ * the same place — never for the identical-string duplicates the ephemeral-id bug
+ * produced. A blank/absent workspace_root falls back to the instance_id as its own
+ * key, so a rootless entry is never merged into another card.
+ */
+export function groupBrainCards(entries: InstanceRegistryEntry[]): HallBrainGroup[] {
+  const order: string[] = [];
+  const groups = new Map<string, { entry: InstanceRegistryEntry; roots: Set<string> }>();
+  for (const entry of entries) {
+    const key = canonRootForCompare(entry.workspace_root) ?? entry.instance_id;
+    const group = groups.get(key);
+    if (group) {
+      // A later (staler) entry for the same workspace: keep the incumbent (the
+      // freshest, already stored), only record its distinct root string.
+      group.roots.add(entry.workspace_root);
+    } else {
+      groups.set(key, { entry, roots: new Set([entry.workspace_root]) });
+      order.push(key);
+    }
+  }
+  return order.map((key) => {
+    const group = groups.get(key)!;
+    return { entry: group.entry, duplicateWorkspace: group.roots.size > 1 };
+  });
 }


### PR DESCRIPTION
Field bug, hit twice by the owner in one day: clicking "Open brain" on a dormant brain DUPLICATED its Hall card. Root cause (read, then RED-proven both ways): the eviction gate drops a warm brain's handle without release(), the orphan entry lingers under the still-live owner pid (dead-pid GC can never reap it), and the next resolve mints a NEW ephemeral instance id (`generate_instance_id` mixes pid+clock+seq) — N entries, same workspace, N cards.

The fix: a brain's registry entry gets a DETERMINISTIC id (`stable_brain_instance_id`, the module's own path-hash scheme minus the nonce) — `set_brain_kind` re-keys the entry onto it, warm-boots upsert the same file, and `reconcile_brain_duplicates` sweeps stale same-store twins on every registration (the inherited duplicates die brain-by-brain as they open), all while PRESERVING live read-only attachers (the N-attacher design is untouched, pinned by test). Defense in depth in the Hall: `groupBrainCards` renders one card per canonical workspace (freshest wins, order preserved) and the duplicate-workspace badge appears only when two genuinely distinct roots collapse.

RED proof: with the re-key neutered, boot-twice mints two ids and the twin survives; restored, one stable entry and the twin dies. 809 m1nd-mcp tests (+4) · 446 UI (+5) · clippy/fmt/tsc/eslint clean · no-leak clean.