### PR TITLE
fix: read panoramas never queue behind graph work

### DIFF
--- a/docs/HUMAN-VIEW-V2-F30-UNIVERSE.md
+++ b/docs/HUMAN-VIEW-V2-F30-UNIVERSE.md
@@ -127,7 +127,7 @@ fabricated "live" state.
       "letters": { "merge_wait": 2, "total": 7 }
     }
   ],
-  "owner": { "alerts_pending": 1 },
+  "owner": { "alerts_pending": 1 },   // null + a "note" when the owner is busy (see §3a)
   "totals": { "worlds": 3, "awake": 1, "pending": 8 }
 }
 ```
@@ -150,6 +150,34 @@ fabricated "live" state.
   `SessionState`; reading a project brain's would require hydrating it (banned). Only the
   OWNER's alerts (the bound session, already resident) are surfaced, owner-scope — the
   `owner` chip, never a world chip.
+
+### 3a · Vitals never block the panorama (server read resilience, 2026-07-15)
+
+**LAW: vitals never block the panorama.** `/api/universe` is a SIDECAR-ONLY read; it must
+never queue behind graph work. Two owner-scope facts (`alerts_pending`, and the registry
+root the presence roster reads) live on the bound `SessionState`, behind the session lock —
+the SAME lock the gardener tick holds across a re-ingest + `rebuild_engines` for minutes on a
+post-kickstart warm. Taking that lock on the read's first line made the WHOLE panorama queue
+behind the tick: it read as a deadlock (CPU 0%, 15-20s timeouts, the SPA falling back to the
+old doctrine on every boot), but was only transient contention.
+
+So `universe_body` **`try_lock`s** the session for the owner vitals:
+- **lock free** → the real values (the registry root + the unacked `alerts_pending` count) —
+  byte-identical to the prior behavior;
+- **lock busy** → the panorama is served WITHOUT the session-live vitals, an HONEST omission:
+  `owner` becomes `{ "alerts_pending": null, "note": "owner busy — vitals omitted" }`,
+  `totals.pending` folds the missing count as zero (never inflated), and the presence roster
+  degrades to the immutable boot registry hint (`AppState.registry_dir`, captured once at
+  boot) or an empty roster — the established fail-open posture. Never a stall, never a
+  fabricated zero.
+
+The disk-sourced worlds (manifests, mission boxes, SystemBlock stores) need no session lock,
+so the panorama's spine is always served. RED-first proof (`universe_endpoint.rs`
+`universe_never_queues_behind_a_held_session_lock`): a background thread holds the session
+lock for 2s; the read must still answer 200 within a 500ms ceiling carrying the honest
+omission — it took 2.001s on the pre-fix code, well under 500ms after. Client side,
+`buildLandingItems` treats the null vital as NO owner chip (an omitted count never coerces
+into a gesture).
 
 ### Client read resilience (`useUniverse`; honest doors, 2026-07-14)
 

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -49,6 +49,26 @@ same bar, applied to building the organism outward.
 
 ## Current State (2026-07-12, checkpoint 18 — the voice; dated blocks below are the era log)
 
+> **2026-07-15 — "VITALS NEVER BLOCK THE PANORAMA" fix on `fix/panorama-never-waits` (branch, NOT yet landed).**
+> A field report (2×, live) caught `/api/universe` stalling for 15-20s after a kickstart — it read as a deadlock
+> (CPU 0%), but was transient contention: `universe_body` took `state.session.lock()` on its FIRST line (just for
+> `alerts_pending` + the presence registry root), and the gardener/daemon tick holds that SAME lock for minutes
+> across a re-ingest + `rebuild_engines`. A sidecar-only READ surface was queuing behind graph work — against the
+> F30 spirit; every boot the Home Universe was unreachable and the SPA fell back to the old doctrine. Fix (minimal,
+> in the house style — fail-open + honest omission): `universe_body` now **`try_lock`s** the session — lock free →
+> the real vitals (byte-identical); lock busy → the panorama serves WITHOUT them, an honest omission
+> (`owner: { alerts_pending: null, note: "owner busy — vitals omitted" }`, `totals.pending` never inflated, the
+> presence roster degrading to the immutable boot registry hint `AppState.registry_dir`). The disk-sourced worlds
+> need no lock, so the spine is always served. RED-first proof (`universe_endpoint.rs`
+> `universe_never_queues_behind_a_held_session_lock`): a held lock made the read take 2.001s pre-fix (ceiling
+> 500ms), well under after. UI degrades honest (`buildLandingItems`: a null vital → no owner chip; +1 spec).
+> Green: `m1nd-mcp --features serve` suite (40 bins) + `m1nd-ui` `node --test` (617) + fmt + clippy `-D warnings` +
+> tsc + eslint, all clean. Docs same PR (F30 §3a + this block). Related ARC (registered, NOT in this PR): the same
+> `session.lock()`-for-`registry_root` pattern is in `handle_presences` (owner-wide), `handle_health`,
+> `handle_instance_self`, `handle_instances` — each a read surface that would also queue behind the tick; a
+> follow-up should give the registry root a lock-free owner-level source and `try_lock` the live vitals there too.
+> Next: land the burst PR.
+
 > **2026-07-14 — "HONEST DOORS AND EXITS" burst on `fix/honest-doors-and-exits` (branch, NOT yet landed).**
 > A UI-only burst (zero engine change) closing eight honesty gaps a hands-on sweep + an askGOD full cut found
 > across the Universe/Hall/map/tray surfaces: **(1)** the map's **Reconcile** asks first — a two-step confirm

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -1072,13 +1072,29 @@ async fn handle_universe(State(state): State<Arc<AppState>>) -> impl IntoRespons
 /// `ProjectBrainRegistry.brains` is untouched (HARD LAW, tests/universe_endpoint.rs).
 pub fn universe_body(state: &AppState) -> serde_json::Value {
     let now = crate::util::now_ms();
-    // Owner-scope facts, read ONCE from the already-resident bound session (never a
-    // project brain): the shared registry root (for presences) + the owner's own
-    // unacked daemon alerts (owner-scope — the alert chip is `owner`, never a world).
-    let (registry_root, alerts_pending) = {
-        let session = state.session.lock();
-        let alerts = session.daemon_alerts.iter().filter(|a| !a.acked).count() as u64;
-        (session.instance.registry_root(), alerts)
+    // Owner-scope facts read from the already-resident bound session (never a project
+    // brain): the shared registry root (for presences) + the owner's own unacked daemon
+    // alerts (owner-scope — the alert chip is `owner`, never a world).
+    //
+    // VITALS NEVER BLOCK THE PANORAMA (F30 §3a). This is a SIDECAR-ONLY read surface; it
+    // must never queue behind graph work. The gardener tick holds the session lock across
+    // a re-ingest + rebuild_engines for minutes — blocking here stalled the whole Universe
+    // read (it read as a deadlock: CPU 0%, 15-20s timeouts, the SPA falling back to old
+    // doctrine, but was transient contention). So we TRY the session lock and, if the owner
+    // is busy, serve the panorama WITHOUT the session-live vitals — an HONEST omission (a
+    // declared note + a null count below), never a stall.
+    let (registry_root, alerts_pending) = match state.session.try_lock() {
+        Some(session) => {
+            let alerts = session.daemon_alerts.iter().filter(|a| !a.acked).count() as u64;
+            (session.instance.registry_root(), Some(alerts))
+        }
+        None => {
+            // Owner busy (graph work holds the lock). Presences degrade to the immutable
+            // boot registry hint if this owner recorded one (else an empty roster — the
+            // established fail-open posture, never a stall); the owner alert count is
+            // omitted with a declared note in the body below.
+            (state.registry_dir.clone().unwrap_or_default(), None)
+        }
     };
     // The owner-wide live presence roster — a cross-brain read of the presence dir,
     // grouped per world below by each sidecar's `brain` (its writing session's
@@ -1161,13 +1177,26 @@ pub fn universe_body(state: &AppState) -> serde_json::Value {
     }
 
     // Owner alerts are a universe-wide pending gesture too (owner-scope, one bucket).
-    total_pending += alerts_pending;
+    // When the owner was busy (lock held) the count is OMITTED — folded in as zero so the
+    // total is never inflated by a fabricated value, and declared in the body below.
+    total_pending += alerts_pending.unwrap_or(0);
     let world_count = worlds.len() as u64;
+
+    // Owner vitals: the real unacked count when we read it, or an HONEST omission (a null
+    // count + a declared note) when the owner was busy — the panorama degrades, never
+    // stalls, and never fabricates a zero it did not read.
+    let owner = match alerts_pending {
+        Some(n) => serde_json::json!({ "alerts_pending": n }),
+        None => serde_json::json!({
+            "alerts_pending": serde_json::Value::Null,
+            "note": "owner busy — vitals omitted",
+        }),
+    };
 
     serde_json::json!({
         "schema": "m1nd-universe-v0",
         "worlds": worlds,
-        "owner": { "alerts_pending": alerts_pending },
+        "owner": owner,
         "totals": { "worlds": world_count, "awake": total_awake, "pending": total_pending },
     })
 }

--- a/m1nd-mcp/tests/universe_endpoint.rs
+++ b/m1nd-mcp/tests/universe_endpoint.rs
@@ -339,3 +339,75 @@ async fn universe_aggregates_presences_stamps_and_totals_per_world() {
         "no hydration under aggregation"
     );
 }
+
+// ---------------------------------------------------------------------------
+// (3) VITALS NEVER BLOCK THE PANORAMA — a sidecar-only read surface must never
+// queue behind graph work. The gardener tick holds the session lock across a
+// re-ingest + rebuild_engines (minutes); the panorama must answer ANYWAY,
+// omitting the owner-scope vitals HONESTLY rather than stalling. RED-first: on
+// main, `universe_body` took `state.session.lock()` unconditionally on its first
+// line, so this read queued behind the held lock (it read as a deadlock — CPU 0%,
+// 15-20s timeouts — but was transient contention). Law: F30 §3a, vitals never
+// block the panorama.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn universe_never_queues_behind_a_held_session_lock() {
+    let tmp = tempfile::tempdir().unwrap();
+    let runtime = tmp.path().join("runtime");
+    let app = mk_app(&runtime);
+
+    let repo = tmp.path().join("world-a");
+    let root = write_dormant_brain(&app, &repo, 64, 128, now_ms());
+
+    // Simulate the gardener tick: a background holder grabs the session lock and
+    // keeps it far longer than any acceptable panorama latency (the real tick holds
+    // it across a re-ingest + rebuild_engines — minutes).
+    let held = app.session.clone();
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let holder = std::thread::spawn(move || {
+        let _guard = held.lock();
+        tx.send(()).unwrap(); // the lock is provably HELD now
+        std::thread::sleep(std::time::Duration::from_secs(2));
+    });
+    rx.recv().unwrap(); // only drive the read once the lock is held
+
+    // The panorama must answer within a tight ceiling DESPITE the held lock.
+    let start = std::time::Instant::now();
+    let (status, body) = get_universe(&app).await;
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        status, 200,
+        "the panorama serves 200 even under a held lock: {body}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "the panorama must NEVER queue behind graph work: took {elapsed:?} (ceiling 500ms)"
+    );
+
+    // The dormant world is still served from its on-disk manifest (the sidecar path
+    // needs no session lock).
+    let w = world_by_root(&body, &root)
+        .unwrap_or_else(|| panic!("world served from disk under contention: {body}"));
+    assert_eq!(
+        w["node_count"],
+        serde_json::json!(64u64),
+        "manifest counts served under contention: {w}"
+    );
+
+    // Owner vitals OMITTED HONESTLY (the lock was held): null + a declared note —
+    // never a stall, never a fabricated zero.
+    assert_eq!(
+        body["owner"]["alerts_pending"],
+        serde_json::Value::Null,
+        "owner alerts omitted (not fabricated) while the owner is busy: {body}"
+    );
+    assert_eq!(
+        body["owner"]["note"],
+        serde_json::json!("owner busy — vitals omitted"),
+        "the omission is DECLARED, never silent: {body}"
+    );
+
+    holder.join().unwrap();
+}

--- a/m1nd-ui/src/lib/universe.test.ts
+++ b/m1nd-ui/src/lib/universe.test.ts
@@ -172,6 +172,19 @@ test('buildLandingItems: an empty universe yields an empty queue (honest, not fa
   assert.deepEqual(buildLandingItems(universe()), []);
 });
 
+test('buildLandingItems: an OMITTED owner vital (alerts_pending null, owner busy) shows no chip', () => {
+  // The panorama served under contention: the owner was busy, so its alert count was
+  // omitted (null + a note) rather than stall the read. That omission must NOT coerce
+  // into an owner gesture — honest absence, never a fabricated bell.
+  const u = universe({ owner: { alerts_pending: null, note: 'owner busy — vitals omitted' } });
+  const items = buildLandingItems(u);
+  assert.equal(
+    items.some((i) => i.kind === 'alert'),
+    false,
+    'a null (omitted) owner vital never becomes an owner alert chip',
+  );
+});
+
 test('buildLandingItems: singular vs plural is honest in the human line', () => {
   const u = universe({
     worlds: [world({ key: 'a', root: '/w/a', name: 'alpha', pending: { stamps: 1, ratifies: 1 } })],

--- a/m1nd-ui/src/lib/universe.ts
+++ b/m1nd-ui/src/lib/universe.ts
@@ -36,11 +36,13 @@ export interface UniverseWorld {
   letters: { merge_wait: number; total: number };
 }
 
-/** The `GET /api/universe` body (`m1nd-universe-v0`). */
+/** The `GET /api/universe` body (`m1nd-universe-v0`). Owner vitals degrade honestly:
+ *  `alerts_pending` is `null` (with a `note`) when the owner was busy and the count was
+ *  OMITTED rather than stall the panorama behind graph work — never a fabricated zero. */
 export interface UniverseResponse {
   schema: string;
   worlds: UniverseWorld[];
-  owner: { alerts_pending: number };
+  owner: { alerts_pending: number | null; note?: string };
   totals: { worlds: number; awake: number; pending: number };
 }
 
@@ -214,7 +216,9 @@ export function buildLandingItems(universe: UniverseResponse): LandingItem[] {
       });
     }
   }
-  if (universe.owner.alerts_pending > 0) {
+  // An OMITTED owner vital (`alerts_pending == null`, the owner was busy) contributes
+  // no chip — the queue degrades honestly rather than coerce the null into a gesture.
+  if (universe.owner.alerts_pending != null && universe.owner.alerts_pending > 0) {
     items.push({
       id: 'owner:alerts',
       kind: 'alert',


### PR DESCRIPTION
## The bug (field report, 2× live)

After a kickstart, `GET /api/universe` stalled for 15-20s — it read as a deadlock (CPU 0%), but was transient contention. `universe_body` took `state.session.lock()` on its **first line**, only to read two owner-scope facts (`alerts_pending` + the presence registry root). The gardener/daemon tick holds that **same** lock across a re-ingest + `rebuild_engines` for minutes on a post-boot warm — so a sidecar-only READ surface queued behind graph work. On every boot the Home Universe was unreachable and the SPA fell back to the old doctrine. This is against the F30 spirit.

## The fix (minimal, house style — fail-open + honest omission)

`universe_body` now **`try_lock`s** the session for the owner vitals:

- **lock free** → the real values (registry root + unacked `alerts_pending`) — byte-identical to before;
- **lock busy** → the panorama is served **without** them, an honest omission: `owner` becomes `{ "alerts_pending": null, "note": "owner busy — vitals omitted" }`, `totals.pending` folds the missing count as zero (never inflated), and the presence roster degrades to the immutable boot registry hint (`AppState.registry_dir`) or an empty roster — the established fail-open posture. Never a stall, never a fabricated zero.

The disk-sourced worlds (manifests, mission boxes, SystemBlock stores) need no session lock, so the panorama's spine is always served.

## Proof (RED-first)

`universe_endpoint.rs::universe_never_queues_behind_a_held_session_lock` holds the session lock in a background thread for 2s and asserts `/api/universe` answers `200` within a **500ms** ceiling with the honest omission.

- **RED (pre-fix):** `the panorama must NEVER queue behind graph work: took 2.001685792s (ceiling 500ms)` → FAILED.
- **GREEN (post-fix):** 3/3 `universe_endpoint` tests pass.

UI degrades honestly: `buildLandingItems` drops the owner chip when the vital is omitted (a null count never coerces into a gesture) — `+1` spec.

Gates: `m1nd-mcp --features serve` suite (40 binaries) + `m1nd-ui` `node --test` (617) + `cargo fmt --check` + `clippy -D warnings` + `tsc` + `eslint` — all clean.

## Docs (same PR)

- `HUMAN-VIEW-V2-F30-UNIVERSE.md` §3a — the law "vitals never block the panorama" + the omission shape.
- `PATHOS.md` — checkpoint block.

## Registered arc (NOT in this PR)

The same `session.lock()`-for-`registry_root` pattern lives in `handle_presences` (owner-wide), `handle_health`, `handle_instance_self`, and `handle_instances` — each a read surface that would also queue behind the tick. A follow-up should give the registry root a lock-free owner-level source and `try_lock` the live vitals there too.
