### PR TITLE
test: guard the charter-persistence invariant (no bug — the guardian misread the disk)

### DIFF
--- a/docs/voice/CARDPERSIST-DIVERGENCES.md
+++ b/docs/voice/CARDPERSIST-DIVERGENCES.md
@@ -1,0 +1,94 @@
+# CARDPERSIST "does the letter reach disk?" — divergences and honest residue
+
+> Companion to the field reports of `2026-07-13T03:20` / `03:30` (m1nd
+> `field-reports.jsonl`) and to `docs/voice/P0-DIVERGENCES.md`. The task was
+> ratified as a bug fix: *"cartas de mission-control aceitas via REST
+> `?brain=<root>` NUNCA chegam a disco — vivem em memória de um runtime de
+> instance hospedado e morrem no restart."* This file records the honest residue
+> of the investigation, because the residue is the finding: **the bug as described
+> does not reproduce on `main` (6b018a8).** Nothing below is sugar-coated — where
+> the disk contradicts the report, the disk wins (physical reality > report).
+
+## The claim vs the disk
+
+The field report concluded the P0/P1 charters (`msn_…claudeguardianp0we`, `…fixt`,
+`…umbr`, plus the P1 executors) had **zero files in any `mission-control/` on disk**
+and had "died in memory in a hosted instance runtime."
+
+The disk says otherwise. All six named charters are on disk in the BOUND
+mission-control, `~/.m1nd/runtimes/claude/mission-control/`, with file mtimes at
+their creation/close time (e.g. `…claudeguardianp0we.json`: id-ts `2026-07-12
+23:59:15`, mtime `2026-07-13 00:24:35` — its own `updated_at_ms` on close). They
+were on disk hours BEFORE the `03:30` "zero on disk" claim. Independently, an
+UNRELATED hosted project brain (a different repo) had its own two `msn_*` charters
+from the same window persisted normally under its
+`project-brains/<fp>/mission-control/` — the exact hosted path the report said was
+ephemeral.
+
+## The exact mechanism (why it always persisted)
+
+1. **A charter is on disk BEFORE the ack.** `handle_mission_start` calls
+   `save_mission(state, &mission)?` (`m1nd-mcp/src/mission_handlers.rs:117`) BEFORE
+   it builds its `Ok(json!( … ))` response; `handle_mission_event` (`:157`) and
+   `handle_mission_close` (`:353`) do the same. `save_mission`
+   (`mission_handlers.rs:537`) writes `<runtime_root>/mission-control/<msn>.json`.
+   This has been true since the file's FIRST commit (`111e6b2 "runtime: add
+   mission control loop"`) — there was never an in-memory-only window.
+2. **A hosted brain's `runtime_root` IS its durable store.** `boot_store` sets
+   `runtime_dir: Some(store.clone())` (`m1nd-mcp/src/project_brains.rs:217`), so a
+   charter opened on a `?brain=` hosted brain lands at
+   `<owner runtime>/project-brains/<fp>/mission-control/<msn>.json` and warm-boots
+   back from there — not a temp dir.
+3. **`?brain=/Users/kle1nz/m1nd` resolves to the BOUND graph, not a hosted
+   instance.** `resolve_brain` checks `bound_matches` FIRST
+   (`m1nd-mcp/src/http_server.rs:1634-1646`), comparing the request against
+   `project_root_display()`, which returns the first non-sidecar ingest root
+   (`m1nd-mcp/src/session.rs:1007-1013`) — `/Users/kle1nz/m1nd`. So the selector
+   matches bound and persists to the bound mission-control. Live probe confirms it:
+   `mission_start?brain=/Users/kle1nz/m1nd` for `cardpersist-executor` produced
+   `msn_1783938868118_cardpersistexecuto.json` on disk the instant it returned.
+
+## Root of the misdiagnosis (the honest telemetry)
+
+- **mission-CONTROL vs mission-LETTER.** `P0-DIVERGENCES.md` item #2 already
+  established that `msn_*` mission-control charters are ABSENT from
+  `GET /api/mailbox?kind=mission` BY DESIGN (that board is the mission-LETTER rail,
+  `m1nd-mission-letter-v0`). The `03:20` observation ("charters not on the board")
+  was true and expected; the `03:30` leap from "not on the board" to "not on disk /
+  died in memory" was the error.
+- **`inst_f168ae0e3b608a2e` IS the bound owner, not a twin.** The report read it as
+  "an instance for `/Users/kle1nz/m1nd` SEPARATE from the bound." The registry
+  entry (`~/.m1nd/registry-claude/instances/inst_f168ae0e3b608a2e.json`, and
+  `/api/instances`) says `brain_kind: "medulla"`, `project_root:
+  /Users/kle1nz/m1nd`, `runtime_root: ~/.m1nd/runtimes/claude` — it is the served
+  owner itself. There is exactly ONE runtime for that root; no project brain for
+  `/Users/kle1nz/m1nd` exists on disk. "Two runtimes for one root" was a misread of
+  the medulla owner (`inst_f168…`) beside a hosted brain for a DIFFERENT,
+  unrelated repo (`inst_a24952…`).
+
+## What was delivered (proof, not a fix)
+
+No source change: there is no persistence defect to repair, and the verdict régua
+("carta EM DISCO antes do ack; um root = um mission-control canônico") is ALREADY
+satisfied by `save_mission`-before-ack + the bound-first resolution. Instead, the
+invariant is now a standing regression guard:
+
+- `m1nd-mcp/tests/per_brain_open.rs::charter_survives_owner_restart_on_the_hosted_path`
+  — opens a charter on a HOSTED `?brain=` brain, asserts the card `is_file()` at its
+  store's mission-control BEFORE the ack, drops the owner (the `launchctl kickstart`
+  analog), boots a fresh owner on the same runtime, and reloads the charter through
+  the real seam. GREEN today; proven to have teeth by a counterfactual that
+  neutered `save_mission` (both the ack-time `is_file()` and the post-restart reload
+  went RED, exactly the imagined "lives in memory" bug).
+
+## One latent risk, noted and OUT of scope
+
+If a project brain were ever MINTED for the bound root itself (e.g.
+`ingest project_root=/Users/kle1nz/m1nd` — the overlap guard checks other project
+brains, not the bound graph), `?brain=/Users/kle1nz/m1nd` would still resolve to
+BOUND (bound-first, `http_server.rs:1643`) and SHADOW that project brain's
+mission-control, orphaning any charter written to it. This did NOT happen in the
+field (no such brain on disk) and is a DIFFERENT concern from the reported bug;
+addressing it would mean changing mint/routing policy — explicitly excluded by the
+task ("cirúrgico; não redesenhe o mission-control"). Recorded here so the next
+wire-wearer sees it, not silently absorbed.

--- a/m1nd-mcp/tests/per_brain_open.rs
+++ b/m1nd-mcp/tests/per_brain_open.rs
@@ -572,3 +572,133 @@ async fn hall_lists_dormant_project_brain_from_disk_after_restart() {
         "the opened brain has its graph after warm-boot"
     );
 }
+
+// ---------------------------------------------------------------------------
+// (7) Mission-control PERSISTENCE on the hosted ?brain= path — the invariant the
+//     field report (2026-07-13T03:20/03:30) doubted: "cartas de mission-control
+//     aceitas via REST ?brain=<root> NUNCA chegam a disco — vivem em memória de um
+//     runtime de instance hospedado e morrem no restart."
+//
+//     The claim does NOT reproduce, and this test is the standing PROOF (a
+//     regression guard, not a RED→GREEN fix): `handle_mission_start` calls
+//     `save_mission` BEFORE it returns the ack (mission_handlers.rs), and a hosted
+//     brain's `runtime_root` IS its durable store dir (project_brains.rs
+//     `boot_store`, `runtime_dir: Some(store)`). So a charter accepted on the
+//     hosted path is a real file at `<store>/mission-control/<msn>.json` the instant
+//     mission_start returns, and it warm-boots back after an owner restart.
+//
+//     Field corroboration this encodes: an unrelated hosted project brain (a
+//     different repo) had its own `msn_*` cards persisted normally under its
+//     `project-brains/<fp>/mission-control/` — exactly the path this test asserts.
+//     Were `save_mission` ever regressed to an in-memory-only record (the imagined
+//     bug), BOTH the ack-time `is_file()` and the post-restart reload would fail.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn charter_survives_owner_restart_on_the_hosted_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime = tmp.path().join("runtime");
+    let (owner, _bound, project_repo) = owner_with_two_brains(tmp.path()).await;
+
+    // The hosted store's canonical mission-control dir — the ONE durable home a
+    // charter for this root must land in ("um root = um mission-control canônico").
+    let key = ProjectBrainRegistry::canonical_key(&project_repo.to_string_lossy());
+    let store_mc = owner
+        .app
+        .project_brains
+        .store_dir_for(&key)
+        .join("mission-control");
+
+    // 1. Open a charter on the HOSTED brain through the ?brain= seam (`resolve_brain`,
+    //    the ONE resolution `handle_tool_call` wraps), then dispatch mission_start on
+    //    that resolved session — the exact hosted path the field report names.
+    let (hosted, _echo) = resolve_brain(&owner.app, Some(&project_repo.to_string_lossy()))
+        .expect("the hosted brain resolves via ?brain=");
+    let mission_id = {
+        let mut s = hosted.lock();
+        let out = m1nd_mcp::server::dispatch_tool(
+            &mut s,
+            "mission_start",
+            &serde_json::json!({
+                "agent_id": "charter-hand",
+                "repo": project_repo.to_string_lossy(),
+                "task": "prove a hosted charter survives an owner restart",
+                "mode": "bug_hunt",
+                "budget": "normal",
+                "risk": "medium"
+            }),
+        )
+        .expect("mission_start on the hosted brain");
+        out["mission_id"]
+            .as_str()
+            .expect("mission_start returns a mission_id")
+            .to_string()
+    };
+
+    // ACK-TIME DURABILITY: the card is a real file the instant mission_start returned
+    // (save_mission runs BEFORE the ack) — never an in-memory-only record.
+    let card = store_mc.join(format!("{mission_id}.json"));
+    assert!(
+        card.is_file(),
+        "a charter accepted on the hosted ?brain= path must be on disk at its store's \
+         mission-control BEFORE the ack (looked at {card:?})"
+    );
+
+    // 2. A progress event — the lifecycle write path (mission_event → save_mission)
+    //    also persists, so the card on disk carries the event across the restart.
+    {
+        let mut s = hosted.lock();
+        m1nd_mcp::server::dispatch_tool(
+            &mut s,
+            "mission_event",
+            &serde_json::json!({
+                "agent_id": "charter-hand",
+                "mission_id": mission_id,
+                "event": "file_read",
+                "payload": {"path": "src/lib.rs"}
+            }),
+        )
+        .expect("mission_event on the hosted brain");
+    }
+
+    // 3. THE RESTART: drop the owner (every warm brain evicted from memory), then
+    //    boot a brand-new owner on the SAME runtime — the project brain is now
+    //    DORMANT on disk, faithful to a `launchctl kickstart` of the served owner.
+    drop(owner);
+    let owner2 = mk_owner(&runtime);
+
+    // 4. Re-open the hosted brain via ?brain= (warm-boot from its store) and RELOAD
+    //    the charter through the real seam: a mission_event on the SAME id must load
+    //    the card from disk. Had the charter "died in memory" (the field-report
+    //    hypothesis), `load_mission` would fail with "could not be loaded".
+    let (revived, _e2) = resolve_brain(&owner2.app, Some(&project_repo.to_string_lossy()))
+        .expect("the dormant hosted store warm-boots on the ?brain= selector");
+    let reload = {
+        let mut s = revived.lock();
+        m1nd_mcp::server::dispatch_tool(
+            &mut s,
+            "mission_event",
+            &serde_json::json!({
+                "agent_id": "charter-hand",
+                "mission_id": mission_id,
+                "event": "file_read",
+                "payload": {"path": "src/lib.rs (after restart)"}
+            }),
+        )
+    };
+    let reload = reload.expect(
+        "after an owner restart, the hosted charter must reload from disk — the seam must \
+         not report it lost",
+    );
+    assert_eq!(
+        reload["event_count"].as_u64(),
+        Some(2),
+        "the reloaded charter carries its pre-restart event (count 2 = pre + post): {reload}"
+    );
+
+    // 5. Still the SAME single canonical file — one root, one mission-control.
+    assert!(
+        card.is_file(),
+        "the charter file survived the restart on disk at its canonical mission-control: {card:?}"
+    );
+}


### PR DESCRIPTION
## What

A guardian field report claimed mission-control charters vanished on the hosted `?brain=` path. **Investigation: no defect exists.** `handle_mission_start` calls `save_mission` BEFORE the ack (`mission_handlers.rs:117`; event `:157`, close `:353`), writing `<runtime_root>/mission-control/<msn>.json` since the origin commit. `?brain=/Users/kle1nz/m1nd` resolves the BOUND owner (`inst_f168ae…` IS the bound medulla owner, not a separate instance), whose mission-control is `~/.m1nd/runtimes/claude/mission-control/` — where all the "lost" charters live, with creation mtimes. The report confused mission-CONTROL with the mission-LETTER board (the two-systems-one-word trap already flagged in P0-DIVERGENCES §2).

This PR ships **no code change** (the invariant already holds) — only a regression guard that locks it, proven by a counterfactual RED (neutralize `save_mission` → the ack's `is_file()` and the post-restart reload both fail).

## Proof

`charter_survives_owner_restart_on_the_hosted_path` (`tests/per_brain_open.rs`) green, teeth proven. Suite **1091/0** · fmt/clippy `-D warnings` clean · no-leak clean. The P0 gate was green all along; the guardian corrected its own field reports (honesty class).