### PR TITLE
fix(g4): close residual Windows directory-fsync sites; diagnose the macOS recovery flake

### DIFF
--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -4009,10 +4009,9 @@ fn sync_directory(path: &Path) -> std::io::Result<()> {
 
 #[cfg(windows)]
 fn sync_directory(_path: &Path) -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "directory fsync is not proven on Windows",
-    ))
+    // Windows refuses fsync on directory handles; write-through covers renames —
+    // the same platform law the rest of the workspace already follows.
+    Ok(())
 }
 
 /// Type-level reminder used by registry wrappers: preparation receives a

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -10,7 +10,7 @@ mod graph_ingest_a2;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, SyncSender};
@@ -6130,7 +6130,14 @@ fn sha256_bytes(bytes: &[u8]) -> String {
 }
 
 fn sync_parent(path: &Path) -> std::io::Result<()> {
-    File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+    // Windows refuses fsync on directory handles; write-through covers renames.
+    #[cfg(windows)]
+    {
+        let _ = path;
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    std::fs::File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
 }
 
 fn is_digest(value: &str) -> bool {


### PR DESCRIPTION
## G4 phase 2 — remaining Windows failures + the macOS flake

Phase-2 attack on the Windows CI scoreboard, driven from macOS, by class, in an
isolated worktree. **One class shipped with local proof** (residual directory
fsync, ~69 failures); the macOS flake is **diagnosed to root cause but its fix
reverted** (it can only be fixed via a shared-method/product change — owner
call); the remaining clusters are classified and left for **this PR's CI run to
score on the real Windows/3-core runners** (no merge, no auto-merge).

### Attacked — class 1: residual Windows directory-fsync (~69 failures)

The era's directory-fsync platform law (`f76e7244`: *Windows refuses fsync on
directory handles; `std::fs::rename` is write-through, so the parent-directory
fsync is a POSIX-only durability step*) had two un-adopted sites, both in
failing modules:

- **`external_mutation_service::sync_parent`** was **unconditional** —
  `File::open(<dir>).sync_all()` fails on Windows (os error 5), so every OCC
  staging/publish write returned `Io`. This is the `external_mutation_service`
  cluster (~40). Now gated with the exact `#[cfg(not(windows))]` shape as
  `http_security::sync_parent`.
- **`brain_runtime::sync_directory`**'s `#[cfg(windows)]` arm **actively
  returned `Unsupported`** — a fail-closed choice from the candidate-freeze
  commit `70598733` that predates the later-ratified no-op law. Every
  persistence/restore/rollback path therefore failed on Windows
  (`brain_runtime` cluster, ~29). Now returns `Ok(())`, matching the workspace.

Proof (macOS): `brain_runtime` 32/32 green; `m1nd-mcp` `clippy -D warnings`
clean; `fmt --check` clean.

### Diagnosed, fix reverted — the macOS actor-recovery flake (needs owner)

`external_mutation_service::tests::source_outer_cut_matrix_recovers_boot_preserves_target_and_replays_pending_reconciliation`.

**Root cause (proven, and it is *not* the hint's fixture-held lock):** the
recovery matrix test threads **one** `restarted` brain cell through its
recover → pending-read → terminal-replay phases. Each phase binds that cell's
**bound** actor in a fresh `ProjectBrainRegistry`, and
`ProjectBrainRegistry::shutdown` releases **hosted** brains' instance leases
inline after their actor stops (`release_hosted_instance_after_actor_stop`,
`project_brains.rs` ~927) but leaves the **bound** actor's `runtime_root`
checkpoint lease held until the registry's **asynchronous Drop**. On a 3-core
runner that Drop isn't scheduled promptly, so the next phase's bind spins its
wait loop for all `300 × 100ms` attempts and panics
(`source replay actor id after 300 waits`). The era's `50→300` retry widening
(`f76e7244`) was a palliative for exactly this. Timing evidence (macOS,
unloaded): the single test runs ~37–40s across its 8 cuts, dominated by
per-bind actor startup + the async-release waits.

**A deterministic-release fix was attempted and then reverted.** The intended
shape — give each phase its own throwaway replica cell and retire it
(`shutdown` + `lock_mut_before_actor` + `instance.release`) so the lease is free
before the next bind — is the right *direction*, but it must touch
`recover_for_boot` and `pending_recovery_is_empty`, which are **shared** across
several boot-recovery tests (`source_service_boot_cleans_staged_orphan…`,
`…rediscovers…pre_stage_cleanup`, the ratify siblings). Those callers **reuse**
the same brain cell after the phase, so releasing its instance inside the shared
method regressed them deterministically (`lost its instance owner`). Reverted to
keep the tree green; only the dir-fsync class ships here.

**Why this is an owner call, not a blind patch:** the real asymmetry is in
product code — `shutdown` releases hosted instances but not the bound one — and
the test-side `retire_bound_owner_for_restart` helper already *depends* on that
(`shutdown` then a manual `instance.release`). A correct fix is either (a) make
`shutdown` symmetric for the bound actor and update the restart helper that
relies on the current behavior, or (b) restructure every
`recover_for_boot`/`pending_recovery_is_empty` caller onto per-phase throwaway
cells. Both are design decisions with real blast radius, and the 3-core
starvation spin is **not reproducible on 14-core hardware** (there is always a
free core for the async Drop to finish), so neither can be proven locally. Left
for the owner with the root cause pinned.

### Classified, NOT attacked — deferred to this PR's CI

These clusters were read but not fixed: without a Windows host the precise
runtime cause can't be confirmed, and blind test-fixture edits risk masking the
real cause or regressing POSIX. Best-effort classification:

| Module (failures) | Likely class |
|---|---|
| `surgical_handlers::source_edit_transaction` (11) | runtime file-transaction on Windows (staging/publish/rollback crash-recovery cuts); unix perm/uid product code is already `#[cfg(unix)]`-gated, so **not** a compile/permission class |
| `mcp_http::tests` (10) | actor-binding/timing (same family as the flake) and/or POSIX caller-root fixtures (`/tmp/...`) |
| `server::tests` (7) | POSIX path fixtures (`/tmp/...`) + open-file `remove_file` |
| `http_server::tests` (7) | `TcpListener` bind / server-lifecycle timing (SIGTERM watcher itself is correctly `#[cfg(unix)]`/`#[cfg(not(unix))]`-paired) |
| `project_brains::*` (9) | actor-lifecycle/timing + `/tmp`→canonicalization aliasing (product path code is already `\\`-normalized and Windows-aware) |
| `perspective::peek_security` (4) | to determine on CI |
| `authority_wal` partial-byte (1) | byte-level WAL durability, not path |
| `ui_bundle_attestation` (1) | POSIX `/tmp/ui` fixture in `for_http` mode |

### Validation
macOS only. `brain_runtime` 32/32 green; the dir-fsync change is behaviourally
identical to the original on non-Windows (the `#[cfg(not(windows))]` arms *are*
the original code, so it cannot regress macOS/Linux by construction); `fmt` and
`clippy -D warnings` clean. Windows is the CI's to judge.

_Note: under a full-parallel `external_mutation_service` run the machine
self-starves and the same actor-recovery flake class surfaces in the `ratify`
sibling too — pre-existing, unrelated to this diff, and the second data point
for the diagnosis above._
