### PR TITLE
fix: write doors check identity and sanity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,10 @@ bound brain because the writer never checked which brain it was talking to.
    gesture BEFORE any write: `ingest project_root=<your repo root>` — a single call
    creates/resolves YOUR brain, ingests it, binds the session, and returns its north in the
    same response; from then on your root routes to your brain automatically. Then write.
-   (The mechanical write-refusal is landing; the doctrine holds now.)
+   (The mechanical write-refusal has LANDED — every skeleton write verb
+   (`skeleton_candidate`, `candidate_edit`, `system_blocks_seed_import`/`_ratify`/`_reconcile`/
+   `_archive`/`_delete`, `candidate_lease` acquire) refuses under mismatch with a teaching
+   `brainless_root` that names both roots; the doctrine holds regardless.)
 2. **No twin brains.** Minting a brain for a root that is the PARENT, CHILD, or WORKTREE of
    an existing brain is refused with a teaching error (`overlap_parent` / `overlap_child` /
    `overlap_worktree`) that names the conflict and the two ways forward: bind to the existing
@@ -204,3 +207,13 @@ never carry `receipt.imported==true` (never a landing in disguise), and it may o
 `merge_wait` head — the board's FIRST transition rule (`invalid_transition` otherwise). **An agent
 never archives; the owner's screen does** — an agent must never silence its own unproven work. Full
 rule: `HUMAN-VIEW-V2-F25-TECH` §1h + § archived.
+
+**Two more write-door guards (2026-07-15 field hardening).** (1) A `mission_post` letter carrying a
+`receipt_candidate` is now checked against the LIVE block at post time: a candidate whose
+`scope.boundary_version` no longer matches the block is refused `stale_scope` naming both versions —
+dead evidence is declared at the door instead of surviving as an orphan letter the tray would offer
+for a one-click import that `receipt_import` then rejects. (2) The owner's graph persist gained a
+catastrophic-shrink guard: when an incoming graph holds under 20% of the nodes in the existing
+on-disk snapshot, the prior snapshot is renamed to `<path>.bak-<unix_ts>` before it is overwritten
+(fail-open — a legitimate shrink is never blocked, the large snapshot is never lost in silence).
+This is defense in depth behind the #370 binding fix, after a snapshot was overwritten 10573→704.

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -103,6 +103,28 @@ same bar, applied to building the organism outward.
 > Docs same PR (F30 "§ The hash router" amendment + this block; corrected the stale "NOT yet landed" markers on the landed
 > Universe arc #371/#372/#373). Next: land this PR, then PR 2 of Pista A (the live map arc) — separate.
 
+> **2026-07-15 — "GUARDS AT THE WRITE DOORS" burst on `fix/write-door-guards` (branch, NOT yet landed).**
+> Field triage 2026-07-15 ranked three write-door guards; two were real and open, one was a stale triage claim.
+> **Commit A (mission_post boundary):** the mission-letter contract checked a `receipt_candidate`'s evidence for
+> COMPLETENESS but never that its `scope.boundary_version` still matched the LIVE block — so a candidate proving a
+> boundary the block had moved past was appended silently (how the orphan `msn_17a1d1f9b013` was born) and only
+> caught later at import. `handle_mission_post` now compares the candidate's boundary against the live block
+> (reusing the store it already loads for the `unknown_block` guard) and refuses `stale_scope` at post, naming both
+> versions — dead evidence declared at the door. **Commit B (persist shrink):** defense in depth behind #370 —
+> `snapshot::save_graph` peeks the existing on-disk node count and, when the incoming graph holds under 20% of a
+> non-trivial prior snapshot, renames it to `<path>.bak-<unix_ts>` before overwriting (fail-open — a legitimate
+> shrink is never blocked, the large snapshot is never lost in silence; the incident was a 10573→704 overwrite).
+> Both RED→GREEN. **The triage's P0 was already CLOSED:** "skeleton write-verbs refuse under `caller_root_mismatch`"
+> landed 2026-07-11 in **#340** (`skeleton_write_needs_root_gate`, `server.rs:4773`, covering all eight verbs) — the
+> triage checked `GRAPH_MUTATION_TOOLS`/`READ_ONLY_DENIED_TOOLS` and missed the dedicated gate; no new code, the
+> existing tests already cover it (a verify-before-declare catch). **A fourth guard (a chain has one writer, from an
+> askGOD verdict) was OPT-OUT:** the bell-silencing hole is real (a stranger can move a `merge_wait` head with a
+> seq+1 non-archived letter; the landing bell counts only `merge_wait` heads), but a letter chain is multi-writer BY
+> DESIGN (F25-TECH §4a/§5b: the oracle posts seq 1, **runnerd** streams seq 2+ on the same chain under a different
+> identity), and the board's transitions past `archived` are explicitly "left undesigned" — closing it correctly
+> needs the chain-write AUTHORIZATION model designed (a contract slice with its own verdict), not a mechanical
+> `agent_id` gate that would break the dispatch→execute loop.
+
 > **2026-07-15 — "VITALS NEVER BLOCK THE PANORAMA" fix on `fix/panorama-never-waits` (#373, LANDED — origin/main HEAD).**
 > A field report (2×, live) caught `/api/universe` stalling for 15-20s after a kickstart — it read as a deadlock
 > (CPU 0%), but was transient contention: `universe_body` took `state.session.lock()` on its FIRST line (just for

--- a/m1nd-core/src/snapshot.rs
+++ b/m1nd-core/src/snapshot.rs
@@ -5,7 +5,7 @@ use crate::graph::{Graph, NodeProvenanceInput, ResolvedNodeProvenance};
 use crate::plasticity::SynapticState;
 use crate::types::*;
 use std::io::{BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
 // Snapshot — JSON graph persistence
@@ -141,10 +141,75 @@ fn snapshot_from_provenance(value: ResolvedNodeProvenance) -> NodeProvenanceSnap
 // Graph save/load
 // ---------------------------------------------------------------------------
 
+// Catastrophic-shrink guard (defense in depth). Incident 2026-07-15: the owner's
+// `graph_snapshot.json` was overwritten from 10573 nodes to 704 with NO backup
+// (the foreign-ingest root cause was closed by #370; this is the second line of
+// defense). A canonical snapshot must never be replaced by a catastrophically
+// smaller one in silence — the large snapshot is preserved as a timestamped
+// `.bak-<unix_ts>` sibling first. Fail-open: the write always proceeds (a
+// legitimate shrink is not blocked), the big graph is simply never lost silently.
+
+/// The existing on-disk snapshot must hold at least this many nodes for the guard
+/// to engage — below it, shrinking is ordinary churn on a small/fresh brain.
+const SHRINK_GUARD_FLOOR: usize = 100;
+
+/// Count the nodes in an on-disk snapshot cheaply, without reconstructing the
+/// graph: only the `nodes` array length is read (its elements and the `edges`
+/// array are skipped). Returns `None` if the file is absent or unreadable — the
+/// guard then does nothing (best-effort, never blocks a persist).
+fn snapshot_node_count_on_disk(path: &Path) -> Option<usize> {
+    #[derive(serde::Deserialize)]
+    struct NodeCountPeek {
+        #[serde(default)]
+        nodes: Vec<serde::de::IgnoredAny>,
+    }
+    let bytes = std::fs::read(path).ok()?;
+    let peek: NodeCountPeek = serde_json::from_slice(&bytes).ok()?;
+    Some(peek.nodes.len())
+}
+
+/// If `path` already holds a non-trivial snapshot and `new_node_count` is under
+/// 20% of it, rename the existing file to `<path>.bak-<unix_ts>` before it is
+/// overwritten. Returns the backup path when one was made. Fail-open: any I/O
+/// hiccup (unreadable prior file, rename failure) skips the backup and lets the
+/// write proceed — the guard never blocks a legitimate persist.
+fn backup_if_catastrophic_shrink(path: &Path, new_node_count: usize) -> Option<PathBuf> {
+    let existing = snapshot_node_count_on_disk(path)?;
+    if existing < SHRINK_GUARD_FLOOR {
+        return None;
+    }
+    // Catastrophic := new < 20% of existing, i.e. `new * 5 < existing`.
+    if new_node_count.saturating_mul(5) >= existing {
+        return None;
+    }
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut bak = path.as_os_str().to_owned();
+    bak.push(format!(".bak-{ts}"));
+    let bak = PathBuf::from(bak);
+    match std::fs::rename(path, &bak) {
+        Ok(()) => {
+            eprintln!(
+                "[m1nd] WARNING: snapshot {} holds {existing} nodes but the incoming graph has \
+                 {new_node_count} (< 20%) — backed up the prior snapshot to {} before overwriting",
+                path.display(),
+                bak.display()
+            );
+            Some(bak)
+        }
+        Err(_) => None,
+    }
+}
+
 /// Save full graph to JSON snapshot. Atomic write: temp file + rename (FM-PL-008).
 /// Serializes all nodes and edges so the graph can be fully reconstructed on load.
 pub fn save_graph(graph: &Graph, path: &Path) -> M1ndResult<()> {
     let n = graph.num_nodes() as usize;
+
+    // Defense in depth: never silently overwrite a large snapshot with a tiny one.
+    let _ = backup_if_catastrophic_shrink(path, n);
 
     // Build reverse map: NodeId -> external_id string
     let mut node_to_ext_id = vec![String::new(); n];
@@ -382,4 +447,79 @@ pub fn load_co_change_matrix(path: &Path) -> M1ndResult<crate::temporal::CoChang
     // Return empty matrix; full deserialization needs graph context
     let graph = Graph::new();
     crate::temporal::CoChangeMatrix::bootstrap(&graph, 500_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph_with_nodes(n: usize) -> Graph {
+        let mut g = Graph::new();
+        for i in 0..n {
+            let id = format!("node_{i}");
+            g.add_node(&id, &id, NodeType::File, &[], 0.0, 0.0)
+                .expect("add node");
+        }
+        g
+    }
+
+    fn bak_siblings(dir: &Path, stem: &str) -> Vec<std::path::PathBuf> {
+        std::fs::read_dir(dir)
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(stem) && n.contains(".bak-"))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn owner_persist_refuses_or_backs_up_on_catastrophic_node_shrink() {
+        // Defense in depth (incident 2026-07-15: graph_snapshot.json overwritten
+        // 10573 -> 704 nodes with no backup). Overwriting a large canonical
+        // snapshot with a catastrophically smaller graph must never lose the big
+        // one in silence — the prior snapshot is preserved as a timestamped backup.
+        let base =
+            std::env::temp_dir().join(format!("m1nd_snapshot_shrink_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+
+        // Scenario A — catastrophic shrink (500 -> 10, well under 20%): backup made.
+        let dir_a = base.join("a");
+        std::fs::create_dir_all(&dir_a).expect("mk a");
+        let path_a = dir_a.join("graph_snapshot.json");
+        save_graph(&graph_with_nodes(500), &path_a).expect("save big");
+        save_graph(&graph_with_nodes(10), &path_a).expect("save tiny (fail-open)");
+
+        let baks = bak_siblings(&dir_a, "graph_snapshot.json");
+        assert_eq!(
+            baks.len(),
+            1,
+            "a catastrophic shrink must back up the prior large snapshot before overwriting"
+        );
+        let backed = load_graph(&baks[0]).expect("the backup is a valid snapshot");
+        assert_eq!(
+            backed.num_nodes(),
+            500,
+            "the backup preserves the large graph, not the tiny replacement"
+        );
+        // The write still happened (fail-open): the live snapshot is the tiny one.
+        assert_eq!(load_graph(&path_a).expect("live loads").num_nodes(), 10);
+
+        // Scenario B — a moderate shrink (500 -> 300, above 20%) is normal churn:
+        // no backup, the write proceeds untouched.
+        let dir_b = base.join("b");
+        std::fs::create_dir_all(&dir_b).expect("mk b");
+        let path_b = dir_b.join("graph_snapshot.json");
+        save_graph(&graph_with_nodes(500), &path_b).expect("save big");
+        save_graph(&graph_with_nodes(300), &path_b).expect("save moderate");
+        assert!(
+            bak_siblings(&dir_b, "graph_snapshot.json").is_empty(),
+            "a non-catastrophic shrink must not spawn a backup"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/m1nd-mcp/src/mission_letter_handlers.rs
+++ b/m1nd-mcp/src/mission_letter_handlers.rs
@@ -156,6 +156,39 @@ pub fn handle_mission_post(state: &mut SessionState, input: MissionPostInput) ->
                     ),
                 });
             }
+            // The boundary-staleness guard (field bug: the orphan letter
+            // msn_17a1d1f9b013). A `receipt_candidate` is the one-click import the
+            // tray offers; the §1 contract gate only proved its evidence was
+            // COMPLETE (artifact_hash + evidence_refs), never that its
+            // `scope.boundary_version` still matched the LIVE block. A candidate
+            // proving a boundary the block has moved past is dead evidence —
+            // `receipt_import` would reject it with `stale_scope`, yet the letter
+            // was already appended (that is how the orphan was born). Declare the
+            // staleness at POST, naming both versions, and append nothing. Mirrors
+            // the import law (`system_blocks`: receipt.scope.boundary_version !=
+            // block.boundary_version).
+            if let Some(candidate) = &input.letter.receipt_candidate {
+                if let Some(block) = store
+                    .blocks
+                    .iter()
+                    .find(|b| b.block_id == candidate.block_id)
+                {
+                    if candidate.scope.boundary_version != block.boundary_version {
+                        return Err(M1ndError::InvalidParams {
+                            tool: "mission_post".to_string(),
+                            detail: format!(
+                                "stale_scope: the receipt candidate for block '{}' proves \
+                                 boundary_version {} but the live block is at boundary_version {} \
+                                 — re-earn the candidate against the live boundary; nothing was \
+                                 appended",
+                                candidate.block_id,
+                                candidate.scope.boundary_version,
+                                block.boundary_version
+                            ),
+                        });
+                    }
+                }
+            }
         }
     }
     let box_path = mission_box_path(state);

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -7215,6 +7215,94 @@ mod tests {
         let _ = &temp;
     }
 
+    #[test]
+    fn mission_post_refuses_receipt_candidate_with_stale_boundary_version() {
+        // The boundary-staleness guard (field bug: the orphan letter
+        // msn_17a1d1f9b013). A mission letter may carry a `receipt_candidate` — a
+        // one-click import the tray offers. gate #3 only checked the candidate's
+        // evidence was COMPLETE, never that its `scope.boundary_version` still
+        // matched the LIVE block. A candidate proving a boundary the block has
+        // moved past is dead evidence: `receipt_import` would reject it with
+        // `stale_scope`, but the letter was already appended. Declare the staleness
+        // at POST instead, naming both versions. Mirrors the import law
+        // (`system_blocks`: receipt.scope.boundary_version != block.boundary_version).
+        let (temp, mut state) = build_state();
+        let repo = temp.path().join("m1nd");
+        std::fs::create_dir_all(&repo).expect("repo");
+        state.workspace_root = Some(repo.to_string_lossy().to_string());
+        state.ingest_roots = vec![repo.to_string_lossy().to_string()];
+
+        // Seed the real skeleton: sb_m1nd_core_graph_kernel lives at boundary 1.
+        let real_seed = include_str!("../../docs/system-blocks/m1nd.seed.v0.json");
+        super::dispatch_tool(
+            &mut state,
+            "system_blocks_seed_import",
+            &serde_json::json!({"agent_id": "t", "seed_json": real_seed}),
+        )
+        .expect("seed imports");
+
+        // A merge_wait letter (requires a gate) carrying a candidate whose scope
+        // boundary is the parameter under test.
+        let letter = |cand_boundary: u32, mission_id: &str| {
+            serde_json::json!({
+                "schema": "m1nd-mission-letter-v0",
+                "mission_id": mission_id,
+                "mission_seq": 1,
+                "block_id": "sb_m1nd_core_graph_kernel",
+                "brain_ref": "m1nd",
+                "seat": "hand",
+                "capability": "build-runner",
+                "phase": "merge_wait",
+                "gate": {
+                    "command": "cargo test -p m1nd-mcp",
+                    "exit_status": 0,
+                    "artifact_hash": "sha256:gatelog"
+                },
+                "receipt_candidate": {
+                    "block_id": "sb_m1nd_core_graph_kernel",
+                    "type": "spec",
+                    "scope": {"boundary_version": cand_boundary, "contract_version": 1},
+                    "evidence": {
+                        "artifact_hash": "sha256:art",
+                        "evidence_refs": ["artifacts/x.txt"]
+                    }
+                },
+                "packet_ref": "sha256:x",
+                "tokens_total": 0,
+                "started_at": "2026-07-10T00:00:00Z",
+                "updated_at": "2026-07-10T00:00:00Z",
+            })
+        };
+
+        // A candidate proving the LIVE boundary (1) posts cleanly — the control.
+        super::dispatch_tool(
+            &mut state,
+            "mission_post",
+            &serde_json::json!({"agent_id": "t", "letter": letter(1, "msn_0123456789ab")}),
+        )
+        .expect("a candidate proving the live boundary posts");
+
+        // A candidate proving a boundary the block is NOT at (3 != live 1) is
+        // refused, naming both versions. On main (no gate) this posts silently —
+        // the exact vector that birthed the orphan letter.
+        let err = super::dispatch_tool(
+            &mut state,
+            "mission_post",
+            &serde_json::json!({"agent_id": "t", "letter": letter(3, "msn_abcdef012345")}),
+        )
+        .expect_err("a stale-boundary candidate must be refused at post");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("stale_scope"),
+            "refusal names the staleness: {msg}"
+        );
+        assert!(
+            msg.contains('3') && msg.contains('1'),
+            "refusal names both boundary versions (candidate 3 vs live 1): {msg}"
+        );
+        let _ = &temp;
+    }
+
     /// THE CURATION-DISPATCH BATTERY (field bug 2026-07-10, seen twice in human
     /// dogfood): the map's "Send to an agent for curation" letter was refused on a
     /// HOSTED brain. Two composed causes: (1) the UI derived `brain_ref` from the


### PR DESCRIPTION
Three write-door guards from the 2026-07-15 field triage. Two were real and open (landed here, RED→GREEN); the triage's P0 was already closed; a fourth (from an askGOD verdict) is an honest opt-out.

## Landed

**`mission_post` refuses a stale-boundary receipt candidate.** The mission-letter contract validated a `receipt_candidate`'s evidence for completeness (`artifact_hash` + `evidence_refs`) but never checked that its `scope.boundary_version` still matched the live block. A candidate proving a boundary the block has moved past is dead evidence — `receipt_import` rejects it with `stale_scope`, yet the letter had already been appended (how the orphan `msn_17a1d1f9b013` was born). `handle_mission_post` now compares the candidate's boundary against the live block (reusing the store it already loads for the `unknown_block` guard) and refuses `stale_scope` at post, naming both versions. RED test: `mission_post_refuses_receipt_candidate_with_stale_boundary_version`.

**Owner persist backs up on catastrophic node shrink.** Defense in depth behind #370: the owner's `graph_snapshot.json` was overwritten 10573 → 704 nodes with no backup. `snapshot::save_graph` now peeks the existing on-disk node count and, when the incoming graph holds under 20% of a non-trivial prior snapshot, renames it to `<path>.bak-<unix_ts>` before overwriting. Fail-open: a legitimate shrink is never blocked, the large snapshot is never lost in silence. RED test: `owner_persist_refuses_or_backs_up_on_catastrophic_node_shrink`.

## Already closed (no code)

The triage's P0 — "skeleton write-verbs refuse under `caller_root_mismatch`" — already landed 2026-07-11 in #340 (`skeleton_write_needs_root_gate`, `server.rs:4773`, covering all eight verbs). The triage checked `GRAPH_MUTATION_TOOLS`/`READ_ONLY_DENIED_TOOLS` and missed the dedicated gate; the existing tests already cover it. Verify-before-declare catch — no duplicate test added.

## Opt-out (needs its own slice + verdict)

A fourth guard — "a letter chain has one writer" — was proposed to close a real bell-silencing hole (a stranger can move a `merge_wait` head with a seq+1 non-archived letter). But a letter chain is multi-writer BY DESIGN (`HUMAN-VIEW-V2-F25-TECH` §4a/§5b: the oracle posts seq 1, runnerd streams seq 2+ on the same chain under a different identity), and the board's transitions past `archived` are explicitly "left undesigned." A mechanical `agent_id` gate would break the dispatch→execute loop. Closing it correctly needs the chain-write authorization model designed — a contract slice with its own verdict.

## Gate

`fmt --check` clean · `clippy -D warnings` clean · full suite green (m1nd-core 162, m1nd-mcp 895, all integration binaries) · no-leak clean.
