### PR TITLE
voice: slice 2 — the pulse signature, the map fact, and the cockpit verb

### DIFF
--- a/DIVERGENCES.md
+++ b/DIVERGENCES.md
@@ -4,7 +4,7 @@ Honest record of every point where the implementation deviates from the judged
 design (`docs/voice/M1ND-VOICE-DESIGN.md` + `docs/voice/ASKGOD-VERDICT-HUMAN-VIEW.md`),
 per the slice's standing order: implement the honest subset, never invent.
 
-## 1. Line 1 omits the ratified-maps segment (coordinator-ruled)
+## 1. Line 1 omits the ratified-maps segment (coordinator-ruled) — RESOLVED in slice 2
 
 The judged signature is `m1nd │ <trust> · <N nodes> · <M memories> · <K maps
 ratified>`. The north packet carries NO ratified-map count today: the
@@ -18,6 +18,12 @@ compose time would violate G1's "only facts already in the packet".
 (mirroring the field's own law: a segment without a value is omitted, never
 zero-stuffed). Exposing a ratified-map count in the packet is a slice-2
 decision.
+
+**RESOLVED (slice 2, feat/voice-slice2, 2026-07-12):** the count is now measured
+from the SAME `system_blocks_snapshot` read (no new read, no invented number):
+the packet carries a `map` field (`{ratified_blocks, coherence}`, per-brain,
+present iff a store exists) and line 1 gains a `map <K> blocks` segment (omitted
+when zero). See `docs/voice/SLICE2-DIVERGENCES.md` for the slice-2 record.
 
 ## 2. Overflow drops whole lines — no `…` ellipsis truncation
 

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -70,6 +70,39 @@ same bar, applied to building the organism outward.
 > alone); slice 2 (the navigable cockpit verb — its verdict is already emitted, also under
 > `docs/voice/`) queues AFTER this v1 lands and the owner stamps the provador.
 
+> **2026-07-12 — the HUMAN-LAYER VOICE arc, slice 2: the PULSE is stamped, the map fact lands, and the navigable `cockpit` verb ships (§C11-style amendment).**
+> The owner stamped the mark: the **PULSE** (`M1ND-VOICE-ALIEN.md` §5 variant C) is now the
+> OFFICIAL signature of the voice. Line 1 hangs `m1nd ` + a FIVE-cell pulse row (calm `╷` / raised
+> `│`) in a FIXED-FOREVER order — `trust · graph · focus · bell · coherence` (the anti-equalizer
+> law, pinned by test); read as an EXPRESSION (all low = calm, one stem up = look), never
+> cell-by-cell; DROPPED whole under `caller_root_mismatch` (the plain spine returns — the vitals
+> would read the wrong brain); the cells join the `state_sig` (`…|pulse:╷╷╷│╷`). **Slice-1's honest
+> residue is resolved:** line 1 gains a `map <N> blocks` segment (the served brain's ratified
+> SystemBlock count, PER-BRAIN, omitted when zero) measured from the SAME `system_blocks_snapshot`
+> read that feeds coherence — no new read, no invented number — and the packet carries a small `map`
+> field (`{ratified_blocks, coherence}`, present iff a store exists, mirroring `landing_bell`). **The
+> navigable cockpit shipped:** `cockpit` (`m1nd-cockpit-v0`) — a DEDICATED read-only verb, a SIBLING
+> of north (breaks alone, never a north field), the human's ON-REQUEST router over m1nd's read
+> surfaces. Its law is the askGOD verdict "the navigable cockpit" (the 10 amendments,
+> `docs/voice/ASKGOD-VERDICT-COCKPIT.md`): seven stable-slot collections (the tray + missions are
+> POINTERS — no verb; the map/health/trust/memories/drift are argument-less reads); the read-only
+> law is DERIVED (every routed verb filtered against `READ_ONLY_DENIED_TOOLS`, pinned by
+> `cockpit_read_verbs ∩ deny = ∅`); `menu_sig` on every response (the short reference a widget button
+> carries back, never free text/never a write); a drill re-asserts `store_version`/`state_sig` and
+> says "state moved" when the caller's snapshot diverged; the `why` text is lifted from the ONE help
+> catalog (never a parallel one). The official **widget template** is versioned
+> (`docs/voice/WIDGET-TEMPLATE.md` — the h4nd skin, STATE-JSON + render, no-write law, links-by-origin,
+> modal-in-normal-flow, payload = number + menu_sig). Render doctrine is doctrine on ALL surfaces in
+> the same burst: `M1ND_INSTRUCTIONS` §7 (the pulse, the deep-rung legend + proof glyphs `⊢`/`∎`, the
+> cockpit's on-request-only default, the extended ASCII map `╷`→`.`) + the three skills. Proven: 20
+> new unit tests (14 human_view incl. the pulse anti-equalizer + map segment + mismatch-drop; 6
+> cockpit incl. the read-only derivation + stable slots + menu_sig + state-moved), full
+> `m1nd-mcp` suite green, **two budgets re-pinned live** — north ~1,404 tokens (≤2k, fresh ingest
+> 9,178 nodes) with the pulse + map mounted; the cockpit's OWN budget ~695 tokens root (≤800), ~430
+> drill. HONEST residue (slice-2 DIVERGENCES): the cockpit is a ROUTER in v1 (presents the read to
+> run, like the help overview; its output carries the receipts — never fabricated), not an inline
+> executor; per-item drill (impact/why/trace, depth 2) is deferred by the verdict.
+
 > **2026-07-11 — ARC-1 + ARC-2 closed: the proof system hardened, F12 ratified and implemented, and the FIRST AUTONOMOUS CURATION ratified by the owner.**
 > The integrity burst (#342) closed all four open field reports: the field spool is runtime-scoped
 > (an ephemeral owner can never read or write the production box again), receipts refuse temporal

--- a/docs/uml/cockpit.md
+++ b/docs/uml/cockpit.md
@@ -1,0 +1,165 @@
+# The Cockpit — the navigable m1nd menu (`cockpit`)
+
+`cockpit(agent_id, select?, seen_store_version?)` is a pure read-only COMPOSER:
+the human's ON-REQUEST router over m1nd's read surfaces. It is a **sibling of
+`north`, never a field of it** — if it breaks it breaks ALONE, never taking
+`north` down (fail-open does not apply). It reads the same cheap surfaces
+`north` already touches (the mission box, the served brain's SystemBlock store,
+the durable-memory count, the reception verdict) to label the menu honestly, and
+never mutates anything.
+
+Law source: the askGOD verdict "the navigable cockpit" (2026-07-12, CHANGE with
+10 required changes) — `docs/voice/ASKGOD-VERDICT-COCKPIT.md`. The widget that
+renders it: `docs/voice/WIDGET-TEMPLATE.md`.
+
+## Class
+
+```mermaid
+classDiagram
+    class handle_cockpit {
+        <<composer, cockpit.rs>>
+        +agent_id: String (required)
+        +select: Option~String~ (a slot "1".."7", or "0" = root)
+        +seen_store_version: Option~u64~
+        +compose() CockpitResponse
+        %% read-only; NEVER in READ_ONLY_DENIED_TOOLS; breaks alone
+    }
+
+    class Facts {
+        <<read once, fail-open>>
+        +merge_wait: usize (mission box)
+        +mission_total: usize (mission box)
+        +store_present: bool (SystemBlock store)
+        +store_version: Option~u64~
+        +ratified_blocks: usize
+        +block_count: usize
+        +coherence: Option~String~
+        +memory_count: usize (light_memory_count)
+        +recv_mismatch: bool (reception_verdict)
+    }
+
+    class Collection {
+        <<7 stable slots, amendment 4 order>>
+        +slot: u8 (STABLE — condition moves the LABEL only)
+        +key: str (tray|map|missions|health|trust|memories|drift)
+        +label: String (condition-driven)
+        +verb: Option~str~ (Some=read, None=POINTER)
+        +door: Option~str~ (Some=pointer door text)
+    }
+
+    class RootResponse {
+        <<m1nd-cockpit-v0, depth 0>>
+        +schema
+        +depth: 0
+        +menu_sig: "mc_XXXXXXXX"
+        +state_sig
+        +store_version: Option~u64~
+        +entries: [read|pointer]
+        +on_request_only: true
+        +reception? (present iff mismatch)
+        +non_claims
+    }
+
+    class DrillResponse {
+        <<m1nd-cockpit-v0, depth 1>>
+        +schema
+        +depth: 1
+        +slot + key + label
+        +kind: read|pointer
+        +verb + arguments + why   %% read entries only
+        +door + facts             %% pointer entries only
+        +menu_sig + state_sig + store_version
+        +state_moved: bool (+ note when true)
+        +back: "select 0 to re-serve the root"
+    }
+
+    handle_cockpit --> Facts : reads once (fail-open)
+    handle_cockpit --> Collection : builds 7, filters by deny-list
+    handle_cockpit --> RootResponse : select absent/"0"
+    handle_cockpit --> DrillResponse : select "1".."7"
+    Collection ..> help_guidance : why lifted from catalog_entry (amendment 10)
+    Collection ..> read_only_denied : read verbs filtered (amendment 2)
+```
+
+## Sequence — compose + drill
+
+```mermaid
+sequenceDiagram
+    participant H as Human (via agent)
+    participant K as handle_cockpit (cockpit.rs)
+    participant B as mission box
+    participant S as system_blocks_snapshot
+    participant R as reception_verdict
+    participant Cat as help catalog
+
+    H->>K: cockpit {agent_id, select?, seen_store_version?}
+    K->>K: validate agent_id (non-empty)
+    K->>B: read_letters -> heads_by_mission (fail-open)
+    B-->>K: merge_wait, mission_total
+    K->>S: snapshot (served brain only)
+    S-->>K: store_present, store_version, ratified_blocks, coherence
+    K->>R: reception_verdict()
+    R-->>K: recv_mismatch (+ honest)
+    K->>K: build 7 collections, FILTER read verbs by read_only_denied
+    K->>Cat: catalog_entry(verb).one_liner for each read `why`
+    K->>K: menu_sig = hash(slots+labels+verbs, store_version, state_sig)
+    alt select absent or "0"
+        K-->>H: RootResponse (depth 0, 7 entries, menu_sig, on_request_only)
+    else select "1".."7"
+        K->>K: state_moved = seen_store_version present && != store_version
+        K-->>H: DrillResponse (depth 1, re-asserts store_version/state_sig, back="0")
+    else select invalid
+        K-->>H: InvalidParams (honest: "select must be 0 or 1..=7")
+    end
+```
+
+## The ten laws (amendment → where it lands)
+
+| # | Amendment | Where it lands |
+|---|---|---|
+| 1 | dedicated read-only verb, sibling of north, no fail-open | `handle_cockpit`; NOT in `READ_ONLY_DENIED_TOOLS`; own dispatch arm |
+| 2 | read-only law DERIVED from the single source + Rust test | `.filter(read_only_denied)`; `cockpit_read_verbs_are_never_write_denied` |
+| 3 | pointer entries carry NO verb — only door text | `Collection.verb == None` for tray/missions; `pointer_entries_carry_no_verb` |
+| 4 | root = argument-less reads only; impact/why/trace OUT | seven collections; no analysis verb in the root |
+| 5 | max depth 3 (root→collection→item); "0" = back | `depth` 0/1; `select:"0"` re-serves root |
+| 6 | stable slots for the trio; menu_sig; drill re-asserts store_version/state_sig | `slots_are_stable_across_conditions`; `state_moved` |
+| 7 | widget payload = number + menu_sig, never free text / write verb | `menu_sig`; `docs/voice/WIDGET-TEMPLATE.md` |
+| 8 | on-request only; no landing auto-serve | `on_request_only:true`; negative default in `M1ND_INSTRUCTIONS` §7 + 3 skills |
+| 9 | own budget, battery-pinned | ~695 tokens root (≤800 ceiling); ~430 drill — 2026-07-12 |
+| 10 | reuse the help machine (catalog), never a parallel one | `why` from `help_guidance::catalog_entry` |
+
+## Invariantes
+
+- **Sibling, not a field — breaks alone**: `cockpit` has its own dispatch arm and
+  is read-only-safe; a compose miss returns a cockpit error and never touches the
+  `north` packet (cockpit.rs; amendment 1).
+- **Read-only derivation, mechanical**: every root read verb is filtered through
+  `server::read_only_denied` at compose time, and `cockpit_read_verbs_are_never_write_denied`
+  intersects the routed set with the write deny-list — a verb that becomes a
+  mutation drops itself, no hand-kept list (amendment 2).
+- **Pointer purity**: the tray and missions carry a `door` and NO `verb` — there
+  is nothing to execute even by mistake; the stamp stays a human gesture at the
+  tray (amendment 3).
+- **Per-brain only**: the map/bell/memory facts read the BOUND brain's own
+  surfaces; the cockpit never aggregates across brains, and warns honestly under
+  `caller_root_mismatch` (the menu describes the bound brain, not the caller's repo).
+- **Stable slots, moving labels**: the seven collections keep their slots across
+  every condition; only the label moves (`slots_are_stable_across_conditions`;
+  amendment 6).
+- **Anti-staleness**: `menu_sig` is a deterministic digest of the served menu; a
+  drill re-asserts `store_version`/`state_sig` and flags `state_moved` when the
+  caller's `seen_store_version` diverged (amendment 6).
+- **Own budget**: root ~695 tokens, drill ~430 (≤800 ceiling), battery-pinned
+  2026-07-12 — north's pin does not cover it (amendment 9).
+
+## Gaps / deferred (honest)
+
+- **Router, not executor (v1 scope)**: a read drill presents the argument-less
+  call to RUN (like the help overview presents `minimal_calls`); its OUTPUT carries
+  the live detail (receipts/hashes render in the item view, amendment 5). The
+  cockpit never fabricates a receipt — it routes. Serving verb output inline is a
+  future slice.
+- **Per-item drill (depth 2, impact/why/trace)**: explicitly OUT of v1 (amendment
+  4) — reserved as drill-down actions from a selected item.
+- **`state_sig` is the menu's own** (`bell|map|coh|recv|sv`), not byte-identical to
+  the human_view sig; both re-affirm the same beat. Unifying them is a future tidy.

--- a/docs/uml/spine-north.md
+++ b/docs/uml/spine-north.md
@@ -33,6 +33,7 @@ classDiagram
         +needs: Option~String~
         +recovery_playbook: Option~Value~
         +landing_bell: Option~Value~ (present iff merge_wait>0)
+        +map: Option~Value~ (present iff a SystemBlock store exists: ratified_blocks+coherence)
         +human_view: Option~HumanView~ (present iff composed)
         +proof_state: "triaging"
         +non_claims: [4 disclaimers]
@@ -42,9 +43,9 @@ classDiagram
         <<m1nd-human-view-v0, human_view.rs>>
         +schema: "m1nd-human-view-v0"
         +state: clean|bell|coherence|mismatch|needs_ingest
-        +state_sig: "trust|bell:N|coh:ok·sick|recv:match·mismatch"
-        +lines: Vec~String~ (mounted, <=4, <=80 cols)
-        %% composed AFTER reception — pure, fail-open
+        +state_sig: "trust|bell:N|coh:ok·sick|recv:match·mismatch|pulse:╷╷╷╷╷"
+        +lines: Vec~String~ (mounted, wordmark + PULSE + gutter, <=4, <=80 cols)
+        %% composed AFTER reception — pure, fail-open; pulse dropped under mismatch
     }
 
     class BindingSlice {
@@ -238,8 +239,8 @@ with 10 amendments) + the SPINE design — both versioned under `docs/voice/`.
 "human_view": {
   "schema": "m1nd-human-view-v0",
   "state": "clean",
-  "state_sig": "full_trust|bell:0|coh:ok|recv:match",
-  "lines": ["m1nd │ full trust · 9,113 nodes · 30 memories"]
+  "state_sig": "full_trust|bell:0|coh:ok|recv:match|pulse:╷╷╷╷╷",
+  "lines": ["m1nd ╷╷╷╷╷  full trust · 9,113 nodes · 30 memories"]
 }
 ```
 
@@ -279,25 +280,74 @@ mismatch > needs_ingest > bell > coherence):
   `needs_ingest`, where it IS the message). Numbers render with the thousands
   separator (`9,024`), nothing else is reformatted.
 - The `state_sig` is the mechanical anti-repetition key
-  (`trust|bell:N|coh:ok·sick|recv:match·mismatch`): equal state ⇒ equal sig;
-  agents never render the same sig twice in a session (cadence law in
-  `M1ND_INSTRUCTIONS` §7 and the three skills).
+  (`trust|bell:N|coh:ok·sick|recv:match·mismatch|pulse:╷╷╷╷╷`): equal state ⇒
+  equal sig; agents never render the same sig twice in a session (cadence law
+  in `M1ND_INSTRUCTIONS` §7 and the three skills). The pulse row is appended so
+  a change in the graph/focus vitals (not only the four legacy tokens) flips
+  the key.
 
-**The mark is pluggable** (amendment 7): the brand anchor is the WORD `m1nd`
-(always lowercase) + the spine `│` (U+2502) — both already accepted. Line 1 is
-composed by `compose_voice_signature()` alone, so a future mark (the PULSE row
-`╷╷╷│╷` awaits the owner's explicit stamp) plugs in at one seam without
-touching the composition laws. ASCII fallback is the AGENT's duty (1:1 map
-`│`→`|`, `·`→`.`, `—`→`-`; widths identical).
+**The mark is the PULSE** (amendment 7; the owner's explicit stamp 2026-07-12 —
+`M1ND-VOICE-ALIEN.md` §5 variant C). The brand anchor is the WORD `m1nd`
+(always lowercase) followed by a FIVE-cell pulse row: `m1nd ╷╷╷│╷  <facts>`. A
+cell is calm `╷` (U+2577, narrow-guaranteed) or raised `│` (U+2502, the spine
+standing up). The cell order is FIXED FOREVER (the anti-equalizer law, pinned
+by `pulse_is_the_fixed_five_cell_signature`): `trust · graph · focus · bell ·
+coherence` —
+- **trust** rises when `trust_mode != full_trust` (calm on `needs_ingest`, where
+  the graph cell owns the message);
+- **graph** rises on `needs_ingest`/empty graph;
+- **focus** rises when a populated graph activated no focus node;
+- **bell** rises when `merge_wait > 0`;
+- **coherence** rises on a skeleton-coherence mismatch/stale signal.
 
-**Line-1 signature**: `m1nd │ <trust> · <N nodes> · <M memories>` — the
-ratified-maps segment is OMITTED in v1 because the packet does not carry a
-ratified-map count today (see `DIVERGENCES.md` at the slice root; exposing the
-count is a slice-2 decision, never an invented number).
+Read the row as an EXPRESSION (all low = calm; one stem up = look), never
+cell-by-cell in the compact card. The first cell sits at column 6, exactly
+under the continuation gutter's spine — the lombada is BORN from the pulse.
+Under `caller_root_mismatch` the pulse is DROPPED WHOLE and the plain spine
+`m1nd │ ` returns (the vitals would read the wrong brain — S3 is its own
+warning). Line 1 is composed by `compose_voice_signature()` alone (the pluggable
+seam). ASCII fallback is the AGENT's duty (1:1 map `╷`→`.`, `│`→`|`, `·`→`.`,
+`—`→`-`, and the deep-rung proof glyphs `⊢`→`>`, `∎`→`#`; widths identical).
 
-**Budget**: re-pinned with the field mounted — the packet measures ~1,391
-tokens (≤2,000 ceiling); the card costs ~174 chars (~43 tokens) on a clean
-beat, worst case ≤4×80 + envelope (~120 tokens).
+**Line-1 signature**: `m1nd ╷╷╷│╷  <trust> · <N nodes> · <M memories> · map <K>
+blocks` — the **map segment** is the SERVED brain's ratified SystemBlock count
+(slice-2; the packet's `map` field, PER-BRAIN, never a cross-brain total),
+OMITTED when zero (G1: a zero is not "the map exists"). This resolves slice-1
+`DIVERGENCES.md` §1, which omitted the segment because the packet carried no
+ratified-block count; slice 2 exposes it honestly from the same
+`system_blocks_snapshot` read that feeds the coherence signal.
+
+**The `map` field** rides the packet ONLY when the served brain has a
+SystemBlock store (absent — not null — otherwise, mirroring `landing_bell`):
+`{ "ratified_blocks": <K>, "coherence": "ok"|"mismatch" }`.
+
+**Budget**: re-pinned with the pulse + map field mounted — the packet measures
+~1,404 tokens (≤2,000 ceiling; battery `north_packet_within_budget`, fresh
+ingest 9,178 nodes, 2026-07-12); the card costs ~43 tokens on a clean beat,
+worst case ≤4×80 + envelope (~120 tokens). The pulse adds 5 cells (chars that
+were spaces) to line 1 and the cells to `state_sig` (`…|pulse:╷╷╷│╷`); the
+width cap is re-verified by the human_view tests.
+
+## cockpit — the navigable menu (`m1nd-cockpit-v0`)
+
+A DEDICATED read-only verb (askGOD verdict "the navigable cockpit", the 10
+amendments — `docs/voice/ASKGOD-VERDICT-COCKPIT.md`), the human's ON-REQUEST
+router over m1nd's read surfaces. It is a **sibling of `north`, never a field**:
+if it breaks it breaks alone, never taking `north` down (fail-open does not
+apply). Full contract + class/sequence: `docs/uml/cockpit.md`. In three lines:
+- **Root = seven stable-slot collections** (labels move with state, slots never
+  do): the tray (POINTER), the map (`system_blocks_snapshot`), missions
+  (POINTER), health (`doctor`), trust (`trust`), recent-memories (`boot_memory`,
+  fixed projection), drift (`drift`). Pointer entries carry NO verb (amendment 3).
+- **The read-only law is DERIVED**: every routed verb is filtered at compose
+  time against `server::read_only_denied`, pinned by the test
+  `cockpit_read_verbs ∩ READ_ONLY_DENIED_TOOLS = ∅` (amendment 2); the `why`
+  text is lifted from the one help catalog (amendment 10), never a parallel one.
+- **Navigation**: `select="<slot>"` drills (depth ≤3; `"0"` re-serves root); every
+  response carries `menu_sig` (the short reference a widget button carries back —
+  never free text, never a write verb) + `store_version` + `state_sig`, and a
+  drill says "state moved" when the caller's `seen_store_version` diverged
+  (amendment 6). Own budget pinned ~695 tokens (root, ≤800 ceiling; drill ~430).
 
 ## Gaps
 

--- a/docs/voice/SLICE2-DIVERGENCES.md
+++ b/docs/voice/SLICE2-DIVERGENCES.md
@@ -1,0 +1,65 @@
+# DIVERGENCES — human_view slice 2 (feat/voice-slice2)
+
+Honest record of every point where the slice-2 implementation deviates from, or
+makes a bounded decision beneath, the judged designs (`M1ND-VOICE-ALIEN.md` §5,
+`ASKGOD-VERDICT-COCKPIT.md`, `M1ND-VOICE-DESIGN.md`), per the standing order:
+implement the honest subset, never invent.
+
+## 1. The map segment reads `map <N> blocks`, not `<N> maps ratified`
+
+The design docs illustrate the maps segment as `4 maps ratified`
+(`M1ND-VOICE-DESIGN.md` §5). The slice-2 order gives the literal segment
+`map <N> blocks`, and this is what ships. It is the MORE honest noun: the served
+brain has ONE skeleton with N ratified SystemBlocks, not "N maps". The count is
+strictly the ratified-block count; a zero omits the segment (G1). The structured
+`map` field names it unambiguously (`ratified_blocks`).
+
+## 2. The cockpit is a ROUTER in v1, not an inline executor
+
+The verdict's amendment 5 ("receipts/hashes render INSIDE the item view") and
+amendment 6 ("drill-down responses carry store_version/state_sig") admit two
+readings: (a) the cockpit executes each read verb and serves its output inline;
+(b) the cockpit is a navigation ROUTER (like the help overview) that presents the
+argument-less call to run, whose OWN output carries the receipts. **Slice 2 ships
+(b)** — the pure-router reading — because it is what "reuse the help machine"
+(amendment 10) means: the help overview presents `minimal_calls`, it never
+executes. The cockpit therefore never fabricates a receipt; a read drill hands
+the exact argument-less call, and the verb's output renders the receipts in the
+item view (as S5 already does). Serving verb output inline is a future slice.
+This is a scope decision, not a law break: all ten laws hold on the router.
+
+## 3. Missions is a POINTER (to the tray), not a served list verb
+
+Amendment 4 lists `missions` as a root collection. There is no argument-less MCP
+READ verb that lists mission letters (the box is read via the tray/HTTP surface,
+and `mission_next` needs a `mission_id`). Slice 2 renders `missions` as a POINTER
+to the tray (carrying a measured count label from the same box read the bell
+uses) — faithful to amendment 3 (pointer = door, no verb) and to "the tray is
+the door". The mission COUNT is honest (measured); the ACTION lives at the tray.
+
+## 4. The cockpit's `state_sig` is the menu's own, not byte-identical to human_view's
+
+The human_view `state_sig` is `trust|bell:N|coh|recv|pulse`. The cockpit
+re-asserts state with its own menu-shaped key `bell:N|map:K|coh|recv|sv:V`
+(amendment 6 requires "store_version/state_sig", and `sv` carries the store
+version the pulse sig does not). Both re-affirm the same beat; they are not the
+same string. Unifying them is a future tidy, noted in `docs/uml/cockpit.md`.
+
+## 5. `health` folds `alerts` into one slot
+
+Amendment 4 writes "health (doctor/alerts)". Slice 2 maps the health slot to the
+`doctor` read (the richer census) and names alerts in its label/why, rather than
+minting a separate `alerts_list` slot — keeping the root at the seven collections
+the amendment enumerates. `alerts_list` remains a valid read the human can run
+from doctor's output.
+
+## 6. Live bell/map render is unit-pinned, not shown on the fresh-ingest probe
+
+The budget probe ingests a throwaway temp graph with no missions and no
+SystemBlock store, so the LIVE render shows the calm state
+(`m1nd ╷╷╷╷╷  full trust · 9,178 nodes`) with no bell/map segment. The bell
+render (`m1nd ╷╷╷│╷  …` + the verbatim bell line), the map segment
+(`· map 12 blocks`), the needs_ingest pulse (`╷│╷╷╷`), and the mismatch
+pulse-drop are pinned deterministically by the human_view unit tests rather than
+by the live probe. No behavior is unproven — only the surface that would require
+seeding missions + a store to exercise live.

--- a/docs/voice/WIDGET-TEMPLATE.md
+++ b/docs/voice/WIDGET-TEMPLATE.md
@@ -1,0 +1,198 @@
+# The cockpit-chat widget — official template (`m1nd-cockpit-widget-v0`)
+
+Versioned material. This is the ONE reference skin an agent pastes to render the
+`cockpit` menu (or the human_view deep rung) as a rich, navigable card in a chat
+that supports HTML widgets. It is fed by a STATE JSON (the `cockpit` verb's own
+output is that JSON source) + this template; the agent pastes both.
+
+> Law source: askGOD verdict "the navigable cockpit" (`ASKGOD-VERDICT-COCKPIT.md`)
+> amendment 7 + the owner's field notes on the v3.2 prototype. Skin: h4nd
+> (`~/god-hud`). The widget renders READS and navigation only — it NEVER carries
+> a write.
+
+---
+
+## 1. The five laws of this widget (non-negotiable)
+
+1. **No write, ever.** No button names or triggers a write verb (ratify, import,
+   post, apply, memorize, …). Pointer entries (the tray) render as a DOOR that
+   points to where the human acts — never as an in-widget action. Approving
+   inside the widget is laundered consent (a click fabricates a message with the
+   user's authority); the lowest legitimate friction is a deep-link to the tray
+   card, where the click travels browser→server with no model in between.
+2. **The payload is a short reference, never free text.** A button sends only
+   `select <slot>` + the `menu_sig` it was rendered from — the SAME thing a
+   human would type. NEVER a command string, NEVER a string interpolated from
+   graph/repo content (that is a prompt-injection channel).
+3. **Links by origin.** An `https://` external link is a native `<a href>`
+   (opens out). A `localhost`/`127.0.0.1` link (the served UI, the tray) goes
+   through the agent via `sendPrompt` — the browser widget cannot reach the
+   owner's loopback, and the agent deep-links honestly.
+4. **Modal lives in normal flow.** Any expanded detail / "modal" is a normal
+   block with `min-height`, pushed into the document flow — NEVER `position:
+   absolute`/`fixed` alone (it detaches from the transcript and clips in chat).
+5. **Two skins, one geometry** (uiproof + the ASCII fallback law): the rich HTML
+   skin and the plain text card (the human_view lines) carry the SAME facts and
+   the SAME navigation; the widget is an enrichment, never a second source.
+
+---
+
+## 2. The h4nd skin (the design system tokens)
+
+```
+--breu:        #0E0D0C;   /* dark ink — the ground */
+--papel:       #F2EFE9;   /* paper — the card */
+--papel-2:     #E8E4DA;   /* paper, one step down (rows) */
+--ink:         #1A1815;   /* body text on paper */
+--ink-soft:    #6B655C;   /* secondary text */
+--vermilion:   #C43422;   /* the stamp / the one alarm accent */
+--line:        #0E0D0C;   /* hard 1px rule */
+--grid:        24px;      /* everything snaps to a 24px grid */
+--shadow-hard: 3px 3px 0 #0E0D0C;   /* solid, no blur */
+--shadow-lift: 4px 4px 0 #0E0D0C;   /* raised elements */
+```
+
+House rules:
+- **Hard solid shadows only** (`3px 3px 0` / `4px 4px 0`) — never a soft/blurred
+  shadow; the look is printed paper on ink, not glass.
+- **The vermilion stamp** is the ONLY saturated color and appears ONCE per card,
+  tilted `-1deg` (`transform: rotate(-1deg)`) like a rubber stamp — reserved for
+  the calling state (a raised pulse cell, a bell awaiting a stamp). Never fill a
+  whole surface with it.
+- **24px grid**: padding, gaps, and row heights are multiples of 24px.
+- **Monospace for the wordmark + pulse** (they must align to the text card);
+  the labels may use the system UI stack.
+- **Theme-aware**: paper card on ink ground reads in both light and dark chat;
+  the tokens above are the dark-ground default. Under a light chat, keep the
+  paper card (it is the product's identity), only softening the outer ground.
+
+---
+
+## 3. The STATE contract (what the cockpit verb feeds)
+
+The widget renders THIS shape verbatim (it is the `cockpit` response, trimmed to
+what the skin needs). The agent pastes it into `STATE` and never edits values:
+
+```json
+{
+  "schema": "m1nd-cockpit-v0",
+  "depth": 0,
+  "menu_sig": "mc_fd063e9a",
+  "state_sig": "bell:3|map:12|coh:ok|recv:match|sv:7",
+  "store_version": 7,
+  "wordmark": "m1nd",
+  "pulse": "╷╷╷│╷",
+  "entries": [
+    { "slot": 1, "kind": "pointer", "label": "the tray · 3 await your stamp",
+      "door": "open the tray — the stamp lives there" },
+    { "slot": 2, "kind": "read", "label": "the map · 12 blocks ratified",
+      "verb": "system_blocks_snapshot", "why": "…" }
+  ]
+}
+```
+
+- `pulse` mirrors the human_view line-1 row; a raised cell `│` gets the vermilion
+  stamp treatment, a calm cell `╷` stays ink.
+- A `read` entry renders a button whose payload is `select <slot> @ <menu_sig>`.
+- A `pointer` entry renders a DOOR (a labelled link), NEVER a submit button.
+
+---
+
+## 4. Reference render (self-contained; inline everything)
+
+```html
+<style>
+  .m1c { background: var(--breu, #0E0D0C); padding: 24px; font: 14px/1.5 ui-sans-serif, system-ui; }
+  .m1c__card { background: #F2EFE9; color: #1A1815; border: 1px solid #0E0D0C;
+    box-shadow: 4px 4px 0 #0E0D0C; padding: 24px; max-width: 560px; }
+  .m1c__head { display: flex; align-items: baseline; gap: 12px; font-family: ui-monospace, Menlo, monospace;
+    border-bottom: 1px solid #0E0D0C; padding-bottom: 12px; margin-bottom: 12px; }
+  .m1c__mark { font-weight: 700; }
+  .m1c__pulse { letter-spacing: 2px; }
+  .m1c__pulse .up { color: #C43422; }              /* raised cell = the stamp accent */
+  .m1c__crumb { color: #6B655C; font-size: 12px; margin-bottom: 12px; }
+  .m1c__row { display: flex; justify-content: space-between; align-items: center;
+    background: #E8E4DA; border: 1px solid #0E0D0C; box-shadow: 3px 3px 0 #0E0D0C;
+    padding: 12px; margin-bottom: 12px; min-height: 24px; }
+  .m1c__btn { font: inherit; cursor: pointer; background: #F2EFE9; border: 1px solid #0E0D0C;
+    box-shadow: 3px 3px 0 #0E0D0C; padding: 6px 12px; }
+  .m1c__btn:active { box-shadow: 1px 1px 0 #0E0D0C; transform: translate(2px,2px); }
+  .m1c__door { color: #C43422; text-decoration: underline; transform: rotate(-1deg);
+    display: inline-block; font-weight: 600; }
+  .m1c__modal { border: 1px solid #0E0D0C; box-shadow: 4px 4px 0 #0E0D0C; background: #F2EFE9;
+    padding: 24px; margin-top: 12px; min-height: 96px; }  /* NORMAL FLOW, min-height — never absolute */
+</style>
+
+<div class="m1c">
+  <div class="m1c__card" id="m1c-card"></div>
+</div>
+
+<script>
+  // STATE is pasted by the agent from the cockpit verb output — never hand-edited.
+  const STATE = /*__STATE__*/ { schema:"m1nd-cockpit-v0", depth:0, menu_sig:"mc_0",
+    state_sig:"", store_version:null, wordmark:"m1nd", pulse:"╷╷╷╷╷", entries:[] };
+
+  function renderPulse(p){
+    return [...p].map(c => c === '│'
+      ? '<span class="up">│</span>' : '<span>╷</span>').join('');
+  }
+
+  function render(state){
+    const crumb = state.depth === 0 ? 'root' : `root › ${state.label || 'detail'}`;
+    const rows = (state.entries || []).map(e => {
+      if (e.kind === 'pointer') {
+        // A DOOR — never a submit. Points to where the human acts.
+        return `<div class="m1c__row"><span>${escapeHtml(e.label)}</span>
+          <span class="m1c__door" data-door="${escapeAttr(e.door||'')}">${escapeHtml(e.door||'open')}</span></div>`;
+      }
+      // A READ button — payload is the SHORT reference only.
+      return `<div class="m1c__row"><span>${escapeHtml(e.label)}</span>
+        <button class="m1c__btn" data-slot="${e.slot}">look ›</button></div>`;
+    }).join('');
+
+    document.getElementById('m1c-card').innerHTML = `
+      <div class="m1c__head">
+        <span class="m1c__mark">${escapeHtml(state.wordmark || 'm1nd')}</span>
+        <span class="m1c__pulse">${renderPulse(state.pulse || '╷╷╷╷╷')}</span>
+      </div>
+      <div class="m1c__crumb">${escapeHtml(crumb)} · ${escapeHtml(state.menu_sig || '')}</div>
+      ${rows}`;
+
+    // READ button → sends the SHORT reference a human would type (law 2).
+    document.querySelectorAll('.m1c__btn').forEach(b => b.onclick = () => {
+      const slot = b.getAttribute('data-slot');
+      // payload = number + menu_sig, NEVER free text, NEVER graph content.
+      sendPrompt(`cockpit select ${slot} @ ${state.menu_sig}`);
+    });
+    // DOOR → the agent deep-links (localhost via agent; https as native anchor).
+    document.querySelectorAll('[data-door]').forEach(d => d.onclick = () => {
+      sendPrompt(`open the tray for me`);   // a request, not a write; no interpolated graph string
+    });
+  }
+
+  function escapeHtml(s){ return String(s).replace(/[&<>"]/g, m =>
+    ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m])); }
+  function escapeAttr(s){ return escapeHtml(s).replace(/'/g, '&#39;'); }
+  render(STATE);
+</script>
+```
+
+### Notes on the reference
+
+- **`sendPrompt` payloads are references, not commands.** `cockpit select 2 @
+  mc_fd063e9a` is what a human would type; the agent re-invokes `cockpit` with
+  `select:"2"` and the `menu_sig` proves the human acted on the menu it saw
+  (anti-staleness). A door sends a plain request ("open the tray for me"), never
+  a graph-derived string.
+- **External vs localhost links.** For an `https://…` link (docs, a public page)
+  render a native `<a href target="_blank" rel="noopener">` — it opens out and
+  needs no agent. For a `localhost`/served-UI link, DO NOT `<a href>` (the widget
+  sandbox cannot reach the owner's loopback): send a `sendPrompt` request and let
+  the agent deep-link.
+- **The modal (`.m1c__modal`)** is appended in the normal document flow with a
+  `min-height`; it is never `position:absolute/fixed` alone — a detached modal
+  clips inside a chat transcript and loses the breadcrumb.
+- **Two skins, one geometry:** this widget and the plain text card
+  (`m1nd ╷╷╷│╷  …`) render the SAME `menu_sig`/`state_sig` and the SAME entries;
+  when the surface cannot hold the widget, the text card is the honest fallback
+  (the ASCII pulse `...|.`), and nothing about the navigation changes.

--- a/m1nd-mcp/src/cockpit.rs
+++ b/m1nd-mcp/src/cockpit.rs
@@ -1,0 +1,670 @@
+//! cockpit — the navigable m1nd menu (`m1nd-cockpit-v0`).
+//!
+//! A DEDICATED read-only verb (askGOD verdict "the navigable cockpit",
+//! 2026-07-12 — the 10 amendments; `docs/voice/ASKGOD-VERDICT-COCKPIT.md`).
+//! It is the human's on-request router over m1nd's read surfaces — a sibling of
+//! `north`, NEVER a field of it. The laws it obeys, by amendment:
+//!
+//! 1. DEDICATED read-only verb, a pure composer sibling of `north`; fail-open
+//!    does NOT apply — if it breaks it breaks ALONE, never taking `north` down.
+//! 2. The read-only law is DERIVED from the single source: every routed verb is
+//!    filtered at compose time against `server::read_only_denied`, and the test
+//!    `cockpit_read_verbs ∩ READ_ONLY_DENIED_TOOLS = ∅` pins it — no hand-kept
+//!    second list.
+//! 3. Pointer entries (the tray) carry NO `verb` field — only door text; there
+//!    is nothing to execute even by mistake.
+//! 4. The root is argument-less READS only (the map/health/trust/memories/drift
+//!    reads + the tray/missions pointers). `impact`/`why`/`trace` stay OUT of
+//!    the root (future per-item drill-downs).
+//! 5. Max depth 3 (root → collection → item); `select:"0"` re-serves the root.
+//! 6. The permanent trio sits in STABLE SLOTS (condition changes the LABEL, not
+//!    the slot); `menu_sig` is mandatory; a drill re-asserts `store_version` +
+//!    `state_sig` and says "state moved" honestly when the caller's
+//!    `seen_store_version` diverged.
+//! 8. On-request only — the caller invokes it ("?"/explicit ask); at a landing
+//!    the S5 card speaks, never an auto-served menu.
+//! 9. Its OWN budget, battery-pinned (north's pin does not cover it).
+//! 10. It REUSES the help machine — each read entry's `why` is lifted from
+//!     `help_guidance::catalog_entry` (the one canonical catalog), never a
+//!     parallel one.
+//!
+//! The widget payload law (amendment 7) lives in `docs/voice/WIDGET-TEMPLATE.md`:
+//! a button carries the SAME short reference a human would type — a number +
+//! `menu_sig` — never free command text, never a graph-interpolated string, and
+//! never a write verb.
+
+use serde_json::{json, Value};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use m1nd_core::error::{M1ndError, M1ndResult};
+
+use crate::session::SessionState;
+
+/// Wire schema of the cockpit response.
+pub const COCKPIT_SCHEMA: &str = "m1nd-cockpit-v0";
+
+/// The tool name (used by the schema + dispatch arm).
+pub const COCKPIT_TOOL: &str = "cockpit";
+
+/// The read verbs the cockpit routes to — the SINGLE list the read-only test
+/// (amendment 2) intersects with `READ_ONLY_DENIED_TOOLS`. Each is argument-less
+/// (only `agent_id`, plus `boot_memory`'s fixed `action:"list"` projection).
+pub fn cockpit_read_verbs() -> &'static [&'static str] {
+    &[
+        "system_blocks_snapshot",
+        "doctor",
+        "trust",
+        "boot_memory",
+        "drift",
+    ]
+}
+
+/// One root collection. `verb == None` marks a POINTER (a door, amendment 3);
+/// `verb == Some` marks an argument-less READ the human/agent runs.
+struct Collection {
+    slot: u8,
+    key: &'static str,
+    label: String,
+    /// Present iff this is a READ entry — never for a pointer (amendment 3).
+    verb: Option<&'static str>,
+    /// Present iff this is a POINTER — the door text, never an executable verb.
+    door: Option<&'static str>,
+}
+
+/// The live facts the cockpit reads once, to label the menu honestly.
+struct Facts {
+    merge_wait: usize,
+    mission_total: usize,
+    store_present: bool,
+    store_version: Option<u64>,
+    ratified_blocks: usize,
+    block_count: usize,
+    coherence: Option<String>,
+    memory_count: usize,
+    recv_mismatch: bool,
+    reception_honest: Option<String>,
+}
+
+/// `cockpit` (READ). Serves the root menu, or drills one collection when
+/// `select` names a slot. Pure composer, read-only, breaks alone.
+pub fn handle_cockpit(state: &mut SessionState, params: &Value) -> M1ndResult<Value> {
+    let agent_id = params
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| M1ndError::InvalidParams {
+            tool: COCKPIT_TOOL.to_string(),
+            detail: "agent_id is required".to_string(),
+        })?
+        .to_string();
+
+    let select = params
+        .get("select")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let seen_store_version = params.get("seen_store_version").and_then(Value::as_u64);
+
+    let facts = read_facts(state);
+    let state_sig = compose_state_sig(&facts);
+
+    // Build the stable-slot collections, then DERIVE the read-only law: drop any
+    // read entry whose verb became a write (amendment 2). Today none do — the
+    // filter makes the containment MECHANICAL, not a hand-kept promise.
+    let collections: Vec<Collection> = root_collections(&facts)
+        .into_iter()
+        .filter(|c| {
+            c.verb
+                .map(|v| !crate::server::read_only_denied(v, &json!({})))
+                .unwrap_or(true)
+        })
+        .collect();
+
+    let menu_sig = compose_menu_sig(&collections, facts.store_version, &state_sig);
+
+    match select {
+        None | Some("0") => Ok(compose_root(
+            &agent_id,
+            &collections,
+            &facts,
+            &menu_sig,
+            &state_sig,
+        )),
+        Some(sel) => match sel.parse::<u8>() {
+            Ok(slot) if (1..=collections.len() as u8).contains(&slot) => Ok(compose_drill(
+                &agent_id,
+                &collections,
+                slot,
+                &facts,
+                &menu_sig,
+                &state_sig,
+                seen_store_version,
+            )),
+            _ => Err(M1ndError::InvalidParams {
+                tool: COCKPIT_TOOL.to_string(),
+                detail: format!(
+                    "select must be \"0\" (re-serve root) or a slot 1..={} — got {sel:?}",
+                    collections.len()
+                ),
+            }),
+        },
+    }
+}
+
+/// Read the live facts ONCE from the cheap surfaces `north` already touches: the
+/// mission box (bell + missions), the served brain's SystemBlock store (map),
+/// the durable-memory count, and the reception verdict (honesty). Every read
+/// FAILS OPEN — an unreadable surface labels as empty, never an error.
+fn read_facts(state: &mut SessionState) -> Facts {
+    // Bell + missions — the same box the tray and `mission_post` speak.
+    let (merge_wait, mission_total) = {
+        let box_path = crate::mission_letter_handlers::mission_box_path(state);
+        match crate::mailbox::read_letters(&box_path) {
+            Ok(letters) => {
+                let heads = crate::mission_letter::heads_by_mission(&letters);
+                let merge_wait = heads
+                    .values()
+                    .filter(|h| h.head.phase == crate::mission_letter::Phase::MergeWait)
+                    .count();
+                (merge_wait, heads.len())
+            }
+            Err(_) => (0, 0),
+        }
+    };
+
+    // The map — the SERVED brain's store only (per-brain, never cross-brain).
+    let (store_present, store_version, ratified_blocks, block_count, coherence) =
+        match crate::system_blocks_handlers::handle_system_blocks_snapshot(
+            state,
+            crate::system_blocks_handlers::SnapshotInput { agent_id: None },
+        ) {
+            Ok(snap) if snap["present"] == Value::Bool(true) => {
+                let store_version = snap["store_version"].as_u64();
+                let block_count = snap["block_count"].as_u64().unwrap_or(0) as usize;
+                let ratified_blocks = snap["store"]["blocks"]
+                    .as_array()
+                    .map(|blocks| {
+                        blocks
+                            .iter()
+                            .filter(|b| b["state"] == json!("ratified"))
+                            .count()
+                    })
+                    .unwrap_or(0);
+                let coherence = snap["skeleton_coherence"]["status"]
+                    .as_str()
+                    .map(str::to_string);
+                (true, store_version, ratified_blocks, block_count, coherence)
+            }
+            _ => (false, None, 0, 0, None),
+        };
+
+    let memory_count = state.light_memory_count();
+
+    let reception = state.reception_verdict();
+    let recv_mismatch = reception
+        .as_ref()
+        .and_then(|r| r.get("match").and_then(Value::as_str))
+        == Some("caller_root_mismatch");
+    let reception_honest = reception
+        .as_ref()
+        .filter(|_| recv_mismatch)
+        .and_then(|r| r.get("honest").and_then(Value::as_str))
+        .map(str::to_string);
+
+    Facts {
+        merge_wait,
+        mission_total,
+        store_present,
+        store_version,
+        ratified_blocks,
+        block_count,
+        coherence,
+        memory_count,
+        recv_mismatch,
+        reception_honest,
+    }
+}
+
+/// The seven stable-slot collections (amendment 4 order). Slots 1–3 are the
+/// permanent trio (the tray, the map, missions); their LABELS move with state,
+/// their SLOTS never do (amendment 6). Slots 4–7 are the argument-less reads.
+fn root_collections(f: &Facts) -> Vec<Collection> {
+    // 1 — the tray (POINTER: bell + the human stamp gesture; no verb).
+    let tray_label = if f.merge_wait > 0 {
+        format!("the tray · {} await your stamp", f.merge_wait)
+    } else {
+        "the tray · quiet".to_string()
+    };
+    // 2 — the map (READ: the served brain's SystemBlock store).
+    let map_label = if !f.store_present {
+        "the map · no skeleton yet".to_string()
+    } else if f.ratified_blocks > 0 {
+        format!("the map · {} blocks ratified", f.ratified_blocks)
+    } else {
+        format!("the map · {} blocks (candidate)", f.block_count)
+    };
+    // 3 — missions (POINTER → the tray; the box is not an MCP read verb).
+    let missions_label = if f.mission_total > 0 {
+        format!(
+            "missions · {} in flight ({} awaiting)",
+            f.mission_total, f.merge_wait
+        )
+    } else {
+        "missions · none in flight".to_string()
+    };
+    // 6 — recent memories (READ: boot_memory, the fixed-N projection).
+    let memories_label = if f.memory_count > 0 {
+        format!("memories · {} durable claim(s)", f.memory_count)
+    } else {
+        "memories · none yet".to_string()
+    };
+
+    vec![
+        Collection {
+            slot: 1,
+            key: "tray",
+            label: tray_label,
+            verb: None,
+            door: Some("open the tray — the stamp lives there"),
+        },
+        Collection {
+            slot: 2,
+            key: "map",
+            label: map_label,
+            verb: Some("system_blocks_snapshot"),
+            door: None,
+        },
+        Collection {
+            slot: 3,
+            key: "missions",
+            label: missions_label,
+            verb: None,
+            door: Some("the tray lists them — the stamp lands there"),
+        },
+        Collection {
+            slot: 4,
+            key: "health",
+            label: "health · the doctor's read (topology · verification · git · alerts)"
+                .to_string(),
+            verb: Some("doctor"),
+            door: None,
+        },
+        Collection {
+            slot: 5,
+            key: "trust",
+            label: "trust · the binding's verdict + freshness".to_string(),
+            verb: Some("trust"),
+            door: None,
+        },
+        Collection {
+            slot: 6,
+            key: "memories",
+            label: memories_label,
+            verb: Some("boot_memory"),
+            door: None,
+        },
+        Collection {
+            slot: 7,
+            key: "drift",
+            label: "drift · nodes whose evidence moved under the graph".to_string(),
+            verb: Some("drift"),
+            door: None,
+        },
+    ]
+}
+
+/// The mechanical anti-repetition / re-affirmation key: the menu's measured
+/// state. Same shape family as the human_view state_sig; carries the map's
+/// `store_version` so a drill can honestly say "state moved".
+fn compose_state_sig(f: &Facts) -> String {
+    format!(
+        "bell:{}|map:{}|coh:{}|recv:{}|sv:{}",
+        f.merge_wait,
+        f.ratified_blocks,
+        f.coherence.as_deref().unwrap_or("none"),
+        if f.recv_mismatch { "mismatch" } else { "match" },
+        f.store_version
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+    )
+}
+
+/// `menu_sig` — a short, stable digest of the served menu (slots + labels +
+/// verbs) plus the store version and state signature. This is the exact short
+/// reference a widget button carries back (amendment 7), never free text.
+fn compose_menu_sig(
+    collections: &[Collection],
+    store_version: Option<u64>,
+    state_sig: &str,
+) -> String {
+    let mut hasher = DefaultHasher::new();
+    for c in collections {
+        c.slot.hash(&mut hasher);
+        c.key.hash(&mut hasher);
+        c.label.hash(&mut hasher);
+        c.verb.hash(&mut hasher);
+        c.door.hash(&mut hasher);
+    }
+    store_version.hash(&mut hasher);
+    state_sig.hash(&mut hasher);
+    format!("mc_{:08x}", (hasher.finish() as u32))
+}
+
+/// Serialize one collection as a root entry. Read entries carry the canonical
+/// `why` lifted from the help catalog (amendment 10); pointer entries carry the
+/// door text and NO verb (amendment 3).
+fn entry_json(c: &Collection) -> Value {
+    match (c.verb, c.door) {
+        (Some(verb), _) => {
+            let why = crate::help_guidance::catalog_entry(verb)
+                .map(|e| e.one_liner)
+                .unwrap_or_default();
+            json!({
+                "slot": c.slot,
+                "key": c.key,
+                "kind": "read",
+                "label": c.label,
+                "verb": verb,
+                "why": why,
+            })
+        }
+        (None, Some(door)) => json!({
+            "slot": c.slot,
+            "key": c.key,
+            "kind": "pointer",
+            "label": c.label,
+            "door": door,
+        }),
+        // A collection with neither verb nor door is a construction bug; render
+        // it as an inert pointer rather than fabricating a verb.
+        (None, None) => json!({
+            "slot": c.slot,
+            "key": c.key,
+            "kind": "pointer",
+            "label": c.label,
+        }),
+    }
+}
+
+fn reception_note(f: &Facts) -> Option<Value> {
+    f.recv_mismatch.then(|| {
+        json!({
+            "match": "caller_root_mismatch",
+            "honest": f
+                .reception_honest
+                .clone()
+                .unwrap_or_else(|| "this graph does NOT cover your repo".to_string()),
+            "note": "this menu describes the BOUND brain, not your repo — ingest your root to route to your own brain",
+        })
+    })
+}
+
+fn non_claims() -> Value {
+    json!([
+        "cockpit composes read-only menu entries; it never mutates, ratifies, imports, or lands anything.",
+        "the menu describes the BOUND brain only — never a cross-brain aggregate.",
+        "pointer entries carry no verb — the stamp is a human gesture at the tray, never a cockpit click.",
+        "labels are facts measured at compose time; run the routed read to see live detail.",
+    ])
+}
+
+fn compose_root(
+    agent_id: &str,
+    collections: &[Collection],
+    f: &Facts,
+    menu_sig: &str,
+    state_sig: &str,
+) -> Value {
+    let entries: Vec<Value> = collections.iter().map(entry_json).collect();
+    let mut out = json!({
+        "schema": COCKPIT_SCHEMA,
+        "depth": 0,
+        "title": "m1nd cockpit — reply with a slot number to look; 0 re-serves this root",
+        "menu_sig": menu_sig,
+        "state_sig": state_sig,
+        "store_version": f.store_version,
+        "entries": entries,
+        "on_request_only": true,
+        "agent_id": agent_id,
+        "non_claims": non_claims(),
+    });
+    if let Some(recv) = reception_note(f) {
+        out.as_object_mut()
+            .unwrap()
+            .insert("reception".to_string(), recv);
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compose_drill(
+    agent_id: &str,
+    collections: &[Collection],
+    slot: u8,
+    f: &Facts,
+    menu_sig: &str,
+    state_sig: &str,
+    seen_store_version: Option<u64>,
+) -> Value {
+    let c = collections
+        .iter()
+        .find(|c| c.slot == slot)
+        .expect("slot bounds checked by caller");
+
+    // Amendment 6: a drill re-asserts store_version + state_sig, and says "state
+    // moved" honestly when the caller's snapshot diverged.
+    let state_moved =
+        matches!((seen_store_version, f.store_version), (Some(seen), sv) if Some(seen) != sv);
+
+    let mut detail = match (c.verb, c.door) {
+        (Some(verb), _) => {
+            let why = crate::help_guidance::catalog_entry(verb)
+                .map(|e| e.one_liner)
+                .unwrap_or_default();
+            // Present the argument-less call to RUN (router pattern, like help):
+            // its own output carries the receipts/hashes, rendered in the item
+            // view (amendment 5) — the cockpit never fabricates a receipt.
+            let arguments = if verb == "boot_memory" {
+                json!({ "agent_id": agent_id, "action": "list" })
+            } else {
+                json!({ "agent_id": agent_id })
+            };
+            json!({
+                "kind": "read",
+                "verb": verb,
+                "arguments": arguments,
+                "why": why,
+                "note": "run this read — its output carries the live detail (receipts/hashes render in the item view)",
+            })
+        }
+        (None, door) => json!({
+            "kind": "pointer",
+            "door": door.unwrap_or("open the tray — the stamp lives there"),
+            // The pointer's facts are already measured — no verb, nothing to run.
+            "facts": {
+                "merge_wait": f.merge_wait,
+                "missions_in_flight": f.mission_total,
+            },
+            "note": "the stamp is a human gesture at the tray — the cockpit never lands it",
+        }),
+    };
+
+    let obj = detail.as_object_mut().unwrap();
+    obj.insert("schema".to_string(), json!(COCKPIT_SCHEMA));
+    obj.insert("depth".to_string(), json!(1));
+    obj.insert("slot".to_string(), json!(slot));
+    obj.insert("key".to_string(), json!(c.key));
+    obj.insert("label".to_string(), json!(c.label));
+    obj.insert("menu_sig".to_string(), json!(menu_sig));
+    obj.insert("state_sig".to_string(), json!(state_sig));
+    obj.insert("store_version".to_string(), json!(f.store_version));
+    obj.insert("state_moved".to_string(), json!(state_moved));
+    if state_moved {
+        obj.insert(
+            "state_moved_note".to_string(),
+            json!("the store moved since you last read it — re-serve the root (select 0) before you act"),
+        );
+    }
+    obj.insert("back".to_string(), json!("select 0 to re-serve the root"));
+    if let Some(recv) = reception_note(f) {
+        obj.insert("reception".to_string(), recv);
+    }
+    obj.insert("non_claims".to_string(), non_claims());
+    detail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Amendment 2 — the read-only law, DERIVED, not hand-kept: NO cockpit read
+    /// verb may appear in the write deny-list. This is the mechanical guard the
+    /// verdict demanded (`entries.verb ∩ READ_ONLY_DENIED_TOOLS = ∅`).
+    #[test]
+    fn cockpit_read_verbs_are_never_write_denied() {
+        for verb in cockpit_read_verbs() {
+            assert!(
+                !crate::server::read_only_denied(verb, &json!({})),
+                "cockpit routes to `{verb}`, but it is on the read-only write deny-list — \
+                 a menu entry must never name a mutation (amendment 2)"
+            );
+        }
+    }
+
+    fn empty_facts() -> Facts {
+        Facts {
+            merge_wait: 0,
+            mission_total: 0,
+            store_present: false,
+            store_version: None,
+            ratified_blocks: 0,
+            block_count: 0,
+            coherence: None,
+            memory_count: 0,
+            recv_mismatch: false,
+            reception_honest: None,
+        }
+    }
+
+    /// Amendment 3 — pointer entries (the tray, missions) carry NO verb field;
+    /// there is nothing to execute even by mistake.
+    #[test]
+    fn pointer_entries_carry_no_verb() {
+        let cols = root_collections(&empty_facts());
+        for c in &cols {
+            if c.door.is_some() {
+                assert!(
+                    c.verb.is_none(),
+                    "pointer collection `{}` must not carry a verb",
+                    c.key
+                );
+                let e = entry_json(c);
+                assert_eq!(e["kind"], "pointer");
+                assert!(e.get("verb").is_none(), "no verb serialized for a pointer");
+            }
+        }
+        // The tray and missions are pointers; the map/health/trust/memories/drift
+        // are reads.
+        let tray = cols.iter().find(|c| c.key == "tray").unwrap();
+        assert!(tray.verb.is_none() && tray.door.is_some());
+        let map = cols.iter().find(|c| c.key == "map").unwrap();
+        assert_eq!(map.verb, Some("system_blocks_snapshot"));
+    }
+
+    /// Amendment 6 — the permanent trio sits in stable slots 1..=3, condition
+    /// changing only the LABEL; and the root always serves the seven collections.
+    #[test]
+    fn slots_are_stable_across_conditions() {
+        let quiet = root_collections(&empty_facts());
+        let mut busy = empty_facts();
+        busy.merge_wait = 3;
+        busy.mission_total = 4;
+        busy.store_present = true;
+        busy.ratified_blocks = 12;
+        busy.store_version = Some(7);
+        let loud = root_collections(&busy);
+
+        assert_eq!(quiet.len(), 7);
+        assert_eq!(loud.len(), 7);
+        for (a, b) in quiet.iter().zip(loud.iter()) {
+            assert_eq!(a.slot, b.slot, "slot is stable");
+            assert_eq!(a.key, b.key, "collection identity is stable");
+            assert_eq!(a.verb, b.verb, "verb (or its absence) is stable");
+        }
+        // The label DID move for the stateful trio members.
+        let tray_quiet = &quiet[0].label;
+        let tray_loud = &loud[0].label;
+        assert_ne!(tray_quiet, tray_loud, "the tray label moves with the bell");
+        assert!(loud[0].label.contains('3'), "the loud tray names the count");
+        assert!(loud[1].label.contains("12 blocks ratified"));
+    }
+
+    /// The menu_sig is deterministic for an equal menu and shifts when the menu
+    /// shifts — the short reference a widget button carries (amendment 7).
+    #[test]
+    fn menu_sig_is_stable_and_shifts_with_state() {
+        let f = empty_facts();
+        let cols = root_collections(&f);
+        let sig_a = compose_menu_sig(&cols, f.store_version, &compose_state_sig(&f));
+        let sig_b = compose_menu_sig(&cols, f.store_version, &compose_state_sig(&f));
+        assert_eq!(sig_a, sig_b, "equal menu ⇒ equal sig");
+        assert!(
+            sig_a.starts_with("mc_"),
+            "menu_sig is the short mc_ reference"
+        );
+
+        let mut moved = empty_facts();
+        moved.merge_wait = 2;
+        let cols2 = root_collections(&moved);
+        let sig_c = compose_menu_sig(&cols2, moved.store_version, &compose_state_sig(&moved));
+        assert_ne!(sig_a, sig_c, "a changed menu ⇒ a changed sig");
+    }
+
+    /// A drill re-asserts store_version + state_sig and flags a diverged snapshot
+    /// honestly (amendment 6).
+    #[test]
+    fn drill_flags_state_moved_when_store_version_diverged() {
+        let mut f = empty_facts();
+        f.store_present = true;
+        f.store_version = Some(9);
+        let cols = root_collections(&f);
+        let sig = compose_menu_sig(&cols, f.store_version, &compose_state_sig(&f));
+        let ss = compose_state_sig(&f);
+
+        // Caller saw v7, store is now v9 → state moved.
+        let drill = compose_drill("t", &cols, 2, &f, &sig, &ss, Some(7));
+        assert_eq!(drill["state_moved"], json!(true));
+        assert!(drill.get("state_moved_note").is_some());
+        assert_eq!(drill["store_version"], json!(9));
+        assert_eq!(drill["depth"], json!(1));
+
+        // Caller saw the current version → no divergence.
+        let fresh = compose_drill("t", &cols, 2, &f, &sig, &ss, Some(9));
+        assert_eq!(fresh["state_moved"], json!(false));
+    }
+
+    /// A pointer drill carries the door + measured facts and NO verb to run
+    /// (amendment 3); a read drill carries the argument-less call to run.
+    #[test]
+    fn drill_shapes_match_the_entry_kind() {
+        let mut f = empty_facts();
+        f.merge_wait = 1;
+        let cols = root_collections(&f);
+        let sig = compose_menu_sig(&cols, f.store_version, &compose_state_sig(&f));
+        let ss = compose_state_sig(&f);
+
+        // Slot 1 = the tray pointer.
+        let tray = compose_drill("t", &cols, 1, &f, &sig, &ss, None);
+        assert_eq!(tray["kind"], "pointer");
+        assert!(tray.get("verb").is_none(), "a pointer drill runs no verb");
+        assert_eq!(tray["facts"]["merge_wait"], json!(1));
+
+        // Slot 6 = memories read → fixed action=list projection.
+        let mem = compose_drill("t", &cols, 6, &f, &sig, &ss, None);
+        assert_eq!(mem["kind"], "read");
+        assert_eq!(mem["verb"], json!("boot_memory"));
+        assert_eq!(mem["arguments"]["action"], json!("list"));
+    }
+}

--- a/m1nd-mcp/src/human_view.rs
+++ b/m1nd-mcp/src/human_view.rs
@@ -21,9 +21,16 @@
 //!   fit the cap falls WHOLE, never truncated — amendment 5;
 //! - brand law G1 as the field's written law: only measured facts already in
 //!   the packet — no uncalibrated adjective, no benefit claim — amendment 8;
-//! - the mark is the SPINE: the `m1nd` wordmark + `│` (U+2502), both already
-//!   accepted; any future mark (the pulse row awaits the owner's explicit
-//!   stamp) plugs into `compose_voice_signature` alone — amendment 7;
+//! - the mark is the PULSE: the `m1nd` wordmark + a 5-cell pulse row `╷╷╷│╷`
+//!   (`M1ND-VOICE-ALIEN.md` §5 variant C, the owner's explicit stamp
+//!   2026-07-12 — the official signature of the voice). Calm `╷` (U+2577) = a
+//!   vital sign at rest; raised `│` (U+2502) = one calling for the human. The
+//!   cell order is FIXED FOREVER (the anti-equalizer law, pinned by test):
+//!   `trust · graph · focus · bell · coherence`. Read the row as an
+//!   EXPRESSION, never cell-by-cell: all low = calm; one stem up = look. Under
+//!   `caller_root_mismatch` the pulse is DROPPED whole (it would measure the
+//!   wrong brain) and the plain spine `│` returns — the S3 card is its own
+//!   warning. The mark plugs into `compose_voice_signature` alone — amendment 7;
 //! - fail-open: composition is pure and total; `north` never becomes
 //!   unavailable over its own voice.
 
@@ -52,6 +59,16 @@ const SPINE: char = '│';
 /// Field separator inside the identity line (U+00B7).
 const SEP: &str = " · ";
 
+/// The pulse cells (`M1ND-VOICE-ALIEN.md` §5). `╷` (U+2577, narrow-guaranteed —
+/// EAW class N) is a vital sign at rest; `│` (U+2502) is the SAME spine glyph,
+/// raised, so a calling cell reads as a stem standing up out of the calm row.
+/// ASCII fallback is the AGENT's duty (1:1 map `╷`→`.`, `│`→`|`; widths
+/// identical), documented in `M1ND_INSTRUCTIONS` §7 and the three skills.
+const PULSE_CALM: char = '╷';
+const PULSE_RAISED: char = '│';
+/// The pulse row width — FIVE cells, frozen forever (the anti-equalizer law).
+const PULSE_CELLS: usize = 5;
+
 /// Everything the composer needs, lifted from data ALREADY in the packet —
 /// the composer performs no reads of its own (pure, total, fail-open).
 pub struct HumanViewInput<'a> {
@@ -62,6 +79,14 @@ pub struct HumanViewInput<'a> {
     pub node_count: u64,
     /// `memory_exists` — the on-disk durable L1GHT claim count.
     pub memory_count: usize,
+    /// Ratified SystemBlock count of the SERVED brain (slice-2 map fact). Line 1
+    /// gains a `map <N> blocks` segment when `> 0`; a zero omits it (G1: only a
+    /// measured fact). PER-BRAIN — never a cross-brain total.
+    pub ratified_blocks: usize,
+    /// Whether `orient` activated any focus node for this task. Drives the
+    /// pulse's `focus` cell in a POPULATED graph (calm on `needs_ingest`, where
+    /// the `graph` cell already carries the message).
+    pub focus_activated: bool,
     /// `landing_bell.merge_wait` (0 = silent).
     pub merge_wait: usize,
     /// The bell line EXACTLY as pushed into `honest_gaps` (amendment 5).
@@ -89,14 +114,17 @@ pub struct ReceptionMismatch<'a> {
 /// Compose the card. Returns `None` only when nothing can be said honestly
 /// (fail-open: the caller omits the field; `north` never errors here).
 pub fn compose_human_view(input: &HumanViewInput) -> Option<serde_json::Value> {
-    let state_sig = compose_state_sig(input);
+    let pulse = compose_pulse(input);
+    let state_sig = compose_state_sig(input, &pulse);
     let (state, lines) = if let Some(mismatch) = &input.reception_mismatch {
         // Amendment 3: the card IS the warning — zero statistics, they would
-        // describe the wrong brain.
+        // describe the wrong brain. The pulse is DROPPED (it would read the
+        // wrong brain's vitals): S3 renders the plain spine, not the pulse.
         ("mismatch", compose_mismatch_lines(mismatch))
     } else if input.needs_ingest {
-        // Amendment 4: the honest "I don't know this repo yet" card.
-        ("needs_ingest", compose_needs_ingest_lines(input))
+        // Amendment 4: the honest "I don't know this repo yet" card. The pulse
+        // shows with only the `graph` cell raised (`╷│╷╷╷`).
+        ("needs_ingest", compose_needs_ingest_lines(input, &pulse))
     } else {
         let state = if input.merge_wait > 0 {
             "bell"
@@ -105,7 +133,7 @@ pub fn compose_human_view(input: &HumanViewInput) -> Option<serde_json::Value> {
         } else {
             "clean"
         };
-        (state, compose_identity_and_signal_lines(input))
+        (state, compose_identity_and_signal_lines(input, &pulse))
     };
     if lines.is_empty() {
         return None;
@@ -119,9 +147,11 @@ pub fn compose_human_view(input: &HumanViewInput) -> Option<serde_json::Value> {
 }
 
 /// The mechanical anti-repetition key (design §2): `trust | bell | coherence |
-/// reception`. Equal state ⇒ equal signature; agents use it to never render
-/// the same card twice in a session.
-fn compose_state_sig(input: &HumanViewInput) -> String {
+/// reception | pulse`. Equal state ⇒ equal signature; agents use it to never
+/// render the same card twice in a session. The pulse row is appended so a
+/// change in ANY vital sign (graph/focus too, not only the four legacy tokens)
+/// flips the key.
+fn compose_state_sig(input: &HumanViewInput, pulse: &str) -> String {
     let coh = if input.coherence_line.is_some() {
         "sick"
     } else {
@@ -133,17 +163,64 @@ fn compose_state_sig(input: &HumanViewInput) -> String {
         "match"
     };
     format!(
-        "{}|bell:{}|coh:{}|recv:{}",
-        input.trust_mode, input.merge_wait, coh, recv
+        "{}|bell:{}|coh:{}|recv:{}|pulse:{}",
+        input.trust_mode, input.merge_wait, coh, recv, pulse
     )
 }
 
+/// Compose the pulse row (`M1ND-VOICE-ALIEN.md` §5) — FIVE cells in a FROZEN
+/// order (the anti-equalizer law, pinned by test): `trust · graph · focus ·
+/// bell · coherence`. Each cell is calm `╷` or raised `│`:
+/// - **trust** rises when `trust_mode != full_trust`;
+/// - **graph** rises on `needs_ingest` or an empty graph (0 nodes);
+/// - **focus** rises when a POPULATED graph activated no focus node (calm on
+///   `needs_ingest` — there the `graph` cell already carries the message, so
+///   the row reads `╷│╷╷╷`, never `╷││╷╷`);
+/// - **bell** rises when `merge_wait > 0`;
+/// - **coherence** rises on a skeleton-coherence mismatch/stale signal.
+///
+/// The row is composed unconditionally (it is also the anti-repetition
+/// fingerprint); the CARD drops it under `caller_root_mismatch` — S3 renders
+/// the plain spine instead (the vitals would describe the wrong brain).
+fn compose_pulse(input: &HumanViewInput) -> String {
+    let cell = |raised: bool| if raised { PULSE_RAISED } else { PULSE_CALM };
+    // trust stays calm on needs_ingest — there the `graph` cell owns the
+    // message; raising trust too would double-signal (ALIEN §5: `╷│╷╷╷`, one
+    // stem up). trust rises only for a genuinely degraded trust over a usable
+    // graph.
+    let trust = input.trust_mode != "full_trust" && !input.needs_ingest;
+    let graph = input.needs_ingest || input.node_count == 0;
+    let focus = !input.needs_ingest && !input.focus_activated;
+    let bell = input.merge_wait > 0;
+    let coherence = input.coherence_line.is_some();
+    let row: String = [
+        cell(trust),
+        cell(graph),
+        cell(focus),
+        cell(bell),
+        cell(coherence),
+    ]
+    .iter()
+    .collect();
+    debug_assert_eq!(row.chars().count(), PULSE_CELLS, "the pulse row is 5 cells");
+    row
+}
+
 /// Line 1 — THE pluggable-mark seam (amendment 7). The signature prefix is the
-/// wordmark hung on the margin with the spine beside it; a future mark (e.g.
-/// the pulse row — awaiting the owner's explicit stamp) changes THIS function
-/// only, never the composition laws.
-fn compose_voice_signature(content: &str) -> Vec<String> {
-    render_wrapped(&format!("{WORDMARK} {SPINE} "), content)
+/// wordmark hung on the margin followed by the PULSE row (the owner's official
+/// stamp, `M1ND-VOICE-ALIEN.md` §5): `m1nd ╷╷╷│╷  <facts>`. The first pulse
+/// cell sits at column 6, exactly under the continuation gutter's spine — the
+/// lombada is BORN from the pulse. When `pulse` is `None` (S3 mismatch), the
+/// plain spine `m1nd │ ` returns: the pulse would read the wrong brain's
+/// vitals, so the S3 warning card carries no pulse.
+fn compose_voice_signature(pulse: Option<&str>, content: &str) -> Vec<String> {
+    let prefix = match pulse {
+        // wordmark + space + 5-cell pulse + TWO spaces (the ALIEN §5 geometry).
+        Some(cells) => format!("{WORDMARK} {cells}  "),
+        // S3: the plain spine, one space each side (v1 geometry unchanged).
+        None => format!("{WORDMARK} {SPINE} "),
+    };
+    render_wrapped(&prefix, content)
 }
 
 /// Continuation-line prefix: the gutter, spine fixed at column 6.
@@ -158,7 +235,7 @@ fn wrap_prefix() -> String {
 
 /// S0/S1/S2 — identity line + signal lines in priority order (bell before
 /// coherence), each verbatim line whole-or-nothing within the 4-line cap.
-fn compose_identity_and_signal_lines(input: &HumanViewInput) -> Vec<String> {
+fn compose_identity_and_signal_lines(input: &HumanViewInput, pulse: &str) -> Vec<String> {
     // Identity segments: each one a measured fact. A zero-valued segment is
     // OMITTED, never rendered as ornament (the zero only speaks in S4).
     let mut segments: Vec<String> = vec![input.trust_mode.replace('_', " ")];
@@ -168,7 +245,15 @@ fn compose_identity_and_signal_lines(input: &HumanViewInput) -> Vec<String> {
     if input.memory_count > 0 {
         segments.push(format!("{} memories", thousands(input.memory_count as u64)));
     }
-    let mut lines = compose_voice_signature(&segments.join(SEP));
+    // Slice-2 map fact: the served brain's ratified SystemBlock count. Omitted
+    // when zero (G1: only a measured fact; a zero is not "the map exists").
+    if input.ratified_blocks > 0 {
+        segments.push(format!(
+            "map {} blocks",
+            thousands(input.ratified_blocks as u64)
+        ));
+    }
+    let mut lines = compose_voice_signature(Some(pulse), &segments.join(SEP));
 
     // Signal lines — the verbatim honest_gaps strings, priority bell >
     // coherence, whole-or-nothing (amendment 5: never truncated).
@@ -181,9 +266,9 @@ fn compose_identity_and_signal_lines(input: &HumanViewInput) -> Vec<String> {
 
 /// S4 — `needs_ingest`: the zero IS the message (`0 nodes`), the gap string
 /// verbatim, and `next:` only when the whole wrapped line still fits.
-fn compose_needs_ingest_lines(input: &HumanViewInput) -> Vec<String> {
+fn compose_needs_ingest_lines(input: &HumanViewInput, pulse: &str) -> Vec<String> {
     let identity = format!("needs_ingest{SEP}{} nodes", thousands(input.node_count));
-    let mut lines = compose_voice_signature(&identity);
+    let mut lines = compose_voice_signature(Some(pulse), &identity);
     push_whole_or_nothing(&mut lines, NEEDS_INGEST_GAP);
     if !input.next_move.is_empty() {
         push_whole_or_nothing(&mut lines, &format!("next: {}", input.next_move));
@@ -196,7 +281,9 @@ fn compose_needs_ingest_lines(input: &HumanViewInput) -> Vec<String> {
 /// `honest` string verbatim; then bound/yours; then the literal repair call.
 /// ZERO statistics — they would describe the wrong brain.
 fn compose_mismatch_lines(m: &ReceptionMismatch) -> Vec<String> {
-    let mut lines = compose_voice_signature(m.honest);
+    // The pulse is dropped under mismatch (amendment 3 + ALIEN §5): the plain
+    // spine returns because the vitals would describe the wrong brain.
+    let mut lines = compose_voice_signature(None, m.honest);
     push_whole_or_nothing(
         &mut lines,
         &format!("bound: {}{SEP}yours: {}", m.bound_workspace, m.caller_root),
@@ -320,6 +407,8 @@ mod tests {
             trust_mode: "full_trust",
             node_count: 9024,
             memory_count: 30,
+            ratified_blocks: 0,
+            focus_activated: true,
             merge_wait: 0,
             bell_line: None,
             coherence_line: None,
@@ -360,8 +449,8 @@ mod tests {
         let lines = lines_of(&card);
         assert_eq!(lines.len(), 1, "clean state = one line");
         assert_eq!(
-            lines[0], "m1nd │ full trust · 9,024 nodes · 30 memories",
-            "the signature line renders the measured facts (maps segment omitted — not in the packet)"
+            lines[0], "m1nd ╷╷╷╷╷  full trust · 9,024 nodes · 30 memories",
+            "the signature line hangs the calm pulse (all five cells low) before the measured facts (map segment omitted — 0 ratified blocks)"
         );
         assert_cap(&lines);
     }
@@ -493,8 +582,8 @@ mod tests {
         assert_eq!(card["state"], "needs_ingest");
         let lines = lines_of(&card);
         assert_eq!(
-            lines[0], "m1nd │ needs_ingest · 0 nodes",
-            "S4 line 1: the zero is the message"
+            lines[0], "m1nd ╷│╷╷╷  needs_ingest · 0 nodes",
+            "S4 line 1: the graph cell alone is raised (the zero is the message), trust stays calm"
         );
         // The gap string rides verbatim, wrapped.
         let mut rebuilt = String::new();
@@ -571,9 +660,12 @@ mod tests {
             );
         }
         // The state still names the TOP signal (bell) and the sig carries the
-        // coherence truth mechanically.
+        // coherence truth mechanically (bell + coherence cells both raised).
         assert_eq!(card["state"], "bell");
-        assert_eq!(card["state_sig"], "full_trust|bell:3|coh:sick|recv:match");
+        assert_eq!(
+            card["state_sig"],
+            "full_trust|bell:3|coh:sick|recv:match|pulse:╷╷╷││"
+        );
     }
 
     /// The state_sig is stable for equal state and matches the pinned example.
@@ -585,9 +677,15 @@ mod tests {
         let a = compose_human_view(&input).expect("card composes");
         let b = compose_human_view(&input).expect("card composes");
         assert_eq!(a["state_sig"], b["state_sig"], "equal state ⇒ equal sig");
-        assert_eq!(a["state_sig"], "full_trust|bell:3|coh:ok|recv:match");
+        assert_eq!(
+            a["state_sig"],
+            "full_trust|bell:3|coh:ok|recv:match|pulse:╷╷╷│╷"
+        );
         let clean = compose_human_view(&clean_input()).expect("card composes");
-        assert_eq!(clean["state_sig"], "full_trust|bell:0|coh:ok|recv:match");
+        assert_eq!(
+            clean["state_sig"],
+            "full_trust|bell:0|coh:ok|recv:match|pulse:╷╷╷╷╷"
+        );
         assert_ne!(
             a["state_sig"], clean["state_sig"],
             "state change ⇒ sig change"
@@ -603,8 +701,8 @@ mod tests {
         let card = compose_human_view(&input).expect("card composes");
         assert_eq!(
             lines_of(&card)[0],
-            "m1nd │ full trust · 9,024 nodes",
-            "a zero memories segment is omitted, never `0 memories`"
+            "m1nd ╷╷╷╷╷  full trust · 9,024 nodes",
+            "a zero memories segment is omitted, never `0 memories` (calm pulse hangs on the margin)"
         );
     }
 
@@ -617,8 +715,104 @@ mod tests {
         assert_eq!(thousands(0), "0");
     }
 
-    /// The geometry law: line 1 hangs the wordmark; every later line keeps the
-    /// spine fixed at column 6 (5 spaces, `│`, space).
+    /// The PULSE is the official signature (owner's stamp, ALIEN §5). The cell
+    /// order is FROZEN FOREVER — `trust · graph · focus · bell · coherence` —
+    /// and this test is the anti-equalizer LAW: each cell rises ONLY on its own
+    /// vital sign, the row is always 5 cells, and calm is all-low `╷╷╷╷╷`.
+    #[test]
+    fn pulse_is_the_fixed_five_cell_signature() {
+        // clean: every vital at rest.
+        assert_eq!(compose_pulse(&clean_input()), "╷╷╷╷╷");
+
+        // bell alone (cell 4).
+        let mut i = clean_input();
+        i.merge_wait = 3;
+        i.bell_line = Some(BELL_3);
+        assert_eq!(compose_pulse(&i), "╷╷╷│╷");
+
+        // coherence alone (cell 5).
+        let mut i = clean_input();
+        i.coherence_line = Some(COHERENCE_LINE);
+        assert_eq!(compose_pulse(&i), "╷╷╷╷│");
+
+        // degraded trust over a usable graph (cell 1).
+        let mut i = clean_input();
+        i.trust_mode = "degraded_host_tool_surface";
+        assert_eq!(compose_pulse(&i), "│╷╷╷╷");
+
+        // no focus activated over a populated graph (cell 3).
+        let mut i = clean_input();
+        i.focus_activated = false;
+        assert_eq!(compose_pulse(&i), "╷╷│╷╷");
+
+        // needs_ingest: the graph cell ALONE (cell 2) — trust stays calm.
+        let mut i = clean_input();
+        i.trust_mode = "needs_ingest";
+        i.node_count = 0;
+        i.needs_ingest = true;
+        i.focus_activated = false;
+        assert_eq!(compose_pulse(&i), "╷│╷╷╷");
+
+        // every cell up at once, still exactly 5.
+        let mut i = clean_input();
+        i.trust_mode = "degraded";
+        i.node_count = 0;
+        i.focus_activated = false;
+        i.merge_wait = 1;
+        i.bell_line = Some(BELL_3);
+        i.coherence_line = Some(COHERENCE_LINE);
+        let all = compose_pulse(&i);
+        assert_eq!(all, "│││││");
+        assert_eq!(all.chars().count(), PULSE_CELLS);
+    }
+
+    /// Under mismatch the pulse is DROPPED: line 1 is the plain spine, never a
+    /// pulse cell — the vitals would describe the wrong brain (amendment 3).
+    #[test]
+    fn mismatch_drops_the_pulse_for_the_plain_spine() {
+        let mut input = clean_input();
+        input.reception_mismatch = Some(ReceptionMismatch {
+            honest: "this graph does NOT cover your repo",
+            caller_root: "/tmp/repo-beta",
+            bound_workspace: "/tmp/repo-alpha",
+        });
+        let card = compose_human_view(&input).expect("card composes");
+        let line0 = lines_of(&card)[0].as_str().unwrap().to_string();
+        assert!(
+            line0.starts_with("m1nd │ "),
+            "S3 uses the plain spine: {line0:?}"
+        );
+        assert!(
+            !line0.contains('╷'),
+            "no calm pulse cell rides the mismatch card: {line0:?}"
+        );
+    }
+
+    /// Slice-2 map fact: a served brain with ratified blocks gains a
+    /// `map <N> blocks` segment on line 1; zero ratified blocks omit it (G1).
+    #[test]
+    fn map_segment_rides_only_when_blocks_are_ratified() {
+        let mut input = clean_input();
+        input.ratified_blocks = 12;
+        let card = compose_human_view(&input).expect("card composes");
+        assert_eq!(
+            lines_of(&card)[0],
+            "m1nd ╷╷╷╷╷  full trust · 9,024 nodes · 30 memories · map 12 blocks",
+            "the ratified-block count rides as the map fact"
+        );
+
+        // zero ratified blocks: the segment is omitted entirely.
+        let zero = compose_human_view(&clean_input()).expect("card composes");
+        assert!(
+            !lines_of(&zero)[0].as_str().unwrap().contains("map"),
+            "a zero ratified-block count omits the map segment"
+        );
+        assert_cap(&lines_of(&card));
+    }
+
+    /// The geometry law: line 1 hangs the wordmark + the pulse, whose FIRST
+    /// cell sits at column 6 — exactly where every later line keeps the spine
+    /// (5 spaces, `│`, space). The lombada is born from the pulse.
     #[test]
     fn gutter_is_fixed_at_column_six() {
         let mut input = clean_input();
@@ -626,7 +820,17 @@ mod tests {
         input.bell_line = Some(BELL_3);
         let card = compose_human_view(&input).expect("card composes");
         let lines = lines_of(&card);
-        assert!(lines[0].as_str().unwrap().starts_with("m1nd │ "));
+        let l0: Vec<char> = lines[0].as_str().unwrap().chars().collect();
+        assert_eq!(
+            &l0[..5],
+            &['m', '1', 'n', 'd', ' '],
+            "wordmark hangs on the margin"
+        );
+        assert!(
+            l0[5] == '╷' || l0[5] == '│',
+            "the first pulse cell sits at column 6, under the gutter spine: {:?}",
+            lines[0]
+        );
         for line in lines.iter().skip(1) {
             let s = line.as_str().unwrap();
             let chars: Vec<char> = s.chars().collect();

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -28,6 +28,7 @@ pub mod delegation_handlers;
 pub mod engine_ops;
 // Human-layer voice slice 1 — the `human_view` card composed into the north
 // packet (m1nd-human-view-v0): the m1nd voice for the human, server-mounted.
+pub mod cockpit;
 pub mod human_view;
 pub mod instance_registry;
 pub mod layer_handlers;

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -215,10 +215,20 @@ block — only `receipt_import` does — and `landed` is reserved for a confirme
 
 `north` carries `human_view` (`m1nd-human-view-v0`): the m1nd voice for the HUMAN in the \
 conversation — a server-composed card with `state` (clean|bell|coherence|mismatch|needs_ingest), \
-a mechanical `state_sig`, and `lines[]` already MOUNTED (the `m1nd` wordmark + `│` gutter, ≤4 \
-lines, ≤80 chars). Render it by joining `lines` with newlines inside a fenced code block — never \
-re-compose, re-order, or decorate it. Every line is a measured fact or a verbatim server string \
-(brand law G1: no uncalibrated adjectives, no benefit claims — silence over ornament).
+a mechanical `state_sig`, and `lines[]` already MOUNTED (the `m1nd` wordmark + the PULSE row + \
+`│` gutter, ≤4 lines, ≤80 chars). Render it by joining `lines` with newlines inside a fenced \
+code block — never re-compose, re-order, or decorate it. Every line is a measured fact or a \
+verbatim server string (brand law G1: no uncalibrated adjectives, no benefit claims — silence \
+over ornament). Line 1 may also carry a `map <N> blocks` segment — the served brain's ratified \
+SystemBlock count (per-brain; the packet's `map` field), omitted when zero.
+
+THE PULSE — the official signature of the voice (owner's stamp 2026-07-12). Line 1 hangs \
+`m1nd ` then FIVE pulse cells: `trust · graph · focus · bell · coherence`, each calm `╷` or \
+raised `│` (e.g. `m1nd ╷╷╷│╷` = only the bell is calling). READ IT AS AN EXPRESSION, never \
+cell-by-cell: all low = calm; one stem standing up = look. The cell order is FIXED — never \
+reorder or add a cell. Under a repo mismatch the pulse is DROPPED and the plain spine `m1nd │ ` \
+returns (the vitals would read the wrong brain). Its meaning belongs in the deep rung, never as \
+a per-cell caption in the compact card.
 
 CADENCE — the default is NEGATIVE: Do NOT render the card unless m1nd contributed structurally \
 to the mission AND the content is useful to the human NOW; never in consecutive messages; never \
@@ -226,16 +236,27 @@ the same state_sig twice in a session; on state change or first orient. When in 
 silent — silence is the honest card.
 
 TRANSLATION DUTY: translate the card's CONTENT into the conversation's language while keeping \
-the geometry intact (the gutter at column 6, ≤80 cols) and ids, hashes, tool names, and state \
-tokens (`merge_wait`, `needs_ingest`, `full_trust`) verbatim.
+the geometry intact (the pulse + gutter at column 6, ≤80 cols) and ids, hashes, tool names, and \
+state tokens (`merge_wait`, `needs_ingest`, `full_trust`) verbatim.
 
 THE DEEP RUNG (R2) IS YOURS: when the human asks (\"what's the bell?\", \"show me m1nd\") or at a \
 landing moment, render a deeper card FROM THE PACKET'S STRUCTURED FIELDS (`landing_bell`, the \
 mission tray, blocks) in the SAME grammar — wordmark + gutter, one measured fact per line — \
-never a fact the packet does not carry.
+never a fact the packet does not carry. In the deep rung you MAY render the pulse legend \
+(`pulse ≔ trust ╷ · graph ╷ · focus ╷ · bell │ · coherence ╷`) so the human learns to read the \
+row — this legend is YOURS to render, never served in the compact card. Two proof glyphs are \
+also yours, ONLY where the packet proves them, never as decoration: `⊢` (evidence ⊢ receipt) on \
+a receipt line (`441 tests green ⊢ receipt sha256:…`; ASCII `>`), and `∎` on a consummated \
+landing (`msn_… landed ∎`; ASCII `#`).
 
-ASCII FALLBACK (1:1): when the surface cannot hold unicode, map `│`→`|`, `·`→`.`, `—`→`-` — \
-widths are identical, the geometry never moves.
+ASCII FALLBACK (1:1): when the surface cannot hold unicode, map `╷`→`.`, `│`→`|`, `·`→`.`, \
+`—`→`-`, `⊢`→`>`, `∎`→`#` — widths are identical, the geometry never moves.
+
+THE COCKPIT (`cockpit`) is the human's ON-REQUEST menu — call it ONLY when the human asks to \
+look around (\"?\", \"show me m1nd\", \"what can I check?\"); never auto-serve it, and NEVER at a \
+landing (there the card speaks and the door is the tray). It is read-only: its entries are \
+argument-less reads and pointer doors (the tray carries no verb — the stamp is a human gesture, \
+never a cockpit click). Carry its `menu_sig` back verbatim when navigating.
 
 ATTRIBUTION — the second half of the voice: narrate where m1nd was useful ONLY when it passes \
 the counterfactual test (\"without it, would I have decided differently or worse?\") — it changed \
@@ -601,6 +622,19 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "tier": { "type": "string", "enum": ["project", "medulla", "project+medulla", "all-brains"], "description": "Memory-tier for the packet's recall beat (pull-not-push). Default project+medulla: this brain's own memory + the shared medulla (promoted/doctrine). 'all-brains' fans out over EVERY hosted brain, each memory row labeled origin_brain — the explicit cross-project inspection, never ambient. Another brain's claim reaches your default beat only if it was promoted to the medulla." }
                     },
                     "required": ["agent_id", "task"]
+                }
+            },
+            {
+                "name": "cockpit",
+                "description": "The navigable m1nd menu (m1nd-cockpit-v0) — the human's ON-REQUEST router over m1nd's read surfaces, a read-only sibling of north (never a north field; if it breaks it breaks alone). Call it ONLY when the human asks ('?', 'show me m1nd', 'what can I look at') — at a landing the human_view card speaks, never an auto-served menu. The root is argument-less READS only, in seven stable slots (labels move with state, slots never do): the tray (a POINTER — the human stamp gesture, no verb), the map (system_blocks_snapshot), missions (a POINTER to the tray), health (doctor), trust, recent-memories (boot_memory, fixed projection), and drift. Pointer entries carry NO verb — nothing to execute even by mistake. Pass select=\"<slot>\" to drill one collection (depth ≤3; select=\"0\" re-serves the root); a drill re-asserts store_version + state_sig and says 'state moved' honestly when your seen_store_version diverged. Every response carries menu_sig — the SAME short reference a widget button carries back (never free command text, never a write verb). The read entries are DERIVED and filtered against the write deny-list, so a verb that becomes a mutation drops itself. Read-only safe.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_id": { "type": "string", "description": "Calling agent identifier." },
+                        "select": { "type": "string", "description": "Optional slot to drill (a number 1..=7), or \"0\" to re-serve the root. Absent = the root menu." },
+                        "seen_store_version": { "type": "integer", "description": "Optional: the SystemBlock store_version you last read. If the store has moved since, the drill flags 'state moved' before you act." }
+                    },
+                    "required": ["agent_id"]
                 }
             },
             {
@@ -2969,7 +3003,7 @@ const READ_ONLY_DENIED_TOOLS: &[&str] = &[
 /// writes graph/disk state and is denied. `edit_preview` is intentionally
 /// allowed: it stages an in-memory preview and never writes to disk; only
 /// `edit_commit` performs the write.
-fn read_only_denied(tool_name: &str, params: &serde_json::Value) -> bool {
+pub(crate) fn read_only_denied(tool_name: &str, params: &serde_json::Value) -> bool {
     let bare = tool_name
         .strip_prefix("m1nd.")
         .or_else(|| tool_name.strip_prefix("m1nd_"))
@@ -3934,6 +3968,15 @@ fn handle_north(
     // so the human_view card can reuse it VERBATIM (amendment 5: one sentence
     // per fact — never a second wording).
     let mut coherence_line: Option<String> = None;
+    // Slice-2 map fact (HUMAN-VIEW voice): the SERVED brain's ratified
+    // SystemBlock count + its coherence status. Lifted from the SAME snapshot
+    // read as the coherence signal (one disk touch, no second read). PER-BRAIN
+    // by construction — `handle_system_blocks_snapshot` reads only the bound
+    // brain's store; never a cross-brain total. The structured `map` field
+    // rides ONLY when a store exists (absent — not null — otherwise, mirroring
+    // `landing_bell`: no empty ornament).
+    let mut ratified_blocks: usize = 0;
+    let mut map_field: Option<serde_json::Value> = None;
     if let Ok(snapshot) = crate::system_blocks_handlers::handle_system_blocks_snapshot(
         state,
         crate::system_blocks_handlers::SnapshotInput {
@@ -3952,6 +3995,25 @@ fn handle_north(
             );
             honest_gaps.push(line.clone());
             coherence_line = Some(line);
+        }
+        if snapshot["present"] == serde_json::Value::Bool(true) {
+            ratified_blocks = snapshot["store"]["blocks"]
+                .as_array()
+                .map(|blocks| {
+                    blocks
+                        .iter()
+                        .filter(|b| b["state"] == serde_json::Value::String("ratified".into()))
+                        .count()
+                })
+                .unwrap_or(0);
+            let coherence_status = snapshot["skeleton_coherence"]["status"]
+                .as_str()
+                .unwrap_or("unknown")
+                .to_string();
+            map_field = Some(serde_json::json!({
+                "ratified_blocks": ratified_blocks,
+                "coherence": coherence_status,
+            }));
         }
     }
 
@@ -4021,6 +4083,14 @@ fn handle_north(
             })
         });
         let node_count = state.graph.read().num_nodes() as u64;
+        // The pulse's `focus` cell reads whether orient activated any focus node
+        // for this task — lifted from the context slice already composed above
+        // (null under needs_ingest, where the pulse ignores this cell anyway).
+        let focus_activated = context
+            .get("focus_nodes")
+            .and_then(|f| f.as_array())
+            .map(|nodes| !nodes.is_empty())
+            .unwrap_or(false);
         crate::human_view::compose_human_view(&crate::human_view::HumanViewInput {
             trust_mode: binding
                 .get("trust_mode")
@@ -4028,6 +4098,8 @@ fn handle_north(
                 .unwrap_or("unknown"),
             node_count,
             memory_count: light_memory_on_disk,
+            ratified_blocks,
+            focus_activated,
             merge_wait: bell_merge_wait,
             bell_line: bell_line.as_deref(),
             coherence_line: coherence_line.as_deref(),
@@ -4067,6 +4139,14 @@ fn handle_north(
     if let Some(bell) = landing_bell {
         if let Some(obj) = packet.as_object_mut() {
             obj.insert("landing_bell".to_string(), bell);
+        }
+    }
+    // The map fact rides ONLY when the served brain has a SystemBlock store
+    // (slice-2 voice: ratified-block count + coherence, per-brain). Absent — not
+    // null — when no store exists (no empty ornament, mirroring landing_bell).
+    if let Some(map) = map_field {
+        if let Some(obj) = packet.as_object_mut() {
+            obj.insert("map".to_string(), map);
         }
     }
     // The voice card rides ONLY when composed (fail-open: a compose miss omits
@@ -4604,6 +4684,7 @@ fn dispatch_core_tool(
     match tool_name {
         "orient" => handle_orient(state, params),
         "north" => handle_north(state, params),
+        "cockpit" => crate::cockpit::handle_cockpit(state, params),
         "delegate" => crate::delegation_handlers::handle_delegate(state, params),
         "debrief" => crate::delegation_handlers::handle_debrief(state, params),
         "am_i_stale" => handle_am_i_stale(state, params),
@@ -8932,8 +9013,13 @@ mod tests {
         assert_eq!(lines.len(), 1, "clean state = one line (the whisper)");
         let line = lines[0].as_str().unwrap();
         assert!(
-            line.starts_with("m1nd │ "),
+            line.starts_with("m1nd "),
             "the signature hangs the wordmark on the margin, got {line:?}"
+        );
+        let cell6 = line.chars().nth(5).unwrap();
+        assert!(
+            cell6 == '╷' || cell6 == '│',
+            "the pulse row hangs at column 6 — the lombada is born from it, got {line:?}"
         );
         assert!(
             line.contains("3 nodes"),
@@ -9064,8 +9150,8 @@ mod tests {
         assert_eq!(card["state"], "needs_ingest");
         let lines = card["lines"].as_array().expect("lines array");
         assert_eq!(
-            lines[0], "m1nd │ needs_ingest · 0 nodes",
-            "S4 line 1: the zero is the message"
+            lines[0], "m1nd ╷│╷╷╷  needs_ingest · 0 nodes",
+            "S4 line 1: the graph cell alone is raised, the zero is the message"
         );
         // The wrapped card content reassembles to the exact honest_gaps string.
         let mut rebuilt = String::new();

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -135,8 +135,9 @@ Retrieval is forgiving; writing is not. Four things to know before any write:
 ## The m1nd Voice — rendering `human_view`
 
 The north packet carries `human_view` (`m1nd-human-view-v0`): the m1nd voice for
-the HUMAN — a server-composed, already-mounted card (the `m1nd` wordmark + `│`
-gutter fixed at column 6; ≤4 lines, ≤80 chars/line; states `clean | bell |
+the HUMAN — a server-composed, already-mounted card (the `m1nd` wordmark + the
+PULSE row + `│` gutter fixed at column 6; ≤4 lines, ≤80 chars/line; states
+`clean | bell |
 coherence | mismatch | needs_ingest`; a mechanical `state_sig`). Render it by
 joining `lines[]` with newlines inside a fenced code block — never re-compose
 it, never decorate it. Every line is a measured fact or a verbatim server
@@ -148,14 +149,34 @@ to the human NOW; never in consecutive messages; never the same state_sig twice
 in a session; on state change or first orient. When in doubt, stay silent —
 silence is the honest card.
 
+**The PULSE — the official signature (owner's stamp):** line 1 hangs `m1nd `
+then FIVE cells — `trust · graph · focus · bell · coherence` — each calm `╷` or
+raised `│` (e.g. `m1nd ╷╷╷│╷` = only the bell is calling). Read it as an
+EXPRESSION (all low = calm; one stem standing up = look), never cell-by-cell;
+the cell order is FIXED — never reorder or add one. Under a repo mismatch the
+pulse is DROPPED and the plain `m1nd │ ` returns. Line 1 may also carry a
+`map <N> blocks` segment (the served brain's ratified SystemBlock count). In the
+DEEP rung you MAY render the legend `pulse ≔ trust ╷ · graph ╷ · focus ╷ ·
+bell │ · coherence ╷`, and the two proof glyphs `⊢` (evidence ⊢ receipt; ASCII
+`>`) and `∎` (a landed mission; ASCII `#`) — ONLY where the packet proves them,
+never as decoration.
+
+**The cockpit (`cockpit`) — ON REQUEST only:** when the human asks to look around
+("?", "show me m1nd", "what can I check?"), call `cockpit` for the read-only
+navigable menu; NEVER auto-serve it, and NEVER at a landing (there the card
+speaks and the door is the tray). Its entries are argument-less reads and pointer
+doors — a pointer (the tray) carries no verb, because the stamp is a human
+gesture, never a cockpit click. Carry its `menu_sig` back verbatim when you
+navigate (`select <slot>`).
+
 **Duties:** translate the card's CONTENT into the conversation's language
 keeping the geometry (gutter at column 6, ≤80 cols) and ids/state tokens
 (`merge_wait`, `needs_ingest`, `full_trust`) intact. The DEEP rung (R2) is the
 agent's: when the human asks ("what's the bell?", "show me m1nd") render a
 deeper card FROM the packet's structured fields (`landing_bell`, the mission
 tray, blocks) in the SAME grammar — never a fact the packet does not carry.
-When a surface cannot hold unicode, apply the 1:1 ASCII map `│`→`|`, `·`→`.`,
-`—`→`-` (widths identical, geometry never moves).
+When a surface cannot hold unicode, apply the 1:1 ASCII map `╷`→`.`, `│`→`|`, `·`→`.`,
+`—`→`-`, `⊢`→`>`, `∎`→`#` (widths identical, geometry never moves).
 
 **Attribution — the second half of the voice:** narrate where m1nd helped ONLY
 past the counterfactual test ("without it, would I have decided differently or

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -673,8 +673,9 @@ DIFFERENT agent — grader ≠ author.
 ## The m1nd Voice — rendering `human_view`
 
 The north packet carries `human_view` (`m1nd-human-view-v0`): the m1nd voice for
-the HUMAN — a server-composed, already-mounted card (the `m1nd` wordmark + `│`
-gutter fixed at column 6; ≤4 lines, ≤80 chars/line; states `clean | bell |
+the HUMAN — a server-composed, already-mounted card (the `m1nd` wordmark + the
+PULSE row + `│` gutter fixed at column 6; ≤4 lines, ≤80 chars/line; states
+`clean | bell |
 coherence | mismatch | needs_ingest`; a mechanical `state_sig`). Render it by
 joining `lines[]` with newlines inside a fenced code block — never re-compose
 it, never decorate it. Every line is a measured fact or a verbatim server
@@ -686,14 +687,34 @@ to the human NOW; never in consecutive messages; never the same state_sig twice
 in a session; on state change or first orient. When in doubt, stay silent —
 silence is the honest card.
 
+**The PULSE — the official signature (owner's stamp):** line 1 hangs `m1nd `
+then FIVE cells — `trust · graph · focus · bell · coherence` — each calm `╷` or
+raised `│` (e.g. `m1nd ╷╷╷│╷` = only the bell is calling). Read it as an
+EXPRESSION (all low = calm; one stem standing up = look), never cell-by-cell;
+the cell order is FIXED — never reorder or add one. Under a repo mismatch the
+pulse is DROPPED and the plain `m1nd │ ` returns. Line 1 may also carry a
+`map <N> blocks` segment (the served brain's ratified SystemBlock count). In the
+DEEP rung you MAY render the legend `pulse ≔ trust ╷ · graph ╷ · focus ╷ ·
+bell │ · coherence ╷`, and the two proof glyphs `⊢` (evidence ⊢ receipt; ASCII
+`>`) and `∎` (a landed mission; ASCII `#`) — ONLY where the packet proves them,
+never as decoration.
+
+**The cockpit (`cockpit`) — ON REQUEST only:** when the human asks to look around
+("?", "show me m1nd", "what can I check?"), call `cockpit` for the read-only
+navigable menu; NEVER auto-serve it, and NEVER at a landing (there the card
+speaks and the door is the tray). Its entries are argument-less reads and pointer
+doors — a pointer (the tray) carries no verb, because the stamp is a human
+gesture, never a cockpit click. Carry its `menu_sig` back verbatim when you
+navigate (`select <slot>`).
+
 **Duties:** translate the card's CONTENT into the conversation's language
 keeping the geometry (gutter at column 6, ≤80 cols) and ids/state tokens
 (`merge_wait`, `needs_ingest`, `full_trust`) intact. The DEEP rung (R2) is the
 agent's: when the human asks ("what's the bell?", "show me m1nd") render a
 deeper card FROM the packet's structured fields (`landing_bell`, the mission
 tray, blocks) in the SAME grammar — never a fact the packet does not carry.
-When a surface cannot hold unicode, apply the 1:1 ASCII map `│`→`|`, `·`→`.`,
-`—`→`-` (widths identical, geometry never moves).
+When a surface cannot hold unicode, apply the 1:1 ASCII map `╷`→`.`, `│`→`|`, `·`→`.`,
+`—`→`-`, `⊢`→`>`, `∎`→`#` (widths identical, geometry never moves).
 
 **Attribution — the second half of the voice:** narrate where m1nd helped ONLY
 past the counterfactual test ("without it, would I have decided differently or

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -65,8 +65,9 @@ repair, refresh the host, or mutate the graph.
 ## The m1nd Voice — rendering `human_view`
 
 The north packet carries `human_view` (`m1nd-human-view-v0`): the m1nd voice for
-the HUMAN — a server-composed, already-mounted card (the `m1nd` wordmark + `│`
-gutter fixed at column 6; ≤4 lines, ≤80 chars/line; states `clean | bell |
+the HUMAN — a server-composed, already-mounted card (the `m1nd` wordmark + the
+PULSE row + `│` gutter fixed at column 6; ≤4 lines, ≤80 chars/line; states
+`clean | bell |
 coherence | mismatch | needs_ingest`; a mechanical `state_sig`). Render it by
 joining `lines[]` with newlines inside a fenced code block — never re-compose
 it, never decorate it. Every line is a measured fact or a verbatim server
@@ -78,14 +79,34 @@ to the human NOW; never in consecutive messages; never the same state_sig twice
 in a session; on state change or first orient. When in doubt, stay silent —
 silence is the honest card.
 
+**The PULSE — the official signature (owner's stamp):** line 1 hangs `m1nd `
+then FIVE cells — `trust · graph · focus · bell · coherence` — each calm `╷` or
+raised `│` (e.g. `m1nd ╷╷╷│╷` = only the bell is calling). Read it as an
+EXPRESSION (all low = calm; one stem standing up = look), never cell-by-cell;
+the cell order is FIXED — never reorder or add one. Under a repo mismatch the
+pulse is DROPPED and the plain `m1nd │ ` returns. Line 1 may also carry a
+`map <N> blocks` segment (the served brain's ratified SystemBlock count). In the
+DEEP rung you MAY render the legend `pulse ≔ trust ╷ · graph ╷ · focus ╷ ·
+bell │ · coherence ╷`, and the two proof glyphs `⊢` (evidence ⊢ receipt; ASCII
+`>`) and `∎` (a landed mission; ASCII `#`) — ONLY where the packet proves them,
+never as decoration.
+
+**The cockpit (`cockpit`) — ON REQUEST only:** when the human asks to look around
+("?", "show me m1nd", "what can I check?"), call `cockpit` for the read-only
+navigable menu; NEVER auto-serve it, and NEVER at a landing (there the card
+speaks and the door is the tray). Its entries are argument-less reads and pointer
+doors — a pointer (the tray) carries no verb, because the stamp is a human
+gesture, never a cockpit click. Carry its `menu_sig` back verbatim when you
+navigate (`select <slot>`).
+
 **Duties:** translate the card's CONTENT into the conversation's language
 keeping the geometry (gutter at column 6, ≤80 cols) and ids/state tokens
 (`merge_wait`, `needs_ingest`, `full_trust`) intact. The DEEP rung (R2) is the
 agent's: when the human asks ("what's the bell?", "show me m1nd") render a
 deeper card FROM the packet's structured fields (`landing_bell`, the mission
 tray, blocks) in the SAME grammar — never a fact the packet does not carry.
-When a surface cannot hold unicode, apply the 1:1 ASCII map `│`→`|`, `·`→`.`,
-`—`→`-` (widths identical, geometry never moves).
+When a surface cannot hold unicode, apply the 1:1 ASCII map `╷`→`.`, `│`→`|`, `·`→`.`,
+`—`→`-`, `⊢`→`>`, `∎`→`#` (widths identical, geometry never moves).
 
 **Attribution — the second half of the voice:** narrate where m1nd helped ONLY
 past the counterfactual test ("without it, would I have decided differently or


### PR DESCRIPTION
## What

Second slice of the human-layer voice arc, under the owner's explicit brand stamp (2026-07-12): **the pulse is the official signature of the voice.**

### The pulse

`compose_voice_signature()` now mounts `m1nd ╷╷╷│╷` — five half-stem cells, one per vital organ, in a row **frozen by law** (`trust · graph · focus · bell · coherence`, pinned by test). A cell stands (`│`) only on a real alarm in the packet. Calm day, live: 

```
m1nd ╷╷╷╷╷  full trust · 9,178 nodes · 30 memories · map 12 blocks
```

Bell ringing: the fourth cell wakes. Under `caller_root_mismatch` the whole pulse drops — it would measure the wrong brain; the card stays the plain warning.

### The map fact

The packet now exposes the served brain's skeleton as a compact fact (per-brain, never cross-brain); line 1 gains `· map 12 blocks` only when ratified — measured facts only (G1).

### The cockpit verb

Dedicated read-only composer, sibling of north (breaks alone, never with it). Seven stable-slot collections: tray/missions are **pointers** (no verb field — the stamp lives in the tray); map/health/trust/memories/drift are argument-less reads **derived from and filtered against `READ_ONLY_DENIED_TOOLS`** (empty-intersection pinned by test). Every response carries `menu_sig`; `select` drills (depth ≤3, `0` = back) re-assert `store_version`/`state_sig` and flag "state moved" honestly. Entry `why` strings lift from the one help catalog — no parallel catalog. Strictly on-request.

### The widget template

`docs/voice/WIDGET-TEMPLATE.md` — the versioned chat-cockpit template (STATE JSON + render, navigation with back/breadcrumb, in-flow modal law, link laws, short-reference button payloads, no write buttons ever).

## Proof

`cargo test -p m1nd-mcp` **1063/0** (14 human_view + 6 cockpit new) · fmt + clippy `-D warnings` clean · budget batteries registered: north **~1,404 tokens** of 2k (v1 was ~1,391), cockpit **~695 root / ~430 drill** of its own 800 ceiling · no-leak clean · doc gate met (spine-north, `docs/uml/cockpit.md`, the three skills, PATHOS §C11 amendment, `docs/voice/SLICE2-DIVERGENCES.md`).