### PR TITLE
presences: the P1 server — sidecar, collision law, cockpit 8th slot, /api/presences

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -49,6 +49,39 @@ same bar, applied to building the organism outward.
 
 ## Current State (2026-07-12, checkpoint 18 — the voice; dated blocks below are the era log)
 
+> **2026-07-13 — ORGANISM-INSIDE P1 "PRESENCES" (server lane): the control room can see the team.**
+> The P1-SERVER lane of the presences arc (askGOD verdict 2026-07-13 APPROVE, binding changes 1–3
+> BINDING — `docs/voice/ASKGOD-VERDICT-P1.md`). What landed on `feat/p1-presences-server`: a NEW
+> module `presence.rs` — durable session-presence sidecars (`m1nd-presence-v0`) molded on
+> `instance_registry` (files in the shared registry dir, minutes-scale TTL, `is_stale` filtered at
+> read so a dead presence DISAPPEARS rather than lying, boot-GC reclaims orphan sidecars after an
+> owner restart). The BEAT is a THROTTLED, fail-open hook inside `track_agent` (session.rs:2235 —
+> the single choke point all four dispatch seams funnel through; ~1 disk write per 5s per session,
+> forced promptly only when a signal changes). Enrichment is measured or declared, never invented:
+> `brain`/`caller_root` from the session's own binding, `task_ref` MEASURED from the agent's own
+> open `mission_start` charter (`mission_handlers::latest_open_mission_for`), and the DECLARED
+> fields (`kind`/`theme`/`intent`/`worktree`/`working_set`) ride NEW optional `session_handshake`
+> fields. The OBSERVED mutation level is stamped in `dispatch_tool` off the single `read_only_denied`
+> classifier. **Collision is DERIVED at read, never materialized**, with the verdict's exact
+> predicate: SAME brain AND (same caller_root/worktree OR working-set overlap) AND BOTH mutating —
+> same-brain alone NEVER warns (three executors in isolated worktrees is the normal burst shape, and
+> the anti-test pins it). **Surfaces:** the cockpit gains its **8th collection** `presences` (ONE
+> root line — the collision warning rides the LABEL, no new schema field — with a capped in-place
+> drill scoped and labeled "this brain"); `north` gains ONE collision honest-gap on the EXISTING
+> `honest_gaps` mechanism, present only on a real collision, derived per-agent so it lands on BOTH
+> colliding sessions' packets; `/api/health` exposes an owner-wide roster + collisions to feed the
+> Hall (m1nd-ui lane). **Budgets RE-PINNED and now MECHANICALLY enforced** by the new battery
+> `cockpit_budget_holds_with_the_eighth_slot` (`chars/4`, worst-case loud fixture): cockpit root
+> ~574 tokens, presences-drill ~567 (the new largest drill), both ≤800; north unchanged (the gap
+> line is present only on collision). **The written LIMITATION** (the verdict's flagged inverse-TTL
+> lie): *presence == activity VISIBLE TO m1nd* — an executor compiling for 20 min makes no calls and
+> expires from the roster; the roster answers "who is talking to m1nd, on what, since when", never
+> "who is alive". Proven: `cargo test -p m1nd-mcp` lib **870/0** (9 presence + the cockpit budget/8th-slot
+> tests among them), `fmt --check` clean, `clippy --all-targets -D warnings` clean. Presence is
+> WITNESS TISSUE — it gates nothing, ratifies nothing, lands nothing (laws 5, 10 hold). Lanes kept
+> apart: no m1nd-ui/ touch, no G1 tick region, no rootfix territory. Next (other lanes): the Hall
+> strip (P1-UI, gate-material) + the live two-session collision gate on the served owner.
+
 > **2026-07-12 — THE ORGANISM FROM INSIDE + 360 arc RATIFIED (§C11-style amendment); P0 "WEAR THE WIRE" in flight.**
 > A new off-§C10 front, opened by the owner's order and ratified the same day (verbatim:
 > *"MUITO BEM! ratificado bora pra frente"*) — registered here as the ladder ritual demands,

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -69,8 +69,11 @@ same bar, applied to building the organism outward.
 > root line — the collision warning rides the LABEL, no new schema field — with a capped in-place
 > drill scoped and labeled "this brain"); `north` gains ONE collision honest-gap on the EXISTING
 > `honest_gaps` mechanism, present only on a real collision, derived per-agent so it lands on BOTH
-> colliding sessions' packets; `/api/health` exposes an owner-wide roster + collisions to feed the
-> Hall (m1nd-ui lane). **Budgets RE-PINNED and now MECHANICALLY enforced** by the new battery
+> colliding sessions' packets; and the Hall's CONTRACT endpoint **`GET /api/presences?brain=`**
+> (`m1nd-ui docs/voice/P1-UI-CONTRACT.md`) serves `{presences, collisions, served_brain?}` — absent
+> `brain` = owner-wide (the Hall's scope), present = that brain + the §4A.9.4 echo, unknown = honest
+> 404; `collisions` always present (server-authoritative); `/api/health` keeps an owner-wide
+> diagnostic block beside `agent_sessions`. **Budgets RE-PINNED and now MECHANICALLY enforced** by the new battery
 > `cockpit_budget_holds_with_the_eighth_slot` (`chars/4`, worst-case loud fixture): cockpit root
 > ~574 tokens, presences-drill ~567 (the new largest drill), both ≤800; north unchanged (the gap
 > line is present only on collision). **The written LIMITATION** (the verdict's flagged inverse-TTL

--- a/docs/UML-ORGANISM.md
+++ b/docs/UML-ORGANISM.md
@@ -106,7 +106,8 @@ These cross every system; no sheet may invent a fifth word for any of them.
 | [cli-operator](uml/cli-operator.md) | npm CLI, restart --binary, release parity | flow·seq·state | macOS reload trio (codesign/kickstart/kill) has zero tests — ledger |
 | [host-integration](uml/host-integration.md) | 22-host matrix, shim, hosts apply, ambient wave | flow·seq | Pre-orient half real; the whole ambient/R12 wave is PRD-only — ledger |
 | [scan-loading](uml/scan-loading.md) | The held `skeleton_candidate` scan wait: client state machine + SSE phase narration + honest abort | seq·state | Real events only — no fabricated %; the owner narrates phases on the existing SSE, degrades clean when silent (slice 2 shipped) |
-| [cockpit](uml/cockpit.md) | The navigable read-only menu verb (`m1nd-cockpit-v0`): seven stable slots, drill, derived deny-filter, `menu_sig` | class·seq | north's on-request sibling — breaks alone; a router in v1 (presents the read, never fabricates a receipt); per-item drill deferred by the verdict |
+| [cockpit](uml/cockpit.md) | The navigable read-only menu verb (`m1nd-cockpit-v0`): eight stable slots (P1 added `presences`), drill, derived deny-filter, `menu_sig` | class·seq | north's on-request sibling — breaks alone; a router in v1 (presents the read, never fabricates a receipt); slot 8 = the P1 control-room roster (this brain, collision on the label) |
+| [presences](uml/presences.md) | Durable session-presence sidecars (`m1nd-presence-v0`): the throttled beat in `track_agent`, TTL + boot-GC, read-time collision derivation, the cockpit 8th slot + north collision gap | class·seq | ORGANISM-INSIDE P1 (verdict 2026-07-13) — witness tissue that gates nothing; presence == activity VISIBLE to m1nd |
 
 ## 5. The consolidated gap ledger — every open debt, ranked
 

--- a/docs/uml/cockpit.md
+++ b/docs/uml/cockpit.md
@@ -120,12 +120,12 @@ sequenceDiagram
 | 1 | dedicated read-only verb, sibling of north, no fail-open | `handle_cockpit`; NOT in `READ_ONLY_DENIED_TOOLS`; own dispatch arm |
 | 2 | read-only law DERIVED from the single source + Rust test | `.filter(read_only_denied)`; `cockpit_read_verbs_are_never_write_denied` |
 | 3 | pointer entries carry NO verb — only door text | `Collection.verb == None` for tray/missions; `pointer_entries_carry_no_verb` |
-| 4 | root = argument-less reads only; impact/why/trace OUT | seven collections; no analysis verb in the root |
+| 4 | root = argument-less reads only; impact/why/trace OUT | eight collections (P1 added `presences`); no analysis verb in the root |
 | 5 | max depth 3 (root→collection→item); "0" = back | `depth` 0/1; `select:"0"` re-serves root |
 | 6 | stable slots for the trio; menu_sig; drill re-asserts store_version/state_sig | `slots_are_stable_across_conditions`; `state_moved` |
 | 7 | widget payload = number + menu_sig, never free text / write verb | `menu_sig`; `docs/voice/WIDGET-TEMPLATE.md` |
 | 8 | on-request only; no landing auto-serve | `on_request_only:true`; negative default in `M1ND_INSTRUCTIONS` §7 + 3 skills |
-| 9 | own budget, battery-pinned | ~695 tokens root (≤800 ceiling); ~430 drill — 2026-07-12 |
+| 9 | own budget, battery-pinned | ≤800 ceiling, now MECHANICALLY pinned by `cockpit_budget_holds_with_the_eighth_slot`: worst-case root ~574 tokens, presences-drill ~567 (the new largest drill) — re-pinned 2026-07-13 after the P1 8th slot |
 | 10 | reuse the help machine (catalog), never a parallel one | `why` from `help_guidance::catalog_entry` |
 
 ## Invariantes
@@ -143,14 +143,19 @@ sequenceDiagram
 - **Per-brain only**: the map/bell/memory facts read the BOUND brain's own
   surfaces; the cockpit never aggregates across brains, and warns honestly under
   `caller_root_mismatch` (the menu describes the bound brain, not the caller's repo).
-- **Stable slots, moving labels**: the seven collections keep their slots across
+- **Stable slots, moving labels**: the eight collections keep their slots across
   every condition; only the label moves (`slots_are_stable_across_conditions`;
-  amendment 6).
+  amendment 6). Slot 8 is the P1 `presences` roster (this brain only); its
+  collision warning rides the LABEL, never a new schema field.
 - **Anti-staleness**: `menu_sig` is a deterministic digest of the served menu; a
   drill re-asserts `store_version`/`state_sig` and flags `state_moved` when the
   caller's `seen_store_version` diverged (amendment 6).
-- **Own budget**: root ~695 tokens, drill ~430 (≤800 ceiling), battery-pinned
-  2026-07-12 — north's pin does not cover it (amendment 9).
+- **Own budget**: ≤800 ceiling, mechanically pinned by
+  `cockpit_budget_holds_with_the_eighth_slot` (compact-wire `chars/4` estimator,
+  worst-case loud fixture): root ~574 tokens, presences-drill ~567 (the new
+  largest drill) — re-pinned 2026-07-13 after the P1 8th slot; north's pin does
+  not cover it (amendment 9). The presences drill is bounded at
+  `PRESENCE_DRILL_CAP` (6) rows with a `capped` flag when more sessions are live.
 
 ## Gaps / deferred (honest)
 

--- a/docs/uml/presences.md
+++ b/docs/uml/presences.md
@@ -60,7 +60,8 @@ hands in ONE worktree; caller_root equality is the measurable signal). Two views
 |---|---|---|
 | cockpit slot 8 `presences` | ONE root line (collision warning rides the LABEL, no new schema field) + a capped in-place drill (`PRESENCE_DRILL_CAP` = 6 rows: agent · theme · where · age · mutating), scope labeled "this brain" | `cockpit.rs` |
 | north collision gap | ONE line on the EXISTING `honest_gaps` mechanism, present only on a real collision, derived per-agent so it lands on BOTH colliding sessions' packets | `server.rs::handle_north` |
-| `/api/health` | owner-wide roster + collisions (data source for the Hall strip, m1nd-ui lane) | `http_server.rs::handle_health` |
+| **`GET /api/presences?brain=`** | **the Hall strip's CONTRACT endpoint** (`m1nd-ui docs/voice/P1-UI-CONTRACT.md`): `{presences, collisions, served_brain?}` — absent `brain` = OWNER-WIDE (the Hall's scope), present = that brain's roster + the §4A.9.4 echo, unknown root = honest 404 (the client degrades to empty); `collisions` ALWAYS present (server-authoritative) | `http_server.rs::handle_presences` · wire mapping `presence.rs::wire_entry/wire_collision/wire_response` |
+| `/api/health` `presences` block | owner-wide roster + collisions as a DIAGNOSTIC beside `agent_sessions` (the Hall reads `/api/presences`, not this) | `http_server.rs::handle_health` |
 
 Budget re-pinned + MECHANICALLY enforced by `cockpit_budget_holds_with_the_eighth_slot`
 (`chars/4`, worst-case): cockpit root ~574 tokens, presences-drill ~567, both ≤800.
@@ -86,7 +87,11 @@ since when"*, never *"who is alive"*. It never invents a heartbeat.
 ## Gaps / deferred (honest)
 
 - **The Hall strip is a separate lane** (m1nd-ui) and is P1-gate-material; the
-  server exposes the data (`/api/health`), the UI renders it.
+  server serves its contract (`GET /api/presences`), the UI renders it.
+- **`task_ref` carries the charter's `msn_` id** (the verdict's binding shape),
+  not the task's free text — the UI contract calls the field "the task line";
+  the id is what is honestly measured and leak-safe (recorded in
+  `P1-SERVER-DIVERGENCES.md`).
 - **task_ref is best-effort** — measured only from an OPEN (`status:"active"`)
   mission-control card under the runtime root; absent otherwise (honest).
 - **The h4nd tray team-view is OUT** (queued in the h4nd house, per the verdict).

--- a/docs/uml/presences.md
+++ b/docs/uml/presences.md
@@ -1,0 +1,92 @@
+# presences — the control room sees the team (`m1nd-presence-v0`)
+
+ORGANISM-INSIDE **P1** (askGOD verdict 2026-07-13 APPROVE, binding changes 1–3 —
+`docs/voice/ASKGOD-VERDICT-P1.md`; PRD §3.3 `docs/ORGANISM-INSIDE-PRD.md`). The
+organism's agents were invisible to the organism itself; P1 makes a live SESSION
+a visible presence — who is working, on what, since when — and derives a
+COLLISION warning before two mutating hands cost hours of recovery. Home:
+`m1nd-mcp/src/presence.rs` (the module), the beat in `session.rs::track_agent`,
+the observed-mutation stamp in `server.rs::dispatch_tool`, the 8th cockpit slot
+in `cockpit.rs`, and the north collision gap in `server.rs::handle_north`.
+
+## Shape
+
+A durable sidecar `<registry_root>/presences/<prs_id>.json`, molded on
+`instance_registry`. `prs_<12hex>` is stable per `(agent_id, brain)` — the beat
+UPSERTS one file, never N.
+
+```
+PresenceRecord (m1nd-presence-v0)
+  presence_id  prs_<12hex> = stable_presence_id(agent_id, brain)
+  agent_id · brain (= workspace_root, the collision key) · caller_root?
+  kind? · theme? · worktree? · working_set[]     — DECLARED (session_handshake)
+  task_ref?                                        — MEASURED (agent's mission_start charter)
+  mutation { observed_at_ms?, declared_intent? }   — the two honest levels (verdict c)
+  first_seen_ms · last_beat_ms · query_count · ttl_ms
+```
+
+## The beat (projection) + the store (sidecar) — a hybrid
+
+- **Beat = projection.** A THROTTLED hook inside `track_agent` (the single choke
+  point all four dispatch seams funnel through — REST, stdio, mcp_http, stdio
+  side-loop). At most one disk write per `PRESENCE_BEAT_THROTTLE_MS` (5s) per
+  session; a changed signal (a declaration or an observed mutation) forces the
+  next beat so a collision surfaces promptly. Wrapped in `vigil_fail_open` — a
+  broken sidecar write can NEVER break a tool call.
+- **Store = sidecar.** In-memory projection dies with LRU brain eviction and
+  `/api/health` only sees the root session; the sidecar survives. `is_stale`
+  (last beat older than `PRESENCE_TTL_MS`, 2 min) filters at READ, so a dead
+  presence DISAPPEARS rather than lying; `gc_stale` reclaims orphan files at boot
+  (`session.rs`, beside `spawn_boot_gc`) after an owner restart.
+- **Enrichment.** `brain`/`caller_root` are the session's own binding (never
+  claimed); `task_ref` is measured from the agent's own open `mission_start`
+  charter (`latest_open_mission_for`); the DECLARED fields ride NEW optional
+  `session_handshake` fields; the OBSERVED mutation level is stamped in
+  `dispatch_tool` off the single `read_only_denied` classifier.
+
+## Collision — DERIVED at read, never stored
+
+The verdict's exact predicate (`presence::collision_between`): **SAME brain AND
+(same caller_root/worktree OR declared working-set overlap) AND BOTH with a
+mutation signal.** Same-brain alone NEVER warns — three executors in isolated
+worktrees on one brain is the NORMAL burst shape (the 2026-07-06 incident was two
+hands in ONE worktree; caller_root equality is the measurable signal). Two views:
+`collisions_for_agent` (per session, for north's per-agent gap) and
+`collisions_in` (every pair, for the cockpit + `/api/health`).
+
+## Surfaces
+
+| Surface | What | Where |
+|---|---|---|
+| cockpit slot 8 `presences` | ONE root line (collision warning rides the LABEL, no new schema field) + a capped in-place drill (`PRESENCE_DRILL_CAP` = 6 rows: agent · theme · where · age · mutating), scope labeled "this brain" | `cockpit.rs` |
+| north collision gap | ONE line on the EXISTING `honest_gaps` mechanism, present only on a real collision, derived per-agent so it lands on BOTH colliding sessions' packets | `server.rs::handle_north` |
+| `/api/health` | owner-wide roster + collisions (data source for the Hall strip, m1nd-ui lane) | `http_server.rs::handle_health` |
+
+Budget re-pinned + MECHANICALLY enforced by `cockpit_budget_holds_with_the_eighth_slot`
+(`chars/4`, worst-case): cockpit root ~574 tokens, presences-drill ~567, both ≤800.
+
+## Laws
+
+- **Witness tissue.** A presence verifies nothing, gates nothing, lands nothing
+  (PRD laws 5, 10). It is advisory telemetry — the organism warns, the human /
+  orchestrator decides (the same posture as reception).
+- **Measured facts only** (G1). Counts come from the registry; nothing is
+  invented. The roster never renders a presence the registry did not serve
+  (INV-10 applied to sessions).
+- **Fail-open for voice.** Every read surface drops the roster whole on an
+  unreadable registry — north/cockpit/health never break over presence.
+
+## The written limitation (the inverse-TTL lie)
+
+**presence == activity VISIBLE TO m1nd.** An executor compiling for 20 minutes
+makes no m1nd calls, so its beat lapses and it expires from the roster — a live
+agent can read as absent. The roster answers *"who is talking to m1nd, on what,
+since when"*, never *"who is alive"*. It never invents a heartbeat.
+
+## Gaps / deferred (honest)
+
+- **The Hall strip is a separate lane** (m1nd-ui) and is P1-gate-material; the
+  server exposes the data (`/api/health`), the UI renders it.
+- **task_ref is best-effort** — measured only from an OPEN (`status:"active"`)
+  mission-control card under the runtime root; absent otherwise (honest).
+- **The h4nd tray team-view is OUT** (queued in the h4nd house, per the verdict).

--- a/docs/uml/spine-north.md
+++ b/docs/uml/spine-north.md
@@ -335,10 +335,12 @@ amendments — `docs/voice/ASKGOD-VERDICT-COCKPIT.md`), the human's ON-REQUEST
 router over m1nd's read surfaces. It is a **sibling of `north`, never a field**:
 if it breaks it breaks alone, never taking `north` down (fail-open does not
 apply). Full contract + class/sequence: `docs/uml/cockpit.md`. In three lines:
-- **Root = seven stable-slot collections** (labels move with state, slots never
+- **Root = eight stable-slot collections** (labels move with state, slots never
   do): the tray (POINTER), the map (`system_blocks_snapshot`), missions
   (POINTER), health (`doctor`), trust (`trust`), recent-memories (`boot_memory`,
-  fixed projection), drift (`drift`). Pointer entries carry NO verb (amendment 3).
+  fixed projection), drift (`drift`), and P1 `presences` (POINTER — the
+  control-room roster of THIS brain, drilled in place; the collision warning
+  rides the label). Pointer entries carry NO verb (amendment 3).
 - **The read-only law is DERIVED**: every routed verb is filtered at compose
   time against `server::read_only_denied`, pinned by the test
   `cockpit_read_verbs ∩ READ_ONLY_DENIED_TOOLS = ∅` (amendment 2); the `why`
@@ -347,7 +349,16 @@ apply). Full contract + class/sequence: `docs/uml/cockpit.md`. In three lines:
   response carries `menu_sig` (the short reference a widget button carries back —
   never free text, never a write verb) + `store_version` + `state_sig`, and a
   drill says "state moved" when the caller's `seen_store_version` diverged
-  (amendment 6). Own budget pinned ~695 tokens (root, ≤800 ceiling; drill ~430).
+  (amendment 6). Own budget ≤800 ceiling, now mechanically pinned by
+  `cockpit_budget_holds_with_the_eighth_slot`: worst-case root ~574 tokens,
+  presences-drill ~567 (re-pinned 2026-07-13 after the P1 8th slot).
+
+`north` itself gains ONE P1 line: a **collision honest-gap** — present only when
+this session collides with another live mutating hand on the same brain (same
+caller_root/worktree or overlapping working set). It rides the EXISTING
+`honest_gaps` mechanism (no new schema field), is advisory (never blocking), and
+the P1 gate requires it on BOTH colliding sessions' packets — each derives its
+own (server.rs `handle_north`, `presence::collisions_for_agent`).
 
 ## Gaps
 

--- a/docs/voice/ASKGOD-VERDICT-P1.md
+++ b/docs/voice/ASKGOD-VERDICT-P1.md
@@ -1,0 +1,71 @@
+# askGOD verdict — P1 Presences + G1 (the burst) — 2026-07-13
+
+VERDICT: APPROVE · CONFIDENCE 0.78 · required changes are BINDING.
+
+## The architecture ruled (question by question)
+
+(a) **Hybrid, not sidecar-pure nor projection-pure.** The BEAT is projection: a throttled
+hook inside `track_agent` (session.rs:2235 — where `mark_heartbeat` already piggybacks on
+traffic; all four seams pass through it). The STORE is a sidecar in the instance-registry
+pattern (files in the registry dir, TTL, `is_stale` filtered at read, GC at boot —
+instance_registry.rs:284-297,354,446,477) because in-memory projection dies with LRU brain
+eviction (project_brains.rs:36-44) and /api/health only sees the root session
+(http_server.rs:895-909). Enrichment ("where/on what") comes from OPTIONAL fields on
+`session_handshake` + the agent's own `mission_start` charter (task/repo measured from the
+charter, never free declaration). Zero new verbs, zero new daemons. All wrapped in
+`vigil_fail_open`.
+
+(b) **"Alive" = last_seen-by-traffic within TTL** (minutes scale), AGE always rendered.
+Expired = absent at read + GC'd. Disk beat THROTTLED. No invented heartbeats.
+
+(c) **"Mutant" in two honest levels:** OBSERVED — the session dispatched a verb classified
+mutating by `read_only_denied()` (server.rs:4518), timestamped; DECLARED — handshake
+intent, rendered as declared cloth. m1nd does not see git; nothing more is claimable.
+
+(d) **Collision derived at read, never materialized.**
+
+## Binding changes
+
+1. Presence sidecar as above; hook in track_agent; enrichment via handshake+charter.
+2. **Collision predicate:** same brain AND (same caller_root/worktree OR declared
+   working-set overlap) AND both with mutation signal. Same-brain alone NEVER warns —
+   3 executors in isolated worktrees on the m1nd brain is the NORMAL burst shape
+   (AGENTS.md:111-117). The 2026-07-06 incident was two hands in ONE worktree —
+   caller_root equality is the measurable signal.
+3. **Surfaces cut:** cockpit gains the 8th collection (ONE line at root + capped drill;
+   RE-PIN both budgets — ~105 tokens of root slack fit a line, not a list; update every
+   doc that says "seven stable slots"). Hall strip (m1nd-ui) is IN as its own lane and is
+   GATE-MATERIAL (the P1 gate requires it). h4nd tray is OUT — queued slice in the h4nd
+   house. north: NO new schema field — the collision line rides the existing honest-gaps
+   mechanism, present only when a collision exists (P1 gate requires it on both sessions'
+   packets, PRD:466-468).
+4. **G1:** the daemon tick moves INTO `dispatch_tool` mirroring the auto-ingest vigil
+   (server.rs:4609-4630 precedent), condition `active && !tick_in_flight &&
+   should_autotick_daemon(tool) && due` INLINE (nested internal dispatches would inflate
+   pending_rerun otherwise); DELETE the pre-dispatch block in handle_mcp_method
+   (server.rs:5518-5525) same PR — one seam only. This fixes THREE deaf seams at once
+   (REST, stdio side-loop, mcp_http — the oracle verified all three lack ticks).
+   `track_agent` stays per-seam. Tests: new RED-first driving dispatch_tool directly;
+   keep the skip-list regression pinned to the REAL list (server.rs:5571-5590 —
+   daemon_*/alerts_*/session_handshake/trust_selftest/recovery_playbook/mission_* — the
+   dossier wrongly said recall verbs are in it; they are NOT). Measure tick wall-clock
+   inside the REST 30s window in the PR.
+5. **Burst shape:** each executor opens/events/closes its OWN charter under its OWN
+   agent_id (ensure_agent respected by construction) — otherwise P1 has no three
+   presences to show and the gate starves. The orchestrator keeps an umbrella charter
+   referencing the child msn_ ids. EVERY REST call in the burst passes `?brain=`
+   explicitly (the post-restart mismatch makes implicit binding untrustworthy today).
+6. **The REST-without-brain field report** = separate INVESTIGATION mission (may be
+   doctrine-that-was-missing, not a bug: the owner may be medulla-stamped at boot,
+   http_server.rs:574). Confirm before verdicting. Not folded into G1.
+
+## Risks flagged
+
+spawn_blocking holds the brain lock past the REST 30s timeout (measure; maybe skip inline
+tick when the entry tool is already heavy) · the inverse TTL lie (a live executor
+compiling 20min vanishes from the roster — write the limitation into the surfaces:
+"presence = activity visible to m1nd") · cockpit presence scope must be decided and
+LABELED (owner-wide vs served-brain roster) before coding the slot · free-text
+theme/working_set never in commits (no-leak; neutral fixtures) · sessions HashMap grows
+without GC (sidecar must not depend on it to expire) · boot-GC must sweep stale sidecar
+files after owner restart · the P1 gate requires the Hall — the UI lane is gate-material.

--- a/docs/voice/P1-SERVER-DIVERGENCES.md
+++ b/docs/voice/P1-SERVER-DIVERGENCES.md
@@ -1,0 +1,63 @@
+# ORGANISM-INSIDE P1-SERVER "PRESENCES" — divergences and honest residue
+
+> Companion to `docs/ORGANISM-INSIDE-PRD.md` (the arc) and
+> `docs/voice/ASKGOD-VERDICT-P1.md` (the binding verdict). The server lane of P1
+> landed all four binding changes; nothing was forced past the grammar. Recorded
+> here verbatim instead of silently absorbed — the honest residue is the gold.
+
+1. **The beat rides `track_agent` WITHOUT changing its signature.** The verdict
+   put the beat "inside `track_agent`". `track_agent(agent_id)` has ~22 call
+   sites; threading the tool name + a mutation flag through all of them would be
+   churn and risk. Reuse-first resolution: the beat stays inside `track_agent`
+   (the single choke point all four seams funnel through), and the OBSERVED
+   mutation level is stamped by a SEPARATE one-line call `note_mutation_observed`
+   in `dispatch_tool`, off the same `read_only_denied` classifier the verdict
+   named. Same seam, same classifier, no 22-site signature change. The mutation
+   lands on the next beat within one throttle cycle (a changed signal clears the
+   throttle so a collision surfaces promptly).
+
+2. **Budget re-pin: a NEW mechanical battery replaces the manual pins.** The
+   pre-P1 cockpit budget (~695 root / ~430 drill) was a doc-recorded MANUAL
+   measurement — no battery test existed in the tree (`north_packet_within_budget`
+   is referenced in docs but is not a live test). P1 lands
+   `cockpit_budget_holds_with_the_eighth_slot`: a real test measuring the
+   worst-case loud root + the presences drill via the repo's own
+   `estimate_tokens_from_chars` (chars/4), pretty-print basis (the conservative,
+   larger number). Measured: root ~574, presences-drill ~567 — both under the
+   ≤800 ceiling, now MECHANICALLY enforced, not hand-kept. The presences drill is
+   the new largest drill; `PRESENCE_DRILL_CAP` (6) sizes it to fit.
+
+3. **The historical PATHOS "seven" mentions were LEFT INTACT.** The verdict said
+   "update every doc that says 'seven stable slots'". The living surfaces
+   (`uml/cockpit.md`, `uml/spine-north.md`, `UML-ORGANISM.md`, the code comments,
+   the tool description) now say EIGHT. But three "seven"/"~695/~430" mentions in
+   `docs/PATHOS.md` sit inside DATED checkpoint-18 (2026-07-12) era-log blocks —
+   they record what the cockpit was WHEN IT SHIPPED that day. Rewriting them would
+   falsify the era log (the heading says "dated blocks below are the era log").
+   The new 2026-07-13 P1 era block records the evolution to eight + the re-pin.
+   Current-state truth is eight everywhere; history stays honest.
+
+4. **The LIVE two-session collision gate is a burst-closing, cross-lane step —
+   deliberately NOT run in this lane.** The served owner at `:1338` runs the
+   pre-P1 binary and other executors are working against it; rebuilding +
+   restarting shared infra mid-burst was declined. The PRD P1 gate ("two real
+   mutating sessions visible; an arranged collision surfaces on both north packets
+   AND the Hall") also needs the Hall (m1nd-ui lane, gate-material, separate).
+   The logic is proven MECHANICALLY here (registration by traffic, TTL expiry, GC,
+   throttle, fail-open, collision positive + the isolated-worktrees anti-test, the
+   honest_gap derived for both agents, the cockpit 8th slot + budget). The live
+   gate is the orchestrator's close, once `:1338` carries this binary and the Hall
+   lands. Recorded in the mission card's gaps.
+
+5. **`task_ref` is best-effort MEASURED, honest-absent otherwise.** It is read
+   only from an OPEN (`status:"active"`) mission-control card under the runtime
+   root (`mission_handlers::latest_open_mission_for`), on the throttled beat. No
+   open card → no `task_ref` (never fabricated). This honors "measured from the
+   charter, never free declaration" while staying total and cheap.
+
+6. **Presences are exposed on `/api/health`, owner-wide.** The verdict named the
+   cockpit slot + the north gap; the Hall (m1nd-ui lane) needs a server data
+   source. Rather than a new REST route, the roster + collisions ride the existing
+   `/api/health` (beside `agent_sessions`), owner-wide (collisions are same-brain
+   by construction, so no cross-brain pairing leaks). The UI lane consumes it; no
+   m1nd-ui/ file was touched.

--- a/docs/voice/P1-SERVER-DIVERGENCES.md
+++ b/docs/voice/P1-SERVER-DIVERGENCES.md
@@ -55,9 +55,33 @@
    open card → no `task_ref` (never fabricated). This honors "measured from the
    charter, never free declaration" while staying total and cheap.
 
-6. **Presences are exposed on `/api/health`, owner-wide.** The verdict named the
-   cockpit slot + the north gap; the Hall (m1nd-ui lane) needs a server data
-   source. Rather than a new REST route, the roster + collisions ride the existing
-   `/api/health` (beside `agent_sessions`), owner-wide (collisions are same-brain
-   by construction, so no cross-brain pairing leaks). The UI lane consumes it; no
-   m1nd-ui/ file was touched.
+6. **The Hall's data source is `GET /api/presences` (the UI contract), not
+   `/api/health`.** This lane FIRST exposed the roster on `/api/health` (beside
+   `agent_sessions`); the burst close then surfaced the P1-UI lane's declared
+   contract (`m1nd-ui docs/voice/P1-UI-CONTRACT.md`): a dedicated
+   `GET /api/presences?brain=` returning `{presences, collisions?, served_brain?}`.
+   The endpoint now exists and honors that contract: absent `brain` = OWNER-WIDE
+   (the Hall's declared scope), present = that brain's roster (filtered by the
+   RESOLVED session's own `workspace_root` — the exact key its beats write) + the
+   §4A.9.4 `served_brain` echo, unknown root = the house 404 (the client degrades
+   to an empty roster), `collisions` ALWAYS present (server-authoritative, the
+   client never re-derives). The `/api/health` block REMAINS as an owner-wide
+   diagnostic beside `agent_sessions` — same pure functions, one truth.
+
+7. **Contract fields the server serves differently (all honest, none fabricated):**
+   - `task_ref` — the UI contract calls it "the task line"; the server sends the
+     charter's **`msn_` id** (the verdict's binding shape: "task_ref?: msn_ of
+     the agent's charter"). The id is what is honestly measured from the mission
+     card and is leak-safe (free task text may carry personal context; the
+     no-leak law applies). The UI renders the id or adapts at the burst close.
+   - `PresenceCollision` is emitted **per colliding pair** (`agent_ids` always
+     2); three hands in one worktree arrive as pairs, not one merged triple —
+     same information, no invented grouping.
+   - On the `same_worktree` arm, `caller_root` carries the shared **measured
+     caller_root path when that matched**, else the shared **declared worktree
+     string** (both are the measurable arm; the value is what matched, never
+     invented). A pure working-set overlap (`declared_overlap`) claims no
+     location, exactly as the contract states.
+   - The endpoint's owner-wide response carries **no `served_brain` echo** — the
+     contract marks the field optional, and echoing the BOUND brain over an
+     owner-wide roster would mislabel the scope (INV-15 posture).

--- a/m1nd-mcp/src/cockpit.rs
+++ b/m1nd-mcp/src/cockpit.rs
@@ -84,7 +84,17 @@ struct Facts {
     memory_count: usize,
     recv_mismatch: bool,
     reception_honest: Option<String>,
+    // P1 (ORGANISM-INSIDE): the served-brain presence roster + derived collisions
+    // (slot 8). "This brain" only — never a cross-brain aggregate.
+    presences: Vec<crate::presence::PresenceRecord>,
+    presence_collisions: Vec<crate::presence::Collision>,
 }
+
+/// Cap on presence rows the drill renders (Budget Law — the roster is a bounded
+/// render, never an unbounded list; the count + `capped` flag stay honest when
+/// more sessions are live than shown). Sized so the drill holds under the ≤800
+/// token ceiling even at worst-case field lengths (battery-pinned below).
+const PRESENCE_DRILL_CAP: usize = 6;
 
 /// `cockpit` (READ). Serves the root menu, or drills one collection when
 /// `select` names a slot. Pure composer, read-only, breaks alone.
@@ -202,6 +212,11 @@ fn read_facts(state: &mut SessionState) -> Facts {
 
     let memory_count = state.light_memory_count();
 
+    // P1 presences — the served brain's live roster + derived collisions. Reads
+    // the presence sidecars (fail-open: an unreadable registry yields an empty
+    // roster, never an error). Scoped to THIS brain by construction.
+    let (presences, presence_collisions) = state.presence_roster();
+
     let reception = state.reception_verdict();
     let recv_mismatch = reception
         .as_ref()
@@ -224,12 +239,17 @@ fn read_facts(state: &mut SessionState) -> Facts {
         memory_count,
         recv_mismatch,
         reception_honest,
+        presences,
+        presence_collisions,
     }
 }
 
-/// The seven stable-slot collections (amendment 4 order). Slots 1–3 are the
+/// The eight stable-slot collections (amendment 4 order). Slots 1–3 are the
 /// permanent trio (the tray, the map, missions); their LABELS move with state,
 /// their SLOTS never do (amendment 6). Slots 4–7 are the argument-less reads.
+/// Slot 8 is the P1 presence roster — the team talking to m1nd, this brain only,
+/// a cockpit-composed render drilled in place (ORGANISM-INSIDE, verdict
+/// 2026-07-13; the collision warning rides the LABEL, no new schema field).
 fn root_collections(f: &Facts) -> Vec<Collection> {
     // 1 — the tray (POINTER: bell + the human stamp gesture; no verb).
     let tray_label = if f.merge_wait > 0 {
@@ -259,6 +279,20 @@ fn root_collections(f: &Facts) -> Vec<Collection> {
         format!("memories · {} durable claim(s)", f.memory_count)
     } else {
         "memories · none yet".to_string()
+    };
+    // 8 — presences (POINTER: the cockpit-composed roster of THIS brain, drilled
+    //     in place; no external verb). The collision warning rides the LABEL —
+    //     ONE root line whether quiet or colliding (Budget Law).
+    let presences_label = if f.presences.is_empty() {
+        "presences · none in this brain".to_string()
+    } else if !f.presence_collisions.is_empty() {
+        format!(
+            "presences · {} in this brain · ⚠ {} collision(s)",
+            f.presences.len(),
+            f.presence_collisions.len()
+        )
+    } else {
+        format!("presences · {} in this brain", f.presences.len())
     };
 
     vec![
@@ -311,6 +345,13 @@ fn root_collections(f: &Facts) -> Vec<Collection> {
             label: "drift · nodes whose evidence moved under the graph".to_string(),
             verb: Some("drift"),
             door: None,
+        },
+        Collection {
+            slot: 8,
+            key: "presences",
+            label: presences_label,
+            verb: None,
+            door: Some("the team talking to m1nd — drill to see who, where, since when"),
         },
     ]
 }
@@ -388,6 +429,58 @@ fn entry_json(c: &Collection) -> Value {
     }
 }
 
+/// The slot-8 drill body: the served brain's live presence roster (capped at
+/// [`PRESENCE_DRILL_CAP`]) + any derived collisions. A cockpit-composed render —
+/// measured from the sidecars, ages ALWAYS rendered, honest-absent on expiry.
+/// Scope is decided and LABELED here: the served-brain roster ("this brain").
+fn presence_drill_detail(f: &Facts) -> Value {
+    let now = crate::util::now_ms();
+    let rows: Vec<Value> = f
+        .presences
+        .iter()
+        .take(PRESENCE_DRILL_CAP)
+        .map(|p| {
+            // where = the most specific declared location, else the brain root.
+            let location = p
+                .worktree
+                .clone()
+                .or_else(|| p.caller_root.clone())
+                .unwrap_or_else(|| p.brain.clone());
+            // The verdict's four fields — agent · where · age · mutation — plus
+            // the declared theme (the "on what"). Richer enrichment (kind /
+            // task_ref) lives in the unbudgeted /api/health roster, not this
+            // budget-bound drill.
+            json!({
+                "agent": p.agent_id,
+                "theme": p.theme,
+                "where": location,
+                "age_secs": p.age_ms(now) / 1000,
+                "mutating": p.has_mutation_signal(now),
+            })
+        })
+        .collect();
+    let collisions: Vec<Value> = f
+        .presence_collisions
+        .iter()
+        .map(|c| {
+            json!({
+                "between": [&c.subject_agent, &c.other_agent],
+                "overlap": c.overlap,
+            })
+        })
+        .collect();
+    json!({
+        "kind": "presences",
+        "scope": "this brain",
+        "roster_count": f.presences.len(),
+        "shown": rows.len(),
+        "capped": f.presences.len() > PRESENCE_DRILL_CAP,
+        "roster": rows,
+        "collisions": collisions,
+        "note": "presence == activity VISIBLE TO m1nd — a session compiling for minutes makes no calls and expires from the roster; never read as 'who is alive'",
+    })
+}
+
 fn reception_note(f: &Facts) -> Option<Value> {
     f.recv_mismatch.then(|| {
         json!({
@@ -458,37 +551,42 @@ fn compose_drill(
     let state_moved =
         matches!((seen_store_version, f.store_version), (Some(seen), sv) if Some(seen) != sv);
 
-    let mut detail = match (c.verb, c.door) {
-        (Some(verb), _) => {
-            let why = crate::help_guidance::catalog_entry(verb)
-                .map(|e| e.one_liner)
-                .unwrap_or_default();
-            // Present the argument-less call to RUN (router pattern, like help):
-            // its own output carries the receipts/hashes, rendered in the item
-            // view (amendment 5) — the cockpit never fabricates a receipt.
-            let arguments = if verb == "boot_memory" {
-                json!({ "agent_id": agent_id, "action": "list" })
-            } else {
-                json!({ "agent_id": agent_id })
-            };
-            json!({
-                "kind": "read",
-                "verb": verb,
-                "arguments": arguments,
-                "why": why,
-                "note": "run this read — its output carries the live detail (receipts/hashes render in the item view)",
-            })
+    let mut detail = if c.key == "presences" {
+        // Slot 8: a cockpit-composed roster drilled IN PLACE (no external verb).
+        presence_drill_detail(f)
+    } else {
+        match (c.verb, c.door) {
+            (Some(verb), _) => {
+                let why = crate::help_guidance::catalog_entry(verb)
+                    .map(|e| e.one_liner)
+                    .unwrap_or_default();
+                // Present the argument-less call to RUN (router pattern, like help):
+                // its own output carries the receipts/hashes, rendered in the item
+                // view (amendment 5) — the cockpit never fabricates a receipt.
+                let arguments = if verb == "boot_memory" {
+                    json!({ "agent_id": agent_id, "action": "list" })
+                } else {
+                    json!({ "agent_id": agent_id })
+                };
+                json!({
+                    "kind": "read",
+                    "verb": verb,
+                    "arguments": arguments,
+                    "why": why,
+                    "note": "run this read — its output carries the live detail (receipts/hashes render in the item view)",
+                })
+            }
+            (None, door) => json!({
+                "kind": "pointer",
+                "door": door.unwrap_or("open the tray — the stamp lives there"),
+                // The pointer's facts are already measured — no verb, nothing to run.
+                "facts": {
+                    "merge_wait": f.merge_wait,
+                    "missions_in_flight": f.mission_total,
+                },
+                "note": "the stamp is a human gesture at the tray — the cockpit never lands it",
+            }),
         }
-        (None, door) => json!({
-            "kind": "pointer",
-            "door": door.unwrap_or("open the tray — the stamp lives there"),
-            // The pointer's facts are already measured — no verb, nothing to run.
-            "facts": {
-                "merge_wait": f.merge_wait,
-                "missions_in_flight": f.mission_total,
-            },
-            "note": "the stamp is a human gesture at the tray — the cockpit never lands it",
-        }),
     };
 
     let obj = detail.as_object_mut().unwrap();
@@ -545,6 +643,29 @@ mod tests {
             memory_count: 0,
             recv_mismatch: false,
             reception_honest: None,
+            presences: Vec::new(),
+            presence_collisions: Vec::new(),
+        }
+    }
+
+    fn presence(agent: &str, brain: &str) -> crate::presence::PresenceRecord {
+        let now = crate::util::now_ms();
+        crate::presence::PresenceRecord {
+            schema: crate::presence::PRESENCE_SCHEMA.to_string(),
+            presence_id: crate::presence::stable_presence_id(agent, brain),
+            agent_id: agent.to_string(),
+            brain: brain.to_string(),
+            caller_root: None,
+            kind: Some("executor".to_string()),
+            theme: Some("slice".to_string()),
+            worktree: None,
+            working_set: Vec::new(),
+            task_ref: None,
+            mutation: crate::presence::MutationSignal::default(),
+            first_seen_ms: now,
+            last_beat_ms: now,
+            query_count: 3,
+            ttl_ms: crate::presence::PRESENCE_TTL_MS,
         }
     }
 
@@ -574,7 +695,7 @@ mod tests {
     }
 
     /// Amendment 6 — the permanent trio sits in stable slots 1..=3, condition
-    /// changing only the LABEL; and the root always serves the seven collections.
+    /// changing only the LABEL; and the root always serves the eight collections.
     #[test]
     fn slots_are_stable_across_conditions() {
         let quiet = root_collections(&empty_facts());
@@ -586,8 +707,8 @@ mod tests {
         busy.store_version = Some(7);
         let loud = root_collections(&busy);
 
-        assert_eq!(quiet.len(), 7);
-        assert_eq!(loud.len(), 7);
+        assert_eq!(quiet.len(), 8);
+        assert_eq!(loud.len(), 8);
         for (a, b) in quiet.iter().zip(loud.iter()) {
             assert_eq!(a.slot, b.slot, "slot is stable");
             assert_eq!(a.key, b.key, "collection identity is stable");
@@ -666,5 +787,124 @@ mod tests {
         assert_eq!(mem["kind"], "read");
         assert_eq!(mem["verb"], json!("boot_memory"));
         assert_eq!(mem["arguments"]["action"], json!("list"));
+    }
+
+    /// P1 budget RE-PIN (battery): the cockpit's own budget holds after adding
+    /// the 8th collection — root AND the presences drill both stay under the ≤800
+    /// ceiling (amendment 9). Measured with the same `chars/4` estimator the north
+    /// battery uses. The 8th ROOT line costs ~one line (the ~105-token root slack
+    /// the verdict noted absorbs it); the presences DRILL is a bounded render
+    /// (capped at PRESENCE_DRILL_CAP rows).
+    #[test]
+    fn cockpit_budget_holds_with_the_eighth_slot() {
+        // A LOUD root: every label populated + a colliding presence roster (the
+        // longest presence root line).
+        let mut f = empty_facts();
+        f.merge_wait = 7;
+        f.mission_total = 12;
+        f.store_present = true;
+        f.store_version = Some(4096);
+        f.ratified_blocks = 128;
+        f.block_count = 130;
+        f.coherence = Some("mismatch".to_string());
+        f.memory_count = 342;
+        f.presences = (0..PRESENCE_DRILL_CAP)
+            .map(|i| {
+                let mut p = presence(&format!("executor-agent-number-{i}"), "/Users/x/m1nd");
+                p.worktree = Some(format!("feat/some-longish-worktree-name-{i}"));
+                p.caller_root = Some(format!("/Users/x/m1nd-worktree-{i}"));
+                p.task_ref = Some(format!("msn_1783903278219_executoragent{i}"));
+                p.mutation.observed_at_ms = Some(crate::util::now_ms());
+                p
+            })
+            .collect();
+        f.presence_collisions = vec![crate::presence::Collision {
+            subject_agent: "executor-agent-number-0".into(),
+            subject_presence: "prs_000000000000".into(),
+            other_agent: "executor-agent-number-1".into(),
+            other_presence: "prs_000000000001".into(),
+            overlap: vec!["worktree:feat/some-longish-worktree-name-0".into()],
+        }];
+
+        let cols = root_collections(&f);
+        let ss = compose_state_sig(&f);
+        let sig = compose_menu_sig(&cols, f.store_version, &ss);
+
+        // Pretty-print basis (the conservative, larger number — comparable to the
+        // pre-P1 manual pins ~695 root / ~430 drill).
+        let root = compose_root("budget-probe-agent", &cols, &f, &sig, &ss);
+        let root_chars = serde_json::to_string_pretty(&root).unwrap().chars().count();
+        let root_tokens = crate::result_shaping::estimate_tokens_from_chars(root_chars);
+
+        let drill = compose_drill("budget-probe-agent", &cols, 8, &f, &sig, &ss, None);
+        let drill_chars = serde_json::to_string_pretty(&drill)
+            .unwrap()
+            .chars()
+            .count();
+        let drill_tokens = crate::result_shaping::estimate_tokens_from_chars(drill_chars);
+
+        eprintln!(
+            "cockpit budget re-pin (P1, 8 slots): root ~{root_tokens} tokens ({root_chars} chars); presences drill ~{drill_tokens} tokens ({drill_chars} chars)"
+        );
+        assert!(
+            root_tokens <= 800,
+            "cockpit root budget breach: ~{root_tokens} tokens (>800 ceiling, amendment 9)"
+        );
+        assert!(
+            drill_tokens <= 800,
+            "cockpit presences-drill budget breach: ~{drill_tokens} tokens (>800 ceiling)"
+        );
+    }
+
+    /// P1 — slot 8 is the presence roster. Its ROOT line is ONE line whether
+    /// quiet or colliding (Budget Law), the collision warning rides the LABEL
+    /// (no new schema field), and the DRILL renders the capped roster + the
+    /// derived collisions, scope LABELED "this brain".
+    #[test]
+    fn presences_slot_root_line_and_drill() {
+        // Quiet: one root line, no warning.
+        let mut quiet = empty_facts();
+        quiet.presences = vec![presence("exec-a", "/m1nd")];
+        let cols = root_collections(&quiet);
+        assert_eq!(cols.len(), 8);
+        let slot8 = cols.iter().find(|c| c.key == "presences").unwrap();
+        assert_eq!(slot8.slot, 8);
+        assert!(slot8.verb.is_none(), "presences is a pointer, never a verb");
+        assert!(slot8.label.contains("1 in this brain"));
+        assert!(
+            !slot8.label.contains("collision"),
+            "quiet root names no collision"
+        );
+
+        // Colliding: the SAME one root line, now carrying the warning.
+        let mut loud = empty_facts();
+        loud.presences = vec![presence("hand-a", "/m1nd"), presence("hand-b", "/m1nd")];
+        loud.presence_collisions = vec![crate::presence::Collision {
+            subject_agent: "hand-a".into(),
+            subject_presence: "prs_a".into(),
+            other_agent: "hand-b".into(),
+            other_presence: "prs_b".into(),
+            overlap: vec!["worktree:feat/x".into()],
+        }];
+        let loud_cols = root_collections(&loud);
+        assert_eq!(loud_cols.len(), 8, "the root is still ONE line per slot");
+        let loud8 = loud_cols.iter().find(|c| c.key == "presences").unwrap();
+        assert!(
+            loud8.label.contains("⚠ 1 collision"),
+            "the warning rides the label"
+        );
+
+        // Drill: capped roster + collisions, scope labeled.
+        let sig = compose_menu_sig(&loud_cols, loud.store_version, &compose_state_sig(&loud));
+        let ss = compose_state_sig(&loud);
+        let drill = compose_drill("t", &loud_cols, 8, &loud, &sig, &ss, None);
+        assert_eq!(drill["kind"], "presences");
+        assert_eq!(drill["scope"], "this brain");
+        assert_eq!(drill["roster_count"], json!(2));
+        assert_eq!(drill["collisions"].as_array().unwrap().len(), 1);
+        assert!(
+            drill["roster"][0].get("age_secs").is_some(),
+            "age is always rendered"
+        );
     }
 }

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -832,6 +832,7 @@ fn tool_error_payload(e: &m1nd_core::error::M1ndError) -> serde_json::Value {
 pub fn build_router(state: Arc<AppState>, dev_mode: bool) -> Router {
     let api = Router::new()
         .route("/api/health", get(handle_health))
+        .route("/api/presences", get(handle_presences))
         .route("/api/instance/self", get(handle_instance_self))
         .route("/api/instances", get(handle_instances))
         .route("/api/instance/save", post(handle_instance_save))
@@ -965,6 +966,75 @@ async fn handle_health(State(state): State<Arc<AppState>>) -> impl IntoResponse 
     .expect("spawn_blocking panicked");
 
     (StatusCode::OK, Json(result))
+}
+
+/// `GET /api/presences?brain=` — the P1 presence endpoint the Hall strip reads
+/// (contract: `m1nd-ui` `docs/voice/P1-UI-CONTRACT.md`; authority: the P1
+/// verdict, binding changes 1–3). Envelope: `{presences, collisions, served_brain?}`.
+///
+/// - `brain` ABSENT ⇒ the OWNER-WIDE roster (the Hall's control-room scope):
+///   every live presence across all this owner's brains, no `served_brain` echo
+///   (echoing the bound brain would mislabel an owner-wide roster).
+/// - `brain` PRESENT ⇒ that brain's roster, filtered by the RESOLVED session's
+///   own `workspace_root` (the exact key its sessions' beats write), with the
+///   §4A.9.4 `served_brain` echo; an unknown root 404s honestly (the client
+///   degrades to an empty roster per the contract).
+/// - Pure READ, fail-open: an unreadable registry serves an empty roster; TTL
+///   filtering at read (`list_live`) means no ghost is ever rendered.
+/// - `collisions` is ALWAYS present (server-authoritative, even `[]`), derived
+///   at read with the P1 predicate — the same one the cockpit and north use.
+async fn handle_presences(
+    State(state): State<Arc<AppState>>,
+    Query(brain): Query<BrainQuery>,
+) -> impl IntoResponse {
+    let result = tokio::task::spawn_blocking(move || {
+        let now = crate::util::now_ms();
+        match brain
+            .brain
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None => {
+                // Owner-wide: one registry serves every brain of this owner; the
+                // collision predicate is same-brain by construction, so no
+                // cross-brain pair can fire.
+                let registry_root = {
+                    let session = state.session.lock();
+                    session.instance.registry_root()
+                };
+                let roster = crate::presence::list_live(&registry_root, now);
+                Ok(crate::presence::wire_response(&roster, now))
+            }
+            Some(root) => {
+                let (target, served_echo) = resolve_brain(&state, Some(root))?;
+                let (registry_root, brain_key) = {
+                    let session = target.lock();
+                    (
+                        session.instance.registry_root(),
+                        session.workspace_root.clone(),
+                    )
+                };
+                // The sidecar's `brain` field IS the writing session's
+                // workspace_root — filter by the resolved session's own key so
+                // the scope matches exactly what its traffic wrote. An unbound
+                // session has no roster to join: honest empty.
+                let roster = match brain_key.as_deref() {
+                    Some(key) => crate::presence::roster_for_brain(&registry_root, key, now),
+                    None => Vec::new(),
+                };
+                let mut body = crate::presence::wire_response(&roster, now);
+                body["served_brain"] = served_echo;
+                Ok(body)
+            }
+        }
+    })
+    .await
+    // Fail-open for voice: a panicked read serves the honest empty envelope,
+    // never an error wall (the same posture the contract's client side takes).
+    .unwrap_or_else(|_| Ok(serde_json::json!({ "presences": [], "collisions": [] })));
+
+    graph_response(result)
 }
 
 async fn handle_instance_self(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -3233,6 +3303,10 @@ mod tests {
             graph_source: runtime.join("graph_snapshot.json"),
             plasticity_state: runtime.join("plasticity_state.json"),
             runtime_dir: Some(runtime.to_path_buf()),
+            // Isolated registry: these tests exercise real dispatch (which beats
+            // presence sidecars + instance heartbeats) — they must never write
+            // into the developer's real ~/.m1nd/registry.
+            registry_dir: Some(runtime.join("registry")),
             ..Default::default()
         };
         let session = crate::server::McpServer::new(config)
@@ -3596,5 +3670,214 @@ mod tests {
             app.project_brains.knows(&parent.to_string_lossy()),
             "the deliberate overlap brain must exist"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // P1 — GET /api/presences (the Hall strip's contract endpoint)
+    // -----------------------------------------------------------------------
+
+    /// Drive the REAL `/api/presences` handler; return (status, parsed payload).
+    async fn call_presences(
+        app: &Arc<AppState>,
+        brain: Option<String>,
+    ) -> (StatusCode, serde_json::Value) {
+        let resp = handle_presences(State(app.clone()), Query(BrainQuery { brain }))
+            .await
+            .into_response();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let payload =
+            serde_json::from_slice::<serde_json::Value>(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, payload)
+    }
+
+    /// Seed one presence sidecar straight into the owner's (isolated) registry —
+    /// the same file the throttled beat writes. Neutral fixture names only.
+    fn seed_presence(
+        registry: &std::path::Path,
+        agent: &str,
+        brain: &str,
+        caller_root: Option<&str>,
+        mutate: bool,
+        last_beat_ms: u64,
+    ) {
+        let record = crate::presence::PresenceRecord {
+            schema: crate::presence::PRESENCE_SCHEMA.to_string(),
+            presence_id: crate::presence::stable_presence_id(agent, brain),
+            agent_id: agent.to_string(),
+            brain: brain.to_string(),
+            caller_root: caller_root.map(str::to_string),
+            kind: None,
+            theme: None,
+            worktree: None,
+            working_set: Vec::new(),
+            task_ref: None,
+            mutation: crate::presence::MutationSignal {
+                observed_at_ms: mutate.then_some(last_beat_ms),
+                declared_intent: None,
+            },
+            first_seen_ms: last_beat_ms,
+            last_beat_ms,
+            query_count: 1,
+            ttl_ms: crate::presence::PRESENCE_TTL_MS,
+        };
+        crate::presence::write_presence(registry, &record).expect("seed presence");
+    }
+
+    /// The contract's scope semantics: absent `brain` ⇒ the OWNER-WIDE roster
+    /// (no served_brain echo); present ⇒ that brain's roster with the §4A.9.4
+    /// echo; an unknown root ⇒ an honest 404 (the client degrades to empty);
+    /// an expired presence is ABSENT from both scopes (no ghost).
+    #[tokio::test]
+    async fn presences_endpoint_owner_wide_scoped_and_404() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bound = tmp.path().join("repo-alpha");
+        write_repo(&bound, "repoalpha");
+        let app = rest_owner(&tmp.path().join("runtime"));
+        ingest_bound(&app, &bound).await;
+
+        let (registry, bound_key) = {
+            let s = app.session.lock();
+            (
+                s.instance.registry_root(),
+                s.workspace_root.clone().expect("bound workspace_root"),
+            )
+        };
+        let now = crate::util::now_ms();
+        // One presence on the bound brain, one on a foreign brain, one GHOST
+        // (expired) on the bound brain.
+        seed_presence(&registry, "exec-alpha", &bound_key, None, false, now);
+        seed_presence(&registry, "exec-beta", "/wt/other-brain", None, false, now);
+        seed_presence(
+            &registry,
+            "exec-ghost",
+            &bound_key,
+            None,
+            false,
+            now.saturating_sub(crate::presence::PRESENCE_TTL_MS + 60_000),
+        );
+
+        // Owner-wide: both live agents, never the ghost, no served_brain echo.
+        let (status, body) = call_presences(&app, None).await;
+        assert_eq!(status, StatusCode::OK);
+        let agents: Vec<&str> = body["presences"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["agent_id"].as_str().unwrap())
+            .collect();
+        assert!(
+            agents.contains(&"exec-alpha"),
+            "owner-wide sees the bound brain: {body}"
+        );
+        assert!(
+            agents.contains(&"exec-beta"),
+            "owner-wide sees every brain: {body}"
+        );
+        assert!(
+            !agents.contains(&"exec-ghost"),
+            "an expired presence is absent: {body}"
+        );
+        assert!(
+            body.get("served_brain").is_none(),
+            "owner-wide carries no served_brain echo: {body}"
+        );
+        assert!(body["collisions"].is_array(), "collisions always present");
+
+        // Scoped to the bound brain: only its roster + the echo.
+        let (status, body) = call_presences(&app, Some(bound.to_string_lossy().to_string())).await;
+        assert_eq!(status, StatusCode::OK);
+        let scoped: Vec<&str> = body["presences"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p["agent_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            scoped,
+            vec!["exec-alpha"],
+            "scoped roster is this brain only: {body}"
+        );
+        assert!(
+            body["served_brain"]["project_root"].is_string(),
+            "scoped response echoes served_brain: {body}"
+        );
+
+        // Unknown brain: honest 404 (the client degrades to an empty roster).
+        let (status, body) = call_presences(&app, Some("/nowhere/unknown-brain".to_string())).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "unknown brain 404s: {body}");
+        assert_eq!(body["error"], "unknown_brain");
+    }
+
+    /// The contract's collision + wire shape on the endpoint: two mutating hands
+    /// sharing one caller_root produce ONE `same_worktree` collision naming both
+    /// agents; and an empty owner serves the honest empty envelope.
+    #[tokio::test]
+    async fn presences_endpoint_collision_and_honest_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let app = rest_owner(&tmp.path().join("runtime"));
+        let registry = app.session.lock().instance.registry_root();
+
+        // Honest empty FIRST (nothing seeded).
+        let (status, body) = call_presences(&app, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["presences"], serde_json::json!([]));
+        assert_eq!(body["collisions"], serde_json::json!([]));
+
+        // Two mutating hands in ONE worktree on one brain → the collision.
+        let now = crate::util::now_ms();
+        seed_presence(
+            &registry,
+            "hand-a",
+            "/wt/one-brain",
+            Some("/wt/shared"),
+            true,
+            now,
+        );
+        seed_presence(
+            &registry,
+            "hand-b",
+            "/wt/one-brain",
+            Some("/wt/shared"),
+            true,
+            now,
+        );
+        // And the NORMAL shape beside it: a third mutating hand, same brain,
+        // its OWN worktree — never part of the warning.
+        seed_presence(
+            &registry,
+            "hand-c",
+            "/wt/one-brain",
+            Some("/wt/isolated"),
+            true,
+            now,
+        );
+
+        let (status, body) = call_presences(&app, None).await;
+        assert_eq!(status, StatusCode::OK);
+        let collisions = body["collisions"].as_array().unwrap();
+        assert_eq!(collisions.len(), 1, "exactly one colliding pair: {body}");
+        assert_eq!(collisions[0]["reason"], "same_worktree");
+        assert_eq!(collisions[0]["brain_root"], "/wt/one-brain");
+        assert_eq!(collisions[0]["caller_root"], "/wt/shared");
+        let ids = collisions[0]["agent_ids"].as_array().unwrap();
+        assert!(ids.contains(&serde_json::json!("hand-a")));
+        assert!(ids.contains(&serde_json::json!("hand-b")));
+        assert!(
+            !ids.contains(&serde_json::json!("hand-c")),
+            "the isolated worktree hand never joins the warning: {body}"
+        );
+        // Entry wire shape: caller_root present when it differs from root.
+        let a = body["presences"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["agent_id"] == "hand-a")
+            .unwrap();
+        assert_eq!(a["root"], "/wt/one-brain");
+        assert_eq!(a["caller_root"], "/wt/shared");
+        assert!(a["mutation"]["observed_at_ms"].is_number());
     }
 }

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -900,6 +900,18 @@ async fn handle_health(State(state): State<Arc<AppState>>) -> impl IntoResponse 
         let node_count = graph.num_nodes() as usize;
         let edge_count = graph.num_edges();
         drop(graph);
+        // P1 (ORGANISM-INSIDE): the durable presence roster + derived collisions.
+        // Owner-wide (every brain the registry serves — collisions are same-brain
+        // by construction, so no cross-brain pairing leaks); the data source the
+        // Hall strip (m1nd-ui lane) and any HTTP consumer read. Fail-open: an
+        // unreadable registry yields an empty roster, never a failed health read.
+        let (presences, presence_collisions) = {
+            let now = crate::util::now_ms();
+            let registry_root = session.instance.registry_root();
+            let roster = crate::presence::list_live(&registry_root, now);
+            let collisions = crate::presence::collisions_in(&roster, now);
+            (roster, collisions)
+        };
         serde_json::json!({
             "status": if node_count > 0 { "ok" } else { "empty" },
             "uptime_secs": session.uptime_seconds(),
@@ -907,6 +919,12 @@ async fn handle_health(State(state): State<Arc<AppState>>) -> impl IntoResponse 
             "edge_count": edge_count,
             "queries_processed": session.queries_processed,
             "agent_sessions": session.session_summary(),
+            "presences": {
+                "schema": crate::presence::PRESENCE_SCHEMA,
+                "scope": "owner-wide",
+                "roster": presences,
+                "collisions": presence_collisions,
+            },
             "domain": session.domain.name.as_str(),
             "graph_generation": session.graph_generation,
             "plasticity_generation": session.plasticity_generation,

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -45,6 +45,9 @@ pub mod mission_local;
 pub mod persist_handlers;
 pub mod perspective;
 pub mod perspective_handlers;
+// ORGANISM-INSIDE P1 — durable session-presence sidecars (m1nd-presence-v0): the
+// control room sees the team, collisions derived at read (askGOD verdict 2026-07-13).
+pub mod presence;
 // HUMAN VIEW v2 F2.5c — the owner's runnerd surface (announce liveness registry +
 // the mission_spawn proxy that keeps the shared secret owner-side).
 pub mod runnerd_owner;

--- a/m1nd-mcp/src/mission_handlers.rs
+++ b/m1nd-mcp/src/mission_handlers.rs
@@ -481,6 +481,40 @@ fn mission_dir(state: &SessionState) -> PathBuf {
     state.runtime_root.join("mission-control")
 }
 
+/// P1 presence enrichment: the MEASURED `task_ref` for a presence sidecar — the
+/// `msn_…` id of the agent's newest still-open (`status == "active"`)
+/// mission-control charter under `runtime_root`, or `None`. Measured from the
+/// charter, never a free declaration (askGOD verdict 2026-07-13). Best-effort and
+/// total: any unreadable/unparseable card is skipped, an absent dir yields `None`.
+pub fn latest_open_mission_for(runtime_root: &Path, agent_id: &str) -> Option<String> {
+    let dir = runtime_root.join("mission-control");
+    let entries = fs::read_dir(&dir).ok()?;
+    let mut best: Option<(u64, String)> = None;
+    for item in entries.flatten() {
+        let path = item.path();
+        if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(mission) = serde_json::from_str::<MissionState>(&raw) else {
+            continue;
+        };
+        if mission.agent_id != agent_id || mission.status != "active" {
+            continue;
+        }
+        let supersedes = match best.as_ref() {
+            Some((ts, _)) => mission.updated_at_ms >= *ts,
+            None => true,
+        };
+        if supersedes {
+            best = Some((mission.updated_at_ms, mission.mission_id));
+        }
+    }
+    best.map(|(_, id)| id)
+}
+
 /// Acquire the per-mission exclusive lock held across a load→mutate→save
 /// read-modify-write, so two concurrent writers to the same mission cannot
 /// clobber each other's update. Reuses the memorize lock primitive

--- a/m1nd-mcp/src/presence.rs
+++ b/m1nd-mcp/src/presence.rs
@@ -1,0 +1,588 @@
+//! presence — durable session-presence sidecars (`m1nd-presence-v0`).
+//!
+//! ORGANISM-INSIDE **P1**, askGOD verdict 2026-07-13 (binding changes 1–2,
+//! `docs/voice/ASKGOD-VERDICT-P1.md`). A runtime sidecar per live agent session,
+//! MOLDED on [`crate::instance_registry`]: files in the shared registry dir
+//! (sibling of `instances/`), TTL'd (minutes-scale), honest-absent on expiry,
+//! GC'd at boot. The BEAT rides `track_agent` (throttled — never one write per
+//! call, wrapped fail-open); COLLISIONS are DERIVED at read, never materialized.
+//!
+//! Laws (verdict + PRD §3.3): a presence is self-declared witness tissue — it
+//! verifies nothing, gates nothing; a dead presence DISAPPEARS rather than
+//! lying; the roster never renders a presence the registry did not serve
+//! (INV-10's discipline applied to sessions). Enrichment is measured or declared,
+//! never invented: `brain`/`caller_root` come from the session's own binding;
+//! `task_ref` is measured from the agent's own mission card; the DECLARED fields
+//! (`kind`/`theme`/`intent`/`working_set`/`worktree`) ride the optional
+//! `session_handshake` fields.
+//!
+//! **LIMITATION, written per the verdict's flagged risk (the inverse TTL lie):**
+//! *presence == activity VISIBLE TO m1nd.* An executor compiling for 20 minutes
+//! makes no m1nd calls, so its beat lapses and it expires from the roster — a
+//! live agent can read as absent. The roster answers "who is *talking to m1nd*,
+//! on what, since when", never "who is alive". It never invents a heartbeat.
+
+use crate::util::now_ms;
+use m1nd_core::error::{M1ndError, M1ndResult};
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+/// Wire schema of a presence sidecar.
+pub const PRESENCE_SCHEMA: &str = "m1nd-presence-v0";
+
+/// Sidecar directory under the shared registry root (sibling of `instances/`).
+const PRESENCE_DIR_NAME: &str = "presences";
+
+/// Minutes-scale TTL: a presence whose last beat is older than this is stale —
+/// absent at read, swept at boot. Well above [`PRESENCE_BEAT_THROTTLE_MS`] so a
+/// live, talking session never flickers to stale between two beats.
+pub const PRESENCE_TTL_MS: u64 = 120_000; // 2 minutes
+
+/// The beat is throttled to at most one disk write per this interval per session
+/// (the verdict's binding word: THROTTLED, "not one write per call"). Far below
+/// the TTL so freshness is never at risk.
+pub const PRESENCE_BEAT_THROTTLE_MS: u64 = 5_000; // 5 seconds
+
+/// Boot-GC grace: reclaim presence files whose last beat is older than this. Set
+/// to the TTL — an expired presence is already invisible at read; the sweep only
+/// reclaims its file so a restarted owner never inherits orphan sidecars.
+const PRESENCE_GC_AFTER_MS: u64 = PRESENCE_TTL_MS;
+
+/// The two honest levels of the mutation signal (verdict c). OBSERVED is measured
+/// from the agent's own dispatch; DECLARED is the agent's handshake intent. m1nd
+/// does not see git — nothing more is claimable.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MutationSignal {
+    /// Epoch ms of the last verb this session dispatched that
+    /// `server::read_only_denied` classifies as mutating (the OBSERVED level).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_at_ms: Option<u64>,
+    /// The session's self-declared handshake intent (the DECLARED level). Free
+    /// text; `"mutate"` is the signal word.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_intent: Option<String>,
+}
+
+/// A durable presence sidecar. Every field is measured or declared — nothing is
+/// invented (G1: measured facts only).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PresenceRecord {
+    pub schema: String,
+    /// Stable per `(agent_id, brain)` — the beat upserts one file, never N.
+    pub presence_id: String,
+    pub agent_id: String,
+    /// The bound brain's root (the session's `workspace_root`) — the collision
+    /// key. Never claimed: it is the session's own binding.
+    pub brain: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_root: Option<String>,
+    /// DECLARED via `session_handshake`: orchestrator|executor|pool-hand|… .
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// DECLARED via `session_handshake`: one free-text line ("reader slice 1").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+    /// DECLARED via `session_handshake`: the worktree/branch display string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    /// DECLARED via `session_handshake`: repo-relative paths and/or `sb_` blocks.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub working_set: Vec<String>,
+    /// MEASURED from the agent's own open `mission_start` charter (`msn_…`), never
+    /// free declaration. Absent when the agent holds no open mission card.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_ref: Option<String>,
+    #[serde(default)]
+    pub mutation: MutationSignal,
+    pub first_seen_ms: u64,
+    pub last_beat_ms: u64,
+    pub query_count: u64,
+    pub ttl_ms: u64,
+}
+
+impl PresenceRecord {
+    /// A presence is stale once its last beat is older than its own TTL. Stale
+    /// presences are absent at read and swept at boot (a dead presence
+    /// disappears rather than lying).
+    pub fn is_stale(&self, now: u64) -> bool {
+        now.saturating_sub(self.last_beat_ms) > self.ttl_ms
+    }
+
+    /// Age of the session in ms (always rendered, per the verdict).
+    pub fn age_ms(&self, now: u64) -> u64 {
+        now.saturating_sub(self.first_seen_ms)
+    }
+
+    /// Whether this session carries a mutation signal at either honest level.
+    /// OBSERVED counts only while still within the presence's TTL (a mutation
+    /// seen long ago is not a live collision signal); DECLARED counts whenever
+    /// the handshake intent is `mutate`.
+    pub fn has_mutation_signal(&self, now: u64) -> bool {
+        let observed = self
+            .mutation
+            .observed_at_ms
+            .map(|ts| now.saturating_sub(ts) <= self.ttl_ms)
+            .unwrap_or(false);
+        let declared = self
+            .mutation
+            .declared_intent
+            .as_deref()
+            .map(|intent| intent.eq_ignore_ascii_case("mutate"))
+            .unwrap_or(false);
+        observed || declared
+    }
+}
+
+/// A DERIVED collision (never stored): two live, mutating presences on the same
+/// brain whose declared work co-locates. `overlap` names the measurable signal
+/// (shared caller_root/worktree, or shared working-set entries).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Collision {
+    pub subject_agent: String,
+    pub subject_presence: String,
+    pub other_agent: String,
+    pub other_presence: String,
+    pub overlap: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Paths + ids
+// ---------------------------------------------------------------------------
+
+fn presence_dir(registry_root: &Path) -> PathBuf {
+    registry_root.join(PRESENCE_DIR_NAME)
+}
+
+fn presence_path(registry_root: &Path, presence_id: &str) -> PathBuf {
+    presence_dir(registry_root).join(format!("{presence_id}.json"))
+}
+
+/// Stable presence id for a `(agent_id, brain)` pair: the same session on the
+/// same brain always upserts ONE file. `prs_<12hex>`.
+pub fn stable_presence_id(agent_id: &str, brain: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    agent_id.hash(&mut hasher);
+    0u8.hash(&mut hasher); // domain separator so "a"+"b" ≠ "ab"
+    brain.hash(&mut hasher);
+    format!("prs_{:012x}", hasher.finish() & 0xffff_ffff_ffff)
+}
+
+// ---------------------------------------------------------------------------
+// Write (the throttled beat's disk half) — fail-open at the call site
+// ---------------------------------------------------------------------------
+
+/// Atomically upsert a presence sidecar. Callers wrap this in the vigil
+/// fail-open guard so a broken write can never break a tool call.
+pub fn write_presence(registry_root: &Path, record: &PresenceRecord) -> M1ndResult<()> {
+    let path = presence_path(registry_root, &record.presence_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(record).map_err(|error| {
+        M1ndError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "failed to serialize presence {}: {error}",
+                record.presence_id
+            ),
+        ))
+    })?;
+    let temp = path.with_extension("tmp");
+    fs::write(&temp, json)?;
+    fs::rename(temp, &path)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Read (honest-absent on expiry)
+// ---------------------------------------------------------------------------
+
+/// Read every parseable presence sidecar. Unparseable/foreign files are skipped
+/// (never surfaced, never deleted). No staleness filter — see [`list_live`].
+fn read_all(registry_root: &Path) -> Vec<PresenceRecord> {
+    let dir = presence_dir(registry_root);
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return out; // dir absent = no presences yet
+    };
+    for item in entries.flatten() {
+        let path = item.path();
+        if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(raw) = fs::read_to_string(&path) {
+            if let Ok(record) = serde_json::from_str::<PresenceRecord>(&raw) {
+                out.push(record);
+            }
+        }
+    }
+    out
+}
+
+/// The live roster across ALL brains served by this registry: every non-stale
+/// presence. A stale presence is honest-absent (a dead presence disappears).
+pub fn list_live(registry_root: &Path, now: u64) -> Vec<PresenceRecord> {
+    let mut live: Vec<PresenceRecord> = read_all(registry_root)
+        .into_iter()
+        .filter(|p| !p.is_stale(now))
+        .collect();
+    // Youngest beat first, then a stable agent order.
+    live.sort_by(|a, b| {
+        b.last_beat_ms
+            .cmp(&a.last_beat_ms)
+            .then_with(|| a.agent_id.cmp(&b.agent_id))
+    });
+    live
+}
+
+/// The live roster scoped to ONE brain (the served-brain roster the cockpit and
+/// north render — "this brain", never a cross-brain aggregate).
+pub fn roster_for_brain(registry_root: &Path, brain: &str, now: u64) -> Vec<PresenceRecord> {
+    list_live(registry_root, now)
+        .into_iter()
+        .filter(|p| p.brain == brain)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Boot GC — reclaim orphan sidecars after an owner restart
+// ---------------------------------------------------------------------------
+
+/// Sweep presence files whose last beat is older than [`PRESENCE_GC_AFTER_MS`].
+/// Conservative: any file that fails to read/parse is SKIPPED (never deleted),
+/// so corrupt/foreign files are left untouched. Returns the number removed. Safe
+/// to call at boot: a still-live session's fresh file is never touched.
+pub fn gc_stale(registry_root: &Path) -> usize {
+    let dir = presence_dir(registry_root);
+    let now = now_ms();
+    let mut removed = 0usize;
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return 0;
+    };
+    for item in entries.flatten() {
+        let path = item.path();
+        if path.extension().and_then(|v| v.to_str()) != Some("json") {
+            continue;
+        }
+        // Conservative: unreadable/unparseable -> skip (do NOT delete).
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(record) = serde_json::from_str::<PresenceRecord>(&raw) else {
+            continue;
+        };
+        if now.saturating_sub(record.last_beat_ms) > PRESENCE_GC_AFTER_MS
+            && fs::remove_file(&path).is_ok()
+        {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+// ---------------------------------------------------------------------------
+// Collision derivation (read-time, pure — never stored)
+// ---------------------------------------------------------------------------
+
+/// The co-location signal (verdict binding change 2): same caller_root/worktree
+/// OR declared working-set overlap. Empty values never count. `None` when the
+/// two sessions share no measurable work signal.
+fn overlap_signal(a: &PresenceRecord, b: &PresenceRecord) -> Option<Vec<String>> {
+    let mut sig = Vec::new();
+    if let (Some(ca), Some(cb)) = (a.caller_root.as_deref(), b.caller_root.as_deref()) {
+        if !ca.is_empty() && ca == cb {
+            sig.push(format!("caller_root:{ca}"));
+        }
+    }
+    if let (Some(wa), Some(wb)) = (a.worktree.as_deref(), b.worktree.as_deref()) {
+        if !wa.is_empty() && wa == wb {
+            sig.push(format!("worktree:{wa}"));
+        }
+    }
+    for path in &a.working_set {
+        if !path.is_empty() && b.working_set.contains(path) {
+            sig.push(format!("path:{path}"));
+        }
+    }
+    if sig.is_empty() {
+        None
+    } else {
+        Some(sig)
+    }
+}
+
+/// The full collision predicate (verdict binding change 2): SAME brain AND (same
+/// caller_root/worktree OR working-set overlap) AND BOTH with a mutation signal.
+/// Same-brain alone NEVER warns — three executors in isolated worktrees on one
+/// brain is the NORMAL burst shape. Returns the overlap descriptor on a hit.
+fn collision_between(a: &PresenceRecord, b: &PresenceRecord, now: u64) -> Option<Vec<String>> {
+    if a.brain.is_empty() || a.brain != b.brain {
+        return None; // same brain required (and never on an unbound sentinel)
+    }
+    if !(a.has_mutation_signal(now) && b.has_mutation_signal(now)) {
+        return None; // both must carry a mutation signal
+    }
+    overlap_signal(a, b) // and the work must co-locate
+}
+
+/// All collisions in a brain-scoped roster, from the SUBJECT agent's point of
+/// view. Each returned collision names `subject_agent` first — so north can push
+/// the gap line onto exactly the sessions involved (the P1 gate requires it on
+/// BOTH sessions' packets, and each session derives its own).
+pub fn collisions_for_agent(roster: &[PresenceRecord], agent_id: &str, now: u64) -> Vec<Collision> {
+    let mut out = Vec::new();
+    let subjects = roster.iter().filter(|p| p.agent_id == agent_id);
+    for subject in subjects {
+        for other in roster {
+            if other.presence_id == subject.presence_id || other.agent_id == subject.agent_id {
+                continue;
+            }
+            if let Some(overlap) = collision_between(subject, other, now) {
+                out.push(Collision {
+                    subject_agent: subject.agent_id.clone(),
+                    subject_presence: subject.presence_id.clone(),
+                    other_agent: other.agent_id.clone(),
+                    other_presence: other.presence_id.clone(),
+                    overlap,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Every unordered colliding pair in a brain-scoped roster (for the cockpit root
+/// line + drill). Each pair appears once.
+pub fn collisions_in(roster: &[PresenceRecord], now: u64) -> Vec<Collision> {
+    let mut out = Vec::new();
+    for i in 0..roster.len() {
+        for j in (i + 1)..roster.len() {
+            let a = &roster[i];
+            let b = &roster[j];
+            if a.agent_id == b.agent_id {
+                continue;
+            }
+            if let Some(overlap) = collision_between(a, b, now) {
+                out.push(Collision {
+                    subject_agent: a.agent_id.clone(),
+                    subject_presence: a.presence_id.clone(),
+                    other_agent: b.agent_id.clone(),
+                    other_presence: b.presence_id.clone(),
+                    overlap,
+                });
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(agent: &str, brain: &str, now: u64) -> PresenceRecord {
+        PresenceRecord {
+            schema: PRESENCE_SCHEMA.to_string(),
+            presence_id: stable_presence_id(agent, brain),
+            agent_id: agent.to_string(),
+            brain: brain.to_string(),
+            caller_root: None,
+            kind: None,
+            theme: None,
+            worktree: None,
+            working_set: Vec::new(),
+            task_ref: None,
+            mutation: MutationSignal::default(),
+            first_seen_ms: now,
+            last_beat_ms: now,
+            query_count: 1,
+            ttl_ms: PRESENCE_TTL_MS,
+        }
+    }
+
+    #[test]
+    fn stable_id_is_deterministic_and_pair_scoped() {
+        assert_eq!(
+            stable_presence_id("exec-a", "/repo/x"),
+            stable_presence_id("exec-a", "/repo/x"),
+            "same (agent, brain) -> same id (the beat upserts one file)"
+        );
+        assert_ne!(
+            stable_presence_id("exec-a", "/repo/x"),
+            stable_presence_id("exec-a", "/repo/y"),
+            "same agent, different brain -> different file"
+        );
+        assert_ne!(
+            stable_presence_id("a", "b/x"),
+            stable_presence_id("ab", "/x"),
+            "domain separator: concatenation collisions are avoided"
+        );
+        assert!(stable_presence_id("a", "b").starts_with("prs_"));
+    }
+
+    #[test]
+    fn write_read_roundtrip_and_ttl_absence() {
+        let tmp = std::env::temp_dir().join(format!("m1nd-presence-test-{}", now_ms()));
+        let now = now_ms();
+        let r = rec("exec-1", "/brain/one", now);
+        write_presence(&tmp, &r).unwrap();
+
+        // Fresh -> present at read.
+        let live = list_live(&tmp, now);
+        assert_eq!(live.len(), 1, "a fresh presence is present at read");
+
+        // Aged past its TTL -> honest-absent (a dead presence disappears).
+        let future = now + PRESENCE_TTL_MS + 1;
+        assert!(
+            list_live(&tmp, future).is_empty(),
+            "an expired presence is absent at read, never a lingering ghost"
+        );
+        // ...but the file still exists until GC reclaims it.
+        assert_eq!(read_all(&tmp).len(), 1, "the file lingers until GC");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn gc_reclaims_only_expired_sidecars() {
+        let tmp = std::env::temp_dir().join(format!("m1nd-presence-gc-{}", now_ms()));
+        let now = now_ms();
+        // A live one and an orphan aged well past the GC grace.
+        let live = rec("live", "/b", now);
+        let mut orphan = rec("orphan", "/b", now);
+        orphan.last_beat_ms = now.saturating_sub(PRESENCE_GC_AFTER_MS + 60_000);
+        write_presence(&tmp, &live).unwrap();
+        write_presence(&tmp, &orphan).unwrap();
+
+        let removed = gc_stale(&tmp);
+        assert_eq!(
+            removed, 1,
+            "boot GC reclaims the orphan sidecar, not the live one"
+        );
+        let remaining = read_all(&tmp);
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].agent_id, "live");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn mutation_signal_two_honest_levels() {
+        let now = now_ms();
+        let mut observed = rec("o", "/b", now);
+        observed.mutation.observed_at_ms = Some(now);
+        assert!(
+            observed.has_mutation_signal(now),
+            "OBSERVED counts while fresh"
+        );
+        assert!(
+            !observed.has_mutation_signal(now + PRESENCE_TTL_MS + 1),
+            "OBSERVED lapses past the TTL"
+        );
+
+        let mut declared = rec("d", "/b", now);
+        declared.mutation.declared_intent = Some("mutate".to_string());
+        assert!(declared.has_mutation_signal(now), "DECLARED mutate counts");
+
+        let mut reader = rec("r", "/b", now);
+        reader.mutation.declared_intent = Some("read".to_string());
+        assert!(
+            !reader.has_mutation_signal(now),
+            "a declared reader carries no signal"
+        );
+    }
+
+    #[test]
+    fn collision_fires_on_shared_worktree_when_both_mutate() {
+        let now = now_ms();
+        let mut a = rec("hand-a", "/m1nd", now);
+        let mut b = rec("hand-b", "/m1nd", now);
+        a.worktree = Some("feat/x".to_string());
+        b.worktree = Some("feat/x".to_string());
+        a.mutation.declared_intent = Some("mutate".to_string());
+        b.mutation.declared_intent = Some("mutate".to_string());
+
+        let roster = vec![a, b];
+        let pairs = collisions_in(&roster, now);
+        assert_eq!(pairs.len(), 1, "two mutating hands in ONE worktree collide");
+        assert!(pairs[0]
+            .overlap
+            .iter()
+            .any(|o| o.contains("worktree:feat/x")));
+
+        // Both sessions derive it from their own point of view (the P1 gate).
+        assert_eq!(collisions_for_agent(&roster, "hand-a", now).len(), 1);
+        assert_eq!(collisions_for_agent(&roster, "hand-b", now).len(), 1);
+    }
+
+    #[test]
+    fn collision_fires_on_working_set_overlap() {
+        let now = now_ms();
+        let mut a = rec("a", "/m1nd", now);
+        let mut b = rec("b", "/m1nd", now);
+        a.working_set = vec!["src/server.rs".into(), "src/a.rs".into()];
+        b.working_set = vec!["src/b.rs".into(), "src/server.rs".into()];
+        a.mutation.observed_at_ms = Some(now);
+        b.mutation.observed_at_ms = Some(now);
+        let roster = vec![a, b];
+        let pairs = collisions_in(&roster, now);
+        assert_eq!(pairs.len(), 1);
+        assert!(pairs[0].overlap.iter().any(|o| o == "path:src/server.rs"));
+    }
+
+    #[test]
+    fn anti_test_isolated_worktrees_never_warn() {
+        // The NORMAL burst shape: three executors, same brain, DISTINCT worktrees,
+        // non-overlapping work, all mutating. Same-brain alone must NEVER warn.
+        let now = now_ms();
+        let mut mk = |agent: &str, wt: &str| {
+            let mut r = rec(agent, "/m1nd", now);
+            r.worktree = Some(wt.to_string());
+            r.caller_root = Some(format!("/Users/dev/{wt}"));
+            r.mutation.declared_intent = Some("mutate".to_string());
+            r
+        };
+        let roster = vec![
+            mk("p1-server", "m1nd-p1srv"),
+            mk("p1-ui", "m1nd-p1ui"),
+            mk("g1", "m1nd-g1"),
+        ];
+        assert!(
+            collisions_in(&roster, now).is_empty(),
+            "three mutating executors in isolated worktrees on one brain do NOT collide"
+        );
+        assert!(collisions_for_agent(&roster, "p1-server", now).is_empty());
+    }
+
+    #[test]
+    fn no_collision_when_only_one_mutates() {
+        let now = now_ms();
+        let mut a = rec("a", "/m1nd", now);
+        let mut b = rec("b", "/m1nd", now);
+        a.caller_root = Some("/shared/wt".to_string());
+        b.caller_root = Some("/shared/wt".to_string());
+        a.mutation.declared_intent = Some("mutate".to_string());
+        // b declares read.
+        b.mutation.declared_intent = Some("read".to_string());
+        let roster = vec![a, b];
+        assert!(
+            collisions_in(&roster, now).is_empty(),
+            "co-located but only one hand mutating is not a collision"
+        );
+    }
+
+    #[test]
+    fn roster_for_brain_scopes_to_one_brain() {
+        let tmp = std::env::temp_dir().join(format!("m1nd-presence-scope-{}", now_ms()));
+        let now = now_ms();
+        write_presence(&tmp, &rec("a", "/brain/one", now)).unwrap();
+        write_presence(&tmp, &rec("b", "/brain/two", now)).unwrap();
+        let one = roster_for_brain(&tmp, "/brain/one", now);
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].brain, "/brain/one");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/m1nd-mcp/src/presence.rs
+++ b/m1nd-mcp/src/presence.rs
@@ -379,6 +379,81 @@ pub fn collisions_in(roster: &[PresenceRecord], now: u64) -> Vec<Collision> {
     out
 }
 
+// ---------------------------------------------------------------------------
+// Wire shape — the P1-UI contract (`GET /api/presences`, P1-UI-CONTRACT.md)
+// ---------------------------------------------------------------------------
+
+/// One contract `PresenceEntry` for the `/api/presences` wire: `{agent_id, root,
+/// caller_root?, first_seen_ms, last_seen_ms, query_count, mutation, task_ref?}`.
+/// `root` is the sidecar's `brain`; `caller_root` is OMITTED when it equals the
+/// root (the contract's absent-when-equal rule); `last_seen_ms` is the last real
+/// sighting (the throttled beat — never a synthetic ping); optional fields are
+/// absent, never null-fabricated.
+pub fn wire_entry(p: &PresenceRecord) -> serde_json::Value {
+    let mut entry = serde_json::json!({
+        "agent_id": p.agent_id,
+        "root": p.brain,
+        "first_seen_ms": p.first_seen_ms,
+        "last_seen_ms": p.last_beat_ms,
+        "query_count": p.query_count,
+        // MutationSignal serializes exactly the contract's PresenceMutation:
+        // {observed_at_ms?, declared_intent?}, both skip-if-none.
+        "mutation": serde_json::to_value(&p.mutation).unwrap_or_else(|_| serde_json::json!({})),
+    });
+    if let Some(caller_root) = p.caller_root.as_deref().filter(|c| *c != p.brain) {
+        entry["caller_root"] = serde_json::json!(caller_root);
+    }
+    if let Some(task_ref) = p.task_ref.as_deref() {
+        entry["task_ref"] = serde_json::json!(task_ref);
+    }
+    entry
+}
+
+/// One contract `PresenceCollision`: `{brain_root, caller_root?, agent_ids,
+/// reason}`. `reason` maps the derived overlap onto the contract's two arms —
+/// any shared `caller_root:`/`worktree:` signal is the measurable
+/// `same_worktree` arm (carrying the shared location), a pure working-set
+/// overlap is `declared_overlap` (no location claimed). `None` only when the
+/// collision's subject presence is not in the roster it was derived from
+/// (impossible by construction; skipped fail-open rather than fabricated).
+pub fn wire_collision(roster: &[PresenceRecord], c: &Collision) -> Option<serde_json::Value> {
+    let subject = roster
+        .iter()
+        .find(|p| p.presence_id == c.subject_presence)?;
+    // Prefer the caller_root signal (a measured path), then the declared
+    // worktree string — both are the same_worktree arm.
+    let shared_location = c
+        .overlap
+        .iter()
+        .find_map(|o| o.strip_prefix("caller_root:"))
+        .or_else(|| c.overlap.iter().find_map(|o| o.strip_prefix("worktree:")));
+    let mut out = serde_json::json!({
+        "brain_root": subject.brain,
+        "agent_ids": [c.subject_agent, c.other_agent],
+        "reason": if shared_location.is_some() { "same_worktree" } else { "declared_overlap" },
+    });
+    if let Some(location) = shared_location {
+        out["caller_root"] = serde_json::json!(location);
+    }
+    Some(out)
+}
+
+/// The `/api/presences` wire body over a (possibly brain-scoped) roster:
+/// `{presences: [...], collisions: [...]}`. `collisions` is ALWAYS present (even
+/// empty) — per the contract, a present array makes the SERVER authoritative and
+/// the client renders it verbatim instead of re-deriving. The caller attaches
+/// the optional `served_brain` echo when the `?brain=` selector was used.
+pub fn wire_response(roster: &[PresenceRecord], now: u64) -> serde_json::Value {
+    let collisions: Vec<serde_json::Value> = collisions_in(roster, now)
+        .iter()
+        .filter_map(|c| wire_collision(roster, c))
+        .collect();
+    serde_json::json!({
+        "presences": roster.iter().map(wire_entry).collect::<Vec<_>>(),
+        "collisions": collisions,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -584,5 +659,90 @@ mod tests {
         assert_eq!(one.len(), 1);
         assert_eq!(one[0].brain, "/brain/one");
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// P1-UI contract — the wire `PresenceEntry`: `root` carries the brain,
+    /// `caller_root` is OMITTED when it equals the root and present when it
+    /// differs, `last_seen_ms` mirrors the beat, optional fields are absent
+    /// (never null-fabricated), and mutation carries the two honest levels.
+    #[test]
+    fn wire_entry_matches_the_ui_contract_shape() {
+        let now = now_ms();
+        let mut p = rec("exec-a", "/brain/one", now);
+        p.caller_root = Some("/brain/one".to_string()); // equals root → omitted
+        let e = wire_entry(&p);
+        assert_eq!(e["agent_id"], "exec-a");
+        assert_eq!(e["root"], "/brain/one");
+        assert!(
+            e.get("caller_root").is_none(),
+            "caller_root == root is omitted"
+        );
+        assert!(e.get("task_ref").is_none(), "absent task_ref stays absent");
+        assert_eq!(e["last_seen_ms"], serde_json::json!(p.last_beat_ms));
+        assert_eq!(e["first_seen_ms"], serde_json::json!(p.first_seen_ms));
+        assert_eq!(
+            e["mutation"],
+            serde_json::json!({}),
+            "quiet read-only presence"
+        );
+
+        p.caller_root = Some("/wt/lane-a".to_string()); // differs → present
+        p.task_ref = Some("msn_000000000000_neutral".to_string());
+        p.mutation.observed_at_ms = Some(now);
+        let e2 = wire_entry(&p);
+        assert_eq!(e2["caller_root"], "/wt/lane-a");
+        assert_eq!(e2["task_ref"], "msn_000000000000_neutral");
+        assert_eq!(e2["mutation"]["observed_at_ms"], serde_json::json!(now));
+        assert!(e2["mutation"].get("declared_intent").is_none());
+    }
+
+    /// P1-UI contract — the wire `PresenceCollision`: the measurable arm maps to
+    /// reason `same_worktree` carrying the shared location; a pure working-set
+    /// overlap maps to `declared_overlap` with NO location claimed; `agent_ids`
+    /// names both hands; the envelope's `collisions` is present even when empty
+    /// (server-authoritative).
+    #[test]
+    fn wire_collision_and_response_match_the_ui_contract() {
+        let now = now_ms();
+        // same_worktree arm (shared caller_root).
+        let mut a = rec("hand-a", "/brain/one", now);
+        let mut b = rec("hand-b", "/brain/one", now);
+        a.caller_root = Some("/wt/shared".to_string());
+        b.caller_root = Some("/wt/shared".to_string());
+        a.mutation.declared_intent = Some("mutate".to_string());
+        b.mutation.observed_at_ms = Some(now);
+        let roster = vec![a, b];
+        let body = wire_response(&roster, now);
+        assert_eq!(body["presences"].as_array().unwrap().len(), 2);
+        let collisions = body["collisions"].as_array().unwrap();
+        assert_eq!(collisions.len(), 1);
+        assert_eq!(collisions[0]["reason"], "same_worktree");
+        assert_eq!(collisions[0]["brain_root"], "/brain/one");
+        assert_eq!(collisions[0]["caller_root"], "/wt/shared");
+        let ids = collisions[0]["agent_ids"].as_array().unwrap();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&serde_json::json!("hand-a")));
+        assert!(ids.contains(&serde_json::json!("hand-b")));
+
+        // declared_overlap arm (working-set only, no shared location).
+        let mut c = rec("hand-c", "/brain/one", now);
+        let mut d = rec("hand-d", "/brain/one", now);
+        c.working_set = vec!["src/shared.rs".into()];
+        d.working_set = vec!["src/shared.rs".into()];
+        c.mutation.declared_intent = Some("mutate".to_string());
+        d.mutation.declared_intent = Some("mutate".to_string());
+        let roster2 = vec![c, d];
+        let body2 = wire_response(&roster2, now);
+        let col2 = &body2["collisions"].as_array().unwrap()[0];
+        assert_eq!(col2["reason"], "declared_overlap");
+        assert!(
+            col2.get("caller_root").is_none(),
+            "declared_overlap claims no location"
+        );
+
+        // Empty roster → honest empty envelope, collisions PRESENT (authoritative).
+        let empty = wire_response(&[], now);
+        assert_eq!(empty["presences"], serde_json::json!([]));
+        assert_eq!(empty["collisions"], serde_json::json!([]));
     }
 }

--- a/m1nd-mcp/src/protocol/core.rs
+++ b/m1nd-mcp/src/protocol/core.rs
@@ -217,7 +217,7 @@ pub struct HealthInput {
 }
 
 /// Input for m1nd.session_handshake.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct SessionHandshakeInput {
     pub agent_id: String,
     #[serde(default)]
@@ -228,6 +228,26 @@ pub struct SessionHandshakeInput {
     pub missing_tools: Vec<String>,
     #[serde(default)]
     pub scope: Option<String>,
+    // --- ORGANISM-INSIDE P1 — optional presence DECLARATION (askGOD verdict
+    //     2026-07-13). The session's self-declared control-room enrichment, all
+    //     optional and honest-absent. Measured facts (brain / caller_root /
+    //     task_ref) are NEVER taken from here — only what the agent chooses to
+    //     declare about itself. ---
+    /// orchestrator | executor | pool-hand | runner | oracle | human-ui.
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// One free-text line ("reader slice 1", "F12 curation lane").
+    #[serde(default)]
+    pub theme: Option<String>,
+    /// `read` | `mutate` — the DECLARED mutation level (verdict c).
+    #[serde(default)]
+    pub intent: Option<String>,
+    /// Worktree/branch display string.
+    #[serde(default)]
+    pub worktree: Option<String>,
+    /// Declared working set: repo-relative paths and/or `sb_` block ids.
+    #[serde(default)]
+    pub working_set: Vec<String>,
 }
 
 /// Input for m1nd.trust_selftest.

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -11083,4 +11083,167 @@ mod tests {
             "sanity: the bare key really does float the undated claim to the front"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // P1 presences — the beat by traffic, its throttle, its fail-open, and the
+    // north collision gap on BOTH colliding sessions' packets.
+    // -----------------------------------------------------------------------
+
+    fn presence_dir_of(state: &SessionState) -> std::path::PathBuf {
+        state.instance.registry_root().join("presences")
+    }
+
+    fn read_presence_file(
+        state: &SessionState,
+        agent: &str,
+        brain: &str,
+    ) -> Option<crate::presence::PresenceRecord> {
+        let path = presence_dir_of(state).join(format!(
+            "{}.json",
+            crate::presence::stable_presence_id(agent, brain)
+        ));
+        let raw = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    /// Registration by traffic + the throttle: the FIRST tracked call writes the
+    /// sidecar; an immediate second call is THROTTLED (no second write); a
+    /// changed signal (an observed mutation) clears the throttle so the next
+    /// call carries it promptly.
+    #[test]
+    fn presence_beat_registers_by_traffic_and_throttles() {
+        let (_temp, mut state) = build_state();
+        let brain = "/wt/beat-brain";
+        state.workspace_root = Some(brain.to_string());
+
+        // 1. Registration by traffic — the seam call is track_agent.
+        state.track_agent("beat-agent");
+        let first = read_presence_file(&state, "beat-agent", brain)
+            .expect("first tracked call writes the presence sidecar");
+        assert_eq!(first.agent_id, "beat-agent");
+        assert_eq!(first.brain, brain);
+        assert_eq!(first.query_count, 1);
+
+        // 2. Throttle — an immediate second call updates memory, not disk.
+        state.track_agent("beat-agent");
+        let after = read_presence_file(&state, "beat-agent", brain).expect("sidecar persists");
+        assert_eq!(
+            after.query_count, 1,
+            "an immediate re-beat is throttled: the sidecar still carries the first write"
+        );
+
+        // 3. A changed signal clears the throttle: the observed mutation rides
+        //    the very next tracked call.
+        state.note_mutation_observed("beat-agent");
+        state.track_agent("beat-agent");
+        let mutated = read_presence_file(&state, "beat-agent", brain).expect("sidecar persists");
+        assert!(
+            mutated.mutation.observed_at_ms.is_some(),
+            "the observed-mutation stamp must ride the next beat promptly"
+        );
+        assert_eq!(
+            mutated.query_count, 3,
+            "the forced beat carries fresh counters"
+        );
+    }
+
+    /// FAIL-OPEN: a broken sidecar (the presences dir path occupied by a FILE)
+    /// must never break the tool call — track_agent still succeeds and the
+    /// in-memory session still advances.
+    #[test]
+    fn presence_beat_fails_open_when_sidecar_write_breaks() {
+        let (_temp, mut state) = build_state();
+        state.workspace_root = Some("/wt/failopen-brain".to_string());
+        // Occupy the presences DIR path with a regular file so create_dir_all fails.
+        let dir = presence_dir_of(&state);
+        std::fs::create_dir_all(dir.parent().expect("registry root")).expect("mk registry");
+        std::fs::write(&dir, b"not a directory").expect("plant the blocker");
+
+        state.track_agent("unlucky-agent");
+
+        let session = state
+            .sessions
+            .get("unlucky-agent")
+            .expect("session tracked");
+        assert_eq!(
+            session.query_count, 1,
+            "the tool call's tracking must survive a broken sidecar (fail-open)"
+        );
+    }
+
+    /// The P1 gate's packet law: an arranged collision surfaces in the north
+    /// honest_gaps of BOTH colliding sessions — and NOT in a bystander's packet.
+    #[test]
+    fn north_collision_gap_rides_both_colliding_packets() {
+        let (_temp, mut state) = build_state();
+        let brain = "/wt/north-brain";
+        state.workspace_root = Some(brain.to_string());
+        let registry = state.instance.registry_root();
+        let now = crate::util::now_ms();
+
+        let seed = |agent: &str, caller: &str| {
+            let record = crate::presence::PresenceRecord {
+                schema: crate::presence::PRESENCE_SCHEMA.to_string(),
+                presence_id: crate::presence::stable_presence_id(agent, brain),
+                agent_id: agent.to_string(),
+                brain: brain.to_string(),
+                caller_root: Some(caller.to_string()),
+                kind: None,
+                theme: None,
+                worktree: None,
+                working_set: Vec::new(),
+                task_ref: None,
+                mutation: crate::presence::MutationSignal {
+                    observed_at_ms: Some(now),
+                    declared_intent: None,
+                },
+                first_seen_ms: now,
+                last_beat_ms: now,
+                query_count: 1,
+                ttl_ms: crate::presence::PRESENCE_TTL_MS,
+            };
+            crate::presence::write_presence(&registry, &record).expect("seed presence");
+        };
+        // Two mutating hands in ONE worktree; a third in its own worktree.
+        seed("hand-a", "/wt/shared");
+        seed("hand-b", "/wt/shared");
+        seed("hand-c", "/wt/isolated");
+
+        let gaps_of = |state: &mut SessionState, agent: &str| -> Vec<String> {
+            let north = super::dispatch_tool(
+                state,
+                "north",
+                &serde_json::json!({ "agent_id": agent, "task": "collision probe" }),
+            )
+            .expect("north packet");
+            north["honest_gaps"]
+                .as_array()
+                .map(|gaps| {
+                    gaps.iter()
+                        .filter_map(|g| g.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+
+        let a_gaps = gaps_of(&mut state, "hand-a");
+        assert!(
+            a_gaps
+                .iter()
+                .any(|g| g.starts_with("COLLISION:") && g.contains("hand-b")),
+            "hand-a's packet must carry the collision gap naming hand-b: {a_gaps:?}"
+        );
+        let b_gaps = gaps_of(&mut state, "hand-b");
+        assert!(
+            b_gaps
+                .iter()
+                .any(|g| g.starts_with("COLLISION:") && g.contains("hand-a")),
+            "hand-b's packet must carry the collision gap naming hand-a: {b_gaps:?}"
+        );
+        let c_gaps = gaps_of(&mut state, "hand-c");
+        assert!(
+            !c_gaps.iter().any(|g| g.starts_with("COLLISION:")),
+            "the isolated-worktree hand must NOT carry a collision gap: {c_gaps:?}"
+        );
+    }
 }

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -641,7 +641,7 @@ fn all_tool_schemas_inner() -> serde_json::Value {
             },
             {
                 "name": "cockpit",
-                "description": "The navigable m1nd menu (m1nd-cockpit-v0) — the human's ON-REQUEST router over m1nd's read surfaces, a read-only sibling of north (never a north field; if it breaks it breaks alone). Call it ONLY when the human asks ('?', 'show me m1nd', 'what can I look at') — at a landing the human_view card speaks, never an auto-served menu. The root is argument-less READS only, in seven stable slots (labels move with state, slots never do): the tray (a POINTER — the human stamp gesture, no verb), the map (system_blocks_snapshot), missions (a POINTER to the tray), health (doctor), trust, recent-memories (boot_memory, fixed projection), and drift. Pointer entries carry NO verb — nothing to execute even by mistake. Pass select=\"<slot>\" to drill one collection (depth ≤3; select=\"0\" re-serves the root); a drill re-asserts store_version + state_sig and says 'state moved' honestly when your seen_store_version diverged. Every response carries menu_sig — the SAME short reference a widget button carries back (never free command text, never a write verb). The read entries are DERIVED and filtered against the write deny-list, so a verb that becomes a mutation drops itself. Read-only safe.",
+                "description": "The navigable m1nd menu (m1nd-cockpit-v0) — the human's ON-REQUEST router over m1nd's read surfaces, a read-only sibling of north (never a north field; if it breaks it breaks alone). Call it ONLY when the human asks ('?', 'show me m1nd', 'what can I look at') — at a landing the human_view card speaks, never an auto-served menu. The root is argument-less READS only, in eight stable slots (labels move with state, slots never do): the tray (a POINTER — the human stamp gesture, no verb), the map (system_blocks_snapshot), missions (a POINTER to the tray), health (doctor), trust, recent-memories (boot_memory, fixed projection), drift, and presences (the P1 control-room roster of THIS brain — who is talking to m1nd, on what, since when — with a collision warning on the label when two mutating hands share the work). Pointer entries carry NO verb — nothing to execute even by mistake. Pass select=\"<slot>\" to drill one collection (depth ≤3; select=\"0\" re-serves the root); a drill re-asserts store_version + state_sig and says 'state moved' honestly when your seen_store_version diverged. Every response carries menu_sig — the SAME short reference a widget button carries back (never free command text, never a write verb). The read entries are DERIVED and filtered against the write deny-list, so a verb that becomes a mutation drops itself. Read-only safe.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -1061,7 +1061,7 @@ fn all_tool_schemas_inner() -> serde_json::Value {
             },
             {
                 "name": "session_handshake",
-                "description": "Cheap session trust handshake before relying on m1nd retrieval",
+                "description": "Cheap session trust handshake before relying on m1nd retrieval. Optionally DECLARE your presence for the control room (kind/theme/intent/worktree/working_set) so the cockpit, Hall, and north can see who is working, on what, since when — advisory telemetry, never a gate.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -1069,7 +1069,12 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "observed_tool_count": { "type": "integer", "description": "Optional tools/list count seen by the host client" },
                         "available_tools": { "type": "array", "items": { "type": "string" }, "description": "Optional tool names exposed by the host client" },
                         "missing_tools": { "type": "array", "items": { "type": "string" }, "description": "Optional required tool names missing from the host client surface" },
-                        "scope": { "type": "string", "description": "Optional absolute or repo-relative scope/path to validate against the active workspace binding" }
+                        "scope": { "type": "string", "description": "Optional absolute or repo-relative scope/path to validate against the active workspace binding" },
+                        "kind": { "type": "string", "description": "Optional presence role: orchestrator | executor | pool-hand | runner | oracle | human-ui" },
+                        "theme": { "type": "string", "description": "Optional one-line presence theme (e.g. 'reader slice 1')" },
+                        "intent": { "type": "string", "description": "Optional declared mutation level: 'read' or 'mutate' (advisory collision signal)" },
+                        "worktree": { "type": "string", "description": "Optional worktree/branch display string for collision derivation" },
+                        "working_set": { "type": "array", "items": { "type": "string" }, "description": "Optional declared working set: repo-relative paths and/or sb_ block ids (collision overlap signal)" }
                     },
                     "required": ["agent_id"]
                 }
@@ -4065,6 +4070,30 @@ fn handle_north(
         }
     }
 
+    // P1 (ORGANISM-INSIDE): the collision gap — present ONLY when THIS session
+    // collides with another live mutating hand on the SAME brain whose work
+    // co-locates (same caller_root/worktree or overlapping working set). It rides
+    // the EXISTING honest_gaps mechanism (no new north schema field), and the P1
+    // gate requires it on BOTH colliding sessions' packets — each session derives
+    // its own here. Advisory, never blocking (the same posture as reception).
+    // Fail-open + read-only: an unreadable registry yields no line, never breaks
+    // north; presence is witness tissue that verifies nothing.
+    {
+        let (roster, _) = state.presence_roster();
+        let now = crate::util::now_ms();
+        let collisions = crate::presence::collisions_for_agent(&roster, &agent_id, now);
+        if !collisions.is_empty() {
+            let others: Vec<String> = collisions
+                .iter()
+                .map(|c| format!("{} ({})", c.other_agent, c.overlap.join(", ")))
+                .collect();
+            honest_gaps.push(format!(
+                "COLLISION: another mutating session shares this brain and your work — {}. Advisory only (m1nd sees activity visible to it, not git); coordinate before you both write.",
+                others.join("; ")
+            ));
+        }
+    }
+
     // First-Contact Reception (TWO-TIER-BRAIN-PRD §9.5.5): on a caller_root
     // mismatch this carries the honest front-desk block; on match/unknown it is
     // null (absent-ish). Computed here, after every prior `state` borrow has
@@ -4485,7 +4514,7 @@ fn build_orient_coverage(state: &SessionState, agent_id: &str) -> serde_json::Va
 /// errs, LOGS and SWALLOWS the failure so a watcher can never propagate its error
 /// into the agent's unrelated tool call. Returns `true` on success — surfaced so
 /// tests can pin the fail-open contract directly, and callers may branch on it.
-fn vigil_fail_open<F>(label: &str, tool: &str, vigil: F) -> bool
+pub(crate) fn vigil_fail_open<F>(label: &str, tool: &str, vigil: F) -> bool
 where
     F: FnOnce() -> M1ndResult<()>,
 {
@@ -4558,6 +4587,14 @@ pub fn dispatch_tool(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown")
         .to_string();
+
+    // P1 presence (ORGANISM-INSIDE): stamp the OBSERVED mutation level when this
+    // dispatch is a mutating verb — `read_only_denied` is the single pure
+    // classifier (verdict c). In-memory only; the throttled beat in `track_agent`
+    // carries it to the sidecar. Never a write here, never able to break dispatch.
+    if read_only_denied(&normalized, params) {
+        state.note_mutation_observed(&agent_id);
+    }
 
     // M1ND_PROOF_GATE: when ON, refuse a real code-writing tool BEFORE any write
     // unless every target it will touch was driven to proof_state ==

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -36,6 +36,23 @@ pub struct AgentSession {
     pub first_seen: Instant,
     pub last_seen: Instant,
     pub query_count: u64,
+    // --- ORGANISM-INSIDE P1 — the durable-presence beat state (askGOD verdict
+    //     2026-07-13). In-memory; projected to a sidecar by the throttled beat. ---
+    /// Epoch ms of first contact — the durable age the sidecar renders (`Instant`
+    /// is process-local and meaningless across an owner restart).
+    pub first_seen_ms: u64,
+    /// Throttle clock for the presence beat (at most one disk write per
+    /// [`crate::presence::PRESENCE_BEAT_THROTTLE_MS`]). `None` until the first beat.
+    pub last_presence_beat: Option<Instant>,
+    /// Epoch ms of the last mutating verb this session dispatched (the OBSERVED
+    /// mutation level), stamped by [`SessionState::note_mutation_observed`].
+    pub mutation_observed_at_ms: Option<u64>,
+    /// DECLARED enrichment from `session_handshake` (optional, honest-absent).
+    pub declared_kind: Option<String>,
+    pub declared_theme: Option<String>,
+    pub declared_intent: Option<String>,
+    pub declared_worktree: Option<String>,
+    pub declared_working_set: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1662,6 +1679,19 @@ impl SessionState {
         // written by `acquire_with_mode`) is never touched. Handle dropped:
         // fire-and-forget.
         let _ = crate::instance_registry::spawn_boot_gc(instance.registry_root());
+        // P1 (ORGANISM-INSIDE): reclaim orphan presence sidecars left by sessions
+        // that were live when the owner last restarted (the verdict's flagged
+        // risk: boot-GC must sweep stale sidecars post-restart). Detached, error-
+        // swallowing, never able to delay boot. Read-time filtering already hides
+        // stale presences; this only reclaims their files.
+        {
+            let registry_root = instance.registry_root();
+            let _ = std::thread::Builder::new()
+                .name("m1nd-presence-boot-gc".into())
+                .spawn(move || {
+                    let _ = crate::presence::gc_stale(&registry_root);
+                });
+        }
         let ingest_roots = Self::load_ingest_roots(&config.graph_source);
 
         Ok(Self {
@@ -2232,9 +2262,15 @@ impl SessionState {
 
     /// Track an agent session. Creates a new session if first contact,
     /// otherwise updates last_seen and increments query_count.
+    ///
+    /// P1: all four dispatch seams funnel through here, so this is the single
+    /// choke point for the durable-presence BEAT — a throttled, fail-open
+    /// projection of this live session to a sidecar (`crate::presence`) so the
+    /// control room (cockpit / Hall / north) can see the team.
     pub fn track_agent(&mut self, agent_id: &str) {
         let _ = self.instance.mark_heartbeat();
         let now = Instant::now();
+        let now_ms = crate::util::now_ms();
         let session = self
             .sessions
             .entry(agent_id.to_string())
@@ -2243,9 +2279,186 @@ impl SessionState {
                 first_seen: now,
                 last_seen: now,
                 query_count: 0,
+                first_seen_ms: now_ms,
+                last_presence_beat: None,
+                mutation_observed_at_ms: None,
+                declared_kind: None,
+                declared_theme: None,
+                declared_intent: None,
+                declared_worktree: None,
+                declared_working_set: Vec::new(),
             });
         session.last_seen = now;
         session.query_count += 1;
+        self.beat_presence(agent_id, now, now_ms);
+    }
+
+    /// Stamp the OBSERVED mutation level (verdict c): this session just
+    /// dispatched a verb `server::read_only_denied` classifies as mutating. Pure
+    /// in-memory — the throttled beat carries it to the sidecar. Never a write
+    /// per call, never able to break the tool call it rides.
+    pub fn note_mutation_observed(&mut self, agent_id: &str) {
+        if let Some(session) = self.sessions.get_mut(agent_id) {
+            session.mutation_observed_at_ms = Some(crate::util::now_ms());
+            // A changed signal forces the NEXT beat to write promptly (bypass the
+            // throttle for state changes; pure read spam still stays throttled).
+            session.last_presence_beat = None;
+        }
+    }
+
+    /// Record the DECLARED presence enrichment from a `session_handshake` call
+    /// (all fields optional, honest-absent). Only overwrites a field when the
+    /// caller declared it, so a later bare handshake never erases an earlier
+    /// declaration. Applied to the tracked session (created if first contact).
+    pub fn set_presence_declaration(
+        &mut self,
+        agent_id: &str,
+        kind: Option<String>,
+        theme: Option<String>,
+        intent: Option<String>,
+        worktree: Option<String>,
+        working_set: Vec<String>,
+    ) {
+        let now = Instant::now();
+        let now_ms = crate::util::now_ms();
+        let session = self
+            .sessions
+            .entry(agent_id.to_string())
+            .or_insert_with(|| AgentSession {
+                agent_id: agent_id.to_string(),
+                first_seen: now,
+                last_seen: now,
+                query_count: 0,
+                first_seen_ms: now_ms,
+                last_presence_beat: None,
+                mutation_observed_at_ms: None,
+                declared_kind: None,
+                declared_theme: None,
+                declared_intent: None,
+                declared_worktree: None,
+                declared_working_set: Vec::new(),
+            });
+        let mut changed = false;
+        if kind.is_some() {
+            session.declared_kind = kind;
+            changed = true;
+        }
+        if theme.is_some() {
+            session.declared_theme = theme;
+            changed = true;
+        }
+        if intent.is_some() {
+            session.declared_intent = intent;
+            changed = true;
+        }
+        if worktree.is_some() {
+            session.declared_worktree = worktree;
+            changed = true;
+        }
+        if !working_set.is_empty() {
+            session.declared_working_set = working_set;
+            changed = true;
+        }
+        if changed {
+            // Force the next beat to carry the fresh declaration (bypass throttle).
+            session.last_presence_beat = None;
+        }
+    }
+
+    /// The throttled, fail-open half of the presence beat: at most one disk
+    /// write per session per [`crate::presence::PRESENCE_BEAT_THROTTLE_MS`].
+    /// Composes the record from this session's own measured/declared facts and
+    /// upserts its sidecar. A broken sidecar write can NEVER break a tool call
+    /// (wrapped in the vigil fail-open guard).
+    fn beat_presence(&mut self, agent_id: &str, now: Instant, now_ms: u64) {
+        // A presence needs a served brain — an unbound (pre-ingest) session has
+        // no brain roster to join. Honest-absent until bound.
+        let Some(brain) = self.workspace_root.clone() else {
+            return;
+        };
+        // Throttle.
+        let due = match self
+            .sessions
+            .get(agent_id)
+            .and_then(|s| s.last_presence_beat)
+        {
+            Some(prev) => {
+                now.duration_since(prev).as_millis()
+                    >= crate::presence::PRESENCE_BEAT_THROTTLE_MS as u128
+            }
+            None => true,
+        };
+        if !due {
+            return;
+        }
+        let record = match self.compose_presence(agent_id, &brain, now_ms) {
+            Some(record) => record,
+            None => return,
+        };
+        let registry_root = self.instance.registry_root();
+        crate::server::vigil_fail_open("presence beat", "track_agent", || {
+            crate::presence::write_presence(&registry_root, &record)
+        });
+        if let Some(session) = self.sessions.get_mut(agent_id) {
+            session.last_presence_beat = Some(now);
+        }
+    }
+
+    /// Compose the durable presence record for `agent_id` from this session's own
+    /// facts: measured binding (`brain`/`caller_root`), the in-memory session
+    /// counters, the DECLARED handshake enrichment, and the MEASURED `task_ref`
+    /// (the agent's own open mission charter). `None` when the agent has no
+    /// tracked session yet.
+    fn compose_presence(
+        &self,
+        agent_id: &str,
+        brain: &str,
+        now_ms: u64,
+    ) -> Option<crate::presence::PresenceRecord> {
+        let session = self.sessions.get(agent_id)?;
+        let task_ref =
+            crate::mission_handlers::latest_open_mission_for(&self.runtime_root, agent_id);
+        Some(crate::presence::PresenceRecord {
+            schema: crate::presence::PRESENCE_SCHEMA.to_string(),
+            presence_id: crate::presence::stable_presence_id(agent_id, brain),
+            agent_id: agent_id.to_string(),
+            brain: brain.to_string(),
+            caller_root: self.caller_root.clone(),
+            kind: session.declared_kind.clone(),
+            theme: session.declared_theme.clone(),
+            worktree: session.declared_worktree.clone(),
+            working_set: session.declared_working_set.clone(),
+            task_ref,
+            mutation: crate::presence::MutationSignal {
+                observed_at_ms: session.mutation_observed_at_ms,
+                declared_intent: session.declared_intent.clone(),
+            },
+            first_seen_ms: session.first_seen_ms,
+            last_beat_ms: now_ms,
+            query_count: session.query_count,
+            ttl_ms: crate::presence::PRESENCE_TTL_MS,
+        })
+    }
+
+    /// The live presence roster for the SERVED brain plus any derived collisions
+    /// — the read surface the cockpit, north, and `/api/health` share. Scoped to
+    /// this session's own brain ("this brain", never a cross-brain aggregate);
+    /// empty when the session is unbound. Fail-open: an unreadable registry
+    /// yields an empty roster, never an error.
+    pub fn presence_roster(
+        &self,
+    ) -> (
+        Vec<crate::presence::PresenceRecord>,
+        Vec<crate::presence::Collision>,
+    ) {
+        let Some(brain) = self.workspace_root.as_deref() else {
+            return (Vec::new(), Vec::new());
+        };
+        let now = crate::util::now_ms();
+        let registry_root = self.instance.registry_root();
+        let roster = crate::presence::roster_for_brain(&registry_root, brain, now);
+        let collisions = crate::presence::collisions_in(&roster, now);
+        (roster, collisions)
     }
 
     pub fn next_edit_preview_id(&self, agent_id: &str) -> String {

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -3358,6 +3358,20 @@ pub fn handle_session_handshake(
     state: &mut SessionState,
     input: SessionHandshakeInput,
 ) -> M1ndResult<serde_json::Value> {
+    // P1 presence (ORGANISM-INSIDE): record any DECLARED enrichment this session
+    // carried so the throttled beat projects who/what into the control-room
+    // roster. Handshake is already the session's first call — the natural,
+    // reuse-first carrier (PRD §3.3). Optional and honest-absent: a bare
+    // handshake declares nothing and erases nothing.
+    state.set_presence_declaration(
+        &input.agent_id,
+        input.kind.clone(),
+        input.theme.clone(),
+        input.intent.clone(),
+        input.worktree.clone(),
+        input.working_set.clone(),
+    );
+
     let mut available_tools = input.available_tools.clone();
     available_tools.sort();
     available_tools.dedup();
@@ -3685,6 +3699,7 @@ pub fn handle_trust_selftest(
             available_tools: input.available_tools.clone(),
             missing_tools: input.missing_tools.clone(),
             scope: input.scope.clone(),
+            ..Default::default()
         },
     )?;
 
@@ -3824,6 +3839,7 @@ pub fn handle_recovery_playbook(
             available_tools: input.available_tools.clone(),
             missing_tools: input.missing_tools.clone(),
             scope: input.scope.clone(),
+            ..Default::default()
         },
     )?;
 
@@ -4961,6 +4977,7 @@ mod tests {
                     .collect(),
                 missing_tools: vec![],
                 scope: None,
+                ..Default::default()
             },
         )
         .expect("session_handshake should succeed");
@@ -5067,6 +5084,7 @@ mod tests {
                     .collect(),
                 missing_tools: vec![],
                 scope: None,
+                ..Default::default()
             },
         )
         .expect("session_handshake should succeed");


### PR DESCRIPTION
## What

The P1-server lane of the ORGANISM-INSIDE arc (ratified PRD; oracle verdict APPROVE with binding changes, versioned in-PR as `docs/voice/ASKGOD-VERDICT-P1.md`).

- **The presence sidecar** (`m1nd-presence-v0`, instance-registry mold): durable per-agent files with TTL 120s, throttled 5s beat riding `track_agent` (all four seams), boot-GC for orphans, `is_stale` filtered at read, wrapped in `vigil_fail_open`. Enrichment measured, never declared: `task_ref` from the agent's own `mission_start` charter; intent/worktree/working_set from optional `session_handshake` fields; mutation observed via `read_only_denied`.
- **The collision law** (derived at read, never materialized): same brain AND (same caller_root OR same worktree OR declared working-set overlap) AND both mutating. Same-brain alone never warns — the isolated-worktrees anti-test pins the normal burst shape.
- **Surfaces:** the cockpit's **8th collection** ("presences · this brain", one root line, capped drill) with both budgets re-pinned by a NEW mechanical battery (`root ~574 / drill ~567 of 800`); the north carries a collision line via the existing honest-gaps lane on BOTH sessions' packets (no schema field — Budget Law intact); **`GET /api/presences`** honoring the Hall's declared contract verbatim (owner-wide bare, `?brain=` scoped with `served_brain` echo, honest 404, `collisions` always present).
- The written limitation everywhere it matters: presence = activity visible to m1nd.

## Proof

Suite **1107/0** (endpoint owner-wide/scoped/404/collision/empty/ghost + beat/throttle/fail-open/TTL/GC/both-packets-gap + the anti-test) · fmt/clippy `-D warnings` clean · no-leak clean (neutral fixtures) · budgets battery-pinned.

Ran INSIDE the organism: charter `msn_…p1server` under the burst umbrella — events + close with proof packet; two spurious setup letters honestly closed. Divergences in `docs/voice/P1-SERVER-DIVERGENCES.md` (incl.: the live 2-session gate needs the rebuilt owner + the Hall — run at burst close, recorded).