### PR TITLE
fix(mcp): declare top-level type object on service tool schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,13 @@ Always run `cargo fmt` and `cargo clippy --workspace -- -D warnings` before fini
 If a test flakes under parallel build-cache contention (e.g. `retrobuilder_real`), re-run
 it in isolation (`cargo test -p m1nd-core --test retrobuilder_real`) before concluding.
 
+**MCP tool-schema contract:** every advertised tool's `inputSchema` MUST declare a top-level
+`"type": "object"` (MCP spec). Strict clients (Claude Code) reject the ENTIRE `tools/list`
+when a single tool violates it — the 2026-07-22 incident (a bare top-level `oneOf` on
+`mission_service`/`external_mutation_service`) silently unregistered all 48 tools from live
+sessions. The registry-wide regression test `every_tool_input_schema_is_top_level_object`
+(`m1nd-mcp/src/server.rs`) enforces this; never weaken it to land a schema.
+
 ## Git identity — ABSOLUTE
 
 - Author every commit as **`Max Kle1nz <kleinz@cosmophonix.com>`**. Never as a bot, never as

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -3808,6 +3808,9 @@ fn mission_service_tool_schema() -> serde_json::Value {
         "name": "mission_service",
         "description": "M1ND-10 G3 sole external mission mutation boundary. Accepts the closed v1 action union; authority and owner time are injected by the owner and are forbidden in the body. Legacy mission_post, receipt_import, and raw landed are permanent tombstones.",
         "inputSchema": {
+            // MCP requires a top-level "type": "object"; clients (e.g. Claude Code)
+            // reject the ENTIRE tools/list if any tool ships a bare oneOf.
+            "type": "object",
             "oneOf": [
                 variant(
                     "land_intent",
@@ -3921,6 +3924,9 @@ fn external_mutation_service_tool_schema() -> serde_json::Value {
         "name": "external_mutation_service",
         "description": "M1ND-10 closed MCP-only consumer for exact elevated system-block ratification, brain promotion, source-edit commit, and governed full-root code ingestion. Action, effects, authority identity, and owner time are derived or injected owner-side; lease labels never authorize generic tools.",
         "inputSchema": {
+            // MCP requires a top-level "type": "object"; clients (e.g. Claude Code)
+            // reject the ENTIRE tools/list if any tool ships a bare oneOf.
+            "type": "object",
             "oneOf": [
                 variant(
                     "system_blocks_ratify",
@@ -11700,6 +11706,28 @@ mod tests {
             ESSENTIAL_TOOLS.len(),
             count
         );
+    }
+
+    /// Every advertised tool must declare a top-level `"type": "object"` on its
+    /// inputSchema. The MCP spec requires it and Claude Code validates it
+    /// strictly: ONE offending tool makes the client reject the ENTIRE
+    /// tools/list, silently unregistering every m1nd tool (2026-07-22 incident:
+    /// mission_service/external_mutation_service shipped a bare top-level oneOf).
+    #[test]
+    fn every_tool_input_schema_is_top_level_object() {
+        let full = all_tool_schemas();
+        let tools = full["tools"].as_array().expect("tools array");
+        assert!(!tools.is_empty(), "registry must not be empty");
+        for tool in tools {
+            let name = tool["name"].as_str().unwrap_or("<unnamed>");
+            let ty = tool["inputSchema"]["type"].as_str();
+            assert_eq!(
+                ty,
+                Some("object"),
+                "tool '{name}' inputSchema.type must be \"object\" (got {ty:?}); a single \
+                 violation makes MCP clients drop the whole tools/list"
+            );
+        }
     }
 
     /// all_tool_schemas() must always return the full registry regardless of tier,


### PR DESCRIPTION
## P0 — release blocker for v1.5.0

**Symptom:** sessions served by the current binary register ZERO m1nd tools in Claude Code, even though the server connects and delivers instructions.

**Root cause:** `mission_service` and `external_mutation_service` advertise a bare top-level `oneOf` on `inputSchema`. The MCP spec requires `inputSchema.type == "object"`; Claude Code validates strictly and rejects the **entire** `tools/list` when one tool violates it (log: `invalid_value path tools.42.inputSchema.type expected object`).

**Fix:** add the literal top-level `"type": "object"` beside the `oneOf` in both schemas (each branch is already an object — semantics unchanged), plus a registry-wide regression test (`every_tool_input_schema_is_top_level_object`) proven RED before the fix and GREEN after.

**Proof:** live stdio probe post-fix — 48 tools, zero violations; targeted suite 86 passed; clippy `-D warnings` and fmt clean.

Must land in main before the `v1.5.0` tag (#388).