### PR TITLE
ci: cut Actions spend without blinding coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Cancel superseded runs so rapid fix-pushes to a PR don't each hold a full 3-OS
+# matrix. Keyed by ref: on a PR (github.ref = refs/pull/N/merge) a newer push
+# cancels the in-flight run; on the protected branch (refs/heads/main|master) we
+# keep every run so main's CI history stays complete. Biggest recurring saving,
+# zero coverage loss. Other PRs (different refs) are never touched.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
 jobs:
   check:
     name: Check
@@ -63,21 +72,11 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
 
-  build:
-    name: Build (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - if: runner.os != 'Windows'
-        run: cargo build --release --workspace
-      - if: runner.os == 'Windows'
-        run: cargo build --release -p m1nd-core -p m1nd-ingest -p m1nd-mcp
+  # The release-mode build (cargo build --release across 3 OSes) is intentionally
+  # NOT in the PR/push path: it was never a required check (required = Test, Clippy,
+  # Format), cargo check/test/clippy already compile the whole workspace on every
+  # PR, and release.yml builds + ships the release binaries per target on tag. The
+  # cross-OS macos/windows coverage that caught the port flake stays in `test`.
 
   # Fails a PR that changes agent-workflow surfaces (MCP instructions/schemas,
   # verb dispatch, skills/, the npm host installer) without also updating the

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -442,6 +442,21 @@ without ALSO updating agent-facing docs in the same PR (`skills/`, `docs/` incl.
 an instructions-only edit self-satisfies; the `agent-docs-exempt` label skips it for genuine
 no-behavioral-change refactors.
 
+**CI cost discipline (`.github/workflows/ci.yml`).** m1nd is the account's heaviest Actions
+consumer (a burst can fire ~19 PRs, each a 3-OS matrix, in two days), so the CI is tuned to spend
+only where it buys bug-catching. Two levers, both coverage-neutral: (1) a `concurrency` group keyed
+by ref with `cancel-in-progress` — a newer push to a PR cancels its own in-flight run (no more one
+full matrix per rapid fix-push), while the protected branch keeps every run (`cancel-in-progress`
+is false on `refs/heads/main|master`); other PRs, on different refs, are never touched. (2) The
+release-mode build (`cargo build --release` × 3 OSes) is OFF the PR/push path — it was never a
+required check, `cargo check`/`test`/`clippy` already compile the whole workspace on every PR, and
+`release.yml` builds + ships the release binaries per target on tag. **Deliberately PRESERVED:** the
+cross-OS `test` matrix (ubuntu/macos/windows, `fail-fast: false`) — it is what caught the macOS
+port flake; blinding it trades a dollar bill for a bug you ship. **Deliberately NOT done:**
+workflow-level `paths`/`paths-ignore` filters — the required checks are exactly `Test`, `Clippy`,
+`Format`, and a path-skipped required check never reports, trapping a docs-only PR forever; the safe
+levers above capture the waste without that risk.
+
 ## Access Map
 - Battery harness: `scratchpad/m1nd_battery.py` — **TRACKED in-repo** (protected by the `.gitignore`
   negation `!scratchpad/m1nd_battery.py`, so it survives scratchpad clears). Fresh ingest +


### PR DESCRIPTION
## Why

The m1nd CI is the owner's largest GitHub Actions consumer — the orchestrator fired ~19 PRs × a 3-OS matrix in two days. This cuts the waste without removing the cross-OS coverage that catches real bugs.

## The safe cut

Branch protection requires exactly **`Test`, `Clippy`, `Format`** (strict). The `build` job (a 3-OS `cargo build --release`) is **not** a required check — that's what makes removing it safe (a path-skipped or removed required check would trap a PR forever; this doesn't touch any required check).

1. **`concurrency`** keyed by workflow+ref, `cancel-in-progress` true on PRs but **false on main/master** (protected history kept; other PRs on other refs untouched). Rapid fix-pushes no longer stack whole matrices.
2. **Removed the `build` job** from the PR/push path — `check`/`test`/`clippy` already compile the workspace every PR, and `release.yml` builds + ships the real binaries per target on tag. This drops 3 release compiles per PR **and** per merge — including the **10×-billed macOS** and 2×-billed Windows ones, the biggest line-item.

## Preserved on purpose

The cross-OS `test` matrix (ubuntu/macos/windows, `fail-fast: false`, rust-cache) stays — it caught this week's macOS port flake. Blinding it would trade dollars for shipped bugs. No cron exists to cut.

## What runs when

| Event | Required checks report? | Release build |
|---|---|---|
| PR (docs or .rs) | Yes — all 3 | no |
| push main | n/a | no |
| tag v* | n/a | **yes** (release.yml) |

`actionlint` clean on all 4 workflows. PATHOS Operating Doctrine gained the CI-cost note.