### PR TITLE
fix(ingest): the workspace_root flip — the #326 family's 3rd member

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,13 @@ bound brain because the writer never checked which brain it was talking to.
    exactly why. It holds on BOTH doors — the MCP wire and REST `POST /api/tools/ingest` route
    through one guarded core. A burst worktree does NOT get its own brain; bind to the main
    repo's. This stops one repo growing two brains (double ingest cost, memories fragmented).
+3. **Memory writes never move your code root.** `memorize` (and any agent-memory ingest
+   merge) can no longer demote a brain's `workspace_root` onto its own memory-store dir —
+   the write path guards it (the #326 family, third member), and a brain found already
+   flipped self-heals at the boot/load seam with an honest log line
+   (`healed workspace_root: <from> -> <to>`). If you ever see a bare-REST
+   `caller_root_mismatch` naming an `agent-memory` dir as the bound workspace, that is this
+   disease on a pre-fix binary — rebuild/restart heals it; never hand-edit the manifest.
 
 Editing the block map (the skeleton) is one atomic verb, `candidate_edit`, and it refuses on
 a ratified skeleton (candidate-only). **Ratifying a skeleton is a human-only gesture — no

--- a/m1nd-mcp/src/light_author_handlers.rs
+++ b/m1nd-mcp/src/light_author_handlers.rs
@@ -1135,6 +1135,95 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Test 2b (#326 family, 3rd member): the memorize / agent-memory merge must
+    // NEVER demote a real code `workspace_root` onto the memory store dir. RED
+    // before the `handle_ingest` guard: memorize writes
+    // `<runtime>/agent-memory/<slug>.light.md`, ingests it, and the ingest wrote
+    // `workspace_root = <runtime>/agent-memory`, flipping the brain's code root
+    // onto its own memory sidecar (the field-reported production flip).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn memorize_never_demotes_workspace_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let proj = temp.path().join("proj");
+        std::fs::create_dir_all(&proj).expect("proj dir");
+        std::fs::write(proj.join("auth.rs"), "pub fn f() -> bool { true }\n").expect("write");
+
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        // Bind the brain to its real code root via a code ingest.
+        let code_ingest = IngestInput {
+            path: proj.to_string_lossy().to_string(),
+            agent_id: "test".into(),
+            incremental: false,
+            adapter: "code".into(),
+            mode: "replace".into(),
+            namespace: None,
+            include_dotfiles: false,
+            dotfile_patterns: vec![],
+            project_root: None,
+        };
+        crate::tools::handle_ingest(&mut state, code_ingest).expect("code ingest");
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(proj.to_string_lossy().as_ref()),
+            "precondition: the code ingest binds workspace_root to the code root"
+        );
+
+        // memorize: writes an agent-memory sidecar and ingests it (the flip path).
+        let input = LightAuthorInput {
+            agent_id: "test".into(),
+            node_label: "Notes".into(),
+            title: None,
+            state: None,
+            claims: vec![LightClaim {
+                label: "Fact".into(),
+                text: Some("A durable fact.".into()),
+                kind: Some("entity".into()),
+                confidence: Some("0.9".into()),
+                ambiguity: None,
+                evidence: vec![],
+                depends_on: vec![],
+            }],
+            output_path: None,
+            namespace: None,
+            ingest_after: true,
+            mode: "merge".into(),
+            supersedes: None,
+            origin_brain: None,
+            origin_claim: None,
+            promoted_by: None,
+            promotion_reason: None,
+            promoted_to: None,
+            evidence_unverifiable: false,
+            soul_source: None,
+        };
+        handle_light_author(&mut state, input).expect("memorize ok");
+
+        // The core assertion: workspace_root still points at the code root, NOT the
+        // agent-memory store dir it was demoted to before the fix.
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(proj.to_string_lossy().as_ref()),
+            "memorize must not demote the code workspace_root onto the memory store dir"
+        );
+        assert!(
+            !crate::session::is_memory_sidecar(state.workspace_root.as_deref().unwrap()),
+            "workspace_root must never be a memory sidecar after memorize"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Test 3: provenance frontmatter (Created + Source-Agent) is stamped
     // -----------------------------------------------------------------------
     #[test]

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -1044,6 +1044,40 @@ impl SessionState {
         None
     }
 
+    /// #326-family auto-heal (load/resolve seam). A prior memorize / agent-memory
+    /// merge could DEMOTE `workspace_root` onto the `agent-memory` store dir (the
+    /// write-path bug fixed in `handle_ingest`); brains already carrying that
+    /// flipped state on disk answer the REST seam with a store-dir workspace_root,
+    /// so every `caller_root` comparison mis-matches. When `workspace_root` is a
+    /// memory sidecar BUT a real code root is still resolvable from the ingest
+    /// roots, repair it to the code root with one honest log line. Idempotent and
+    /// self-limiting: a no-op when `workspace_root` is already a code root or when
+    /// no code root is resolvable (a genuine pure-memory / medulla store keeps its
+    /// sidecar workspace_root). This de-flips the corrupted bound owner on its next
+    /// boot without any manual data surgery.
+    pub fn heal_workspace_root(&mut self) {
+        let flipped = self
+            .workspace_root
+            .as_deref()
+            .map(is_memory_sidecar)
+            .unwrap_or(false);
+        if !flipped {
+            return;
+        }
+        // `code_root_path` never returns a sidecar: in the flipped state it falls
+        // through to the first non-sidecar ingest root that is a real directory.
+        if let Some(code_root) = self.code_root_path() {
+            if self.workspace_root.as_deref() != Some(code_root.as_str()) {
+                let from = self.workspace_root.clone().unwrap_or_default();
+                eprintln!(
+                    "[m1nd] healed workspace_root: {} -> {} (the #326 family)",
+                    from, code_root
+                );
+                self.workspace_root = Some(code_root);
+            }
+        }
+    }
+
     /// True when THIS store is the medulla — the owner's own memory-of-doctrine
     /// store, not a per-project brain (MEDULLA-PRD §4.1: the tier IS the directory).
     ///
@@ -1664,7 +1698,7 @@ impl SessionState {
         let _ = crate::instance_registry::spawn_boot_gc(instance.registry_root());
         let ingest_roots = Self::load_ingest_roots(&config.graph_source);
 
-        Ok(Self {
+        let mut state = Self {
             graph: shared,
             domain,
             orchestrator,
@@ -1756,7 +1790,13 @@ impl SessionState {
             agent_memory_boot: None,
             read_only: config.read_only,
             read_only_persist_logged: std::cell::Cell::new(false),
-        })
+        };
+        // #326-family auto-heal at the boot/load seam: if a prior memorize left
+        // `workspace_root` demoted onto the agent-memory store dir while a real code
+        // root survives in the ingest roots, repair it before the session serves a
+        // single request (de-flips the corrupted bound owner on its next boot).
+        state.heal_workspace_root();
+        Ok(state)
     }
 
     /// Check if auto-persist should trigger. Returns true every N queries.
@@ -2589,6 +2629,115 @@ mod tests {
         state.ingest_roots = vec![];
         state.workspace_root = Some("/Users/x/solo-repo".to_string());
         assert_eq!(state.display_name().as_deref(), Some("solo-repo"));
+    }
+
+    // #326-family auto-heal: a brain whose workspace_root was demoted onto its
+    // agent-memory store dir (the field-reported bound-owner flip) is repaired to
+    // the real code root when one survives in the ingest roots.
+    #[test]
+    fn heal_workspace_root_undemotes_flipped_bound_brain() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let code_root = temp.path().join("m1nd");
+        std::fs::create_dir_all(&code_root).expect("code root");
+        let agent_memory = temp
+            .path()
+            .join("runtimes")
+            .join("claude")
+            .join("agent-memory");
+        std::fs::create_dir_all(&agent_memory).expect("agent-memory dir");
+
+        let config = McpConfig {
+            graph_source: temp.path().join("graph.json"),
+            plasticity_state: temp.path().join("plasticity.json"),
+            runtime_dir: Some(temp.path().to_path_buf()),
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("initialize session");
+
+        // Arrange the flipped production state: workspace_root = the store dir,
+        // the real code root still present among the ingest roots.
+        state.workspace_root = Some(agent_memory.to_string_lossy().to_string());
+        state.ingest_roots = vec![
+            code_root.to_string_lossy().to_string(),
+            agent_memory.to_string_lossy().to_string(),
+        ];
+
+        state.heal_workspace_root();
+
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(code_root.to_string_lossy().as_ref()),
+            "the flipped workspace_root must be healed back to the code root"
+        );
+    }
+
+    // The heal is self-limiting: a genuine pure-memory / medulla store (no code
+    // root in its ingest roots) keeps its sidecar workspace_root untouched.
+    #[test]
+    fn heal_workspace_root_is_noop_without_a_code_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let agent_memory = temp.path().join("agent-memory");
+        std::fs::create_dir_all(&agent_memory).expect("agent-memory dir");
+
+        let config = McpConfig {
+            graph_source: temp.path().join("graph.json"),
+            plasticity_state: temp.path().join("plasticity.json"),
+            runtime_dir: Some(temp.path().to_path_buf()),
+            ..McpConfig::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("initialize session");
+        state.workspace_root = Some(agent_memory.to_string_lossy().to_string());
+        state.ingest_roots = vec![agent_memory.to_string_lossy().to_string()];
+
+        state.heal_workspace_root();
+
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(agent_memory.to_string_lossy().as_ref()),
+            "a pure-memory store with no code root keeps its sidecar workspace_root"
+        );
+    }
+
+    // The heal is wired into the boot/load seam: a brain that boots with a
+    // store-dir workspace_root (graph under `agent-memory`) but whose persisted
+    // ingest_roots carry a real code root is healed by `initialize` itself,
+    // de-flipping the corrupted bound owner on its next boot.
+    #[test]
+    fn initialize_heals_flipped_workspace_root_from_ingest_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let code_root = temp.path().join("m1nd");
+        std::fs::create_dir_all(&code_root).expect("code root");
+        // The graph lives inside the agent-memory store dir, so the boot-time
+        // inference sets workspace_root to that sidecar (the flipped shape).
+        let agent_memory = temp.path().join("agent-memory");
+        std::fs::create_dir_all(&agent_memory).expect("agent-memory dir");
+        // Persist ingest_roots beside the graph (what `load_ingest_roots` reads).
+        std::fs::write(
+            agent_memory.join("ingest_roots.json"),
+            serde_json::to_string(&vec![
+                code_root.to_string_lossy().to_string(),
+                agent_memory.to_string_lossy().to_string(),
+            ])
+            .expect("serialize roots"),
+        )
+        .expect("write ingest_roots.json");
+
+        let config = McpConfig {
+            graph_source: agent_memory.join("graph.json"),
+            plasticity_state: agent_memory.join("plasticity.json"),
+            runtime_dir: Some(agent_memory.clone()),
+            ..McpConfig::default()
+        };
+        let state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("initialize session");
+
+        assert_eq!(
+            state.workspace_root.as_deref(),
+            Some(code_root.to_string_lossy().as_ref()),
+            "initialize must heal the store-dir workspace_root to the code root at boot"
+        );
     }
 
     #[test]

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -853,7 +853,7 @@ fn finalize_ingest(
         }
     }
     let input_path = std::path::Path::new(&input.path);
-    state.workspace_root = Some(if input_path.is_dir() {
+    let candidate_workspace_root = if input_path.is_dir() {
         input.path.clone()
     } else {
         input_path
@@ -861,7 +861,27 @@ fn finalize_ingest(
             .unwrap_or_else(|| std::path::Path::new("."))
             .to_string_lossy()
             .to_string()
-    });
+    };
+    // #326 family (3rd member — the memorize / agent-memory merge path): a
+    // `memorize` writes `<runtime>/agent-memory/<slug>.light.md` and then ingests
+    // it here (adapter=light, mode=merge). The candidate workspace_root above then
+    // resolves to the `agent-memory` STORE dir — and blindly assigning it DEMOTES a
+    // real code `workspace_root` onto the memory sidecar, exactly the store-dir /
+    // code-root confusion #326 named and the #355 `auto_ingest` guard already
+    // fenced off. Mirror that guard: a memory-store ingest NEVER rebases a code (or
+    // manifest-bound) workspace_root onto the sidecar. A store with no code root
+    // yet (a fresh pure-memory / medulla bootstrap) still adopts the candidate, so
+    // nothing regresses.
+    let demotes_to_store = crate::session::is_memory_sidecar(&candidate_workspace_root);
+    let holds_code_root = state
+        .workspace_root
+        .as_deref()
+        .map(|ws| !crate::session::is_memory_sidecar(ws))
+        .unwrap_or(false);
+    let manifest_bound = state.workspace_root_source.as_deref() == Some("project_brain_manifest");
+    if !(demotes_to_store && (holds_code_root || manifest_bound)) {
+        state.workspace_root = Some(candidate_workspace_root);
+    }
 
     if let Err(e) = state.persist() {
         eprintln!("[m1nd] auto-persist after ingest failed: {}", e);


### PR DESCRIPTION
## What

Two independent field reports, one disease: after `memorize` (agent-memory ingest merge), a brain's `workspace_root` flipped to its own memory-store dir — the live served owner has been answering `caller_root_mismatch` on the bare REST seam since.

**Root cause** (`tools.rs:855-864`): `handle_ingest` set `state.workspace_root` to the ingested path's parent **unconditionally**. `memorize` ingests `<runtime>/agent-memory/<slug>.light.md`, so that parent is the STORE dir — demoting the code root. The `ingest_roots` logic two lines above already special-cased this exact sprawl; the `workspace_root` write ignored it.

**Fix (2 lines):** a memory-store ingest never rebases a code/manifest-bound root (mirrors the #355 auto_ingest guard). Fresh pure-memory stores still bootstrap.

**Auto-heal:** `SessionState::heal_workspace_root()` wired into the boot/load seam — a sidecar-flipped root with a resolvable code root in `ingest_roots` repairs itself, logging honestly: `healed workspace_root: <from> -> <to> (the #326 family)`. The corrupted live owner de-flips on its next boot with this binary.

## Proof

RED-first: `memorize_never_demotes_workspace_root` reproduced the flip before the fix, green after. Suite **1093/0** including the #352 (`file_view_brain_root`) and #355 (auto_ingest guard) family harnesses. fmt/clippy `-D warnings` clean · no-leak clean.

Ran INSIDE the organism: charter `msn_…fixt` (bug_hunt) — `mission_event` + `mission_close` accepted, honest gap recorded (the running owner stays flipped until rebuilt; the heal covers it at boot).