### PR TITLE
feat: ambient shim opens with the north voice card when a served owner is live

### DIFF
--- a/docs/HOST-INTEGRATION-MATRIX.md
+++ b/docs/HOST-INTEGRATION-MATRIX.md
@@ -145,8 +145,11 @@ host-neutral front for out-of-loop hooks; `north` remains the in-session front d
 > ```json
 > {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<north packet as text>"}}
 > ```
-> The packet text is the human-readable rendering of `m1nd agent first-minute … --json`.
-> Wrap the shim in a two-line script that runs it, extracts the packet, and prints the
+> The packet text opens with a served owner's `north` **voice card** (`human_view` lines)
+> when one is reachable — the shim finds it the read-only way `--attach auto` does (instance
+> registry, then a short probe of the default serve ports) and calls `north` over HTTP — and
+> otherwise falls back to the human-readable rendering of `m1nd agent first-minute … --json`
+> standalone. Wrap the shim in a two-line script that runs it, extracts the packet, and prints the
 > envelope. This wrapper ships as the `m1nd-north-shim` bin (registered in `package.json`),
 > so every recipe below invokes `m1nd-north-shim` directly — you no longer write it by hand
 > (§6a, SHIPPED 2026-07-03).

--- a/llms-install.md
+++ b/llms-install.md
@@ -100,8 +100,10 @@ m1nd-north-shim --repo "$PWD" --query orient
 ```
 
 An empty output with `exit 0` is the fail-open default (an absent or broken runtime never blocks
-the session), not an error. Otherwise open a fresh session and look for the injected `[m1nd
-north]` orientation — and when the packet carries a `human_view` card, its lines lead. Session-start
+the session), not an error. Otherwise open a fresh session and look for the injected orientation:
+when a served m1nd owner is live, the shim opens with its `north` **voice card** (the `human_view`
+lines lead, then the `[m1nd north]` summary); with no owner reachable it falls back to the
+standalone `first-minute` summary. Session-start
 hooks are **macOS/Linux-only** (§0); MCP itself works everywhere, and the `M1ND_INSTRUCTIONS`
 north-first line reinforces orientation on hosts that render it.
 

--- a/npm/bin/m1nd-north-shim.js
+++ b/npm/bin/m1nd-north-shim.js
@@ -2,13 +2,27 @@
 "use strict";
 
 // m1nd-north-shim: the single stable command that SessionStart-family host hooks
-// call. It runs `m1nd agent first-minute ... --json`, renders the orientation packet
-// to compact human text, and prints the exact hook envelope every host expects:
+// call. It prints the exact hook envelope every host expects:
 //   {"hookSpecificOutput":{"hookEventName":"<event>","additionalContext":"<text>"}}
-// FAIL-OPEN: any error / timeout / non-zero exit / parse failure prints nothing and
-// exits 0, so a broken or absent runtime never blocks the host session.
+//
+// v3 — north-first voice card. When a served m1nd owner is reachable (discovered
+// the same read-only way `--attach auto` finds one: the instance registry, then a
+// short probe of the default serve ports), the shim calls the `north` tool over
+// HTTP and OPENS with that owner's human_view card (the m1nd voice: pulse + lines)
+// before the machine-legible summary. north is READ-ONLY, so the newcomer's first
+// breath never rebinds/ingests/mutates the shared owner.
+//
+// When no served owner answers with a human_view, it falls back EXACTLY to the
+// prior behavior: `m1nd agent first-minute ... --json` rendered to the same
+// summary line (standalone, no card).
+//
+// FAIL-OPEN: any error / timeout / non-zero exit / parse failure prints nothing
+// and exits 0, so a broken or absent runtime never blocks the host session.
 
+const fs = require("fs");
+const os = require("os");
 const path = require("path");
+const http = require("http");
 const { spawnSync } = require("child_process");
 
 function parseArgs(argv) {
@@ -65,11 +79,30 @@ function humanViewLines(data) {
   return [];
 }
 
+// Cap to `max` characters WITHOUT ever splitting a line mid-way: keep whole lines
+// until the next one would overflow, then drop any trailing blank separator left
+// by the cut. Whole-line-or-nothing keeps the voice card legible.
+function capWholeLines(text, max) {
+  const value = String(text || "");
+  if (value.length <= max) return value;
+  const lines = value.split("\n");
+  const kept = [];
+  let length = 0;
+  for (const line of lines) {
+    const add = (kept.length > 0 ? 1 : 0) + line.length;
+    if (length + add > max) break;
+    kept.push(line);
+    length += add;
+  }
+  while (kept.length > 0 && kept[kept.length - 1] === "") kept.pop();
+  return kept.join("\n");
+}
+
 function renderNorthPacket(data) {
   if (!data || typeof data !== "object") return "";
 
-  // v2: open with the human_view card (the human-facing voice) when the packet
-  // carries one, BEFORE the machine-legible summary line.
+  // Open with the human_view card (the human-facing voice) when the packet
+  // carries one, then a blank line, then the machine-legible summary.
   const head = humanViewLines(data);
 
   const fields = [];
@@ -109,13 +142,117 @@ function renderNorthPacket(data) {
   if (nextMove) fields.push(`suggested first move: ${truncate(nextMove, 100)}`);
 
   const summary = fields.length > 0 ? `[m1nd north] ${fields.join(" · ")}` : "";
-  const packet = [...head, summary].filter(Boolean).join("\n");
-  if (!packet.trim()) return "";
-  return packet.length > 1200 ? `${packet.slice(0, 1197)}...` : packet;
+  const blocks = [];
+  if (head.length > 0) blocks.push(head.join("\n"));
+  if (summary) blocks.push(summary);
+  if (blocks.length === 0) return "";
+  // Blank line between the voice card and the summary.
+  return capWholeLines(blocks.join("\n\n"), 1200);
 }
 
-function main() {
-  const args = parseArgs(process.argv.slice(2));
+// Discover reachable served-owner base URLs the SAME read-only way `--attach auto`
+// does: inspect the instance registry (`~/.m1nd/registry/instances/*.json`) for
+// live serve ReadWrite owners that publish a port, freshest-first — then always
+// append the default serve ports as a probe fallback (the registry entry may lack
+// a port even while an owner serves). NEVER acquires a lease or mutates anything.
+function servedOwnerBaseUrls() {
+  const urls = [];
+  try {
+    const dir = path.join(os.homedir(), ".m1nd", "registry", "instances");
+    const entries = fs
+      .readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => safeParse(fs.readFileSync(path.join(dir, name), "utf8")))
+      .filter(
+        (entry) =>
+          entry &&
+          entry.mode === "read_write" &&
+          entry.owner_live === true &&
+          !entry.stale &&
+          entry.port
+      )
+      .sort((a, b) => (b.last_heartbeat_ms || 0) - (a.last_heartbeat_ms || 0));
+    for (const entry of entries) {
+      const bind = !entry.bind || entry.bind === "0.0.0.0" ? "127.0.0.1" : entry.bind;
+      urls.push(`http://${bind}:${entry.port}`);
+    }
+  } catch (_) {
+    // no registry / unreadable — fall through to the fixed probe ports.
+  }
+  urls.push("http://127.0.0.1:1337", "http://127.0.0.1:1338");
+  return [...new Set(urls)];
+}
+
+// POST the read-only `north` tool to one served owner; resolve its unwrapped
+// payload, or null on any error / non-200 / timeout / parse failure.
+function northViaHttp(baseUrl, repo, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+    try {
+      const body = JSON.stringify({
+        agent_id: "m1nd-north-shim",
+        task: "orient this session on the bound workspace",
+      });
+      const url = new URL(`${baseUrl.replace(/\/$/, "")}/api/tools/north`);
+      const req = http.request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+            // Declare the caller's repo the same way the --attach bridge does, so
+            // the owner can align its reception to this session's workspace.
+            "m1nd-caller-root": String(repo || ""),
+          },
+          timeout: timeoutMs,
+        },
+        (res) => {
+          if (res.statusCode !== 200) {
+            res.resume();
+            return finish(null);
+          }
+          let data = "";
+          res.on("data", (chunk) => {
+            data += chunk;
+            if (data.length > 262144) req.destroy();
+          });
+          res.on("end", () => {
+            const parsed = safeParse(data);
+            finish(parsed && parsed.result ? parsed.result : parsed);
+          });
+        }
+      );
+      req.on("error", () => finish(null));
+      req.on("timeout", () => {
+        req.destroy();
+        finish(null);
+      });
+      req.write(body);
+      req.end();
+    } catch (_) {
+      finish(null);
+    }
+  });
+}
+
+function emitEnvelope(event, text) {
+  process.stdout.write(
+    `${JSON.stringify({ hookSpecificOutput: { hookEventName: event, additionalContext: text } })}\n`
+  );
+}
+
+// Fallback: the prior standalone behavior — run `agent first-minute --json` and
+// render its summary line (no human_view card).
+function firstMinuteFallback(args) {
   const cli = path.join(__dirname, "m1nd.js");
   let res;
   try {
@@ -134,10 +271,46 @@ function main() {
   if (!data) process.exit(0);
   const text = renderNorthPacket(data);
   if (!text || !text.trim()) process.exit(0);
-  process.stdout.write(
-    `${JSON.stringify({ hookSpecificOutput: { hookEventName: args.event, additionalContext: text } })}\n`
-  );
+  emitEnvelope(args.event, text);
   process.exit(0);
 }
 
-main();
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  // v3: open with the served owner's north voice card when one is reachable.
+  // A dead/refused port fails in ~3ms (ECONNREFUSED, before the timeout bites),
+  // so the timeout only guards a hung owner. north itself measures ~0.3–0.85s
+  // here, so 2.5s leaves headroom under host-startup load while staying far below
+  // the 8s first-minute fallback — a 1s cap would flap to first-minute (which
+  // rebinds the shared owner) exactly when north is a hair slow.
+  try {
+    for (const baseUrl of servedOwnerBaseUrls()) {
+      const payload = await northViaHttp(baseUrl, args.repo, 2500);
+      if (!payload) continue;
+      if (humanViewLines(payload).length === 0) continue;
+      const text = renderNorthPacket(payload);
+      if (text && text.trim()) {
+        emitEnvelope(args.event, text);
+        process.exit(0);
+      }
+    }
+  } catch (_) {
+    // fall through to the standalone first-minute path
+  }
+
+  firstMinuteFallback(args);
+}
+
+if (require.main === module) {
+  main().catch(() => process.exit(0));
+}
+
+module.exports = {
+  parseArgs,
+  humanViewLines,
+  capWholeLines,
+  renderNorthPacket,
+  servedOwnerBaseUrls,
+  northViaHttp,
+};

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -27,6 +27,7 @@ const {
   shouldKickstartAfterInstall,
 } = require("../lib/cli");
 const { classifyScopeBinding } = require("../lib/agent-cli");
+const northShim = require("../bin/m1nd-north-shim");
 
 const cli = path.resolve(__dirname, "../bin/m1nd.js");
 
@@ -1697,5 +1698,55 @@ function homeForTest() {
     "non-darwin ignores codesign entirely"
   );
 }
+
+// --- m1nd-north-shim (v3 ambient shim: north-first voice card) ---
+// humanViewLines extracts the voice card from a top-level packet and from a
+// first-minute-nested results[0], collapsing whitespace; no card -> [].
+assert.deepStrictEqual(
+  northShim.humanViewLines({ human_view: { lines: ["m1nd ╷ pulse", "  │ two"] } }),
+  ["m1nd ╷ pulse", "│ two"],
+  "humanViewLines reads a top-level human_view card"
+);
+assert.deepStrictEqual(
+  northShim.humanViewLines({ results: [{ human_view: { lines: ["nested"] } }] }),
+  ["nested"],
+  "humanViewLines reads a first-minute nested card"
+);
+assert.deepStrictEqual(northShim.humanViewLines({}), [], "no card -> empty");
+
+// renderNorthPacket opens with the card, then a blank line, then the summary.
+const cardedPacket = northShim.renderNorthPacket({
+  human_view: { lines: ["m1nd ╷ voice", "  │ line two"] },
+  trust: { verdict: "grounded" },
+});
+assert(cardedPacket.startsWith("m1nd ╷ voice"), "packet opens with the voice card");
+assert(cardedPacket.includes("\n\n[m1nd north]"), "blank line separates card and summary");
+
+// No card -> exact prior behavior: the bare summary, no leading blank line.
+const barePacket = northShim.renderNorthPacket({ trust: { verdict: "grounded" } });
+assert(barePacket.startsWith("[m1nd north]"), "cardless packet is the bare summary");
+assert(!barePacket.startsWith("\n"), "cardless packet has no leading blank line");
+
+// capWholeLines never splits a line mid-way and drops a trailing blank separator.
+assert.strictEqual(northShim.capWholeLines("aaa\nbbb\nccc", 5), "aaa", "keeps only whole lines under the cap");
+assert.strictEqual(northShim.capWholeLines("aaa\n\nbbb", 4), "aaa", "drops a trailing blank left by the cut");
+const longPacket = northShim.renderNorthPacket({
+  human_view: { lines: ["A".repeat(400), "B".repeat(400), "C".repeat(400), "D".repeat(400)] },
+  trust: { verdict: "ok" },
+});
+assert(longPacket.length <= 1200, "packet respects the 1200 cap");
+assert(
+  longPacket
+    .split("\n")
+    .filter(Boolean)
+    .every((line) => line.length === 400 || line.startsWith("[m1nd north]")),
+  "every kept line is a whole source line (no mid-line cut)"
+);
+
+// servedOwnerBaseUrls always ends with the default probe ports, deduped.
+const shimUrls = northShim.servedOwnerBaseUrls();
+assert(shimUrls.includes("http://127.0.0.1:1337"), "probe fallback includes :1337");
+assert(shimUrls.includes("http://127.0.0.1:1338"), "probe fallback includes :1338");
+assert.strictEqual(new Set(shimUrls).size, shimUrls.length, "candidate URLs are deduped");
 
 console.log("npm cli tests ok");


### PR DESCRIPTION
## What

The SessionStart-family shim (`npm/bin/m1nd-north-shim.js`) oriented through `m1nd agent first-minute`, which never carries a `human_view` — so a newcomer never saw m1nd's voice card (pulse + lines).

v3 makes the shim **open with the north voice card when a served owner is live**:

1. **Discovery** — the read-only way `--attach auto` finds an owner: inspect the instance registry (`~/.m1nd/registry/instances/*.json`) for live serve ReadWrite owners that publish a port (freshest-first), then always append a short probe of the default serve ports `:1337`/`:1338`. No lease is taken; no port is hardcoded as the only path.
2. **north over HTTP** — call the read-only `north` tool (`POST /api/tools/north`, `m1nd-caller-root` header set to the caller's repo, ~2.5s timeout).
3. **Render** — `additionalContext` opens with `human_view.lines` (up to 4), a blank line, then the existing `[m1nd north]` summary; whole-line capped at 1200 chars (never cuts a card line mid-way).
4. **Fallback** — no reachable owner / no `human_view` → the **exact prior** `first-minute` rendering. Any error, timeout, or parse failure → silent `exit 0` (fail-open unchanged).

## Why read-only (incident-born law)

Running the old `first-minute` path can rebind the shared owner's `workspace_root` (class #326). v3 uses **only read-only verbs** (`north`), so the newcomer's first breath never rebinds/ingests/mutates the shared owner.

**CWD-independence proven:** captured the owner's `workspace_root` before, ran the shim from inside `npm/bin` (the #326 danger dir), captured after — **identical** (`/Users/kle1nz/.m1nd/runtimes/claude`), no mutation.

## Proof

- `node --check` + `npm test` green (added deterministic unit tests for the card-first render, blank-line separator, whole-line cap, and probe-fallback dedup).
- Live run against a serving owner opens with the `m1nd │ …` card, then the summary.
- `northViaHttp` degrades to `null` on dead port / non-JSON 200 / HTTP 500; empty registry still yields the probe fallback.

Docs updated in the same PR (`docs/HOST-INTEGRATION-MATRIX.md`, `llms-install.md`).