### PR TITLE
gardener v1: the organism moves when seen — per-brain daemon, fail-open vigils, yielding auto-reconcile

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -49,6 +49,34 @@ same bar, applied to building the organism outward.
 
 ## Current State (2026-07-12, checkpoint 18 — the voice; dated blocks below are the era log)
 
+> **2026-07-12 — GARDENER v1 built on `feat/gardener-v1` (branch, NOT yet landed): the organism moves when seen.**
+> An off-§C10 front under its askGOD verdict (CHANGE — the law, versioned at
+> `docs/voice/ASKGOD-VERDICT-GARDENER.md`; design + measured cost in `docs/voice/GARDENER-V1.md`,
+> residue in `GARDENER-DIVERGENCES.md`). The seven changes, built exactly as judged: **fail-open
+> first** (a background vigil can never fail an agent's tool call — the violable `?` at the inline
+> auto-ingest tick is now log-and-continue, RED-proven); **the code leg is the per-brain DAEMON**
+> (opt-in per brain in its own store dir, default OFF; watch set = the brain's ingest roots; resume
+> rides the registry warm-boot/resolve — the persisted mid-tick `tick_in_flight:true` that WEDGED
+> every resume is sanitized on load, RED-proven; survives restart AND LRU eviction, both pinned);
+> **auto_ingest stays the documents lane** (plus the cheap guard: a manifest-bound workspace root
+> can no longer be demoted — the #326 class); **honesty by traffic** (v1 freshness = "when seen";
+> a resumed `watch_backend:"native_fs"` downgrades to `polling` — no surface may claim a notify
+> consumer that does not exist; the "continuous monitoring" wording was purged from the tool
+> schema, help guidance and wiki); **burst coalescing** (window 75 ms→500 ms + 5 s cap, registered;
+> the tick detects ONCE per burst into a persisted FIFO backlog drained `max_files`/tick — the old
+> truncate-then-advance hole LOST every file beyond budget on the git backend, RED-proven with a
+> 20-file burst); **auto-reconcile with cedência** (45 s quiet window pushed by every activity
+> tick — one window per burst; voluntary yield to a live candidate_lease; fresh OCC key, 1 retry,
+> then an `auto_reconcile_conflict` alert on the existing lane; candidate skeletons skip — their
+> freshness is another cycle); **intocáveis intactos** (no north fields, human ratify untouched,
+> alerts ride the existing 500-cap lane). **Cost measured before defaults** (bench, release):
+> ~36 ms/file at N≤100, 59.6 ms/file at N=1000 (detection 8.7 s, full drain 59.6 s over 31 ticks)
+> — the number that JUSTIFIES default OFF. Upgrade-safe: pre-gardener `daemon_state.json`
+> deserializes armed (serde defaults, pinned). v2 registered: zero-traffic alerts (per-brain tick
+> task on HTTP, lock contention measured first) and the detection walk's per-tick re-hash.
+> **Next:** orchestrator lands the PR, then arms the daemon on the hot brains (m1nd + game) via
+> explicit opt-in on the served owner.
+
 > **2026-07-12 — the human-layer burst SEALED (checkpoint 18): the VOICE arc + the SCAN-LOADING arc landed as four PRs, then a curation closed the burst.**
 > Four PRs landed the same day and the organism wears all of it. **The VOICE arc** (its two
 > slices detailed in the blocks below): **#348** `human_view` v1 — the north packet's ≤4-line

--- a/docs/uml/auto-ingest-daemon.md
+++ b/docs/uml/auto-ingest-daemon.md
@@ -148,4 +148,32 @@ stateDiagram-v2
 - **[low] Alert ring buffer drains oldest-first with no severity preservation**: a burst of low-value `co_change_prediction` alerts can evict an unacked critical `graph_vs_disk_drift`.
 - **[low] Daemon `last_tick_ms` mutated from a non-tick path** (write-path apply, surgical_handlers.rs:597) — perturbs due/overdue scheduling even when no daemon tick ran.
 - **[low] `file_fingerprint` reads the whole file on every candidate** before the content_hash skip check (:791→:809); no cheap mtime/size pre-filter — a burst forces N full reads + hashes per tick.
-```
+
+## Addendum — Gardener v1 (2026-07-12, `feat/gardener-v1`; line refs above predate this arc)
+
+The arc law is `docs/voice/ASKGOD-VERDICT-GARDENER.md`; design + measured cost in
+`docs/voice/GARDENER-V1.md`. What changed structurally in the systems this sheet maps:
+
+- **Fail-open vigils:** the inline auto-ingest tick in `dispatch_tool` no longer
+  propagates (`vigil_fail_open`, server.rs) — a watcher error can never fail an
+  agent's tool call. The daemon paths were already fail-open (audited).
+- **Resume sanitization:** `load_daemon_state` (session.rs) sanitizes transient
+  runtime flags on boot — `tick_in_flight`/`pending_rerun` reset (the persisted
+  mid-tick `true` used to WEDGE every resumed daemon), and a resumed
+  `watch_backend:"native_fs"` downgrades to `polling` (only a live stdio watcher
+  may claim the label — HTTP status honesty). This CLOSES the two gaps above:
+  "[medium] No auto-resume …" (the daemon half — `active` now resumes AND ticks;
+  the auto-ingest half still requires `auto_ingest_start`) and
+  "[low] daemon active=true persisted but watcher is process-bound" (the label
+  is now honest on watcherless boots; per-brain daemons advance by traffic).
+- **Burst backlog:** `handle_daemon_tick` no longer truncates the changed set —
+  the full detection enters the persisted `pending_backlog` (FIFO, dedup) and
+  drains `max_files` per tick; `git_since_ref` advances immediately because the
+  backlog owns the tail. Coalesce window 75 ms → 500 ms with a 5 s cap
+  (`BURST_COALESCE_WINDOW_MS`/`_CAP_MS`).
+- **Auto-reconcile:** after a burst settles (45 s quiet window, pushed by every
+  activity tick), the tick reconciles the RATIFIED system-blocks store —
+  voluntary yield to a live `candidate_lease`, fresh OCC key per attempt, one
+  retry, then an `auto_reconcile_conflict` alert. Candidate skeletons skip.
+- **Hosted-brain guard:** `auto_ingest_start` can no longer demote a
+  manifest-bound `workspace_root` (the #326 class).

--- a/docs/voice/ASKGOD-VERDICT-GARDENER.md
+++ b/docs/voice/ASKGOD-VERDICT-GARDENER.md
@@ -1,0 +1,71 @@
+# askGOD verdict — the Gardener arc (self-moving organism) — 2026-07-12
+
+> Seat: askGOD verdict (Fable), marcha medium, sources read and cited.
+> Proposal judged: turn on auto_ingest + daemon alerts + auto-reconcile.
+> Owner authorization: "autorizo tudo — isso vai elevar o m1nd a um organismo mais
+> esperto e capaz de responder de verdade sempre que for visto."
+
+VERDICT: CHANGE (direction right; one factual mis-aim, one artifact conflation, one
+architecture hole — do NOT implement the 3 legs as written)
+CONFIDENCE: alta on code facts · média on operational scoping (cost unmeasured)
+
+## The three discoveries that changed the design
+
+1. **auto_ingest is a DOCUMENT watcher, not a code watcher.** `detect_allowed_format`
+   only accepts md/txt/rst/adoc/html/pdf/docx/pptx/xlsx/xml/json/bib — a code upsert
+   becomes an "ignored: unsupported or code file" event (auto_ingest.rs:298-319, 780-787;
+   universal_adapter.rs:68-88). **Code re-ingest belongs to the DAEMON**
+   (daemon_handlers.rs:635-680: the tick calls handle_ingest per changed file AND emits
+   alerts; daemon_start defaults watch_paths = ingest_roots).
+2. **On the HTTP owner, watchers only advance BY TRAFFIC.** The free-running loop
+   (WatchNotice→run_daemon_tick, idle pump) lives ONLY in the stdio loop
+   (server.rs:6040-6160); http_server/mcp_http have none. The owner's phrase —
+   "responder de verdade sempre que for visto" — is LITERALLY the existing
+   traffic-tick mechanism, currently disarmed (server.rs:5475-5482, 4587).
+3. **Reconcile ≠ candidate, and the lease protects nothing by law.**
+   `system_blocks_reconcile` is an OCC write to the RATIFIED store; candidate freshness
+   is a different cycle (skeleton_candidate re-scan). The candidate_lease is advisory
+   BY RATIFIED LAW ("it never blocks an edit") — an auto-reconciler must YIELD
+   voluntarily; the lease cannot shield the human.
+
+## Additional traps found
+
+- **Fail-open is violable today**: server.rs:4587 uses `?` — an auto-ingest tick error
+  propagates into the agent's unrelated tool call. Fix FIRST, before arming anything.
+- **LRU eviction silently kills watchers**: insert_with_eviction drops the SessionState
+  (and its RecommendedWatcher) — "armed today, dead in a week, no alert". Re-arm must
+  live in the ProjectBrainRegistry warm-boot/resolve path.
+- **auto_ingest_start MUTATES workspace_root** (sets it to the first root) — reintroduces
+  the #326 store-dir/code-root bug class if armed on a hosted brain.
+- **OCC churn against the human**: every auto-reconcile bumps store_version and kills an
+  in-flight human candidate_edit batch with Conflict. Only voluntary yielding protects.
+- **rebuild_engines per tick + 200/75ms debounce**: a git checkout (thousands of events)
+  needs burst coalescing measured before aggressive defaults; Linux inotify limits when
+  this ever becomes a cross-platform factory default.
+- **Status honesty**: with traffic-ticks, last_tick_ms ages without traffic — no surface
+  may claim "continuously monitored"; watch_backend must not lie on HTTP.
+
+## The v1 that survives (required changes, condensed)
+
+1. Re-aim leg 1: code re-ingest = DAEMON per-brain (watch_paths = the brain's
+   ingest_roots). auto_ingest stays OUT of v1 (or enters later, honestly named the
+   documents lane).
+2. Fail-open first: log-and-continue at server.rs:4587 (+ audit run_daemon_tick).
+3. Resume on brain warm-boot (registry resolve path), lazy after the listener; the
+   synchronous bootstrap scan never on the boot path. Survives eviction (test it).
+4. Leg 2 honesty: v1 = freshness-by-traffic ("when seen", literal). Zero-traffic alerts
+   = explicit v2 slice (per-brain tick task on HTTP with lock-contention measurement).
+5. Leg 3 rewritten: auto-reconcile runs after a daemon tick that re-ingested files, with
+   a quiet window (30-60s no new events), yields to an active candidate_lease
+   (skip + reschedule), 1 OCC retry then alert — never a loop. Say plainly: reconcile
+   refreshes the STORE; candidate freshness is another cycle, outside this arc.
+6. Untouched: human ratify/import; north Budget Law (alerts ride the existing bell/pulse
+   lanes, alert cap 500 already exists).
+7. Validation accepted + amplified: eviction→rearm test; tick-error-never-fails-tool-call
+   test; quiet-window and lease-yield tests; restart resume test.
+8. Factory default OFF; opt-in per brain; v1 scope = the hot brains (m1nd + game),
+   never all 8.
+
+## Status
+- Executor dispatched with this corrected design (2026-07-12).
+- The organism-inside PRD/UML (Fable author) runs in parallel as the NEXT arc's draft.

--- a/docs/voice/GARDENER-DIVERGENCES.md
+++ b/docs/voice/GARDENER-DIVERGENCES.md
@@ -1,0 +1,47 @@
+# Gardener v1 — divergences and honest residue
+
+> Companion to `docs/voice/GARDENER-V1.md`. Everything the arc did NOT do as
+> literally specified, and why — recorded instead of silently absorbed.
+
+1. **OCC conflict proven at policy level, not end-to-end.** The verdict's
+   "Conflict → 1 retry → alert" is pinned by
+   `occ_conflict_gets_one_retry_then_an_alert_never_a_loop` with an INJECTED
+   `SeedError::Conflict` (attempt-count asserted: exactly 2) plus the settle arm
+   recording the real alert on the real lane. A deterministic END-TO-END
+   conflict is impossible in a unit test: each attempt reads its own fresh
+   `expected_store_version`, so a conflict requires a concurrent writer landing
+   in the microseconds between the fresh read and the reconcile — a race a test
+   cannot arrange without instrumenting production code with test-only seams.
+   The wiring (exhausted → alert) is three lines, reviewed and settle-tested.
+
+2. **The stdio coalesce window is pinned indirectly.** The sliding-silence loop
+   lives inline in `serve()` (a blocking mpsc loop a unit test cannot drive
+   without a full stdio harness). What is pinned: the registered constants
+   (`BURST_COALESCE_WINDOW_MS`/`_CAP_MS`), `daemon_start` persisting the window
+   (`coalesce_window_ms` asserted in the lifecycle test), and the cap guard in
+   the loop (code-reviewed; the loop already broke on Request/StdinClosed).
+   The BEHAVIORAL burst law — thousands of events → one detection, no lost
+   tail — is pinned end-to-end at the tick level instead
+   (`burst_bigger_than_tick_budget_drains_completely_without_losing_the_tail`),
+   which is where the correctness actually lives.
+
+3. **The bound owner's `workspace_root` mutation stays.** The verdict's cheap
+   guard shipped for HOSTED brains (manifest-bound roots can no longer be
+   demoted by `auto_ingest_start` — the #326 class). The BOUND owner keeps the
+   historical mutation: its `workspace_root` is not manifest-anchored, several
+   existing flows (workspace inference, fingerprint display) lean on the
+   mutation, and re-designing bound-owner root semantics is beyond a "se for
+   barato" guard. Residue: an owner-session `auto_ingest_start` over a docs dir
+   still re-points the bound session's workspace root.
+
+4. **Recall verbs do not advance freshness on the HTTP owner.** `seek`,
+   `north`, `boot_memory` and `delegate` route through the tier-compose path,
+   which deliberately does not autotick (read-only recall stays cheap). A
+   session that ONLY calls recall verbs sees `last_tick_ms` age; any other verb
+   advances it. Recorded as part of the honesty doctrine ("fresh when seen"
+   means seen by a non-recall verb), not changed in v1.
+
+5. **Peak-RSS is a coarse proxy.** The bench's allocation number is the whole
+   test process (three sequential repos + graphs + harness) via
+   `/usr/bin/time -l`, not a per-tick allocation profile. Honest as an upper
+   bound; a per-tick allocator profile is v2 work if the number ever matters.

--- a/docs/voice/GARDENER-V1.md
+++ b/docs/voice/GARDENER-V1.md
@@ -1,0 +1,97 @@
+# Gardener v1 — the organism that moves when seen
+
+> Arc law: `docs/voice/ASKGOD-VERDICT-GARDENER.md` (CHANGE verdict, 2026-07-12).
+> This doc records the design as BUILT, the registered numbers, the measured
+> cost, and the v2 slices deliberately left out. Branch: `feat/gardener-v1`.
+
+## The design in five lines
+
+1. **Fail-open first:** a background vigil (auto-ingest tick, daemon tick) can
+   NEVER fail an agent's tool call — the previously violable `?` in
+   `dispatch_tool` is now `vigil_fail_open` (log + swallow), and every other
+   vigil path was audited already-fail-open.
+2. **The code leg is the DAEMON, per brain:** `daemon_start` routed to a brain
+   arms it (watch set = the brain's own ingest roots), the opt-in persists in
+   the brain's OWN store dir (factory default OFF), and the resume rides the
+   registry warm-boot/resolve path — surviving restart AND LRU eviction. The
+   resume is lazy: no scan before the listener; the first traffic tick does the
+   inventory work.
+3. **Honesty by traffic:** v1 freshness is "when seen", literally — on the HTTP
+   owner ticks advance on non-recall verb traffic (recall verbs — seek / north /
+   boot_memory / delegate — do not tick); `watch_backend` can no longer resume
+   the `native_fs` claim of a notify watcher that died with its process, and no
+   surface says "continuously monitored" (tool schema, help guidance and wiki
+   rewritten honestly).
+4. **Bursts coalesce, nothing is lost:** the stdio event window went 75 ms →
+   500 ms silence with a 5 s cap, and the tick itself now detects ONCE per
+   burst, pushes the whole changed set into a persisted FIFO backlog and drains
+   `max_files` per tick — the old truncate-then-advance hole silently LOST every
+   file beyond the budget on the git backend.
+5. **Auto-reconcile with cedência:** a burst schedules a reconcile of the
+   RATIFIED system-blocks store behind a 45 s quiet window (every activity tick
+   pushes the deadline — one window per burst); a live `candidate_lease` makes
+   the reconciler YIELD voluntarily (skip + reschedule; the lease is advisory by
+   ratified law — it cannot block, so WE cede); the write keys on a FRESH
+   `store_version`, gets exactly 1 OCC retry, then an `auto_reconcile_conflict`
+   alert on the existing lane — never a loop. A candidate skeleton is skipped:
+   candidate freshness is another cycle (the re-scan), outside this arc.
+
+## Registered numbers (verdict: "número escolhido REGISTRADO e justificado")
+
+| Constant | Value | Why |
+|---|---|---|
+| `BURST_COALESCE_WINDOW_MS` | 500 ms | git's index/lock/pack pauses run into the low hundreds of ms; 75 ms of silence fired mid-checkout. 500 ms closes one checkout into ONE detection while adding ≤ 0.5 s latency to a single-file save. |
+| `BURST_COALESCE_CAP_MS` | 5 s | a sliding silence window alone can starve under continuous churn; the cap bounds one coalescing pass so the graph advances during a storm. |
+| `AUTO_RECONCILE_QUIET_WINDOW_MS` | 45 s | inside the verdict's 30–60 s band: long enough that one logical burst (checkout + follow-up churn) collapses into one window; short enough the map refreshes within a minute of quiet. |
+| drain budget (`max_files`) | 32 (existing default) | keeps one drain tick at ~1.6–1.9 s measured (below), an acceptable per-routed-call tax for an opt-in brain. |
+
+## Measured cost (the bench the verdict demanded before aggressive defaults)
+
+`bench_daemon_tick_burst` (`#[ignore]`, release, macOS dev machine, git
+backend, drain budget 32; RSS via `/usr/bin/time -l`):
+
+| N changed | detection tick | drain ticks | total | per file |
+|---|---|---|---|---|
+| 10 | 357 ms | 0 | 357 ms | 35.7 ms |
+| 100 | 1 189 ms | 3 (2 477 ms) | 3 666 ms | 36.7 ms |
+| 1000 | 8 673 ms | 31 (50 899 ms) | 59 573 ms | 59.6 ms |
+
+Peak RSS of the whole bench process (three repos + graphs): ~3.7 GB — a coarse
+upper-bound proxy, recorded honestly as such.
+
+**The honest reading:** a drain tick costs ~1.6–1.9 s and the first post-burst
+detection of a 1000-file burst ~8.7 s, paid inline by whatever routed call
+triggers it. This is exactly why the factory default stays OFF and arming is a
+per-brain opt-in on the hot brains only.
+
+## v2 — registered, deliberately out of v1
+
+- **Zero-traffic alerts** (a per-brain tick task on the HTTP owner, with
+  lock-contention measured first) — the verdict's explicit v2 slice. Until
+  then: no traffic, no advance, and every surface says so.
+- **Detection-walk hashing:** `inventory_from_watch_paths` re-hashes every file
+  every tick (the polling-era cost model) — the dominant term in the measured
+  detection cost. The v2 lever is reusing git status to skip unchanged content.
+- **Candidate freshness** (auto re-scan of a candidate skeleton) — another
+  cycle by verdict law; the auto-reconciler skips candidate stores.
+
+## Test map (the names the arc is judged by)
+
+- fail-open: `erroring_auto_ingest_vigil_never_fails_the_agents_tool_call`
+  (RED-proven against the old `?`), `broken_background_tick_never_fails_the_agents_tool_call`,
+  `vigil_fail_open_swallows_a_failing_vigil`
+- restart resume: `armed_daemon_resumes_across_restart_and_ticks_again`
+  (RED-proven: the persisted mid-tick `tick_in_flight: true` wedged every resume)
+- eviction→rearm: `evicted_brains_armed_daemon_rearms_on_the_next_resolve`
+- HTTP status honesty: `resumed_status_never_claims_a_dead_notify_watcher` (RED-proven)
+- burst coalescing: `burst_bigger_than_tick_budget_drains_completely_without_losing_the_tail`
+  (RED-proven against the truncate-then-advance loss)
+- quiet window: `quiet_window_coalesces_bursts_then_reconciles`
+- lease yield: `auto_reconcile_yields_to_a_live_lease_and_reschedules`
+- ratified-only: `auto_reconcile_skips_a_candidate_skeleton`
+- OCC: `occ_conflict_gets_one_retry_then_an_alert_never_a_loop`
+- upgrade safety: `pre_gardener_daemon_state_still_deserializes_and_stays_armed`
+- auto-ingest guard: `auto_ingest_start_never_demotes_a_hosted_brains_code_root`
+- cost: `bench_daemon_tick_burst` (ignored; run manually)
+
+Honest residue and refusals: `docs/voice/GARDENER-DIVERGENCES.md`.

--- a/docs/wiki/src/api-reference/lifecycle.md
+++ b/docs/wiki/src/api-reference/lifecycle.md
@@ -1284,19 +1284,23 @@ Release a lock and free its resources. Removes the lock state, cleans up pending
 <a id="m1nddaemon_start"></a>
 
 ## `daemon_start`
-Start the persisted daemon control plane. Stores watched roots, initializes daemon counters, and begins the long-lived structural monitoring lane.
+Arm the per-brain code daemon: persist the watched roots (empty = the brain's own ingest roots) and initialize the daemon counters. Arming is a per-brain opt-in — the durable state lives in the brain's own store dir, survives owner restarts AND LRU eviction (the daemon re-arms on the next warm-boot/resolve), and the factory default is OFF.
+
+**Freshness is honest, not continuous.** On a served (HTTP) owner ticks advance BY TRAFFIC — any non-recall verb touching the brain runs a due tick ("fresh when seen") — or via an explicit `daemon_tick`. Only a stdio owner additionally holds a live watch-event consumer and an idle clock. No surface claims a free-running monitor; `watch_backend` reports `native_fs` only while a real notify watcher exists.
+
+Bursts coalesce: a branch checkout becomes ONE detection whose full changed set enters a persisted backlog, drained a bounded slice per tick (`max_files`) — no file is lost to truncation. After a burst settles (45 s quiet window, pushed by every activity tick), the daemon auto-reconciles the RATIFIED system-blocks store: it yields voluntarily to a live `candidate_lease`, keys the write on a fresh `store_version`, and gives OCC exactly one retry before raising an `auto_reconcile_conflict` alert.
 
 ### Parameters
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `agent_id` | `string` | Yes | -- | Calling agent identifier. |
-| `watch_paths` | `string[]` | No | current ingest roots | Paths the daemon should monitor. |
-| `poll_interval_ms` | `integer` | No | `500` | Poll interval fallback in milliseconds. |
+| `watch_paths` | `string[]` | No | current ingest roots | Paths the daemon should watch (the per-brain default is the brain's own ingest roots). |
+| `poll_interval_ms` | `integer` | No | `500` | Traffic/idle tick due-interval in milliseconds. |
 
 ### When to Use
 
-- Start of a long-lived agent session
+- Opting a brain into standing freshness (per-brain, durable, default OFF)
 - Before relying on daemon alerts or `daemon_tick`
 - Before background/idle reconciliation should run
 

--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -1272,4 +1272,88 @@ mod tests {
             "the drained Delete reconciled the missing manifest entry"
         );
     }
+
+    /// FAIL-OPEN, end-to-end through the previously violable seam (gardener v1):
+    /// an agent's unrelated tool call used to FAIL when the inline auto-ingest
+    /// vigil errored — `dispatch_tool` propagated `maybe_tick_auto_ingest` with a
+    /// `?`. This test arranges a REAL erroring tick (the tick's end-of-drain
+    /// persist hits a poisoned `auto_ingest_state.tmp` that is a directory, so
+    /// `save_json_atomic`'s `fs::write` fails) and asserts the agent's `health`
+    /// call still SUCCEEDS. RED under the old `?`: dispatch_tool returned the
+    /// vigil's error; GREEN under fail-open: the error is logged and swallowed.
+    #[test]
+    fn erroring_auto_ingest_vigil_never_fails_the_agents_tool_call() {
+        use crate::server::McpConfig;
+        use m1nd_core::domain::DomainConfig;
+        use m1nd_core::graph::Graph;
+
+        let temp = tempfile::tempdir().unwrap();
+        let runtime_dir = temp.path().join("runtime");
+        fs::create_dir_all(&runtime_dir).unwrap();
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir.clone()),
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        // A running auto-ingest with one ready change (debounce 0), exactly as the
+        // idle-pump case above — the drain will reach the end-of-tick persist.
+        let missing = temp.path().join("docs").join("missing.md");
+        let missing_key = missing.to_string_lossy().to_string();
+        {
+            let ai = &mut state.auto_ingest;
+            ai.running = true;
+            ai.persistent.debounce_ms = 0;
+            ai.persistent.roots = vec![temp.path().to_string_lossy().to_string()];
+            ai.persistent.manifest.insert(
+                missing_key.clone(),
+                AutoIngestManifestEntry {
+                    source_path: missing_key.clone(),
+                    format: "light".into(),
+                    namespace: None,
+                    fingerprint: AutoIngestFingerprint {
+                        canonical_path: missing_key.clone(),
+                        size: 1,
+                        mtime_ms: 1,
+                        content_hash: "hash".into(),
+                        detected_format: "light".into(),
+                    },
+                    claims: SourceClaims::default(),
+                    last_ingested_ms: 1,
+                },
+            );
+            AutoIngestState::enqueue_change(
+                &ai.pending,
+                missing_key.clone(),
+                PendingChangeKind::Delete,
+            );
+        }
+
+        // POISON the tick's persist: `save_json_atomic` writes
+        // `auto_ingest_state.tmp` then renames — a DIRECTORY at the tmp path makes
+        // `fs::write` fail on every platform, so the tick returns Err.
+        let tmp_path = AutoIngestState::state_path(&state.runtime_root).with_extension("tmp");
+        fs::create_dir_all(&tmp_path).expect("poison tmp path as a directory");
+        assert!(
+            state.auto_ingest.persist(&state.runtime_root).is_err(),
+            "precondition: the poisoned tmp path must make the vigil's persist fail"
+        );
+
+        // The agent's UNRELATED tool call ('health' is not on the tick's skip
+        // list, so the vigil runs inline) must SUCCEED despite the erroring vigil.
+        let result = crate::server::dispatch_tool(
+            &mut state,
+            "health",
+            &serde_json::json!({ "agent_id": "test" }),
+        );
+        assert!(
+            result.is_ok(),
+            "the agent's tool call must succeed when the auto-ingest vigil errors \
+             (fail-open), got: {:?}",
+            result.err()
+        );
+    }
 }

--- a/m1nd-mcp/src/auto_ingest.rs
+++ b/m1nd-mcp/src/auto_ingest.rs
@@ -585,8 +585,20 @@ impl AutoIngestState {
                 state.ingest_roots.push(root.clone());
             }
         }
-        if let Some(first_root) = self.persistent.roots.first() {
-            state.workspace_root = Some(first_root.clone());
+        // GARDENER v1 GUARD (verdict trap: auto_ingest_start MUTATES
+        // workspace_root — the #326 store-dir/code-root bug class). A HOSTED
+        // brain's workspace_root IS its project root, stamped from its birth
+        // manifest (`project_brain_manifest`); letting a document watcher's
+        // first root overwrite it would demote the brain's code identity to a
+        // docs dir (wrong code_root_path, wrong medulla classification). The
+        // bound owner keeps the historical mutation (its workspace_root is not
+        // manifest-anchored) — registered as residue in the arc's divergences.
+        let manifest_bound =
+            state.workspace_root_source.as_deref() == Some("project_brain_manifest");
+        if !manifest_bound {
+            if let Some(first_root) = self.persistent.roots.first() {
+                state.workspace_root = Some(first_root.clone());
+            }
         }
 
         self.start_watcher()?;
@@ -1270,6 +1282,71 @@ mod tests {
         assert_eq!(
             state.auto_ingest.persistent.removals_applied, 1,
             "the drained Delete reconciled the missing manifest entry"
+        );
+    }
+
+    /// GUARD (gardener v1, verdict item 3): `auto_ingest_start` mutates
+    /// `workspace_root` to its first root — on a HOSTED brain (workspace root
+    /// stamped from the birth manifest) that demoted the brain's CODE identity
+    /// to a docs dir (the #326 store-dir/code-root bug class). The manifest-bound
+    /// root must survive; the bound owner keeps the historical mutation.
+    #[test]
+    fn auto_ingest_start_never_demotes_a_hosted_brains_code_root() {
+        use crate::protocol::auto_ingest::AutoIngestStartInput;
+        use crate::server::McpConfig;
+        use m1nd_core::domain::DomainConfig;
+        use m1nd_core::graph::Graph;
+
+        let temp = tempfile::tempdir().unwrap();
+        let runtime_dir = temp.path().join("runtime");
+        fs::create_dir_all(&runtime_dir).unwrap();
+        let docs = temp.path().join("docs");
+        fs::create_dir_all(&docs).unwrap();
+        fs::write(docs.join("notes.md"), "# notes").unwrap();
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        // A hosted brain: workspace root IS the project root, by manifest.
+        let project_root = temp.path().join("the-project");
+        fs::create_dir_all(&project_root).unwrap();
+        state.workspace_root = Some(project_root.to_string_lossy().to_string());
+        state.workspace_root_source = Some("project_brain_manifest".into());
+
+        let start_input = AutoIngestStartInput {
+            agent_id: "test".into(),
+            roots: vec![docs.to_string_lossy().to_string()],
+            formats: Vec::new(),
+            debounce_ms: 200,
+            namespace: None,
+        };
+        let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+        runtime
+            .start(&mut state, start_input.clone())
+            .expect("auto_ingest start");
+        state.auto_ingest = runtime;
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(project_root.to_string_lossy().to_string().as_str()),
+            "a manifest-bound workspace root must NEVER be demoted to a docs dir"
+        );
+
+        // The bound owner (no manifest anchor) keeps the historical mutation.
+        state.workspace_root_source = None;
+        let mut runtime = std::mem::replace(&mut state.auto_ingest, AutoIngestState::empty());
+        runtime
+            .start(&mut state, start_input)
+            .expect("auto_ingest re-start");
+        state.auto_ingest = runtime;
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(docs.to_string_lossy().to_string().as_str()),
+            "the bound owner's historical mutation is preserved"
         );
     }
 

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -1997,6 +1997,114 @@ mod tests {
         );
     }
 
+    /// HONEST COST BENCH (gardener v1 gate): measures the daemon tick against a
+    /// burst of N changed files on the git backend — the number the verdict
+    /// demands BEFORE any aggressive default. Ignored in CI (wall-clock noise);
+    /// run manually, release, with RSS captured externally:
+    ///   /usr/bin/time -l cargo test -p m1nd-mcp --release --lib -- \
+    ///     bench_daemon_tick_burst --ignored --nocapture
+    /// Numbers are recorded in docs/voice/GARDENER-V1.md.
+    #[test]
+    #[ignore = "cost bench — run manually, numbers recorded in the arc doc"]
+    fn bench_daemon_tick_burst() {
+        for n in [10usize, 100, 1000] {
+            let (temp, mut state) = build_state();
+            let repo = temp.path().join("repo");
+            std::fs::create_dir_all(repo.join("src")).expect("repo src");
+            for i in 0..n {
+                std::fs::write(
+                    repo.join(format!("src/f{i:04}.py")),
+                    format!("def f{i:04}():\n    return {i}\n"),
+                )
+                .expect("write file");
+            }
+            let git = |args: &[&str]| {
+                let out = Command::new("git")
+                    .args(args)
+                    .current_dir(&repo)
+                    .output()
+                    .expect("spawn git");
+                assert!(out.status.success(), "git {args:?} failed");
+            };
+            git(&["init", "-q"]);
+            git(&["config", "user.email", "bench@example.com"]);
+            git(&["config", "user.name", "Bench"]);
+            git(&["add", "."]);
+            git(&["commit", "-q", "-m", "init"]);
+
+            crate::tools::handle_ingest(
+                &mut state,
+                crate::protocol::IngestInput {
+                    path: repo.to_string_lossy().to_string(),
+                    agent_id: "bench".into(),
+                    mode: "replace".into(),
+                    incremental: false,
+                    adapter: "code".into(),
+                    namespace: None,
+                    include_dotfiles: false,
+                    dotfile_patterns: Vec::new(),
+                    project_root: None,
+                },
+            )
+            .expect("initial ingest");
+            handle_daemon_start(
+                &mut state,
+                layers::DaemonStartInput {
+                    agent_id: "bench".into(),
+                    watch_paths: vec![repo.to_string_lossy().to_string()],
+                    poll_interval_ms: 200,
+                },
+            )
+            .expect("daemon start");
+
+            // THE BURST: every file changes, head moves (the checkout shape).
+            for i in 0..n {
+                std::fs::write(
+                    repo.join(format!("src/f{i:04}.py")),
+                    format!("def f{i:04}():\n    return {i} + 1\n"),
+                )
+                .expect("rewrite file");
+            }
+            git(&["add", "."]);
+            git(&["commit", "-q", "-m", "burst"]);
+
+            // Detection tick (default drain budget 32) + drain to empty.
+            let t0 = std::time::Instant::now();
+            let first = handle_daemon_tick(
+                &mut state,
+                layers::DaemonTickInput {
+                    agent_id: "bench".into(),
+                    max_files: 32,
+                },
+            )
+            .expect("detection tick");
+            let detection_ms = t0.elapsed().as_secs_f64() * 1000.0;
+            assert_eq!(first["changed_files_detected"], n);
+
+            let mut drain_ticks = 0usize;
+            let t1 = std::time::Instant::now();
+            while !state.daemon_state.pending_backlog.is_empty() {
+                handle_daemon_tick(
+                    &mut state,
+                    layers::DaemonTickInput {
+                        agent_id: "bench".into(),
+                        max_files: 32,
+                    },
+                )
+                .expect("drain tick");
+                drain_ticks += 1;
+            }
+            let drain_ms = t1.elapsed().as_secs_f64() * 1000.0;
+            let total_ms = detection_ms + drain_ms;
+            println!(
+                "bench_daemon_tick_burst N={n:>5}: detection_tick={detection_ms:>9.1}ms \
+                 drain_ticks={drain_ticks:>3} drain={drain_ms:>9.1}ms \
+                 total={total_ms:>9.1}ms per_file={:>7.2}ms",
+                total_ms / n as f64
+            );
+        }
+    }
+
     /// Backward compatibility (gardener v1): a pre-gardener daemon_state.json
     /// (no `pending_backlog` field) must keep deserializing with `active`
     /// preserved. A parse failure would fall back to Default and silently

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -965,6 +965,78 @@ mod tests {
         assert_eq!(stopped["active"], false);
     }
 
+    /// HTTP status honesty (gardener v1, verdict item 4): a persisted
+    /// `watch_backend: "native_fs"` asserts a LIVE notify watcher, which only the
+    /// stdio serve() loop owns. A freshly booted state (any transport; on the HTTP
+    /// owner, forever) has no such consumer — resuming the label verbatim would
+    /// make `daemon_status` LIE. RED without the load-time downgrade to "polling".
+    /// `git_native_fs` must survive: it names per-tick git-diff detection, true on
+    /// every transport.
+    #[test]
+    fn resumed_status_never_claims_a_dead_notify_watcher() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+
+        // The exact disk shape a stdio owner leaves behind: armed, live-watcher
+        // label, and the mid-tick reentrancy flags.
+        let persisted = crate::session::DaemonRuntimeState {
+            active: true,
+            watch_backend: "native_fs".into(),
+            tick_in_flight: true,
+            pending_rerun: true,
+            ..Default::default()
+        };
+        std::fs::write(
+            runtime_dir.join("daemon_state.json"),
+            serde_json::to_string_pretty(&persisted).expect("serialize"),
+        )
+        .expect("write daemon state");
+
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir.clone()),
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        let status = handle_daemon_status(
+            &mut state,
+            layers::DaemonStatusInput {
+                agent_id: "test".into(),
+            },
+        )
+        .expect("daemon status");
+        assert_eq!(status["active"], true, "the armed daemon resumes active");
+        assert_eq!(
+            status["watch_backend"], "polling",
+            "a resumed status must not claim a notify watcher that no longer exists"
+        );
+        assert_eq!(status["tick_in_flight"], false);
+        assert_eq!(status["pending_rerun"], false);
+
+        // The honest label that DOES survive: per-tick git detection.
+        let persisted_git = crate::session::DaemonRuntimeState {
+            active: true,
+            watch_backend: "git_native_fs".into(),
+            git_root: Some("/tmp/somewhere".into()),
+            ..Default::default()
+        };
+        std::fs::write(
+            runtime_dir.join("daemon_state.json"),
+            serde_json::to_string_pretty(&persisted_git).expect("serialize"),
+        )
+        .expect("write daemon state");
+        let state2 = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session 2");
+        assert_eq!(
+            state2.daemon_state.watch_backend, "git_native_fs",
+            "git_native_fs names per-tick detection and survives a resume"
+        );
+    }
+
     #[test]
     fn daemon_tick_reingests_changed_files() {
         let (temp, mut state) = build_state();

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -9,6 +9,25 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Gardener v1 — burst coalescing numbers (verdict item 7), REGISTERED with
+/// their justification so the choice is auditable:
+///
+/// * `BURST_COALESCE_WINDOW_MS = 500`. The stdio event loop closes a watch-event
+///   burst after this much SILENCE (sliding window). The old 75 ms fragmented a
+///   branch checkout into several ticks: git writes files in dense sub-ms
+///   batches but pauses for index/lock/pack work in the low hundreds of ms, so
+///   75 ms of silence regularly fired mid-checkout. 500 ms spans those pauses —
+///   thousands of events become ONE detection — while adding at most half a
+///   second of latency to a single-file save (invisible for a background vigil
+///   whose poll intervals are measured in seconds).
+/// * `BURST_COALESCE_CAP_MS = 5_000`. A sliding silence window alone can starve
+///   under CONTINUOUS churn (events forever < window apart). The cap bounds one
+///   coalescing pass: after 5 s of sustained events the tick runs anyway, so the
+///   graph keeps advancing during a storm instead of waiting for a quiet that
+///   never comes.
+pub const BURST_COALESCE_WINDOW_MS: u64 = 500;
+pub const BURST_COALESCE_CAP_MS: u64 = 5_000;
+
 fn simple_content_hash(path: &Path) -> Option<String> {
     let bytes = std::fs::read(path).ok()?;
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -341,9 +360,10 @@ pub fn handle_daemon_start(
     state.daemon_state.last_tick_trigger = None;
     state.daemon_state.watch_paths = watch_paths;
     state.daemon_state.poll_interval_ms = input.poll_interval_ms;
-    state.daemon_state.coalesce_window_ms = 75;
+    state.daemon_state.coalesce_window_ms = BURST_COALESCE_WINDOW_MS;
     state.daemon_state.pending_rerun = false;
     state.daemon_state.tick_in_flight = false;
+    state.daemon_state.pending_backlog = Vec::new();
     state.daemon_state.last_coalesced_event_ms = None;
     state.daemon_state.coalesced_event_count = 0;
     state.daemon_state.tracked_files = tracked_files_from_inventory(&initial_inventory);
@@ -476,6 +496,7 @@ pub fn handle_daemon_status(
         "coalesced_event_count": state.daemon_state.coalesced_event_count,
         "alert_count": state.daemon_alerts.len(),
         "tracked_files": state.daemon_state.tracked_files.len(),
+        "pending_backlog_len": state.daemon_state.pending_backlog.len(),
         "tick_count": state.daemon_state.tick_count,
         "last_tick_duration_ms": state.daemon_state.last_tick_duration_ms,
         "last_tick_changed_files": state.daemon_state.last_tick_changed_files,
@@ -630,7 +651,46 @@ pub fn handle_daemon_tick(
     }
 
     changed_entries.sort_by_key(|entry| std::cmp::Reverse(entry.last_modified_ms));
-    changed_entries.truncate(input.max_files);
+    let newly_detected = changed_entries.len();
+
+    // BURST BACKLOG (gardener v1, verdict item 7). The old shape truncated the
+    // changed set to `max_files` AND (on the git backend) advanced
+    // `git_since_ref` past the whole diff — a thousand-file checkout re-ingested
+    // 32 files and silently LOST the tail forever. Now: every detected id is
+    // pushed onto the persisted backlog (dedup — the polling backend re-detects
+    // un-ingested files every tick), and the tick drains a bounded slice from
+    // the FRONT (FIFO: completeness, no starvation; a single burst lands in one
+    // detection anyway, newest-first within the batch). Each drained id is
+    // resolved against the LIVE inventory so the ingest always reads fresh
+    // content; an id that vanished from disk simply drops (the deletion lane
+    // below owns the alert for tracked files).
+    for entry in &changed_entries {
+        if !state
+            .daemon_state
+            .pending_backlog
+            .iter()
+            .any(|id| id == &entry.external_id)
+        {
+            state
+                .daemon_state
+                .pending_backlog
+                .push(entry.external_id.clone());
+        }
+    }
+    let backlog = std::mem::take(&mut state.daemon_state.pending_backlog);
+    let mut drained_entries: Vec<FileInventoryEntry> = Vec::new();
+    let mut kept_backlog: Vec<String> = Vec::new();
+    for id in backlog {
+        if drained_entries.len() >= input.max_files {
+            kept_backlog.push(id);
+            continue;
+        }
+        if let Some(entry) = live_inventory.get(&id) {
+            drained_entries.push(entry.clone());
+        }
+    }
+    state.daemon_state.pending_backlog = kept_backlog;
+    let changed_entries = drained_entries;
 
     let mut ingested_files = Vec::new();
     let mut heuristic_alerts_emitted = 0usize;
@@ -728,7 +788,13 @@ pub fn handle_daemon_tick(
     state.daemon_state.last_tick_changed_files = changed_entries.len();
     state.daemon_state.last_tick_deleted_files = deleted_entries.len();
     state.daemon_state.last_tick_alerts_emitted = emitted_alerts_total;
-    if changed_entries.is_empty() && deleted_entries.is_empty() && emitted_alerts_total == 0 {
+    // A tick with a non-empty remaining backlog is NOT idle — drain work remains,
+    // and backing off would stretch the burst's tail out for no reason.
+    if changed_entries.is_empty()
+        && deleted_entries.is_empty()
+        && emitted_alerts_total == 0
+        && state.daemon_state.pending_backlog.is_empty()
+    {
         state.daemon_state.idle_streak = state.daemon_state.idle_streak.saturating_add(1);
     } else {
         state.daemon_state.idle_streak = 0;
@@ -740,9 +806,10 @@ pub fn handle_daemon_tick(
         "active": true,
         "tick_at_ms": tick_ms,
         "watch_paths": state.daemon_state.watch_paths,
-        "changed_files_detected": changed_entries.len(),
+        "changed_files_detected": newly_detected,
         "deleted_files_detected": deleted_entries.len(),
         "files_reingested": ingested_files.len(),
+        "backlog_len": state.daemon_state.pending_backlog.len(),
         "ingested_files": ingested_files,
         "deleted_files": deleted_entries.into_iter().map(|entry| json!({
             "file_path": entry.file_path,
@@ -948,7 +1015,7 @@ mod tests {
         assert!(status["next_tick_due_ms"].as_u64().is_some());
         assert_eq!(status["overdue_ms"], 0);
         assert_eq!(status["idle_streak"], 0);
-        assert_eq!(status["coalesce_window_ms"], 75);
+        assert_eq!(status["coalesce_window_ms"], BURST_COALESCE_WINDOW_MS);
         assert_eq!(status["pending_rerun"], false);
         assert_eq!(status["tick_in_flight"], false);
         assert_eq!(status["watch_backend"], "polling");
@@ -1311,6 +1378,181 @@ mod tests {
         assert_eq!(status["pending_rerun"], false);
         assert_eq!(status["tick_in_flight"], false);
         assert_eq!(status["watch_backend"], "polling");
+    }
+
+    /// BURST COALESCING (gardener v1, verdict item 7) — the checkout shape on the
+    /// git backend. A burst bigger than one tick's `max_files` budget used to be
+    /// truncated while `git_since_ref` advanced past the WHOLE diff: the tail was
+    /// silently lost forever (20-file burst, budget 6 → 6 ingested, 14 never).
+    /// Now the burst is ONE detection that fills the persisted backlog, and
+    /// bounded drain ticks re-ingest every file. RED under the old truncate:
+    /// ticks after the first find changed_files 0 and the total stalls at 6.
+    #[test]
+    fn burst_bigger_than_tick_budget_drains_completely_without_losing_the_tail() {
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo src");
+        const N: usize = 20;
+        const BUDGET: usize = 6;
+        for i in 0..N {
+            std::fs::write(
+                repo.join(format!("src/f{i:02}.py")),
+                format!("def f{i:02}():\n    return {i}\n"),
+            )
+            .expect("write file");
+        }
+
+        let git = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .expect("spawn git");
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        git(&["add", "."]);
+        git(&["commit", "-m", "init"]);
+
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: repo.to_string_lossy().to_string(),
+                agent_id: "test".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+                project_root: None,
+            },
+        )
+        .expect("initial ingest");
+
+        handle_daemon_start(
+            &mut state,
+            layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![repo.to_string_lossy().to_string()],
+                poll_interval_ms: 200,
+            },
+        )
+        .expect("daemon start");
+        assert_eq!(state.daemon_state.watch_backend, "git_native_fs");
+
+        // THE BURST: every file changes and the head MOVES (the checkout shape —
+        // this is exactly what advanced since_ref past the tail before).
+        for i in 0..N {
+            std::fs::write(
+                repo.join(format!("src/f{i:02}.py")),
+                format!("def f{i:02}():\n    return {i} + 100\n"),
+            )
+            .expect("rewrite file");
+        }
+        git(&["add", "."]);
+        git(&["commit", "-m", "burst"]);
+
+        // Tick 1: ONE detection of the whole burst, a bounded drain, the rest
+        // owned by the persisted backlog while since_ref advances.
+        let tick1 = handle_daemon_tick(
+            &mut state,
+            layers::DaemonTickInput {
+                agent_id: "test".into(),
+                max_files: BUDGET,
+            },
+        )
+        .expect("burst tick");
+        assert_eq!(tick1["changed_files_detected"], N, "one detection sees ALL");
+        assert_eq!(tick1["files_reingested"], BUDGET);
+        assert_eq!(tick1["backlog_len"], N - BUDGET);
+        assert_eq!(
+            state.daemon_state.git_since_ref, state.daemon_state.git_head_ref,
+            "since_ref advances immediately — the backlog owns the tail"
+        );
+
+        // Drain ticks: git reports nothing new (detection already happened), the
+        // backlog empties, and EVERY file of the burst gets re-ingested.
+        let mut total_reingested = tick1["files_reingested"].as_u64().unwrap() as usize;
+        for _ in 0..10 {
+            if state.daemon_state.pending_backlog.is_empty() {
+                break;
+            }
+            let tick = handle_daemon_tick(
+                &mut state,
+                layers::DaemonTickInput {
+                    agent_id: "test".into(),
+                    max_files: BUDGET,
+                },
+            )
+            .expect("drain tick");
+            assert_eq!(
+                tick["changed_files_detected"], 0,
+                "drain ticks detect nothing new — the burst was ONE detection"
+            );
+            total_reingested += tick["files_reingested"].as_u64().unwrap() as usize;
+        }
+        assert!(
+            state.daemon_state.pending_backlog.is_empty(),
+            "the backlog must drain completely"
+        );
+        assert_eq!(
+            total_reingested, N,
+            "every file of the burst is re-ingested — no tail is lost"
+        );
+    }
+
+    /// Backward compatibility (gardener v1): a pre-gardener daemon_state.json
+    /// (no `pending_backlog` field) must keep deserializing with `active`
+    /// preserved. A parse failure would fall back to Default and silently
+    /// DISARM every resumed daemon on upgrade.
+    #[test]
+    fn pre_gardener_daemon_state_still_deserializes_and_stays_armed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+
+        // A faithful pre-gardener shape: serialize the current struct, then
+        // DELETE the new field from the JSON before writing it to disk.
+        let old = crate::session::DaemonRuntimeState {
+            active: true,
+            watch_paths: vec!["/tmp/watch".into()],
+            poll_interval_ms: 60_000,
+            ..Default::default()
+        };
+        let mut value = serde_json::to_value(&old).expect("serialize");
+        value
+            .as_object_mut()
+            .expect("object")
+            .remove("pending_backlog")
+            .expect("the new field exists on the current struct");
+        std::fs::write(
+            runtime_dir.join("daemon_state.json"),
+            serde_json::to_string_pretty(&value).expect("stringify"),
+        )
+        .expect("write old-shape state");
+
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir.clone()),
+            ..McpConfig::default()
+        };
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+        assert!(
+            state.daemon_state.active,
+            "an old-shape daemon_state must resume armed — a parse fallback \
+             to Default would silently disarm it"
+        );
+        assert!(state.daemon_state.pending_backlog.is_empty());
+        assert_eq!(state.daemon_state.poll_interval_ms, 60_000);
     }
 
     #[test]

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -1764,7 +1764,10 @@ mod tests {
             .expect("the yield RESCHEDULES, never drops the debt");
         assert!(rescheduled > now, "rescheduled into the future");
         let untouched = SystemBlockStore::load(&dir).expect("load").expect("store");
-        assert_eq!(untouched.store_version, 1, "the leased store was not touched");
+        assert_eq!(
+            untouched.store_version, 1,
+            "the leased store was not touched"
+        );
 
         // The hand releases → the next elapsed quiet tick RUNS.
         let mut store = SystemBlockStore::load(&dir).expect("load").expect("store");

--- a/m1nd-mcp/src/daemon_handlers.rs
+++ b/m1nd-mcp/src/daemon_handlers.rs
@@ -28,6 +28,147 @@ use std::process::Command;
 pub const BURST_COALESCE_WINDOW_MS: u64 = 500;
 pub const BURST_COALESCE_CAP_MS: u64 = 5_000;
 
+/// Gardener v1 — the auto-reconcile QUIET WINDOW (verdict item 5), REGISTERED:
+/// 45 s sits inside the verdict's 30–60 s band. Long enough that one logical
+/// burst — a checkout plus the seconds of follow-up churn (build artifacts,
+/// editor saves, hook output) — collapses into ONE window (every activity tick
+/// PUSHES the deadline, so a storm coalesces instead of firing per wave); short
+/// enough that the block map refreshes within a minute of the repo going quiet.
+pub const AUTO_RECONCILE_QUIET_WINDOW_MS: u64 = 45_000;
+
+/// Outcome of the 1-retry OCC policy around an auto-reconcile write.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum OccOutcome {
+    /// The reconcile applied (dirty = something actually moved).
+    Ran { dirty: bool },
+    /// Two attempts, two `Conflict`s — give up and ALERT, never loop
+    /// (verdict item 5: "1 retry → alert, nunca loop").
+    ConflictExhausted,
+    /// A non-OCC failure (no store, io, ...): fail-open, log-and-drop.
+    Failed(String),
+}
+
+/// The 1-retry OCC policy (verdict item 5). Each attempt must read its OWN
+/// fresh `expected_store_version` (the closure owns that); a `Conflict` earns
+/// exactly ONE more attempt, anything else settles immediately. Pure policy —
+/// unit-testable with an injected attempt, which is the only deterministic way
+/// to exercise the conflict arm (a real conflict needs a concurrent writer).
+pub(crate) fn occ_retry_outcome(
+    mut attempt: impl FnMut() -> Result<bool, crate::system_blocks::SeedError>,
+) -> OccOutcome {
+    for _ in 0..2 {
+        match attempt() {
+            Ok(dirty) => return OccOutcome::Ran { dirty },
+            Err(crate::system_blocks::SeedError::Conflict { .. }) => continue,
+            Err(other) => return OccOutcome::Failed(other.to_string()),
+        }
+    }
+    OccOutcome::ConflictExhausted
+}
+
+/// Settle an auto-reconcile OCC outcome onto the session: bump the honest
+/// counters on success, record the conflict ALERT on exhaustion (the existing
+/// alert lane — no new surface), log-and-drop a plain failure. Returns the
+/// tick-output label plus the alert id (so the tick's totals stay truthful).
+fn settle_auto_reconcile_outcome(
+    state: &mut SessionState,
+    outcome: OccOutcome,
+) -> (&'static str, Option<String>) {
+    match outcome {
+        OccOutcome::Ran { dirty } => {
+            state.daemon_state.last_auto_reconcile_ms = Some(now_ms());
+            state.daemon_state.auto_reconcile_runs =
+                state.daemon_state.auto_reconcile_runs.saturating_add(1);
+            (if dirty { "ran_dirty" } else { "ran_clean" }, None)
+        }
+        OccOutcome::ConflictExhausted => {
+            let alert = make_daemon_alert(DaemonAlertSeed {
+                severity: "warning".into(),
+                kind: "auto_reconcile_conflict".into(),
+                message: "Auto-reconcile hit an OCC conflict twice in a row — \
+                          another writer is active on the system-blocks store. \
+                          Reconcile manually when the store settles."
+                    .into(),
+                confidence: 0.9,
+                evidence: vec![
+                    "daemon auto-reconcile (quiet window) — 1 OCC retry exhausted".into(),
+                ],
+                suggested_tool: Some("system_blocks_reconcile".into()),
+                suggested_target: None,
+                file_path: None,
+                node_id: None,
+            });
+            let id = alert.alert_id.clone();
+            state.record_daemon_alert(alert);
+            ("conflict_alert", Some(id))
+        }
+        OccOutcome::Failed(error) => {
+            eprintln!("[m1nd] gardener: auto-reconcile failed (fail-open): {error}");
+            ("reconcile_error", None)
+        }
+    }
+}
+
+/// GARDENER v1 — one auto-reconcile pass (verdict item 5), called from a QUIET
+/// tick whose deadline elapsed. Fail-open by construction: every branch returns
+/// a label, never an error. The laws, in order:
+/// 1. no store → nothing owed;
+/// 2. reconcile refreshes the RATIFIED store — a candidate skeleton is another
+///    cycle (candidate freshness re-scan), outside this arc: skip;
+/// 3. a LIVE candidate_lease → VOLUNTARY YIELD + reschedule (the lease is
+///    advisory by ratified law — it cannot block us, so WE cede);
+/// 4. fresh `expected_store_version` per attempt, 1 OCC retry, then alert.
+fn run_auto_reconcile(state: &mut SessionState) -> (&'static str, Option<String>) {
+    use crate::system_blocks::{self, SeedSkeletonState, SystemBlockStore};
+    let dir = crate::system_blocks_handlers::store_dir(state);
+    let store = match SystemBlockStore::load(&dir) {
+        Ok(Some(store)) => store,
+        Ok(None) => {
+            state.daemon_state.reconcile_due_at_ms = None;
+            return ("no_store", None);
+        }
+        Err(error) => {
+            eprintln!("[m1nd] gardener: auto-reconcile store load failed (fail-open): {error}");
+            state.daemon_state.reconcile_due_at_ms = None;
+            return ("store_load_error", None);
+        }
+    };
+    if store.skeleton.state != SeedSkeletonState::Ratified {
+        state.daemon_state.reconcile_due_at_ms = None;
+        return ("skeleton_not_ratified", None);
+    }
+    let now = now_ms();
+    let now_iso = crate::system_blocks_handlers::iso8601_from_ms(now);
+    if store.lease_is_live(&now_iso) {
+        state.daemon_state.reconcile_due_at_ms =
+            Some(now.saturating_add(AUTO_RECONCILE_QUIET_WINDOW_MS));
+        return ("yielded_to_lease", None);
+    }
+    let Some(root) = state.code_root_path() else {
+        state.daemon_state.reconcile_due_at_ms = None;
+        return ("no_code_root", None);
+    };
+    let file_list = match system_blocks::repo_file_list(Path::new(&root)) {
+        Ok(list) => list,
+        Err(error) => {
+            eprintln!("[m1nd] gardener: auto-reconcile file list failed (fail-open): {error}");
+            state.daemon_state.reconcile_due_at_ms = None;
+            return ("file_list_error", None);
+        }
+    };
+    let outcome = occ_retry_outcome(|| {
+        // FRESH expected_store_version per attempt (verdict item 5).
+        let fresh = SystemBlockStore::load(&dir)
+            .ok()
+            .flatten()
+            .map(|s| s.store_version)
+            .unwrap_or(0);
+        system_blocks::reconcile_in_dir(&dir, fresh, &file_list).map(|(_, report)| report.dirty)
+    });
+    state.daemon_state.reconcile_due_at_ms = None;
+    settle_auto_reconcile_outcome(state, outcome)
+}
+
 fn simple_content_hash(path: &Path) -> Option<String> {
     let bytes = std::fs::read(path).ok()?;
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -364,6 +505,9 @@ pub fn handle_daemon_start(
     state.daemon_state.pending_rerun = false;
     state.daemon_state.tick_in_flight = false;
     state.daemon_state.pending_backlog = Vec::new();
+    state.daemon_state.reconcile_due_at_ms = None;
+    state.daemon_state.last_auto_reconcile_ms = None;
+    state.daemon_state.auto_reconcile_runs = 0;
     state.daemon_state.last_coalesced_event_ms = None;
     state.daemon_state.coalesced_event_count = 0;
     state.daemon_state.tracked_files = tracked_files_from_inventory(&initial_inventory);
@@ -497,6 +641,9 @@ pub fn handle_daemon_status(
         "alert_count": state.daemon_alerts.len(),
         "tracked_files": state.daemon_state.tracked_files.len(),
         "pending_backlog_len": state.daemon_state.pending_backlog.len(),
+        "reconcile_due_at_ms": state.daemon_state.reconcile_due_at_ms,
+        "last_auto_reconcile_ms": state.daemon_state.last_auto_reconcile_ms,
+        "auto_reconcile_runs": state.daemon_state.auto_reconcile_runs,
         "tick_count": state.daemon_state.tick_count,
         "last_tick_duration_ms": state.daemon_state.last_tick_duration_ms,
         "last_tick_changed_files": state.daemon_state.last_tick_changed_files,
@@ -766,6 +913,36 @@ pub fn handle_daemon_tick(
         state.file_inventory.remove(&entry.external_id);
     }
 
+    // GARDENER v1 — auto-reconcile scheduling (verdict item 5). Every tick with
+    // ACTIVITY pushes the quiet-window deadline out (one window per burst — a
+    // checkout's thousands of events coalesce into ONE deadline, never one per
+    // wave). A QUIET tick — nothing new, nothing drained, backlog empty — whose
+    // deadline elapsed runs the reconcile: refresh the RATIFIED store against
+    // the real file list, yielding voluntarily to a live candidate_lease and
+    // giving OCC exactly one retry before alerting. Fail-open throughout: no
+    // arm of this block can fail the tick.
+    let mut auto_reconcile_outcome: Option<&'static str> = None;
+    {
+        let now = now_ms();
+        let had_activity =
+            newly_detected > 0 || !changed_entries.is_empty() || !deleted_entries.is_empty();
+        if had_activity {
+            state.daemon_state.reconcile_due_at_ms =
+                Some(now.saturating_add(AUTO_RECONCILE_QUIET_WINDOW_MS));
+        } else if state.daemon_state.pending_backlog.is_empty()
+            && state
+                .daemon_state
+                .reconcile_due_at_ms
+                .is_some_and(|due| now >= due)
+        {
+            let (label, alert_id) = run_auto_reconcile(state);
+            if let Some(id) = alert_id {
+                emitted_alert_ids.push(id);
+            }
+            auto_reconcile_outcome = Some(label);
+        }
+    }
+
     let tick_ms = now_ms();
     let emitted_alerts_total = emitted_alert_ids.len() + heuristic_alerts_emitted;
     state.daemon_state.last_tick_ms = Some(tick_ms);
@@ -810,6 +987,7 @@ pub fn handle_daemon_tick(
         "deleted_files_detected": deleted_entries.len(),
         "files_reingested": ingested_files.len(),
         "backlog_len": state.daemon_state.pending_backlog.len(),
+        "auto_reconcile": auto_reconcile_outcome,
         "ingested_files": ingested_files,
         "deleted_files": deleted_entries.into_iter().map(|entry| json!({
             "file_path": entry.file_path,
@@ -1378,6 +1556,317 @@ mod tests {
         assert_eq!(status["pending_rerun"], false);
         assert_eq!(status["tick_in_flight"], false);
         assert_eq!(status["watch_backend"], "polling");
+    }
+
+    /// A complete ratified seed (copied from the system_blocks fixture — the
+    /// validated shape) so daemon tests can stage a real store in the brain dir.
+    fn gardener_fixture_seed() -> &'static str {
+        r#"{
+  "schema": "m1nd-system-block-seed-v0",
+  "repo": { "repo_id": "repo_a", "root": ".", "source_commit": "abc123" },
+  "skeleton": {
+    "skeleton_id": "sk_repo_a_seed_2026_07",
+    "version": 1,
+    "state": "ratified",
+    "ratification": {
+      "method": "pr_merge",
+      "ratifier": "owner",
+      "ratified_at": "2026-07-07T00:00:00Z",
+      "commit": "abc123"
+    }
+  },
+  "blocks": [
+    {
+      "block_id": "sb_core",
+      "name": "Core",
+      "purpose": "Core graph responsibilities.",
+      "kind": "scanned",
+      "state": "ratified",
+      "boundary_version": 1,
+      "contract_version": 1,
+      "membership_source": "ratified",
+      "membership": [
+        { "path": "src/**", "role": "primary" }
+      ],
+      "sockets": { "inputs": [], "outputs": [], "external": [] },
+      "receipt_contract": {
+        "version": 1,
+        "required": [],
+        "optional": [],
+        "waived": [],
+        "declared_by": "owner",
+        "declared_at": "2026-07-07T00:00:00Z"
+      },
+      "receipts": [],
+      "layout": { "x": null, "y": null, "locked": false, "algorithm_seed": null, "version": 1 },
+      "unmapped_residue": []
+    }
+  ],
+  "unmapped_policy": { "visible": true, "default_action": "leave_unmapped_until_ratified" }
+}"#
+    }
+
+    /// Stage a real system-blocks store (ratified skeleton) in the brain's
+    /// runtime dir — the store the auto-reconcile refreshes.
+    fn stage_ratified_store(state: &SessionState) -> crate::system_blocks::SystemBlockStore {
+        let seed =
+            crate::system_blocks::load_seed(gardener_fixture_seed()).expect("fixture seed parses");
+        let store = crate::system_blocks::SystemBlockStore::from_seed(seed);
+        store
+            .save(&crate::system_blocks_handlers::store_dir(state))
+            .expect("save staged store");
+        store
+    }
+
+    /// Build a state + watched non-git repo + armed daemon (polling backend),
+    /// the common auto-reconcile test stage.
+    fn build_reconcile_stage() -> (tempfile::TempDir, SessionState, PathBuf) {
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join("src")).expect("repo src");
+        std::fs::write(repo.join("src/a.py"), "def a():\n    return 1\n").expect("write a.py");
+        crate::tools::handle_ingest(
+            &mut state,
+            crate::protocol::IngestInput {
+                path: repo.to_string_lossy().to_string(),
+                agent_id: "test".into(),
+                mode: "replace".into(),
+                incremental: false,
+                adapter: "code".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: Vec::new(),
+                project_root: None,
+            },
+        )
+        .expect("initial ingest");
+        handle_daemon_start(
+            &mut state,
+            layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![repo.to_string_lossy().to_string()],
+                poll_interval_ms: 200,
+            },
+        )
+        .expect("daemon start");
+        (temp, state, repo)
+    }
+
+    fn tick(state: &mut SessionState) -> serde_json::Value {
+        handle_daemon_tick(
+            state,
+            layers::DaemonTickInput {
+                agent_id: "test".into(),
+                max_files: 8,
+            },
+        )
+        .expect("tick")
+    }
+
+    /// AUTO-RECONCILE (gardener v1, verdict item 5) — the quiet window COALESCES
+    /// a burst (activity pushes the deadline; an elapsed deadline NEVER fires on
+    /// an activity tick) and a quiet tick past the deadline reconciles the
+    /// ratified store with a fresh OCC key.
+    #[test]
+    fn quiet_window_coalesces_bursts_then_reconciles() {
+        let (_temp, mut state, repo) = build_reconcile_stage();
+        stage_ratified_store(&state);
+        let dir = crate::system_blocks_handlers::store_dir(&state);
+
+        // Quiet tick, nothing owed: no deadline, no reconcile.
+        let t1 = tick(&mut state);
+        assert!(t1["auto_reconcile"].is_null());
+        assert!(state.daemon_state.reconcile_due_at_ms.is_none());
+
+        // Activity: a new file → the deadline is SET, the reconcile does NOT run.
+        std::fs::write(repo.join("src/b.py"), "def b():\n    return 2\n").expect("write b.py");
+        let t2 = tick(&mut state);
+        assert_eq!(t2["files_reingested"], 1);
+        assert!(t2["auto_reconcile"].is_null(), "no reconcile mid-burst");
+        let due_after_first = state
+            .daemon_state
+            .reconcile_due_at_ms
+            .expect("activity schedules the quiet window");
+
+        // COALESCING LAW: even an ELAPSED deadline never fires on an activity
+        // tick — the burst pushes the window out instead (one window per burst).
+        state.daemon_state.reconcile_due_at_ms = Some(1);
+        std::fs::write(repo.join("src/c.py"), "def c():\n    return 3\n").expect("write c.py");
+        let t3 = tick(&mut state);
+        assert!(
+            t3["auto_reconcile"].is_null(),
+            "an activity tick must push the deadline, never reconcile"
+        );
+        let due_after_second = state
+            .daemon_state
+            .reconcile_due_at_ms
+            .expect("the deadline was pushed, not consumed");
+        assert!(
+            due_after_second >= due_after_first,
+            "the pushed deadline moves forward"
+        );
+        assert_eq!(state.daemon_state.auto_reconcile_runs, 0);
+
+        // QUIET + elapsed deadline → the reconcile RUNS with a fresh OCC key.
+        let version_before = crate::system_blocks::SystemBlockStore::load(&dir)
+            .expect("load")
+            .expect("store")
+            .store_version;
+        state.daemon_state.reconcile_due_at_ms = Some(1);
+        let t4 = tick(&mut state);
+        assert_eq!(
+            t4["auto_reconcile"], "ran_dirty",
+            "the first reconcile records baselines — a real write"
+        );
+        assert_eq!(state.daemon_state.auto_reconcile_runs, 1);
+        assert!(state.daemon_state.last_auto_reconcile_ms.is_some());
+        assert!(
+            state.daemon_state.reconcile_due_at_ms.is_none(),
+            "a settled deadline clears"
+        );
+        let store_after = crate::system_blocks::SystemBlockStore::load(&dir)
+            .expect("load")
+            .expect("store");
+        assert!(
+            store_after.store_version > version_before,
+            "the ratified store was refreshed (OCC bump)"
+        );
+    }
+
+    /// LEASE YIELD (gardener v1, verdict item 5): the candidate_lease is advisory
+    /// by ratified law — it cannot block anyone. The auto-reconciler CEDES
+    /// voluntarily: a live lease → skip + reschedule; a released lease → run.
+    #[test]
+    fn auto_reconcile_yields_to_a_live_lease_and_reschedules() {
+        use crate::system_blocks::{LeaseAction, SystemBlockStore};
+        let (_temp, mut state, _repo) = build_reconcile_stage();
+        stage_ratified_store(&state);
+        let dir = crate::system_blocks_handlers::store_dir(&state);
+
+        // A hand holds a LIVE lease.
+        let now = now_ms();
+        let now_iso = crate::system_blocks_handlers::iso8601_from_ms(now);
+        let until_iso = crate::system_blocks_handlers::iso8601_from_ms(now + 900_000);
+        let mut store = SystemBlockStore::load(&dir).expect("load").expect("store");
+        store
+            .apply_lease(LeaseAction::Acquire, "hand-1", &now_iso, &until_iso)
+            .expect("acquire lease");
+        store.save(&dir).expect("save leased store");
+
+        // Elapsed deadline + quiet tick → VOLUNTARY YIELD + reschedule.
+        state.daemon_state.reconcile_due_at_ms = Some(1);
+        let t = tick(&mut state);
+        assert_eq!(t["auto_reconcile"], "yielded_to_lease");
+        assert_eq!(state.daemon_state.auto_reconcile_runs, 0, "nothing ran");
+        let rescheduled = state
+            .daemon_state
+            .reconcile_due_at_ms
+            .expect("the yield RESCHEDULES, never drops the debt");
+        assert!(rescheduled > now, "rescheduled into the future");
+        let untouched = SystemBlockStore::load(&dir).expect("load").expect("store");
+        assert_eq!(untouched.store_version, 1, "the leased store was not touched");
+
+        // The hand releases → the next elapsed quiet tick RUNS.
+        let mut store = SystemBlockStore::load(&dir).expect("load").expect("store");
+        store
+            .apply_lease(LeaseAction::Release, "hand-1", &now_iso, &until_iso)
+            .expect("release lease");
+        store.save(&dir).expect("save released store");
+        state.daemon_state.reconcile_due_at_ms = Some(1);
+        let t = tick(&mut state);
+        assert_eq!(t["auto_reconcile"], "ran_dirty");
+        assert_eq!(state.daemon_state.auto_reconcile_runs, 1);
+    }
+
+    /// RATIFIED-ONLY LAW (gardener v1, verdict item 5): reconcile refreshes the
+    /// RATIFIED store; candidate freshness is ANOTHER cycle (the candidate
+    /// re-scan), outside this arc — a candidate skeleton is skipped, debt cleared.
+    #[test]
+    fn auto_reconcile_skips_a_candidate_skeleton() {
+        use crate::system_blocks::{SeedSkeletonState, SystemBlockStore};
+        let (_temp, mut state, _repo) = build_reconcile_stage();
+        let mut store = stage_ratified_store(&state);
+        let dir = crate::system_blocks_handlers::store_dir(&state);
+        store.skeleton.state = SeedSkeletonState::Candidate;
+        store.save(&dir).expect("save candidate store");
+
+        state.daemon_state.reconcile_due_at_ms = Some(1);
+        let t = tick(&mut state);
+        assert_eq!(t["auto_reconcile"], "skeleton_not_ratified");
+        assert_eq!(state.daemon_state.auto_reconcile_runs, 0);
+        assert!(
+            state.daemon_state.reconcile_due_at_ms.is_none(),
+            "a candidate skeleton clears the debt — its freshness is another cycle"
+        );
+        let untouched = SystemBlockStore::load(&dir).expect("load").expect("store");
+        assert_eq!(untouched.store_version, 1);
+    }
+
+    /// OCC RETRY POLICY (gardener v1, verdict item 5): a Conflict earns exactly
+    /// ONE retry, then the alert — never a loop. The conflict arm is exercised
+    /// with an injected attempt (the only deterministic way: a real conflict
+    /// needs a concurrent writer), and the exhausted outcome must record the
+    /// alert on the existing daemon-alert lane.
+    #[test]
+    fn occ_conflict_gets_one_retry_then_an_alert_never_a_loop() {
+        use crate::system_blocks::SeedError;
+
+        // Conflict, conflict → exhausted after EXACTLY two attempts.
+        let mut calls = 0;
+        let out = occ_retry_outcome(|| {
+            calls += 1;
+            Err(SeedError::Conflict {
+                expected: 1,
+                actual: 2,
+            })
+        });
+        assert_eq!(out, OccOutcome::ConflictExhausted);
+        assert_eq!(calls, 2, "1 retry, never a loop");
+
+        // Conflict, then success → ran on the retry.
+        let mut calls = 0;
+        let out = occ_retry_outcome(|| {
+            calls += 1;
+            if calls == 1 {
+                Err(SeedError::Conflict {
+                    expected: 1,
+                    actual: 2,
+                })
+            } else {
+                Ok(false)
+            }
+        });
+        assert_eq!(out, OccOutcome::Ran { dirty: false });
+        assert_eq!(calls, 2);
+
+        // Immediate success → one attempt.
+        let mut calls = 0;
+        let out = occ_retry_outcome(|| {
+            calls += 1;
+            Ok(true)
+        });
+        assert_eq!(out, OccOutcome::Ran { dirty: true });
+        assert_eq!(calls, 1);
+
+        // A non-OCC failure settles immediately (fail-open, no retry).
+        let mut calls = 0;
+        let out = occ_retry_outcome(|| {
+            calls += 1;
+            Err(SeedError::NoStore)
+        });
+        assert!(matches!(out, OccOutcome::Failed(_)));
+        assert_eq!(calls, 1);
+
+        // Exhaustion RECORDS the alert on the existing lane, with the tick label.
+        let (_temp, mut state) = build_state();
+        let (label, alert_id) =
+            settle_auto_reconcile_outcome(&mut state, OccOutcome::ConflictExhausted);
+        assert_eq!(label, "conflict_alert");
+        let alert_id = alert_id.expect("the conflict alert id rides the tick totals");
+        assert!(state
+            .daemon_alerts
+            .iter()
+            .any(|a| a.alert_id == alert_id && a.kind == "auto_reconcile_conflict"));
     }
 
     /// BURST COALESCING (gardener v1, verdict item 7) — the checkout shape on the

--- a/m1nd-mcp/src/help_guidance.rs
+++ b/m1nd-mcp/src/help_guidance.rs
@@ -1327,7 +1327,7 @@ fn route_guidance(input: &HelpInput, workflow: bool) -> HelpGuidance {
                 tool: "search".into(),
                 reason: "Operations work needs system state, not just text retrieval.".into(),
             }],
-            recovery_steps: vec!["If you need continuous monitoring, move from audit to daemon_start rather than polling search.".into()],
+            recovery_steps: vec!["If you need standing freshness, arm daemon_start rather than polling search — the daemon advances when the brain is seen (verb traffic; plus watch events on a stdio owner), not as a free-running monitor.".into()],
             next_step: Some("Run audit first, then inspect daemon status and alerts.".into()),
             why: "Operations mode should start from repo or runtime health signals rather than content search.".into(),
             confidence: 0.84,

--- a/m1nd-mcp/src/project_brains.rs
+++ b/m1nd-mcp/src/project_brains.rs
@@ -1014,6 +1014,143 @@ mod eviction_gate_tests {
 }
 
 #[cfg(test)]
+mod daemon_rearm_tests {
+    //! Gardener v1 (verdict leg 2): the per-brain daemon SURVIVES the LRU
+    //! eviction gate. `insert_with_eviction` drops the whole SessionState (and
+    //! with it any live watcher) — "armed today, dead in a week, no alert".
+    //! The re-arm lives on the registry's warm-boot/resolve path: `boot_store`
+    //! → `SessionState::initialize` → `load_daemon_state` resumes `active`
+    //! (transient flags sanitized), and the next routed call's traffic tick
+    //! advances it. Lazy by construction: the resume never scans — the first
+    //! traffic tick does the inventory work, after the listener, on demand.
+    use super::*;
+    use serde_json::json;
+
+    fn write_tiny_repo(root: &Path) {
+        std::fs::create_dir_all(root.join("src")).expect("mk src");
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"tiny\"\nversion = \"0.0.0\"\n",
+        )
+        .expect("Cargo.toml");
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn tiny_probe() -> i64 { 1 }\n",
+        )
+        .expect("lib.rs");
+    }
+
+    /// eviction→rearm: arm the daemon on a hosted brain (watch_paths defaulting
+    /// to the BRAIN's ingest_roots, per the verdict), evict the brain through the
+    /// real LRU gate, re-resolve it, and prove the daemon comes back armed AND
+    /// ticks on the same transport seam the served owner uses per routed call.
+    #[test]
+    fn evicted_brains_armed_daemon_rearms_on_the_next_resolve() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Cap 1: bootstrapping a second brain MUST evict the first.
+        let reg = ProjectBrainRegistry::with_capacity(tmp.path().join("pb"), None, 1);
+
+        let root_a = tmp.path().join("repo-a");
+        write_tiny_repo(&root_a);
+        let key_a = ProjectBrainRegistry::canonical_key(&root_a.to_string_lossy());
+        let (brain_a, _ingest, reused) = reg
+            .bootstrap(&root_a.to_string_lossy(), &json!({"agent_id": "t"}))
+            .expect("bootstrap brain A");
+        assert!(!reused, "A is a fresh mint");
+
+        // ARM the daemon on brain A through the routed verb path, with EMPTY
+        // watch_paths — the verdict's per-brain default: the brain's own
+        // ingest_roots become the watch set.
+        {
+            let mut a = brain_a.lock();
+            let started = crate::server::dispatch_tool(
+                &mut a,
+                "daemon_start",
+                &json!({"agent_id": "t", "poll_interval_ms": 1}),
+            )
+            .expect("daemon_start on the hosted brain");
+            assert_eq!(started["active"], true);
+            let watched: Vec<String> = started["watch_paths"]
+                .as_array()
+                .expect("watch_paths array")
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            assert!(
+                watched.iter().any(|p| p.contains("repo-a")),
+                "empty watch_paths must default to the BRAIN's ingest_roots \
+                 (got {watched:?})"
+            );
+
+            // One REAL traffic tick before the eviction — the lived shape: an
+            // armed brain that has already advanced, then goes cold.
+            a.daemon_state.last_tick_ms = Some(0);
+            let request = crate::protocol::core::JsonRpcRequest {
+                jsonrpc: "2.0".into(),
+                id: json!(0),
+                method: "tools/call".into(),
+                params: json!({
+                    "name": "health",
+                    "arguments": { "agent_id": "t" }
+                }),
+            };
+            let response = crate::server::handle_mcp_method(&mut a, &request);
+            assert!(response.error.is_none(), "pre-evict traffic call succeeds");
+            assert!(a.daemon_state.tick_count >= 1, "A ticked before eviction");
+        }
+        drop(brain_a);
+
+        // EVICT A through the real gate: cap is 1, so bootstrapping B drops A.
+        let root_b = tmp.path().join("repo-b");
+        write_tiny_repo(&root_b);
+        reg.bootstrap(&root_b.to_string_lossy(), &json!({"agent_id": "t"}))
+            .expect("bootstrap brain B evicts A");
+        assert!(
+            reg.warm_counts(&key_a).is_none(),
+            "precondition: A was evicted from the warm map"
+        );
+
+        // RE-RESOLVE A: the daemon must come back ARMED (resume on the
+        // warm-boot path) and TICK on the next traffic.
+        let revived = reg.resolve(&key_a).expect("warm-boot A from its store");
+        let mut a = revived.lock();
+        assert!(
+            a.daemon_state.active,
+            "the armed daemon must survive eviction via its store's daemon_state"
+        );
+        assert!(
+            !a.daemon_state.tick_in_flight && !a.daemon_state.pending_rerun,
+            "transient flags are sanitized on the warm-boot resume"
+        );
+
+        // The SAME transport seam a routed call takes: handle_mcp_method's
+        // traffic autotick.
+        a.daemon_state.last_tick_ms = Some(0);
+        let before = a.daemon_state.tick_count;
+        let request = crate::protocol::core::JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: json!(1),
+            method: "tools/call".into(),
+            params: json!({
+                "name": "health",
+                "arguments": { "agent_id": "t" }
+            }),
+        };
+        let response = crate::server::handle_mcp_method(&mut a, &request);
+        assert!(response.error.is_none(), "routed call must succeed");
+        assert!(
+            a.daemon_state.tick_count > before,
+            "the revived brain's daemon must tick on traffic"
+        );
+        assert_eq!(
+            a.daemon_state.last_tick_trigger.as_deref(),
+            Some("traffic"),
+            "freshness-by-traffic: the tick trigger is the routed call"
+        );
+    }
+}
+
+#[cfg(test)]
 mod overlap_guard_tests {
     //! THE OVERLAP GUARD (field friction 2026-07-10: twin brains for one project).
     //! A brain existed for a repo; a session opened in the repo's PARENT folder and

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -4468,6 +4468,26 @@ fn build_orient_coverage(state: &SessionState, agent_id: &str) -> serde_json::Va
 // Zero duplication: McpServer::dispatch_tool() delegates to these.
 // ---------------------------------------------------------------------------
 
+/// FAIL-OPEN guard for a background VIGIL (gardener v1). Runs `vigil`, and if it
+/// errs, LOGS and SWALLOWS the failure so a watcher can never propagate its error
+/// into the agent's unrelated tool call. Returns `true` on success — surfaced so
+/// tests can pin the fail-open contract directly, and callers may branch on it.
+fn vigil_fail_open<F>(label: &str, tool: &str, vigil: F) -> bool
+where
+    F: FnOnce() -> M1ndResult<()>,
+{
+    match vigil() {
+        Ok(()) => true,
+        Err(err) => {
+            eprintln!(
+                "[m1nd] gardener: {label} failed for tool '{tool}' \
+                 (fail-open — the tool call continues): {err}"
+            );
+            false
+        }
+    }
+}
+
 /// Dispatch a tool call by name. Normalizes underscores to dots.
 /// Used by both JSON-RPC stdio and HTTP API -- zero duplication.
 ///
@@ -4584,7 +4604,16 @@ Run surgical_context_v2 (agent_id='{agent}', path='{first}') for each unproven t
             | "mission_handoff"
             | "mission_close"
     ) {
-        auto_ingest::maybe_tick_auto_ingest(state, &normalized)?;
+        // FAIL-OPEN (gardener v1). The inline auto-ingest tick is a background
+        // VIGIL, not part of the agent's request. Before, the `?` here turned a
+        // vigil failure into the agent's unrelated tool-call error. A watcher must
+        // never be able to break a tool call: run it fail-open (log + swallow). The
+        // code daemon's own tick already fails open (`run_daemon_tick` discards the
+        // handle_daemon_tick Result); this closes the matching hole for the
+        // document watcher's inline tick.
+        vigil_fail_open("auto_ingest tick", &normalized, || {
+            auto_ingest::maybe_tick_auto_ingest(state, &normalized)
+        });
     }
 
     let result = match normalized.as_str() {
@@ -6330,6 +6359,85 @@ mod tests {
         let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
             .expect("init session");
         (temp, state)
+    }
+
+    // === Gardener v1: FAIL-OPEN — a background vigil never breaks a tool call ===
+
+    /// The fail-open contract (gardener v1): a vigil that ERRORS is swallowed
+    /// (logged, reported `false`), never propagated. RED against the old `?` at the
+    /// auto-ingest tick seam — a `?` would have surfaced the error into the tool call.
+    #[test]
+    fn vigil_fail_open_swallows_a_failing_vigil() {
+        use super::vigil_fail_open;
+        let ok = vigil_fail_open("test vigil", "search", || {
+            Err(m1nd_core::error::M1ndError::CorruptState {
+                reason: "boom".into(),
+            })
+        });
+        assert!(!ok, "a failing vigil is swallowed and reports false");
+        let ok2 = vigil_fail_open("test vigil", "search", || Ok(()));
+        assert!(ok2, "a succeeding vigil reports true");
+    }
+
+    /// End-to-end through the real traffic-autotick seam: a daemon whose tick CANNOT
+    /// persist (its state path's parent is a regular file, so `save_json_atomic`
+    /// fails) must NOT turn the agent's unrelated tool call into an error. "tick com
+    /// persist quebrado → o tool call do agente SUCEDE."
+    #[test]
+    fn broken_background_tick_never_fails_the_agents_tool_call() {
+        use crate::protocol::core::JsonRpcRequest;
+        let (temp, mut state) = build_state();
+
+        // Arm the daemon (this persists once to the good path), then break its
+        // persist target so the NEXT tick's persist errors.
+        crate::daemon_handlers::handle_daemon_start(
+            &mut state,
+            crate::protocol::layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![temp.path().to_string_lossy().to_string()],
+                poll_interval_ms: 1,
+            },
+        )
+        .expect("daemon start");
+
+        let poison_file = temp.path().join("poison");
+        std::fs::write(&poison_file, b"i am a file, not a dir").expect("write poison file");
+        // A path whose PARENT is a regular file → create_dir_all fails → persist Err.
+        state.daemon_state_path = poison_file.join("daemon_state.json");
+        // Force the traffic autotick to be due.
+        state.daemon_state.last_tick_ms = Some(0);
+
+        // Sanity: the poisoned persist really does error now.
+        assert!(
+            state.persist_daemon_state().is_err(),
+            "precondition: the poisoned daemon_state_path must make persist fail"
+        );
+
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: serde_json::json!(1),
+            method: "tools/call".into(),
+            params: serde_json::json!({
+                "name": "health",
+                "arguments": { "agent_id": "test" }
+            }),
+        };
+        let response = super::handle_mcp_method(&mut state, &request);
+        assert!(
+            response.error.is_none(),
+            "a broken background tick must not surface a JSON-RPC error: {:?}",
+            response.error
+        );
+        let is_error = response
+            .result
+            .as_ref()
+            .and_then(|r| r.get("isError"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        assert!(
+            !is_error,
+            "the agent's tool call must SUCCEED despite the failing background vigil"
+        );
     }
 
     #[test]

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -6109,6 +6109,14 @@ impl McpServer {
                     let coalesced_at_ms = now_ms();
                     self.state.daemon_state.last_watch_event_ms = Some(coalesced_at_ms);
                     loop {
+                        // BURST CAP (gardener v1): the sliding silence window
+                        // alone can starve under continuous churn — bound one
+                        // coalescing pass so the tick runs even during a storm.
+                        if now_ms().saturating_sub(coalesced_at_ms)
+                            >= crate::daemon_handlers::BURST_COALESCE_CAP_MS
+                        {
+                            break;
+                        }
                         match rx.recv_timeout(Duration::from_millis(
                             self.state.daemon_state.coalesce_window_ms.max(1),
                         )) {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -2324,7 +2324,7 @@ fn all_tool_schemas_inner() -> serde_json::Value {
             },
             {
                 "name": "daemon_start",
-                "description": "Start persisted daemon state and store watched paths for continuous structural monitoring.",
+                "description": "Arm the per-brain code daemon: persist watched paths and advance freshness when seen — ticks ride verb traffic (and, on a stdio owner, watch events / the idle clock); this is not a free-running monitor.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -6516,7 +6516,10 @@ mod tests {
             "precondition: the post-traffic-tick disk carries the in-flight flag \
              (this is the exact shape a restart resumes from)"
         );
-        assert_eq!(disk["active"], true, "precondition: the daemon is armed on disk");
+        assert_eq!(
+            disk["active"], true,
+            "precondition: the daemon is armed on disk"
+        );
         drop(state);
 
         // RESTART: a fresh SessionState over the SAME runtime dir.
@@ -6535,7 +6538,10 @@ mod tests {
         resumed.daemon_state.last_tick_ms = Some(0);
         let before = resumed.daemon_state.tick_count;
         let response = super::handle_mcp_method(&mut resumed, &health_call);
-        assert!(response.error.is_none(), "post-restart traffic call must succeed");
+        assert!(
+            response.error.is_none(),
+            "post-restart traffic call must succeed"
+        );
         assert!(
             resumed.daemon_state.tick_count > before,
             "the resumed daemon must tick on traffic — a wedged resume is the bug"

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -6440,6 +6440,105 @@ mod tests {
         );
     }
 
+    // === Gardener v1: RESTART RESUME — an armed daemon survives a boot and ticks ===
+
+    /// The resume law (gardener v1): `active` survives a restart, and the daemon
+    /// actually TICKS again on the first traffic. RED without the load-time
+    /// sanitization: every traffic tick persists MID-tick, so the disk carries
+    /// `tick_in_flight: true` (proven below as a precondition) — a verbatim resume
+    /// wedges `run_daemon_tick` forever (it sees a phantom in-flight tick and
+    /// refuses every new one).
+    #[test]
+    fn armed_daemon_resumes_across_restart_and_ticks_again() {
+        use crate::protocol::core::JsonRpcRequest;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        std::fs::write(repo.join("core.py"), "def core():\n    return 1\n").expect("seed file");
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            registry_dir: Some(runtime_dir.join("registry")),
+            runtime_dir: Some(runtime_dir.clone()),
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        crate::daemon_handlers::handle_daemon_start(
+            &mut state,
+            crate::protocol::layers::DaemonStartInput {
+                agent_id: "test".into(),
+                watch_paths: vec![repo.to_string_lossy().to_string()],
+                poll_interval_ms: 1,
+            },
+        )
+        .expect("daemon start");
+
+        // One REAL traffic tick through the transport seam (handle_mcp_method →
+        // run_daemon_tick), exactly what a served owner does per routed call.
+        state.daemon_state.last_tick_ms = Some(0);
+        let health_call = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: serde_json::json!(1),
+            method: "tools/call".into(),
+            params: serde_json::json!({
+                "name": "health",
+                "arguments": { "agent_id": "test" }
+            }),
+        };
+        let response = super::handle_mcp_method(&mut state, &health_call);
+        assert!(response.error.is_none(), "traffic call must succeed");
+        assert!(
+            state.daemon_state.tick_count >= 1,
+            "the traffic autotick must have run at least one tick"
+        );
+
+        // THE WEDGE SHAPE, pinned as a precondition: the tick persisted itself
+        // while `tick_in_flight` was true, so that is what the disk carries.
+        let disk: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(runtime_dir.join("daemon_state.json"))
+                .expect("read persisted daemon state"),
+        )
+        .expect("parse persisted daemon state");
+        assert_eq!(
+            disk["tick_in_flight"], true,
+            "precondition: the post-traffic-tick disk carries the in-flight flag \
+             (this is the exact shape a restart resumes from)"
+        );
+        assert_eq!(disk["active"], true, "precondition: the daemon is armed on disk");
+        drop(state);
+
+        // RESTART: a fresh SessionState over the SAME runtime dir.
+        let mut resumed = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("re-init session");
+        assert!(
+            resumed.daemon_state.active,
+            "the armed daemon must resume active across a restart"
+        );
+        assert!(
+            !resumed.daemon_state.tick_in_flight && !resumed.daemon_state.pending_rerun,
+            "transient reentrancy flags must be sanitized on load"
+        );
+
+        // And it TICKS again on the first traffic (RED: wedged without the fix).
+        resumed.daemon_state.last_tick_ms = Some(0);
+        let before = resumed.daemon_state.tick_count;
+        let response = super::handle_mcp_method(&mut resumed, &health_call);
+        assert!(response.error.is_none(), "post-restart traffic call must succeed");
+        assert!(
+            resumed.daemon_state.tick_count > before,
+            "the resumed daemon must tick on traffic — a wedged resume is the bug"
+        );
+        assert_eq!(
+            resumed.daemon_state.last_tick_trigger.as_deref(),
+            Some("traffic"),
+            "the resumed tick is the traffic tick (freshness-by-traffic, v1)"
+        );
+    }
+
     #[test]
     fn read_only_deny_list_is_precise() {
         use super::read_only_denied;

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -1918,10 +1918,35 @@ impl SessionState {
     }
 
     fn load_daemon_state(path: &Path) -> DaemonRuntimeState {
-        std::fs::read_to_string(path)
+        let mut state = std::fs::read_to_string(path)
             .ok()
             .and_then(|s| serde_json::from_str::<DaemonRuntimeState>(&s).ok())
-            .unwrap_or_default()
+            .unwrap_or_default();
+        // RESUME SANITIZATION (gardener v1). `active` legitimately survives a
+        // boot — an armed daemon stays armed across restart AND across an LRU
+        // eviction re-resolve (the per-brain opt-in is this file in the brain's
+        // own store dir). But two kinds of field describe the RUNTIME, not the
+        // config, and resuming them verbatim breaks the resume:
+        //  - `tick_in_flight`/`pending_rerun` are in-process reentrancy flags.
+        //    Every traffic tick persists MID-tick (while `tick_in_flight` is
+        //    true) and the post-tick `false` lives only in memory, so the disk
+        //    almost always carries `tick_in_flight: true`. Resuming it verbatim
+        //    WEDGES the daemon forever: `run_daemon_tick` sees a tick "in
+        //    flight" that died with the old process and refuses every new tick.
+        //  - `watch_backend == "native_fs"` asserts a LIVE notify watcher. Only
+        //    the stdio serve() loop owns one (`refresh_daemon_watcher`); a
+        //    freshly booted state has none, and on the HTTP owner none will
+        //    ever exist — resuming the label verbatim makes `daemon_status`
+        //    LIE about an event consumer. Downgrade to the honest "polling";
+        //    the stdio loop re-arms and restores the label only when a real
+        //    watcher starts. (`git_native_fs` survives: it names the per-tick
+        //    git-diff detection, true on every transport.)
+        state.tick_in_flight = false;
+        state.pending_rerun = false;
+        if state.watch_backend == "native_fs" {
+            state.watch_backend = "polling".into();
+        }
+        state
     }
 
     pub fn persist_daemon_alerts(&self) -> M1ndResult<()> {

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -192,6 +192,19 @@ pub struct DaemonRuntimeState {
     pub git_operation_in_progress: bool,
     pub git_operation_kind: Option<String>,
     pub deferred_ticks: u64,
+    /// Gardener v1 — BURST BACKLOG. External ids detected as changed but not yet
+    /// re-ingested (a burst bigger than one tick's `max_files` budget). The tick
+    /// detects ONCE (one git diff / inventory compare per burst), pushes the whole
+    /// changed set here, advances `git_since_ref` immediately (the backlog owns
+    /// the tail), and drains up to `max_files` per tick — so a thousand-file
+    /// checkout is ONE detection plus bounded drain ticks, and NO file is lost to
+    /// the old truncate-then-advance hole. FIFO drain: completeness over recency
+    /// (no starvation; a single burst lands in one detection anyway, newest-first
+    /// within the batch). `serde(default)`: pre-gardener daemon_state.json files
+    /// lack this field and must keep deserializing (a failed parse would fall
+    /// back to Default and silently DISARM a resumed daemon).
+    #[serde(default)]
+    pub pending_backlog: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -205,6 +205,18 @@ pub struct DaemonRuntimeState {
     /// back to Default and silently DISARM a resumed daemon).
     #[serde(default)]
     pub pending_backlog: Vec<String>,
+    /// Gardener v1 — AUTO-RECONCILE quiet-window deadline. Set (and PUSHED) by
+    /// every tick that saw activity; when a quiet tick passes it with an empty
+    /// backlog, the daemon reconciles the RATIFIED system-blocks store (with
+    /// voluntary lease yield and a 1-retry OCC policy). `None` = nothing owed.
+    #[serde(default)]
+    pub reconcile_due_at_ms: Option<u64>,
+    /// When the last auto-reconcile actually ran (status honesty).
+    #[serde(default)]
+    pub last_auto_reconcile_ms: Option<u64>,
+    /// How many auto-reconciles this daemon has run since it was armed.
+    #[serde(default)]
+    pub auto_reconcile_runs: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/m1nd-mcp/src/system_blocks.rs
+++ b/m1nd-mcp/src/system_blocks.rs
@@ -1390,7 +1390,9 @@ impl SystemBlockStore {
     /// Whether a live (unexpired) lease is currently held. A lease with a missing or
     /// past `curating_until` is NOT live — it is reclaimable (o4: no dead-agent trap).
     /// Comparison is lexical over fixed-width RFC3339-UTC stamps (as elsewhere).
-    fn lease_is_live(&self, now_iso: &str) -> bool {
+    /// `pub(crate)`: the gardener's auto-reconcile YIELDS voluntarily to a live
+    /// lease (the lease is advisory by ratified law — it never blocks; WE cede).
+    pub(crate) fn lease_is_live(&self, now_iso: &str) -> bool {
         self.curating_by.is_some()
             && self
                 .curating_until

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -512,7 +512,7 @@ source reads, tests, runtime probes, or CI evidence.
   anchors until direct source/test/runtime proof confirms them.
 - Need stateful navigation instead of stateless retrieval: use `perspective_*`.
 - Need session continuity or handoff: use `trail_save`, `trail_list`, `trail_resume`, `trail_merge`, and sometimes `boot_memory`.
-- Need background structural monitoring: use `daemon_start`, `daemon_status`, `daemon_tick`, `alerts_list`, and `alerts_ack`.
+- Need standing structural freshness: use `daemon_start` (per-brain opt-in; advances when the brain is seen — verb traffic — never a free-running monitor), `daemon_status`, `daemon_tick`, `alerts_list`, and `alerts_ack`.
 - Need to persist a durable finding across sessions: use `memorize` with `evidence` paths pointing at the relevant code; ingest that code first so evidence anchors. Use `mission_close(write_light_memory:true)` for one-step mission + memory commit.
 - Need to check whether memorized claims still cite current code: use `cross_verify(check:["evidence_freshness"])`; returns `stale_evidence[]` + count.
 - Need to know how much to trust the project's PATHOS handoff (near a PR / doc-gate): use `soul_check` — it parses `docs/PATHOS.md` into anchored claims and returns the freshness receipt (N fresh · M stale · K priced @sha), with declared tissue counted but never fake-verified. `soul_read` pulls the body. The curator is a workflow: sweep → verify → `memorize {soul_source}` → prune-never-silently → re-check; its report is seat-verified by a DIFFERENT agent via `soul_check {verify_curator_report}` (§C8.4).

--- a/skills/m1nd-operator/references/tool-families.md
+++ b/skills/m1nd-operator/references/tool-families.md
@@ -185,7 +185,7 @@ Use this before acting as if the current repo is the whole system.
 - `lock_diff`: compare current state with the lock baseline.
 - `lock_rebase`: accept current state as the new baseline.
 - `lock_release`: free the lock.
-- `daemon_start`: start long-lived structural monitoring.
+- `daemon_start`: arm per-brain change tracking (opt-in, default OFF; freshness advances when the brain is seen — verb traffic, plus watch events on a stdio owner — not a free-running monitor).
 - `daemon_stop`: stop monitoring without deleting alert history.
 - `daemon_status`: inspect monitor liveness and counters.
 - `daemon_tick`: force one reconciliation pass.


### PR DESCRIPTION
## What

The Gardener arc v1, oracle-confronted (verdict versioned as `docs/voice/ASKGOD-VERDICT-GARDENER.md` — its ten corrections are this PR's law). The organism stops being honest-but-sedentary: freshness moves by traffic ("when seen", literally), sovereignty untouched.

- **Fail-open first**: the inline vigil `?` that let a watcher error break an agent's UNRELATED tool call is gone (`vigil_fail_open`); every background-vigil path audited. RED-proven (3 tests).
- **The code leg is the per-brain DAEMON** (the oracle proved auto_ingest is a documents watcher — code files are literally "ignored"): durable per-brain opt-in (**factory default OFF**, cost-justified below), watch = the brain's ingest_roots, resume on the registry's warm-boot/resolve path — survives restart AND LRU eviction (both RED-proven). Fixed a real pre-existing wedge: `tick_in_flight:true` persisted mid-tick blocked every resume.
- **Burst coalescing**: 500ms window, 5s cap, persisted FIFO backlog — a branch checkout's thousands of events become one detection; fixed the pre-existing truncate-then-advance that LOST the tail on the git backend.
- **Auto-reconcile that yields**: runs after a tick that re-ingested files, 45s activity-pushed quiet window, **voluntarily yields to an active candidate_lease** (the lease is advisory by ratified law — our code chooses to wait), fresh OCC, 1 retry then an alert — never a loop. Stated plainly: reconcile refreshes the ratified STORE; candidate freshness is a different cycle.
- **Honesty everywhere**: a resurrected `native_fs` degrades to `polling` truthfully; "continuous monitoring" purged from schema/help/wiki/skills — freshness is measured, never presumed. auto_ingest guard: it can never demote a hosted brain's manifest-bound workspace root (the #326 class).

## Cost (measured, release)

35.7ms/file (N=10) · 36.7 (N=100) · 59.6 (N=1000; detection 8.7s, drain 59.6s/31 ticks). This is why the factory default is OFF and arming is per-brain opt-in.

## Proof

`cargo test -p m1nd-mcp` **1089/0** · fmt/clippy `-D warnings` clean · agent-docs gate PASS · no-leak clean · named tests: fail-open ×3, restart-resume, eviction→rearm, burst coalesce, lease yield, OCC retry→alert, HTTP status honesty, backcompat, guard, bench. Divergences recorded in `docs/voice/GARDENER-DIVERGENCES.md`.