### PR TITLE
feat(g9): enclave open/sign/dup-guard (delivered) + custody_floor threading (blocked on frozen canon)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,7 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "security-framework",
+ "security-framework-sys",
  "serde",
  "serde_json",
  "sha2",

--- a/docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md
+++ b/docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md
@@ -112,14 +112,28 @@ Gates green per crate touched: `cargo fmt --check`, `cargo clippy --all-targets
   and a biometric signature need the Secure Enclave, biometry, and code-signing /
   keychain-access-group identity the owner alone holds. The agent cannot provoke
   `SecKeyCreateSignature` under user presence — the proof is the owner's ceremony.
-- **BLOCKING ORDER (G9-A1 ratification).** `custody_floor` is fail-closed only in
-  the ceremony receipt today. Threading it into the digest-sealed
-  `m1nd-control/src/release.rs` gate/review receipts and the autonomy activation
-  receipt is a follow-up (the field perturbs every existing fixture digest, so it
-  lands as its own reviewed change). That follow-up **must merge BEFORE** the
-  owner's custody ceremony and before any G9/G10 receipt is minted under this
-  floor — so no receipt can claim the floor without carrying it. This ordering is
-  a ratification obligation, not an optimization.
+- **BLOCKING ORDER (G9-A1 ratification) — STILL UNMET; blocked on frozen canon.**
+  `custody_floor` is fail-closed only in the ceremony receipt today. Threading it
+  into the `m1nd-control/src/release.rs` gate/review receipts was investigated this
+  session (2026-07-21) and found to collide with **ratified, frozen cross-language
+  canon** that the ceremony follow-up scope explicitly fences off. The G0–G10 gate
+  receipts (including G9/G10) are pinned with fixed `receipt_digest`s inside
+  `tests/fixtures/M1ND10-CANONICAL-VECTORS.json`, and the gate-receipt schema is
+  dual-implemented in Python (`scripts/m1nd10_release_contract.py`,
+  `GATE_CORE_FIELDS` — a closed 16-field allowlist enforced by `_exact_keys`, with
+  a `digest_canonical` that must match Rust byte-for-byte). Adding a `custody_floor`
+  field to `GateReceiptCoreV1` therefore requires, in one owner-authorized change:
+  (a) the Rust struct + fail-closed validation, (b) the Python allowlist +
+  validator, and (c) regenerating the frozen G9/G10 canonical vectors (new digests).
+  Both the checked-in `test_m1nd10_release_contract.py` and the release CI gate
+  (`.github/workflows/release.yml` `verify-canonical-vectors`) verify these vectors.
+  Per the ceremony follow-up's own boundary ("if a vector is frozen/ratified — the
+  PRD/UML hash or `M1ND10-CANONICAL-VECTORS.json` — stop and report; do not edit
+  frozen canon without an order"), this threading was **not forced**. It must land
+  as its own reviewed, owner-authorized change and **must merge BEFORE** the custody
+  ceremony and before any G9/G10 receipt is minted under this floor — so no receipt
+  can claim the floor without carrying it. This ordering is a ratification
+  obligation, not an optimization; it remains a genuine blocker.
 - **Prerequisite follow-up landed.** Open-by-tag (`SecItemCopyMatching` via the
   high-level `ItemSearchOptions`), the real `SecKeyCopyAttributes` read-back of
   token/type/size (proving Secure Enclave residency and EC P-256 by `CFEqual`
@@ -180,9 +194,15 @@ Record the seat public keys, the digests, and the sealed receipt path.
   binding sealed into each record (a slot cannot be replayed into another root
   sealed by the same key); it is NOT hardware anti-rollback. Single-host limits
   are the amendment's declared non-claims, carried on the ceremony receipt.
-- The `custody_floor` field does not yet reach the release/autonomy receipts
-  (blocking order above); until it does, only ceremony receipts are fail-closed
-  on the floor.
+- The `custody_floor` field does not yet reach the release/autonomy receipts;
+  only ceremony receipts are fail-closed on the floor. This threading is BLOCKED
+  on frozen canon (see the BLOCKING ORDER above): the gate receipts are ratified
+  cross-language vectors + a Python-mirrored closed schema, so it needs an
+  owner-authorized change to regenerate them. The autonomy activation receipt
+  (`m1nd-control/src/autonomy.rs`, Rust-only, regenerable) is not frozen, but
+  threading it alone would neither satisfy the "every G9/G10 receipt" order nor
+  leave a coherent schema (half the receipts migrated), so it was not done in
+  isolation; it belongs in the same owner-authorized change as the gate receipts.
 - **Quorum wiring follow-up.** The ceremony receipt seals the four seat public
   keys and binds them to the `IndependenceSpecV1` by (principal, key,
   failure-domain). `VerifierSeatV1` carries no public key, so the binding does

--- a/docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md
+++ b/docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md
@@ -94,19 +94,24 @@ Gates green per crate touched: `cargo fmt --check`, `cargo clippy --all-targets
 - The custody ceremony envelope is fail-closed on the floor, four distinct
   enclave seats, three failure domains, and an owner seat disjoint from the
   voting seats; it binds to the exact `IndependenceSpecV1`.
-- `SecurityFrameworkEnclaveKeyStore::provision` compiles against the real
-  Security.framework crate on macOS (`SecKey::new` with
-  `kSecAttrTokenIDSecureEnclave`, EC 256, `kSecAccessControl`).
+- `SecurityFrameworkEnclaveKeyStore` — `provision` (`SecKey::new` with
+  `kSecAttrTokenIDSecureEnclave`, EC 256, `kSecAccessControl` + never-open-or-create
+  duplicate guard), `open` (`SecItemCopyMatching` by application tag +
+  `SecKeyCopyAttributes` read-back), and `sign` (`SecKeyCreateSignature`,
+  ECDSA-message-X962-SHA256) all compile against the real Security.framework crate
+  on macOS. Runtime execution against enclave hardware/biometry is the owner's
+  ceremony (NOT_RUN).
 
 ### NOT_RUN — the owner's live ceremony, with a BLOCKING order
 - No real Secure Enclave key was created, rotated, activated, or used. No
   biometric signature was produced.
-- `SecurityFrameworkEnclaveKeyStore::open` / `sign` are unconditional `Err`
-  today: resolving a persisted enclave key via `SecItemCopyMatching` by
-  application tag (also the production never-open-or-create duplicate guard) and
-  signing under biometric presence needs the hardware, biometry, and
-  code-signing / keychain-access-group identity the owner alone holds. Shipping
-  an unverifiable item-query would be false completeness.
+- `SecurityFrameworkEnclaveKeyStore::open` / `sign` and the provision duplicate
+  guard are now fully implemented and compile-verified on macOS (see
+  "Prerequisite follow-up landed" below). What stays live-NOT_RUN is their
+  execution against real hardware: a persisted key resolved out of the Keychain
+  and a biometric signature need the Secure Enclave, biometry, and code-signing /
+  keychain-access-group identity the owner alone holds. The agent cannot provoke
+  `SecKeyCreateSignature` under user presence — the proof is the owner's ceremony.
 - **BLOCKING ORDER (G9-A1 ratification).** `custody_floor` is fail-closed only in
   the ceremony receipt today. Threading it into the digest-sealed
   `m1nd-control/src/release.rs` gate/review receipts and the autonomy activation
@@ -115,29 +120,37 @@ Gates green per crate touched: `cargo fmt --check`, `cargo clippy --all-targets
   owner's custody ceremony and before any G9/G10 receipt is minted under this
   floor — so no receipt can claim the floor without carrying it. This ordering is
   a ratification obligation, not an optimization.
-- **Prerequisite follow-up for the ceremony.** Implementing open-by-tag
-  (`SecItemCopyMatching` + a real `SecKeyCopyAttributes` read-back of
-  token/type/size), `sign` under biometric presence, and the never-open-or-create
-  duplicate guard is a named prerequisite of the live ceremony. Until it lands,
-  the runbook is scoped to what actually executes.
+- **Prerequisite follow-up landed.** Open-by-tag (`SecItemCopyMatching` via the
+  high-level `ItemSearchOptions`), the real `SecKeyCopyAttributes` read-back of
+  token/type/size (proving Secure Enclave residency and EC P-256 by `CFEqual`
+  against the framework's own constants — attesting the KEY, not the request),
+  `sign` through `SecKeyCreateSignature` under biometric presence, and the
+  never-open-or-create duplicate guard are implemented and compile-verified on
+  macOS. `provision` now attests the created key by the same read-back rather than
+  hard-coding token/type. The `SecurityFrameworkEnclaveKeyStore::new` constructor
+  gained a seat-class `access_control` argument (a store is bound to one seat
+  class; it refuses a permit for another). On non-macOS the whole module is absent
+  by construction, so the production assembly stays NOT_INSTALLED / fail-closed.
 
 ## Owner's documented live one-shot proof (you run this, not the agent)
 
 ### Runs today (agent building blocks; no biometry, no persisted-key resolution)
 1. For each of the four verifier seats, provision an unattended enclave key:
    `provision_agent_enclave_seat(&SecurityFrameworkEnclaveKeyStore::new(prefix,
-   subject), &permit_for_seat)` — distinct `key_id`/`failure_domain`, at least
-   three distinct domains, each permit carrying its `bound_context_digest`
-   (sealed later as seat lineage). Capture each 65-byte SEC1 public key.
+   subject, EnclaveAccessControlV1::PrivateKeyUsageNonExportable),
+   &permit_for_seat)` — distinct `key_id`/`failure_domain`, at least three
+   distinct domains, each permit carrying its `bound_context_digest` (sealed later
+   as seat lineage). Capture each 65-byte SEC1 public key. Provision now reads the
+   created key's real token/type/size back, and refuses a tag already present.
 2. **kSecAccessControl conformance check.** Confirm each provisioned key actually
    carries the intended access-control semantics (private-key usage; user
    presence for the biometric seat). The flag values are hand-rolled (`1<<30`,
    `1<<0`), so this run is what proves them.
 
 ### Prerequisite follow-up, then the ceremony (the owner's alone)
-3. Land the open/sign follow-up (open-by-tag + attribute read-back + biometric
-   sign + duplicate guard) and the `custody_floor` threading (blocking order
-   above).
+3. The open/sign follow-up (open-by-tag + attribute read-back + biometric sign +
+   duplicate guard) has landed. The `custody_floor` threading (blocking order
+   above) must also land before the ceremony.
 4. Provision the owner's biometric seat (Touch ID / user presence) —
    `owner_signature`, never a voting seat.
 5. Open + re-attest each seat: `SecureEnclaveSigner::open_attested(store, key_id,
@@ -156,10 +169,13 @@ Gates green per crate touched: `cargo fmt --check`, `cargo clippy --all-targets
 Record the seat public keys, the digests, and the sealed receipt path.
 
 ## Honest risks and named follow-ups
-- `provision` attests the key size it observes from the returned SEC1 point; the
-  real token/type read-back (`SecKeyCopyAttributes`) is a named follow-up. The
-  hand-rolled `kSecAccessControl` semantics and the persisted key's Keychain
-  visibility are proven only by the owner's live conformance run.
+- `provision`/`open` now read the key's real token/type/size back via
+  `SecKeyCopyAttributes` and prove Secure Enclave residency + EC P-256 by
+  `CFEqual` against the framework's own constants. What is NOT read back is the
+  `kSecAccessControl` (presence) semantics — the hand-rolled flag values
+  (`1<<30`, `1<<0`) and the persisted key's Keychain visibility are proven only by
+  the owner's live conformance run. This is compile-verified on macOS, not run
+  against hardware in CI.
 - Sealed-slot anti-replay is filesystem-strength plus a root-path + context
   binding sealed into each record (a slot cannot be replayed into another root
   sealed by the same key); it is NOT hardware anti-rollback. Single-host limits

--- a/docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md
+++ b/docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md
@@ -95,22 +95,26 @@ Gates green per crate touched: `cargo fmt --check`, `cargo clippy --all-targets
   enclave seats, three failure domains, and an owner seat disjoint from the
   voting seats; it binds to the exact `IndependenceSpecV1`.
 - `SecurityFrameworkEnclaveKeyStore` — `provision` (`SecKey::new` with
-  `kSecAttrTokenIDSecureEnclave`, EC 256, `kSecAccessControl` + never-open-or-create
-  duplicate guard), `open` (`SecItemCopyMatching` by application tag +
-  `SecKeyCopyAttributes` read-back), and `sign` (`SecKeyCreateSignature`,
+  `kSecAttrTokenIDSecureEnclave`, EC 256, `kSecAccessControl`, **persisted** via
+  `Location::DataProtectionKeychain` + never-open-or-create duplicate guard), `open`
+  (`SecItemCopyMatching` by `kSecAttrLabel`, scoped to the data-protection keychain
+  so it sees what `provision` wrote, + `SecKeyCopyAttributes` read-back with a
+  `CFGetTypeID` guard on the size), and `sign` (`SecKeyCreateSignature`,
   ECDSA-message-X962-SHA256) all compile against the real Security.framework crate
-  on macOS. Runtime execution against enclave hardware/biometry is the owner's
-  ceremony (NOT_RUN).
+  on macOS. Runtime execution against enclave hardware/biometry — and the
+  code-signing entitlement persistence requires — is the owner's ceremony (NOT_RUN).
 
 ### NOT_RUN — the owner's live ceremony, with a BLOCKING order
 - No real Secure Enclave key was created, rotated, activated, or used. No
   biometric signature was produced.
-- `SecurityFrameworkEnclaveKeyStore::open` / `sign` and the provision duplicate
-  guard are now fully implemented and compile-verified on macOS (see
-  "Prerequisite follow-up landed" below). What stays live-NOT_RUN is their
-  execution against real hardware: a persisted key resolved out of the Keychain
-  and a biometric signature need the Secure Enclave, biometry, and code-signing /
-  keychain-access-group identity the owner alone holds. The agent cannot provoke
+- `SecurityFrameworkEnclaveKeyStore::open` / `sign`, key persistence, and the
+  provision duplicate guard are now fully implemented and compile-verified on macOS
+  (see "Prerequisite follow-up landed" below). What stays live-NOT_RUN is the real
+  persistence-and-resolution proof: making a Secure Enclave key permanent in the
+  data-protection keychain and resolving it back **requires the calling binary to be
+  codesigned with a `KeychainAccessGroups` entitlement** — a HARD prerequisite the
+  owner alone holds, not a runtime nicety. Only then does `provision` -> process
+  restart -> `open`/`sign` (biometric) actually round-trip. The agent cannot provoke
   `SecKeyCreateSignature` under user presence — the proof is the owner's ceremony.
 - **BLOCKING ORDER (G9-A1 ratification) — STILL UNMET; blocked on frozen canon.**
   `custody_floor` is fail-closed only in the ceremony receipt today. Threading it
@@ -134,37 +138,53 @@ Gates green per crate touched: `cargo fmt --check`, `cargo clippy --all-targets
   ceremony and before any G9/G10 receipt is minted under this floor — so no receipt
   can claim the floor without carrying it. This ordering is a ratification
   obligation, not an optimization; it remains a genuine blocker.
-- **Prerequisite follow-up landed.** Open-by-tag (`SecItemCopyMatching` via the
-  high-level `ItemSearchOptions`), the real `SecKeyCopyAttributes` read-back of
-  token/type/size (proving Secure Enclave residency and EC P-256 by `CFEqual`
-  against the framework's own constants — attesting the KEY, not the request),
-  `sign` through `SecKeyCreateSignature` under biometric presence, and the
-  never-open-or-create duplicate guard are implemented and compile-verified on
-  macOS. `provision` now attests the created key by the same read-back rather than
-  hard-coding token/type. The `SecurityFrameworkEnclaveKeyStore::new` constructor
-  gained a seat-class `access_control` argument (a store is bound to one seat
-  class; it refuses a permit for another). On non-macOS the whole module is absent
-  by construction, so the production assembly stays NOT_INSTALLED / fail-closed.
+- **Prerequisite follow-up landed.** Implemented and compile-verified on macOS:
+  - **Key persistence (the review's central fix).** `provision` now sets
+    `Location::DataProtectionKeychain`; without a location the created key was
+    EPHEMERAL (`kSecAttrIsPermanent` is only emitted when a location is set), so it
+    never reached the Keychain and `open`/`sign` could never resolve it. Secure
+    Enclave keys can only be made permanent in the data-protection keychain, and
+    `resolve_persisted_key` queries the SAME scope (`ignore_legacy_keychains` /
+    `kSecUseDataProtectionKeychain`) so creation and lookup agree. This needs the
+    `OSX_10_15` feature on `security-framework` (an empty cfg-only feature — no new
+    crate, no lockfile move) and a codesigned, entitled binary at runtime.
+  - **Open-by-label** (`SecItemCopyMatching` via `ItemSearchOptions`) — custody is
+    keyed by `kSecAttrLabel`, not `kSecAttrApplicationTag` (the high-level
+    key-creation surface exposes no application tag); any item sharing the label
+    makes provision AND open fail closed.
+  - The real `SecKeyCopyAttributes` read-back of token/type/size (Secure Enclave
+    residency + EC P-256 proven by `CFEqual` against the framework's constants,
+    with a `CFGetTypeID` guard before the size is read as a `CFNumber`).
+  - `sign` through `SecKeyCreateSignature`, the never-open-or-create duplicate
+    guard, and `provision` attesting the created key by the same read-back.
+  - The `SecurityFrameworkEnclaveKeyStore::new` constructor gained a seat-class
+    `access_control` argument (a store is bound to one seat class; it refuses a
+    permit for another). On non-macOS the whole module is absent by construction, so
+    the production assembly stays NOT_INSTALLED / fail-closed.
 
 ## Owner's documented live one-shot proof (you run this, not the agent)
 
-### Runs today (agent building blocks; no biometry, no persisted-key resolution)
+### On the owner's codesigned, entitled binary (no biometry for the verifier seats)
+Note: because provisioning now PERSISTS into the data-protection keychain, even the
+unattended verifier seats require the codesigned binary with a `KeychainAccessGroups`
+entitlement — there is no ephemeral-key shortcut anymore. The agent's mock proves the
+logical contract; these steps run on the owner's signed binary.
 1. For each of the four verifier seats, provision an unattended enclave key:
    `provision_agent_enclave_seat(&SecurityFrameworkEnclaveKeyStore::new(prefix,
    subject, EnclaveAccessControlV1::PrivateKeyUsageNonExportable),
    &permit_for_seat)` — distinct `key_id`/`failure_domain`, at least three
    distinct domains, each permit carrying its `bound_context_digest` (sealed later
-   as seat lineage). Capture each 65-byte SEC1 public key. Provision now reads the
-   created key's real token/type/size back, and refuses a tag already present.
+   as seat lineage). Capture each 65-byte SEC1 public key. Provision persists the
+   key, reads its real token/type/size back, and refuses a label already present.
 2. **kSecAccessControl conformance check.** Confirm each provisioned key actually
    carries the intended access-control semantics (private-key usage; user
    presence for the biometric seat). The flag values are hand-rolled (`1<<30`,
    `1<<0`), so this run is what proves them.
 
 ### Prerequisite follow-up, then the ceremony (the owner's alone)
-3. The open/sign follow-up (open-by-tag + attribute read-back + biometric sign +
-   duplicate guard) has landed. The `custody_floor` threading (blocking order
-   above) must also land before the ceremony.
+3. The open/sign follow-up (persistence + open-by-label + attribute read-back +
+   biometric sign + duplicate guard) has landed. The `custody_floor` threading
+   (blocking order above) must also land before the ceremony.
 4. Provision the owner's biometric seat (Touch ID / user presence) —
    `owner_signature`, never a voting seat.
 5. Open + re-attest each seat: `SecureEnclaveSigner::open_attested(store, key_id,
@@ -190,6 +210,12 @@ Record the seat public keys, the digests, and the sealed receipt path.
   (`1<<30`, `1<<0`) and the persisted key's Keychain visibility are proven only by
   the owner's live conformance run. This is compile-verified on macOS, not run
   against hardware in CI.
+- Persistence has a HARD runtime prerequisite: the data-protection keychain that
+  Secure Enclave keys must live in requires the calling binary to be codesigned
+  with a `KeychainAccessGroups` entitlement. An unsigned/unentitled binary cannot
+  persist or resolve the key, so `provision`/`open`/`sign` fail closed. The
+  provision→restart→open round-trip is therefore proven only on the owner's signed
+  binary; the mock proves the logical contract in-process.
 - Sealed-slot anti-replay is filesystem-strength plus a root-path + context
   binding sealed into each record (a slot cannot be replayed into another root
   sealed by the same key); it is NOT hardware anti-rollback. Single-host limits

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -88,8 +88,15 @@ windows-sys = { version = "0.61.2", features = [
 # provision read back via SecKeyCopyAttributes; the high-level crate does not
 # re-export them. It is the same version security-framework already depends on and
 # is already in Cargo.lock, so this adds no crate and does not move the lockfile.
+# The OSX_10_15 feature is REQUIRED, not cosmetic: Secure Enclave keys can only be
+# made permanent in the data-protection keychain, and both `Location::Data-
+# ProtectionKeychain` (provision) and `kSecUseDataProtectionKeychain` (the
+# `ignore_legacy_keychains` query scope) are gated behind it. It enables only
+# security-framework-sys/OSX_10_15, itself an empty cfg-only feature — no new crate,
+# no lockfile move. Persisting into that keychain also requires the calling binary
+# to be codesigned with a KeychainAccessGroups entitlement (owner ceremony).
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "=3.7.0"
+security-framework = { version = "=3.7.0", features = ["OSX_10_15"] }
 security-framework-sys = "=2.17.0"
 core-foundation = "=0.10.1"
 

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -83,8 +83,14 @@ windows-sys = { version = "0.61.2", features = [
 # 1<<0 user-presence) because the high-level crate does not export them; the
 # owner's live ceremony must run the documented conformance check that a
 # provisioned key actually carries those access-control semantics.
+# security-framework-sys is pulled in for the exact Keychain attribute constants
+# (kSecAttrTokenID/kSecAttrKeyType/kSecAttrKeySizeInBits) the enclave `open`/
+# provision read back via SecKeyCopyAttributes; the high-level crate does not
+# re-export them. It is the same version security-framework already depends on and
+# is already in Cargo.lock, so this adds no crate and does not move the lockfile.
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "=3.7.0"
+security-framework-sys = "=2.17.0"
 core-foundation = "=0.10.1"
 
 [build-dependencies]

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -1146,44 +1146,64 @@ impl Error for EnclaveError {}
 //
 // This is the production `SecureEnclaveKeyStoreV1` adapter. It is fully
 // implemented and compile-verified on macOS, but NOT_RUN in CI and never
-// exercised by an agent: a real Secure Enclave key, its biometric UI, and the
-// code-signing / keychain-access-group identity are the owner's ceremony.
-// `provision` calls `SecKeyCreateRandomKey` with `kSecAttrTokenIDSecureEnclave`,
-// refuses a tag already present (never-open-or-create), and attests the created
-// key by reading its real attributes back. `open` resolves the persisted key by
-// application tag (`SecItemCopyMatching`) and attests token/type/size via
-// `SecKeyCopyAttributes`. `sign` signs through `SecKeyCreateSignature`; for the
-// biometric owner seat the key's `kSecAccessControl` gates it on user presence,
-// which only the owner's live ceremony can satisfy. The unit tests exercise the
-// whole custody path through the software mock key store; this real adapter is
-// proven live only by the owner's documented one-shot ceremony.
+// exercised by an agent.
+//
+// HARD PREREQUISITE (not optional ceremony scope): persistence requires the
+// calling binary to be codesigned with a `KeychainAccessGroups` entitlement.
+// `provision` files the key into the data-protection keychain
+// (`Location::DataProtectionKeychain`) — the ONLY keychain a Secure Enclave key
+// can be made permanent in — and both that write and the `resolve_persisted_key`
+// query are scoped to it (`kSecUseDataProtectionKeychain`). An unsigned or
+// unentitled binary cannot persist or resolve the key at all, so `open`/`sign`
+// would fail closed. This is a precondition of the owner's ceremony, not a
+// runtime nicety.
+//
+// Custody is keyed by `kSecAttrLabel` (the high-level `GenerateKeyOptions` exposes
+// no `kSecAttrApplicationTag`): `provision` sets a distinct label per key and
+// refuses a label already present (never-open-or-create); `open` resolves by that
+// label and fails closed on zero or more-than-one match. `provision` attests the
+// created key by reading its real attributes back; `open` attests token/type/size
+// via `SecKeyCopyAttributes`; `sign` signs through `SecKeyCreateSignature`, and
+// for the biometric owner seat the key's `kSecAccessControl` gates it on user
+// presence only the owner's live ceremony can satisfy. The unit tests exercise the
+// custody path through the software mock; the real persistence proof (provision ->
+// process restart -> open/sign on a signed, entitled binary) runs only in that
+// ceremony.
 // ===========================================================================
 
 /// Production Secure Enclave key store over Apple's Security.framework. A store is
 /// bound to ONE seat class (`access_control`): the agent-held verifier/quorum seat
 /// or the owner's biometric seat. `provision` refuses a permit for a different
 /// class, and `open` attests the resolved key against this class.
+///
+/// Custody is keyed by `kSecAttrLabel`, not `kSecAttrApplicationTag`:
+/// `GenerateKeyOptions` (the only key-creation surface the high-level crate
+/// exposes) files the key under a label via `set_label`, and the search resolves
+/// it by the same label. A distinct label per `key_id` is the custody handle, and
+/// ANY existing item sharing that label makes provision AND open fail closed
+/// (never-open-or-create; ambiguous custody is refused).
 pub struct SecurityFrameworkEnclaveKeyStore {
-    keychain_application_tag_prefix: String,
+    keychain_label_prefix: String,
     subject_id: String,
     access_control: EnclaveAccessControlV1,
 }
 
 impl SecurityFrameworkEnclaveKeyStore {
     pub fn new(
-        keychain_application_tag_prefix: impl Into<String>,
+        keychain_label_prefix: impl Into<String>,
         subject_id: impl Into<String>,
         access_control: EnclaveAccessControlV1,
     ) -> Self {
         Self {
-            keychain_application_tag_prefix: keychain_application_tag_prefix.into(),
+            keychain_label_prefix: keychain_label_prefix.into(),
             subject_id: subject_id.into(),
             access_control,
         }
     }
 
-    fn application_tag(&self, key_id: &str) -> String {
-        format!("{}.{key_id}", self.keychain_application_tag_prefix)
+    /// The `kSecAttrLabel` this store files `key_id` under (and resolves it by).
+    fn keychain_label(&self, key_id: &str) -> String {
+        format!("{}.{key_id}", self.keychain_label_prefix)
     }
 
     fn access_control_flags(
@@ -1207,11 +1227,17 @@ impl SecurityFrameworkEnclaveKeyStore {
     }
 
     /// Resolve the single persisted enclave key filed under this store's
-    /// application tag for `key_id` via `SecItemCopyMatching` (the high-level
+    /// `kSecAttrLabel` for `key_id` via `SecItemCopyMatching` (the high-level
     /// `ItemSearchOptions` wraps it), returning the private-key reference. `None`
     /// means no such key exists; more than one match fails closed — custody must
     /// never be ambiguous. This one query is also the production
     /// never-open-or-create duplicate guard.
+    ///
+    /// The query is scoped to the data-protection keychain
+    /// (`ignore_legacy_keychains`, i.e. `kSecUseDataProtectionKeychain`) so it sees
+    /// the SAME scope `provision` writes into via `Location::DataProtectionKeychain`
+    /// — Secure Enclave keys live only there. Without matching scope the query
+    /// would silently never find the provisioned key.
     fn resolve_persisted_key(
         &self,
         key_id: &str,
@@ -1219,23 +1245,24 @@ impl SecurityFrameworkEnclaveKeyStore {
         use security_framework::item::{
             ItemClass, ItemSearchOptions, KeyClass, Limit, Reference, SearchResult,
         };
-        let tag = self.application_tag(key_id);
+        let label = self.keychain_label(key_id);
         let results = ItemSearchOptions::new()
             .class(ItemClass::key())
             .key_class(KeyClass::private())
-            .label(&tag)
+            .ignore_legacy_keychains()
+            .label(&label)
             .load_refs(true)
             .limit(Limit::Max(2))
             .search()
             .map_err(|error| {
-                EnclaveError::Open(format!("keychain item query for tag '{tag}': {error}"))
+                EnclaveError::Open(format!("keychain item query for label '{label}': {error}"))
             })?;
         let mut resolved = None;
         for result in results {
             if let SearchResult::Ref(Reference::Key(key)) = result {
                 if resolved.is_some() {
                     return Err(EnclaveError::Open(format!(
-                        "ambiguous enclave custody: more than one key filed under tag '{tag}'"
+                        "ambiguous enclave custody: more than one key filed under label '{label}'"
                     )));
                 }
                 resolved = Some(key);
@@ -1255,7 +1282,7 @@ impl SecurityFrameworkEnclaveKeyStore {
         &self,
         key: &security_framework::key::SecKey,
     ) -> Result<EnclaveKeyAttestationV1, EnclaveError> {
-        use core_foundation::base::{CFEqual, TCFType, ToVoid};
+        use core_foundation::base::{CFEqual, CFGetTypeID, TCFType, ToVoid};
         use core_foundation::number::CFNumber;
         use security_framework_sys::item::{
             kSecAttrKeySizeInBits, kSecAttrKeyType, kSecAttrKeyTypeECSECPrimeRandom,
@@ -1295,6 +1322,14 @@ impl SecurityFrameworkEnclaveKeyStore {
                     "enclave key attributes missing kSecAttrKeySizeInBits".to_owned(),
                 )
             })?;
+        // Verify the CF type before wrapping it: the only otherwise-unchecked
+        // conversion in the attestation. A non-CFNumber value fails closed rather
+        // than being reinterpreted as a number.
+        if unsafe { CFGetTypeID(size.cast()) } != CFNumber::type_id() {
+            return Err(EnclaveError::Open(
+                "enclave key size attribute is not a CFNumber".to_owned(),
+            ));
+        }
         let key_size_bits = unsafe { CFNumber::wrap_under_get_rule(size.cast()) }
             .to_i32()
             .and_then(|bits| u32::try_from(bits).ok())
@@ -1335,7 +1370,8 @@ impl SecurityFrameworkEnclaveKeyStore {
             subject_id: self.subject_id.clone(),
             public_key_sec1: Self::public_key_sec1(key)?,
             attestation: self.attest_persisted_key(key)?,
-            platform_ref: self.application_tag(key_id),
+            // The platform reference is the `kSecAttrLabel` the key is filed under.
+            platform_ref: self.keychain_label(key_id),
         })
     }
 }
@@ -1345,6 +1381,7 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
         &self,
         permit: &EnclaveProvisioningPermitV1,
     ) -> Result<EnclaveOpenedKeyV1, EnclaveError> {
+        use security_framework::item::Location;
         use security_framework::key::{GenerateKeyOptions, KeyType, SecKey, Token};
 
         // A store is bound to one seat class; refuse a permit for a different one so
@@ -1354,13 +1391,13 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
                 "permit access-control class does not match this key store's seat class".to_owned(),
             ));
         }
-        // Production never-open-or-create duplicate guard: refuse a tag already
+        // Production never-open-or-create duplicate guard: refuse a label already
         // present in the Keychain rather than silently adopting or shadowing a key.
         if self.resolve_persisted_key(&permit.key_id)?.is_some() {
             return Err(EnclaveError::Provisioning(format!(
-                "an enclave key already exists under application tag '{}'; \
+                "an enclave key already exists under label '{}'; \
                  provisioning is never open-or-create",
-                self.application_tag(&permit.key_id)
+                self.keychain_label(&permit.key_id)
             )));
         }
 
@@ -1370,7 +1407,15 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
             .set_key_type(KeyType::ec())
             .set_size_in_bits(SECURE_ENCLAVE_KEY_SIZE_BITS)
             .set_token(Token::SecureEnclave)
-            .set_label(self.application_tag(&permit.key_id))
+            // PERSIST the key: without a location the created key is EPHEMERAL
+            // (kSecAttrIsPermanent is only emitted when a location is set), so it
+            // would never reach the Keychain and `open`/`sign` could never resolve
+            // it. Secure Enclave keys can only be made permanent in the
+            // data-protection keychain — the same scope `resolve_persisted_key`
+            // queries. This requires a codesigned binary with a KeychainAccessGroups
+            // entitlement (owner-ceremony prerequisite; see the module boundary note).
+            .set_location(Location::DataProtectionKeychain)
+            .set_label(self.keychain_label(&permit.key_id))
             .set_access_control(access_control);
         let private_key =
             SecKey::new(&options).map_err(|error| EnclaveError::Provisioning(error.to_string()))?;
@@ -1389,14 +1434,14 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
     }
 
     fn open(&self, key_id: &str) -> Result<EnclaveOpenedKeyV1, EnclaveError> {
-        // Resolve the persisted key by application tag (SecItemCopyMatching) and
-        // attest the resolved key's real attributes. No biometry is required to read
-        // a key reference and its metadata; signing (below) is what user presence
-        // gates. A missing key fails closed.
+        // Resolve the persisted key by label (SecItemCopyMatching) and attest the
+        // resolved key's real attributes. No biometry is required to read a key
+        // reference and its metadata; signing (below) is what user presence gates.
+        // A missing key fails closed.
         let key = self.resolve_persisted_key(key_id)?.ok_or_else(|| {
             EnclaveError::Open(format!(
-                "no persisted enclave key filed under application tag '{}'",
-                self.application_tag(key_id)
+                "no persisted enclave key filed under label '{}'",
+                self.keychain_label(key_id)
             ))
         })?;
         self.opened_from_key(key_id, &key)
@@ -1407,12 +1452,12 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
 
         let key = self.resolve_persisted_key(&opened.key_id)?.ok_or_else(|| {
             EnclaveError::Sign(format!(
-                "no persisted enclave key filed under application tag '{}'",
-                self.application_tag(&opened.key_id)
+                "no persisted enclave key filed under label '{}'",
+                self.keychain_label(&opened.key_id)
             ))
         })?;
         // Bind the resolved key to the opened/attested key: the public material must
-        // match, so a key swapped under the tag after `open` cannot sign in its name.
+        // match, so a key swapped under the label after `open` cannot sign in its name.
         if Self::public_key_sec1(&key)? != opened.public_key_sec1 {
             return Err(EnclaveError::Sign(
                 "resolved enclave key public material does not match the opened key".to_owned(),
@@ -1631,6 +1676,43 @@ mod tests {
         provision_agent_enclave_seat(&store, &agent_permit("seat-1")).unwrap();
         let again = provision_agent_enclave_seat(&store, &agent_permit("seat-1"));
         assert!(matches!(again, Err(EnclaveError::Provisioning(_))));
+    }
+
+    #[test]
+    fn persisted_key_round_trips_from_provision_through_reopen() {
+        // The mock persists keys in-process, so it proves the LOGICAL custody
+        // contract: a key provisioned once is resolved back by the same key_id and
+        // signs. The REAL adapter's persistence — provision, then resolve the key
+        // after a PROCESS RESTART out of the data-protection Keychain — is exercised
+        // only by the owner's ceremony on a codesigned, entitled binary; a mock
+        // cannot model the ephemeral-vs-permanent Keychain distinction that the
+        // production `set_location(DataProtectionKeychain)` fix addresses.
+        let store: Arc<dyn SecureEnclaveKeyStoreV1> = Arc::new(MockEnclaveKeyStore::new(
+            EnclaveAccessControlV1::PrivateKeyUsageNonExportable,
+        ));
+        let provisioned =
+            provision_agent_enclave_seat(store.as_ref(), &agent_permit("persist-seat")).unwrap();
+
+        // Re-resolve the SAME key by id (the open-by-label path) and confirm identity.
+        let reopened = store.open("persist-seat").unwrap();
+        assert_eq!(reopened.public_key_sec1, provisioned.public_key_sec1);
+        assert_eq!(reopened.attestation, provisioned.attestation);
+
+        // The reopened key signs and verifies end to end through m1nd-control.
+        let expected = EnclaveKeyAttestationV1::canonical(
+            EnclaveAccessControlV1::PrivateKeyUsageNonExportable,
+        );
+        let signer =
+            SecureEnclaveSigner::open_attested(Arc::clone(&store), "persist-seat", &expected)
+                .unwrap();
+        let verification_key = signer.verification_key(0, 0);
+        let crypto = EnclaveBackedWalRecordCrypto::new(Arc::new(signer), verification_key).unwrap();
+        let message = b"persisted-enclave-round-trip";
+        let signature = crypto.sign(message).unwrap();
+        crypto.verify(message, &signature).unwrap();
+
+        // A key that was never provisioned fails closed on open.
+        assert!(store.open("never-provisioned").is_err());
     }
 
     #[test]

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -849,6 +849,14 @@ impl ProtectedJournalHeadBackendV1 for SecureEnclaveJournalHeadBackend {
 // follow-up. BLOCKING ORDER (G9-A1 ratification): that follow-up must merge
 // BEFORE the owner's custody ceremony and before any G9/G10 receipt is minted
 // under this floor, so no receipt can claim the floor without carrying it.
+//
+// STATUS (2026-07-21): STILL UNMET. Threading was investigated and found to
+// collide with ratified, frozen cross-language canon — the G0-G10 gate receipts
+// are pinned in `tests/fixtures/M1ND10-CANONICAL-VECTORS.json` and the schema is
+// mirrored by a closed Python allowlist (`scripts/m1nd10_release_contract.py`,
+// `GATE_CORE_FIELDS`). Adding the field requires regenerating that frozen canon,
+// which needs an explicit owner order, so it was NOT forced. See
+// `docs/proofs/m1nd10-g9-pathb-enclave-floor-implementation-20260721.md`.
 // ===========================================================================
 
 pub const ENCLAVE_CUSTODY_CEREMONY_SCHEMA: &str = "m1nd-enclave-custody-ceremony-receipt-v1";

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -58,12 +58,14 @@ use crate::protected_journal_head::{
 pub const SECURE_ENCLAVE_CUSTODY_FLOOR_V1: &str = "secure-enclave-single-host-v1";
 
 /// Stable module-level attestation identities. Re-attestation compares an opened
-/// key's attestation against these. The production adapter's read-back of the
-/// REAL Security.framework attributes (`kSecAttrTokenID`, `kSecAttrKeyType`,
-/// `kSecAttrKeySizeInBits`) via `SecKeyCopyAttributes` is a named follow-up (see
-/// `SecurityFrameworkEnclaveKeyStore::provision`); today provisioning attests the
-/// key size it can observe from the returned public key plus the canonical
-/// expectation, and never claims to have read back the token/type.
+/// key's attestation against these. The production adapter reads the REAL
+/// Security.framework attributes back via `SecKeyCopyAttributes` and proves Secure
+/// Enclave residency (`kSecAttrTokenID` == `kSecAttrTokenIDSecureEnclave`) and EC
+/// P-256 type (`kSecAttrKeyType` == `kSecAttrKeyTypeECSECPrimeRandom`) by
+/// `CFEqual` against the framework's own constants, carrying the size the enclave
+/// reports (`kSecAttrKeySizeInBits`) — attesting the KEY, not the request. The
+/// access-control (presence) semantics are the store's seat class; that a
+/// persisted key truly carries them is the owner's live conformance check.
 pub const SECURE_ENCLAVE_TOKEN_ID: &str = "com.apple.setoken";
 pub const SECURE_ENCLAVE_KEY_TYPE_EC_PRIME_RANDOM: &str = "EC_SEC_PRIME_RANDOM_256";
 pub const SECURE_ENCLAVE_KEY_SIZE_BITS: u32 = 256;
@@ -1134,31 +1136,41 @@ impl Error for EnclaveError {}
 // ===========================================================================
 // Real Security.framework key store (macOS).
 //
-// This is the production `SecureEnclaveKeyStoreV1` adapter. It is NOT_RUN in CI
-// and never exercised by an agent: a real Secure Enclave key, its biometric UI,
-// and the code-signing / keychain-access-group identity are the owner's
-// ceremony. `provision` really calls `SecKeyCreateRandomKey` with
-// `kSecAttrTokenIDSecureEnclave`; `open`/`sign` require resolving the persisted
-// key back out of the Keychain (`SecItemCopyMatching` by application tag) and
-// signing under biometric presence — the exact boundary the owner's documented
-// live one-shot proof exercises, so they fail closed here rather than shipping an
-// unverifiable item-query. Tests use the mock key store.
+// This is the production `SecureEnclaveKeyStoreV1` adapter. It is fully
+// implemented and compile-verified on macOS, but NOT_RUN in CI and never
+// exercised by an agent: a real Secure Enclave key, its biometric UI, and the
+// code-signing / keychain-access-group identity are the owner's ceremony.
+// `provision` calls `SecKeyCreateRandomKey` with `kSecAttrTokenIDSecureEnclave`,
+// refuses a tag already present (never-open-or-create), and attests the created
+// key by reading its real attributes back. `open` resolves the persisted key by
+// application tag (`SecItemCopyMatching`) and attests token/type/size via
+// `SecKeyCopyAttributes`. `sign` signs through `SecKeyCreateSignature`; for the
+// biometric owner seat the key's `kSecAccessControl` gates it on user presence,
+// which only the owner's live ceremony can satisfy. The unit tests exercise the
+// whole custody path through the software mock key store; this real adapter is
+// proven live only by the owner's documented one-shot ceremony.
 // ===========================================================================
 
-/// Production Secure Enclave key store over Apple's Security.framework.
+/// Production Secure Enclave key store over Apple's Security.framework. A store is
+/// bound to ONE seat class (`access_control`): the agent-held verifier/quorum seat
+/// or the owner's biometric seat. `provision` refuses a permit for a different
+/// class, and `open` attests the resolved key against this class.
 pub struct SecurityFrameworkEnclaveKeyStore {
     keychain_application_tag_prefix: String,
     subject_id: String,
+    access_control: EnclaveAccessControlV1,
 }
 
 impl SecurityFrameworkEnclaveKeyStore {
     pub fn new(
         keychain_application_tag_prefix: impl Into<String>,
         subject_id: impl Into<String>,
+        access_control: EnclaveAccessControlV1,
     ) -> Self {
         Self {
             keychain_application_tag_prefix: keychain_application_tag_prefix.into(),
             subject_id: subject_id.into(),
+            access_control,
         }
     }
 
@@ -1166,7 +1178,7 @@ impl SecurityFrameworkEnclaveKeyStore {
         format!("{}.{key_id}", self.keychain_application_tag_prefix)
     }
 
-    fn access_control(
+    fn access_control_flags(
         access_control: EnclaveAccessControlV1,
     ) -> Result<security_framework::access_control::SecAccessControl, EnclaveError> {
         use core_foundation::base::CFOptionFlags;
@@ -1185,6 +1197,139 @@ impl SecurityFrameworkEnclaveKeyStore {
         SecAccessControl::create_with_flags(flags)
             .map_err(|error| EnclaveError::Provisioning(error.to_string()))
     }
+
+    /// Resolve the single persisted enclave key filed under this store's
+    /// application tag for `key_id` via `SecItemCopyMatching` (the high-level
+    /// `ItemSearchOptions` wraps it), returning the private-key reference. `None`
+    /// means no such key exists; more than one match fails closed — custody must
+    /// never be ambiguous. This one query is also the production
+    /// never-open-or-create duplicate guard.
+    fn resolve_persisted_key(
+        &self,
+        key_id: &str,
+    ) -> Result<Option<security_framework::key::SecKey>, EnclaveError> {
+        use security_framework::item::{
+            ItemClass, ItemSearchOptions, KeyClass, Limit, Reference, SearchResult,
+        };
+        let tag = self.application_tag(key_id);
+        let results = ItemSearchOptions::new()
+            .class(ItemClass::key())
+            .key_class(KeyClass::private())
+            .label(&tag)
+            .load_refs(true)
+            .limit(Limit::Max(2))
+            .search()
+            .map_err(|error| {
+                EnclaveError::Open(format!("keychain item query for tag '{tag}': {error}"))
+            })?;
+        let mut resolved = None;
+        for result in results {
+            if let SearchResult::Ref(Reference::Key(key)) = result {
+                if resolved.is_some() {
+                    return Err(EnclaveError::Open(format!(
+                        "ambiguous enclave custody: more than one key filed under tag '{tag}'"
+                    )));
+                }
+                resolved = Some(key);
+            }
+        }
+        Ok(resolved)
+    }
+
+    /// Read the resolved key's REAL attributes via `SecKeyCopyAttributes` and prove
+    /// its Secure Enclave residency and EC P-256 type by `CFEqual` against the
+    /// framework's own constants — attesting the KEY, not the request. The key size
+    /// is the value the enclave actually reports. The `access_control` class is the
+    /// store's seat class (a store is bound to one seat class); the live
+    /// `kSecAccessControl` conformance check — that the persisted key truly carries
+    /// the presence semantics — is the owner's ceremony step, not readable here.
+    fn attest_persisted_key(
+        &self,
+        key: &security_framework::key::SecKey,
+    ) -> Result<EnclaveKeyAttestationV1, EnclaveError> {
+        use core_foundation::base::{CFEqual, TCFType, ToVoid};
+        use core_foundation::number::CFNumber;
+        use security_framework_sys::item::{
+            kSecAttrKeySizeInBits, kSecAttrKeyType, kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrTokenID, kSecAttrTokenIDSecureEnclave,
+        };
+
+        let attributes = key.attributes();
+
+        let token = attributes
+            .find(unsafe { kSecAttrTokenID.to_void() })
+            .ok_or_else(|| {
+                EnclaveError::Open("enclave key attributes missing kSecAttrTokenID".to_owned())
+            })?;
+        if unsafe { CFEqual(token.cast(), kSecAttrTokenIDSecureEnclave.cast()) } == 0 {
+            return Err(EnclaveError::AttestationMismatch {
+                expected: format!("token {SECURE_ENCLAVE_TOKEN_ID}"),
+                observed: "key is not resident in the Secure Enclave token".to_owned(),
+            });
+        }
+
+        let key_type = attributes
+            .find(unsafe { kSecAttrKeyType.to_void() })
+            .ok_or_else(|| {
+                EnclaveError::Open("enclave key attributes missing kSecAttrKeyType".to_owned())
+            })?;
+        if unsafe { CFEqual(key_type.cast(), kSecAttrKeyTypeECSECPrimeRandom.cast()) } == 0 {
+            return Err(EnclaveError::AttestationMismatch {
+                expected: SECURE_ENCLAVE_KEY_TYPE_EC_PRIME_RANDOM.to_owned(),
+                observed: "key type is not EC prime random".to_owned(),
+            });
+        }
+
+        let size = attributes
+            .find(unsafe { kSecAttrKeySizeInBits.to_void() })
+            .ok_or_else(|| {
+                EnclaveError::Open(
+                    "enclave key attributes missing kSecAttrKeySizeInBits".to_owned(),
+                )
+            })?;
+        let key_size_bits = unsafe { CFNumber::wrap_under_get_rule(size.cast()) }
+            .to_i32()
+            .and_then(|bits| u32::try_from(bits).ok())
+            .ok_or_else(|| {
+                EnclaveError::Open("enclave key size is not a non-negative integer".to_owned())
+            })?;
+
+        Ok(EnclaveKeyAttestationV1 {
+            token_id: SECURE_ENCLAVE_TOKEN_ID.to_owned(),
+            key_type: SECURE_ENCLAVE_KEY_TYPE_EC_PRIME_RANDOM.to_owned(),
+            key_size_bits,
+            access_control: self.access_control,
+        })
+    }
+
+    /// The uncompressed SEC1 public point of `key` (65 bytes, `0x04 || X || Y`).
+    fn public_key_sec1(key: &security_framework::key::SecKey) -> Result<Vec<u8>, EnclaveError> {
+        let public_key = key.public_key().ok_or_else(|| {
+            EnclaveError::Open("enclave key has no public representation".to_owned())
+        })?;
+        let external = public_key.external_representation().ok_or_else(|| {
+            EnclaveError::Open("enclave public key has no external SEC1 representation".to_owned())
+        })?;
+        let public_key_sec1 = external.bytes().to_vec();
+        require_uncompressed_sec1(&public_key_sec1)?;
+        Ok(public_key_sec1)
+    }
+
+    /// Assemble the opened-key record from a resolved private key: its real
+    /// attestation and its public SEC1 point.
+    fn opened_from_key(
+        &self,
+        key_id: &str,
+        key: &security_framework::key::SecKey,
+    ) -> Result<EnclaveOpenedKeyV1, EnclaveError> {
+        Ok(EnclaveOpenedKeyV1 {
+            key_id: key_id.to_owned(),
+            subject_id: self.subject_id.clone(),
+            public_key_sec1: Self::public_key_sec1(key)?,
+            attestation: self.attest_persisted_key(key)?,
+            platform_ref: self.application_tag(key_id),
+        })
+    }
 }
 
 impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
@@ -1194,7 +1339,24 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
     ) -> Result<EnclaveOpenedKeyV1, EnclaveError> {
         use security_framework::key::{GenerateKeyOptions, KeyType, SecKey, Token};
 
-        let access_control = Self::access_control(permit.access_control)?;
+        // A store is bound to one seat class; refuse a permit for a different one so
+        // an agent store cannot mint the biometric owner seat and vice versa.
+        if permit.access_control != self.access_control {
+            return Err(EnclaveError::Provisioning(
+                "permit access-control class does not match this key store's seat class".to_owned(),
+            ));
+        }
+        // Production never-open-or-create duplicate guard: refuse a tag already
+        // present in the Keychain rather than silently adopting or shadowing a key.
+        if self.resolve_persisted_key(&permit.key_id)?.is_some() {
+            return Err(EnclaveError::Provisioning(format!(
+                "an enclave key already exists under application tag '{}'; \
+                 provisioning is never open-or-create",
+                self.application_tag(&permit.key_id)
+            )));
+        }
+
+        let access_control = Self::access_control_flags(permit.access_control)?;
         let mut options = GenerateKeyOptions::default();
         options
             .set_key_type(KeyType::ec())
@@ -1204,58 +1366,58 @@ impl SecureEnclaveKeyStoreV1 for SecurityFrameworkEnclaveKeyStore {
             .set_access_control(access_control);
         let private_key =
             SecKey::new(&options).map_err(|error| EnclaveError::Provisioning(error.to_string()))?;
-        let public_key = private_key.public_key().ok_or_else(|| {
-            EnclaveError::Provisioning("enclave key has no public representation".to_owned())
-        })?;
-        let external = public_key.external_representation().ok_or_else(|| {
-            EnclaveError::Provisioning(
-                "enclave public key has no external SEC1 representation".to_owned(),
-            )
-        })?;
-        let public_key_sec1 = external.bytes().to_vec();
-        require_uncompressed_sec1(&public_key_sec1)?;
-        // Attest the KEY, not the request: derive the key size from the observed
-        // SEC1 point (a 65-byte uncompressed point is a P-256, i.e. 256-bit, EC
-        // key). The token id carried here is the requested-and-created value, not a
-        // read-back. FOLLOW-UP (owner ceremony prerequisite): reading back the real
-        // token/type via SecKeyCopyAttributes AND refusing a duplicate application
-        // tag via SecItemCopyMatching (production never-open-or-create) need the same
-        // Keychain query as open/sign and are deferred with them.
-        let observed_key_size_bits = (((public_key_sec1.len() - 1) / 2) * 8) as u32;
-        if observed_key_size_bits != SECURE_ENCLAVE_KEY_SIZE_BITS {
+        // Attest the KEY, not the request: read the created key's real token/type/
+        // size back through SecKeyCopyAttributes (proving Secure Enclave residency
+        // and EC P-256 against the framework's own constants). The size invariant is
+        // then confirmed against the custody floor's pinned expectation.
+        let opened = self.opened_from_key(&permit.key_id, &private_key)?;
+        if opened.attestation.key_size_bits != SECURE_ENCLAVE_KEY_SIZE_BITS {
             return Err(EnclaveError::Provisioning(format!(
-                "created key size {observed_key_size_bits} != {SECURE_ENCLAVE_KEY_SIZE_BITS}"
+                "created key size {} != {SECURE_ENCLAVE_KEY_SIZE_BITS}",
+                opened.attestation.key_size_bits
             )));
         }
-        Ok(EnclaveOpenedKeyV1 {
-            key_id: permit.key_id.clone(),
-            subject_id: self.subject_id.clone(),
-            public_key_sec1,
-            attestation: EnclaveKeyAttestationV1 {
-                token_id: SECURE_ENCLAVE_TOKEN_ID.to_owned(),
-                key_type: SECURE_ENCLAVE_KEY_TYPE_EC_PRIME_RANDOM.to_owned(),
-                key_size_bits: observed_key_size_bits,
-                access_control: permit.access_control,
-            },
-            platform_ref: self.application_tag(&permit.key_id),
-        })
+        Ok(opened)
     }
 
     fn open(&self, key_id: &str) -> Result<EnclaveOpenedKeyV1, EnclaveError> {
-        Err(EnclaveError::Open(format!(
-            "resolving the persisted enclave key '{}' via Keychain item query \
-             (SecItemCopyMatching by application tag — also the production \
-             never-open-or-create duplicate guard) is the owner's live ceremony; NOT_RUN here",
-            self.application_tag(key_id)
-        )))
+        // Resolve the persisted key by application tag (SecItemCopyMatching) and
+        // attest the resolved key's real attributes. No biometry is required to read
+        // a key reference and its metadata; signing (below) is what user presence
+        // gates. A missing key fails closed.
+        let key = self.resolve_persisted_key(key_id)?.ok_or_else(|| {
+            EnclaveError::Open(format!(
+                "no persisted enclave key filed under application tag '{}'",
+                self.application_tag(key_id)
+            ))
+        })?;
+        self.opened_from_key(key_id, &key)
     }
 
-    fn sign(&self, opened: &EnclaveOpenedKeyV1, _message: &[u8]) -> Result<Vec<u8>, EnclaveError> {
-        Err(EnclaveError::Sign(format!(
-            "signing with the persisted enclave key '{}' requires the owner's biometric ceremony \
-             (SecKeyCreateSignature after Keychain resolution); NOT_RUN here",
-            opened.key_id
-        )))
+    fn sign(&self, opened: &EnclaveOpenedKeyV1, message: &[u8]) -> Result<Vec<u8>, EnclaveError> {
+        use security_framework::key::Algorithm;
+
+        let key = self.resolve_persisted_key(&opened.key_id)?.ok_or_else(|| {
+            EnclaveError::Sign(format!(
+                "no persisted enclave key filed under application tag '{}'",
+                self.application_tag(&opened.key_id)
+            ))
+        })?;
+        // Bind the resolved key to the opened/attested key: the public material must
+        // match, so a key swapped under the tag after `open` cannot sign in its name.
+        if Self::public_key_sec1(&key)? != opened.public_key_sec1 {
+            return Err(EnclaveError::Sign(
+                "resolved enclave key public material does not match the opened key".to_owned(),
+            ));
+        }
+        // ECDSA over SHA-256 of the message, X9.62 DER — the exact scheme
+        // m1nd-control's verifier expects. The enclave may return high-S DER;
+        // m1nd-control normalizes it to canonical low-S downstream. For the biometric
+        // owner seat, the key's kSecAccessControl gates this call on Touch ID user
+        // presence: the agent cannot provoke a signature without the hardware and
+        // biometry the owner alone holds — that is the live ceremony, NOT_RUN here.
+        key.create_signature(Algorithm::ECDSASignatureMessageX962SHA256, message)
+            .map_err(|error| EnclaveError::Sign(error.to_string()))
     }
 }
 


### PR DESCRIPTION
## G9-A1 custody ceremony follow-ups

Two named prerequisites of the owner's G9 Secure Enclave custody ceremony. One is
delivered; the other is reported as blocked on frozen canon (not forced).

### Follow-up 1 — real enclave `open`/`sign` + duplicate guard  ✅ delivered

`SecurityFrameworkEnclaveKeyStore` (`m1nd-mcp/src/enclave_authority.rs`, whole
module `#[cfg(target_os = "macos")]`, so ubuntu/windows stay NOT_INSTALLED /
fail-closed by construction):

- **`open`** resolves the persisted key by application tag via `SecItemCopyMatching`
  (high-level `ItemSearchOptions`) and attests it by reading the key's **real**
  `token`/`type`/`size` back through `SecKeyCopyAttributes` — proving Secure Enclave
  residency (`kSecAttrTokenID == kSecAttrTokenIDSecureEnclave`) and EC P-256
  (`kSecAttrKeyType == kSecAttrKeyTypeECSECPrimeRandom`) by `CFEqual` against the
  framework's own constants. Attests the KEY, not the request. >1 match fails closed.
- **`sign`** uses `SecKeyCreateSignature` with `ECDSASignatureMessageX962SHA256` —
  the exact scheme `m1nd-control`'s verifier expects; the enclave's possibly-high-S
  DER is normalized to canonical low-S downstream by the existing
  `sign_authority_message` seam. The resolved key's public material is bound to the
  opened key before signing. For the biometric owner seat the key's
  `kSecAccessControl` gates the call on Touch ID user presence.
- **`provision`** now refuses a tag already present (production never-open-or-create
  duplicate guard) and attests the created key by the same real read-back instead of
  hard-coding token/type. A store is bound to one seat class (new `access_control`
  arg on `new()`); it refuses a permit for another.

**Proof honesty:**
- **Run-verified:** the software-mock custody path — `cargo test -p m1nd-mcp --lib
  enclave_authority` (12 tests) green; `cargo clippy --workspace --all-targets -D
  warnings`, `cargo fmt --all --check` green; the Python cross-language contract
  (`test_m1nd10_release_contract.py`, 12) green (frozen canon untouched).
- **Compile-verified only (NOT_RUN):** the real Security.framework adapter — a real
  enclave key, Keychain resolution, and a biometric signature need hardware,
  biometry, and code-signing/keychain-access-group identity the owner alone holds.
  The agent cannot provoke `SecKeyCreateSignature` under user presence. That is the
  owner's live ceremony.

**Manifest note (please eyeball):** adds `security-framework-sys = "=2.17.0"` as a
macOS-only **direct** dep for the `kSecAttr*` constants the high-level crate does
not re-export. It is the exact version `security-framework` already pulls in, so
`Cargo.lock` moves by exactly one dependency edge (no version changed); `--locked`
builds stay valid.

### Follow-up 2 — `custody_floor` threading into G9/G10 receipts  ⛔ blocked on frozen canon

Investigated and **not forced.** Threading `custody_floor` into the
`m1nd-control/src/release.rs` gate receipts collides with ratified, frozen
cross-language canon that the ceremony follow-up scope explicitly fences off:

- the G0–G10 gate receipts (incl. G9/G10) are pinned with fixed `receipt_digest`s
  in `tests/fixtures/M1ND10-CANONICAL-VECTORS.json`;
- the gate-receipt schema is dual-implemented in Python
  (`scripts/m1nd10_release_contract.py`, `GATE_CORE_FIELDS` — a closed 16-field
  allowlist with a `digest_canonical` that must match Rust byte-for-byte);
- both `test_m1nd10_release_contract.py` and the release CI gate
  (`verify-canonical-vectors`) verify these vectors.

Adding the field requires — as **one owner-authorized change** — the Rust struct +
fail-closed validation, the Python allowlist + validator, and regenerating the
frozen G9/G10 vectors (new digests). The autonomy activation receipt
(`autonomy.rs`) is Rust-only/regenerable, but threading it alone would neither
satisfy the "every G9/G10 receipt" order nor leave a coherent schema, so it was not
done in isolation. Per the follow-up's own rule ("if a vector is frozen/ratified —
PRD/UML hash or `M1ND10-CANONICAL-VECTORS.json` — stop and report; do not edit
frozen canon without an order"), this is surfaced for the owner to authorize as its
own reviewed change. **The BLOCKING ORDER remains UNMET** (recorded in the module
comment + proof doc; no false "fulfilled" claim).

### What remains for the ceremony
1. **Owner-authorized:** the Follow-up 2 canon regeneration above (still a
   ratification prerequisite — the ceremony is NOT yet down to "just Touch ID").
2. **Then the owner's ceremony:** provision seats, the `kSecAccessControl`
   conformance run, the biometric owner seat (Touch ID), seal + read-back.

### Risks / honesty
- The real adapter is compile-verified, not hardware-verified — the hand-rolled
  `kSecAccessControl` flags and Keychain visibility are proven only by the owner's
  live conformance run.
- Full `cargo test -p m1nd-mcp --lib`: 1413 passed, 3 failed. The failures are in
  enclave-**unrelated** modules (`tools::tests::universal_provider_failure_...`,
  `project_brain_runtime_internal_tests::multi_brain_actors_are_isolated`, +1) and
  **pass in isolation** — pre-existing parallelism/contention flakiness, not this
  change (my diff is confined to the macOS-gated enclave module + `Cargo.*`).

**No merge** — opened for the owner's review and the Follow-up 2 authorization
decision.
