### PR TITLE
fix(mcp): honest recovery playbook + legacy snapshot adoption at boot

### DIFF
--- a/m1nd-mcp/src/boot_kv_migration.rs
+++ b/m1nd-mcp/src/boot_kv_migration.rs
@@ -192,7 +192,7 @@ fn journal_digest(journal: &MigrationJournalV1) -> M1ndResult<String> {
     )
 }
 
-fn durable_atomic_write(path: &Path, bytes: &[u8]) -> M1ndResult<()> {
+pub(crate) fn durable_atomic_write(path: &Path, bytes: &[u8]) -> M1ndResult<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(parent)?;
     let name = path

--- a/m1nd-mcp/src/legacy_snapshot_adoption.rs
+++ b/m1nd-mcp/src/legacy_snapshot_adoption.rs
@@ -1,0 +1,416 @@
+//! One-time adoption of a pre-1.5 legacy graph snapshot into the runtime root.
+//!
+//! Before 1.5 the graph snapshot lived at `./graph_snapshot.json` (relative to
+//! the working directory). With a dedicated runtime dir (`M1ND_RUNTIME_DIR`) the
+//! snapshot is checkpoint-managed under the runtime root instead. On upgrade the
+//! new runtime graph is born EMPTY while the populated legacy snapshot sits
+//! untouched in the old location — stranding the whole graph and dropping every
+//! upgrader into `needs_ingest` with its brain sitting right there.
+//!
+//! This module adopts the legacy snapshot ONCE at boot: it copies the exact
+//! legacy bytes into the runtime root so the normal load path then finds them. A
+//! typed journal (mirroring `boot_kv_migration`) makes the adoption idempotent
+//! and auditable, and the adoption never overwrites a populated runtime graph.
+
+use m1nd_core::error::M1ndResult;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+/// Journal file written under the runtime root once adoption commits.
+pub const ADOPTION_JOURNAL_FILE: &str = "legacy_graph_adoption_v1.json";
+const JOURNAL_SCHEMA: &str = "m1nd-legacy-graph-adoption-v1";
+const VERSION: u32 = 1;
+
+/// Durable, one-time record of a legacy-snapshot adoption.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LegacyGraphAdoptionJournalV1 {
+    pub schema: String,
+    pub version: u32,
+    pub status: String,
+    pub legacy_source_path: String,
+    pub source_digest: String,
+    pub node_count: u64,
+    pub adopted_at_ms: u64,
+}
+
+/// What the one boot-time adoption attempt decided. Every non-`Adopted` variant
+/// is a deliberate, safe no-op.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LegacyAdoptionOutcome {
+    /// The legacy snapshot was copied into the runtime root.
+    Adopted { node_count: u64 },
+    /// The runtime graph already has nodes — never overwrite it.
+    SkippedRuntimeAlreadyPopulated,
+    /// No legacy snapshot exists (or it is empty), so there is nothing to adopt.
+    SkippedNoLegacySnapshot,
+    /// A prior boot already adopted (the journal is present) — one-time.
+    SkippedAlreadyAdopted,
+    /// The runtime graph path IS the legacy path — no separate location to adopt.
+    SkippedSameLocation,
+    /// The legacy snapshot exists but could not be read/parsed; left untouched.
+    SkippedLegacyUnreadable(String),
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Adopt a pre-1.5 legacy graph snapshot into the runtime root exactly once.
+///
+/// Owner boot only (a read-only attach never writes). Returns a
+/// [`LegacyAdoptionOutcome`]; the only writing path is `Adopted`, and it can
+/// never fire over a populated runtime graph, a previously adopted runtime
+/// (journal present), or a legacy file that fails to parse. The one honest
+/// stderr line is emitted here so the behavior is identical wherever it runs.
+///
+/// When (and only when) the graph is adopted, the legacy plasticity sidecar is
+/// adopted alongside it — best-effort, and ONLY if it parses cleanly. A
+/// known-corrupt legacy-format plasticity file is skipped with a warning so the
+/// graph still boots (Step 4's own "continuing without it" import guard stays
+/// intact).
+pub(crate) fn maybe_adopt_legacy_snapshot(
+    runtime_graph_path: &Path,
+    legacy_graph_path: &Path,
+    runtime_plasticity_path: &Path,
+    legacy_plasticity_path: &Path,
+    runtime_root: &Path,
+) -> LegacyAdoptionOutcome {
+    let journal_path = runtime_root.join(ADOPTION_JOURNAL_FILE);
+
+    // One-time: a committed journal means adoption already ran. Never re-adopt,
+    // even if the runtime graph was later emptied.
+    if journal_path.exists() {
+        return LegacyAdoptionOutcome::SkippedAlreadyAdopted;
+    }
+
+    // No separate legacy location (no runtime dir, or an explicit --graph that
+    // already points at the legacy file): there is nothing to adopt onto itself.
+    if same_file(runtime_graph_path, legacy_graph_path) {
+        return LegacyAdoptionOutcome::SkippedSameLocation;
+    }
+
+    // Cheap gate FIRST: on the overwhelmingly common boot (no legacy file in the
+    // old location) return before touching the runtime graph at all, so this
+    // repair adds no load cost to a normal warm boot.
+    if !legacy_graph_path.exists() {
+        return LegacyAdoptionOutcome::SkippedNoLegacySnapshot;
+    }
+
+    // A legacy candidate exists — only now is it worth the reads. It must parse
+    // as a valid, non-empty snapshot.
+    let legacy_bytes = match std::fs::read(legacy_graph_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            eprintln!(
+                "[m1nd] legacy graph snapshot at {} not adopted (unreadable): {error}",
+                legacy_graph_path.display()
+            );
+            return LegacyAdoptionOutcome::SkippedLegacyUnreadable(error.to_string());
+        }
+    };
+    let node_count = match m1nd_core::snapshot::decode_graph_json(&legacy_bytes) {
+        Ok(graph) => graph.num_nodes() as u64,
+        Err(error) => {
+            eprintln!(
+                "[m1nd] legacy graph snapshot at {} not adopted (invalid snapshot): {error}",
+                legacy_graph_path.display()
+            );
+            return LegacyAdoptionOutcome::SkippedLegacyUnreadable(error.to_string());
+        }
+    };
+    if node_count == 0 {
+        return LegacyAdoptionOutcome::SkippedNoLegacySnapshot;
+    }
+
+    // Never adopt over a populated runtime graph — the adversarial invariant.
+    if runtime_graph_is_populated(runtime_graph_path) {
+        return LegacyAdoptionOutcome::SkippedRuntimeAlreadyPopulated;
+    }
+
+    // Adopt: copy the EXACT legacy bytes into the checkpoint-managed runtime
+    // path (durable, cross-platform), then journal the one-time event.
+    if let Err(error) =
+        crate::boot_kv_migration::durable_atomic_write(runtime_graph_path, &legacy_bytes)
+    {
+        eprintln!(
+            "[m1nd] legacy graph snapshot at {} not adopted (copy failed): {error}",
+            legacy_graph_path.display()
+        );
+        return LegacyAdoptionOutcome::SkippedLegacyUnreadable(format!("copy failed: {error}"));
+    }
+    // The graph is adopted — bring its plasticity sidecar along, best-effort.
+    adopt_legacy_plasticity(runtime_plasticity_path, legacy_plasticity_path);
+
+    let journal = LegacyGraphAdoptionJournalV1 {
+        schema: JOURNAL_SCHEMA.into(),
+        version: VERSION,
+        status: "adopted".into(),
+        legacy_source_path: legacy_graph_path.display().to_string(),
+        source_digest: sha256(&legacy_bytes),
+        node_count,
+        adopted_at_ms: now_ms(),
+    };
+    if let Err(error) = write_journal(&journal_path, &journal) {
+        // The graph copy already succeeded; a journal-write failure must not
+        // crash boot. Re-adoption is still prevented by the now non-empty
+        // runtime graph on the next boot.
+        eprintln!("[m1nd] legacy snapshot adopted but journal write failed: {error}");
+    }
+    eprintln!(
+        "[m1nd] adopted legacy graph snapshot from {} ({node_count} nodes) into runtime root {}",
+        legacy_graph_path.display(),
+        runtime_root.display()
+    );
+    LegacyAdoptionOutcome::Adopted { node_count }
+}
+
+/// Best-effort adoption of the legacy plasticity sidecar, run only when the
+/// graph was just adopted. Copies the exact legacy bytes into the runtime
+/// plasticity path ONLY when the runtime plasticity is absent AND the legacy
+/// file parses cleanly as plasticity state. Every failure is a graceful skip
+/// with one honest warning — the graph is already adopted and boots regardless.
+fn adopt_legacy_plasticity(runtime_plasticity_path: &Path, legacy_plasticity_path: &Path) {
+    if runtime_plasticity_path.exists()
+        || !legacy_plasticity_path.exists()
+        || same_file(runtime_plasticity_path, legacy_plasticity_path)
+    {
+        return;
+    }
+    // Adopt ONLY if it parses cleanly. The field's legacy plasticity is a known
+    // corrupt legacy format — skipped here rather than copied forward.
+    if let Err(error) = m1nd_core::snapshot::load_plasticity_state(legacy_plasticity_path) {
+        eprintln!(
+            "[m1nd] legacy plasticity at {} not adopted (invalid legacy format): {error}; continuing without it",
+            legacy_plasticity_path.display()
+        );
+        return;
+    }
+    let bytes = match std::fs::read(legacy_plasticity_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            eprintln!(
+                "[m1nd] legacy plasticity at {} not adopted (unreadable): {error}; continuing without it",
+                legacy_plasticity_path.display()
+            );
+            return;
+        }
+    };
+    match crate::boot_kv_migration::durable_atomic_write(runtime_plasticity_path, &bytes) {
+        Ok(()) => eprintln!(
+            "[m1nd] adopted legacy plasticity state from {}",
+            legacy_plasticity_path.display()
+        ),
+        Err(error) => eprintln!(
+            "[m1nd] legacy plasticity at {} not adopted (copy failed): {error}; continuing without it",
+            legacy_plasticity_path.display()
+        ),
+    }
+}
+
+/// True when both paths resolve to the same existing file. A path that does not
+/// exist canonicalizes to an error, so an absent runtime graph is never "same".
+fn same_file(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// True only when the runtime snapshot exists AND loads AND has at least one
+/// node. An absent, empty, or unparseable runtime snapshot counts as "not
+/// populated" — boot would start fresh from it anyway, so adopting a valid
+/// legacy snapshot over it is a recovery, never a loss of real graph data.
+fn runtime_graph_is_populated(path: &Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    m1nd_core::snapshot::load_graph(path)
+        .map(|graph| graph.num_nodes() > 0)
+        .unwrap_or(false)
+}
+
+fn write_journal(path: &Path, journal: &LegacyGraphAdoptionJournalV1) -> M1ndResult<()> {
+    crate::boot_kv_migration::durable_atomic_write(path, &serde_json::to_vec_pretty(journal)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use m1nd_core::graph::Graph;
+    use m1nd_core::types::NodeType;
+    use std::path::PathBuf;
+
+    /// Build a snapshot file with `n` real code nodes at `path`.
+    fn write_snapshot_with_nodes(path: &Path, n: usize) {
+        let mut graph = Graph::new();
+        for i in 0..n {
+            graph
+                .add_node(
+                    &format!("file::src/mod{i}.rs"),
+                    &format!("module {i}"),
+                    NodeType::File,
+                    &[],
+                    0.0,
+                    0.0,
+                )
+                .expect("add node");
+        }
+        m1nd_core::snapshot::save_graph(&graph, path).expect("save snapshot");
+    }
+
+    /// A runtime-dir layout mirroring the M1ND_RUNTIME_DIR split: the runtime
+    /// graph lives under the runtime root; the legacy graph in the parent (cwd).
+    struct Layout {
+        _temp: tempfile::TempDir,
+        runtime_root: PathBuf,
+        runtime_graph: PathBuf,
+        legacy_graph: PathBuf,
+        runtime_plasticity: PathBuf,
+        legacy_plasticity: PathBuf,
+    }
+
+    impl Layout {
+        fn adopt(&self) -> LegacyAdoptionOutcome {
+            maybe_adopt_legacy_snapshot(
+                &self.runtime_graph,
+                &self.legacy_graph,
+                &self.runtime_plasticity,
+                &self.legacy_plasticity,
+                &self.runtime_root,
+            )
+        }
+    }
+
+    fn layout() -> Layout {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_root = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_root).expect("runtime root");
+        Layout {
+            runtime_graph: runtime_root.join("graph_snapshot.json"),
+            legacy_graph: temp.path().join("graph_snapshot.json"),
+            runtime_plasticity: runtime_root.join("plasticity_state.json"),
+            legacy_plasticity: temp.path().join("plasticity_state.json"),
+            runtime_root,
+            _temp: temp,
+        }
+    }
+
+    #[test]
+    fn empty_runtime_with_valid_legacy_adopts_and_journals_and_loads() {
+        let l = layout();
+        write_snapshot_with_nodes(&l.legacy_graph, 5);
+
+        assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 5 });
+
+        // Journal written.
+        let journal_path = l.runtime_root.join(ADOPTION_JOURNAL_FILE);
+        assert!(journal_path.exists(), "adoption journal must be written");
+        let journal: LegacyGraphAdoptionJournalV1 =
+            serde_json::from_slice(&std::fs::read(&journal_path).expect("read journal"))
+                .expect("parse journal");
+        assert_eq!(journal.status, "adopted");
+        assert_eq!(journal.node_count, 5);
+        assert_eq!(journal.schema, JOURNAL_SCHEMA);
+
+        // Boot loads N nodes from the runtime path.
+        let loaded =
+            m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("load adopted snapshot");
+        assert_eq!(loaded.num_nodes(), 5);
+    }
+
+    #[test]
+    fn second_boot_is_a_no_op() {
+        let l = layout();
+        write_snapshot_with_nodes(&l.legacy_graph, 3);
+
+        assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 3 });
+        assert_eq!(l.adopt(), LegacyAdoptionOutcome::SkippedAlreadyAdopted);
+
+        // Still exactly the adopted graph.
+        let loaded = m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("load");
+        assert_eq!(loaded.num_nodes(), 3);
+    }
+
+    #[test]
+    fn populated_runtime_is_left_untouched_even_with_legacy_present() {
+        let l = layout();
+        // Runtime already has its own graph; legacy is a different, larger one.
+        write_snapshot_with_nodes(&l.runtime_graph, 2);
+        write_snapshot_with_nodes(&l.legacy_graph, 9);
+        let runtime_digest_before = sha256(&std::fs::read(&l.runtime_graph).expect("read runtime"));
+
+        assert_eq!(
+            l.adopt(),
+            LegacyAdoptionOutcome::SkippedRuntimeAlreadyPopulated
+        );
+
+        // Runtime bytes are byte-for-byte unchanged, and no journal was written.
+        let runtime_digest_after = sha256(&std::fs::read(&l.runtime_graph).expect("read runtime"));
+        assert_eq!(runtime_digest_before, runtime_digest_after);
+        assert!(!l.runtime_root.join(ADOPTION_JOURNAL_FILE).exists());
+        let loaded = m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("load");
+        assert_eq!(loaded.num_nodes(), 2);
+    }
+
+    #[test]
+    fn corrupt_legacy_is_skipped_with_no_adoption() {
+        let l = layout();
+        std::fs::write(&l.legacy_graph, b"this is not a graph snapshot").expect("write corrupt");
+
+        let outcome = l.adopt();
+        assert!(
+            matches!(outcome, LegacyAdoptionOutcome::SkippedLegacyUnreadable(_)),
+            "corrupt legacy must be skipped gracefully, got {outcome:?}"
+        );
+
+        // Nothing adopted: runtime graph absent, no journal, boot starts empty.
+        assert!(!l.runtime_graph.exists(), "runtime graph must stay absent");
+        assert!(!l.runtime_root.join(ADOPTION_JOURNAL_FILE).exists());
+    }
+
+    #[test]
+    fn valid_legacy_plasticity_is_adopted_but_corrupt_is_skipped() {
+        // Valid plasticity → copied alongside the graph.
+        {
+            let l = layout();
+            write_snapshot_with_nodes(&l.legacy_graph, 4);
+            m1nd_core::snapshot::save_plasticity_state(&[], &l.legacy_plasticity)
+                .expect("save legacy plasticity");
+
+            assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 4 });
+            assert!(
+                l.runtime_plasticity.exists(),
+                "valid legacy plasticity must be adopted alongside the graph"
+            );
+            m1nd_core::snapshot::load_plasticity_state(&l.runtime_plasticity)
+                .expect("adopted plasticity still parses at the runtime path");
+        }
+        // Corrupt (known legacy-format) plasticity → graph adopted, plasticity skipped.
+        {
+            let l = layout();
+            write_snapshot_with_nodes(&l.legacy_graph, 4);
+            std::fs::write(&l.legacy_plasticity, b"not plasticity json")
+                .expect("write corrupt plasticity");
+
+            assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 4 });
+            assert!(
+                !l.runtime_plasticity.exists(),
+                "corrupt legacy plasticity must be skipped, never copied forward"
+            );
+            // The graph adoption is unaffected — it still boots.
+            let loaded = m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("graph loads");
+            assert_eq!(loaded.num_nodes(), 4);
+        }
+    }
+}

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -59,6 +59,8 @@ pub mod curation_runner;
 pub mod boot_memory_handlers;
 // M1ND-10 G6 — conservative one-way retirement of arbitrary Boot KV.
 pub mod boot_kv_migration;
+// Upgrade-path repair: one-time boot adoption of a pre-1.5 legacy graph snapshot.
+pub mod legacy_snapshot_adoption;
 // ORGANISM R6 — the delegation layer (`delegate` / `debrief`).
 pub mod delegation_handlers;
 pub mod engine_ops;

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -7442,6 +7442,31 @@ impl McpServer {
         };
         eprintln!("[m1nd] Domain: {}", domain_config.name);
 
+        // Step 0: One-time legacy-snapshot adoption (upgrade-path repair).
+        //
+        // Field-triage 2026-07-22: a pre-1.5 layout kept its populated snapshot at
+        // the legacy `./graph_snapshot.json` (cwd) while the new runtime graph is
+        // born empty under the runtime dir — stranding the whole graph and dropping
+        // upgraders into needs_ingest. Adopt it ONCE into the runtime root before
+        // the load below finds it. Owner boot only (a read-only attach never
+        // writes); idempotent + journaled; never over a populated runtime graph.
+        // Best-effort: the honest stderr line is emitted inside the call, and any
+        // skip/failure leaves the normal load path unchanged.
+        if !config.read_only {
+            if let Some(runtime_root) = config.runtime_dir.as_deref() {
+                let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                let legacy_graph_path = cwd.join("graph_snapshot.json");
+                let legacy_plasticity_path = cwd.join("plasticity_state.json");
+                let _ = crate::legacy_snapshot_adoption::maybe_adopt_legacy_snapshot(
+                    &config.graph_source,
+                    &legacy_graph_path,
+                    &config.plasticity_state,
+                    &legacy_plasticity_path,
+                    runtime_root,
+                );
+            }
+        }
+
         // Step 1: Try to load graph snapshot
         let (mut graph, graph_loaded) = if config.graph_source.exists() {
             match m1nd_core::snapshot::load_graph(&config.graph_source) {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -11041,7 +11041,12 @@ mod tests {
     }
 
     #[test]
-    fn recovery_playbook_empty_graph_returns_needs_ingest() {
+    fn recovery_playbook_empty_graph_refuses_policy_disabled_ingest() {
+        // Field-triage 2026-07-22: an empty brain's needs_ingest playbook used to
+        // recommend `{tool:"ingest"}` — a verb the server's OWN policy refuses on
+        // this binding (graph.ingest.replace = POSITIVE_SOVEREIGN). Recommending a
+        // refused verb sends the agent into a refusal loop. The honest recovery is
+        // still `blocked` + `needs_ingest`, but it names the real gap instead.
         let (_temp, mut state) = build_state();
 
         let output = super::dispatch_tool(
@@ -11057,12 +11062,135 @@ mod tests {
         assert_eq!(output["status"], "blocked");
         assert_eq!(output["trust_mode"], "needs_ingest");
         assert!(
-            output["steps"]
+            !output["steps"]
                 .as_array()
                 .expect("steps")
                 .iter()
-                .any(|step| step["id"] == "call_ingest" && step["tool"] == "ingest"),
-            "recovery playbook should include an ingest step for an empty graph"
+                .any(|step| step["tool"] == "ingest"),
+            "playbook must not recommend the policy-disabled generic ingest verb, got {}",
+            output["steps"]
+        );
+        // The honest gap is named in the existing G2/G3 consumer language.
+        let rendered = serde_json::to_string(&output).expect("serialize playbook");
+        assert!(
+            rendered.contains("brain_bootstrap_consumer_not_installed"),
+            "playbook must name the honest bootstrap gap, got {rendered}"
+        );
+    }
+
+    #[test]
+    fn recovery_playbook_never_recommends_a_policy_refused_tool() {
+        // Property guard: across every recovery scenario, no emitted step may name
+        // a tool whose generic dispatch the server would refuse with the step's own
+        // arguments. The assertion consults the REAL policy gate, so a future
+        // playbook step that recommends a sovereign verb fails this test.
+        fn assert_no_policy_refused_step(output: &serde_json::Value, label: &str) {
+            for step in output["steps"].as_array().expect("steps") {
+                let Some(tool) = step["tool"].as_str() else {
+                    continue;
+                };
+                let args = step
+                    .get("arguments")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({}));
+                assert!(
+                    super::enforce_generic_action_policy(tool, &args).is_ok(),
+                    "playbook step {} recommends policy-refused tool '{tool}' with args {args} \
+                     (scenario {label})",
+                    step["id"],
+                );
+            }
+        }
+
+        // needs_ingest — an empty brain must not name the sovereign ingest verb.
+        {
+            let (_temp, mut state) = build_state();
+            let output = super::dispatch_tool(
+                &mut state,
+                "recovery_playbook",
+                &serde_json::json!({ "agent_id": "jimi" }),
+            )
+            .expect("needs_ingest playbook");
+            assert_eq!(output["trust_mode"], "needs_ingest");
+            assert_no_policy_refused_step(&output, "needs_ingest");
+        }
+
+        // wrong_workspace_binding — a populated brain + an absolute scope outside it.
+        {
+            let (temp, mut state) = build_state();
+            let active_repo = temp.path().join("active-repo");
+            std::fs::create_dir_all(active_repo.join("src")).expect("active src");
+            std::fs::write(active_repo.join("src/lib.rs"), "pub fn active() {}\n")
+                .expect("active file");
+            crate::tools::handle_ingest(
+                &mut state,
+                crate::protocol::IngestInput {
+                    path: active_repo.to_string_lossy().to_string(),
+                    agent_id: "jimi".into(),
+                    mode: "replace".into(),
+                    incremental: false,
+                    adapter: "code".into(),
+                    namespace: None,
+                    include_dotfiles: false,
+                    dotfile_patterns: Vec::new(),
+                    project_root: None,
+                },
+            )
+            .expect("ingest active repo");
+            let other_repo = temp.path().join("other-repo");
+            std::fs::create_dir_all(other_repo.join("src")).expect("other src");
+            let output = super::dispatch_tool(
+                &mut state,
+                "recovery_playbook",
+                &serde_json::json!({
+                    "agent_id": "jimi",
+                    "observed_tool": "seek",
+                    "observed_proof_state": "blocked",
+                    "scope": other_repo.join("src").to_string_lossy(),
+                }),
+            )
+            .expect("wrong_workspace playbook");
+            assert_eq!(output["trust_mode"], "wrong_workspace_binding");
+            assert_no_policy_refused_step(&output, "wrong_workspace_binding");
+        }
+
+        // degraded_host_tool_surface — doctor available, ingest missing.
+        {
+            let (_temp, mut state) = build_state();
+            let output = super::dispatch_tool(
+                &mut state,
+                "recovery_playbook",
+                &serde_json::json!({
+                    "agent_id": "jimi",
+                    "observed_tool_count": 3,
+                    "available_tools": ["seek", "audit", "doctor"],
+                    "missing_tools": ["ingest"],
+                }),
+            )
+            .expect("degraded playbook");
+            assert_no_policy_refused_step(&output, "degraded_host_tool_surface");
+        }
+    }
+
+    #[test]
+    fn ingest_project_root_hint_never_points_at_the_runtime_dir() {
+        // Field-triage 2026-07-22: on a fresh brain the needs_ingest step pointed
+        // ingest at the RUNTIME dir (.m1nd), not the corpus, because `workspace_root`
+        // can be demoted onto the runtime dir. The hint must resolve the real repo.
+        let (_temp, mut state) = build_state();
+        let runtime_dir = state.runtime_root.to_string_lossy().to_string();
+        // Reproduce the demotion: workspace_root sitting on the runtime dir.
+        state.workspace_root = Some(runtime_dir.clone());
+        state.caller_root = Some("/repo/corpus".to_string());
+
+        let hint = crate::tools::ingest_project_root_hint(&state, None);
+        assert_ne!(
+            hint, runtime_dir,
+            "ingest hint must never be the runtime dir, got {hint}"
+        );
+        assert_eq!(
+            hint, "/repo/corpus",
+            "ingest hint must resolve the caller's real repo root"
         );
     }
 

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -70,6 +70,23 @@ fn playbook_step(
     serde_json::Value::Object(step)
 }
 
+/// The repository a needs-ingest playbook should name — the binding's real
+/// PROJECT root, never its runtime sidecar dir.
+///
+/// Field-triage 2026-07-22: on a fresh/empty brain served with a dedicated
+/// runtime dir, `workspace_root` can be demoted onto that runtime dir (`.m1nd`),
+/// so the needs_ingest step pointed `ingest` at the runtime dir instead of the
+/// corpus. Prefer an explicit caller scope, then a resolved code root (which
+/// never returns a memory sidecar or a non-repo runtime dir), then the caller's
+/// own repo root; the placeholder only when nothing real resolves.
+pub(crate) fn ingest_project_root_hint(state: &SessionState, scope: Option<&str>) -> String {
+    scope
+        .map(str::to_string)
+        .or_else(|| state.code_root_path())
+        .or_else(|| state.caller_root.clone())
+        .unwrap_or_else(|| "<intended-repo-path>".to_string())
+}
+
 fn note_learn_node_effect(
     weight_deltas: &mut HashMap<NodeId, f32>,
     edge_events: &mut HashMap<NodeId, u16>,
@@ -4050,11 +4067,7 @@ pub fn handle_recovery_playbook(
         )
         .get("arguments")
         .cloned();
-    let ingest_path = input
-        .scope
-        .clone()
-        .or_else(|| state.workspace_root.clone())
-        .unwrap_or_else(|| "<intended-repo-path>".to_string());
+    let ingest_path = ingest_project_root_hint(state, input.scope.as_deref());
 
     let (status, recovery_goal, next_action, steps) = match trust_mode {
         "wrong_workspace_binding" => {
@@ -4092,16 +4105,37 @@ pub fn handle_recovery_playbook(
                             }
                         })),
                     ),
-                    playbook_step(
-                        "same_binding_ingest_if_intentional",
-                        "If this session should intentionally switch or merge context, call ingest for requested_workspace_hint on this same binding.",
-                        "This is an explicit mutation; do it only when the agent truly wants this runtime to carry that repo context.",
-                        Some("ingest"),
-                        Some(serde_json::json!({
+                    {
+                        // Only recommend the generic ingest verb for an
+                        // intentional context switch when the server's policy
+                        // actually admits it; otherwise name the honest path.
+                        let switch_ingest_args = serde_json::json!({
                             "agent_id": agent_id.clone(),
-                            "path": requested_workspace_hint,
-                        })),
-                    ),
+                            "path": requested_workspace_hint.clone(),
+                        });
+                        if crate::server::enforce_generic_action_policy(
+                            "ingest",
+                            &switch_ingest_args,
+                        )
+                        .is_ok()
+                        {
+                            playbook_step(
+                                "same_binding_ingest_if_intentional",
+                                "If this session should intentionally switch or merge context, call ingest for requested_workspace_hint on this same binding.",
+                                "This is an explicit mutation; do it only when the agent truly wants this runtime to carry that repo context.",
+                                Some("ingest"),
+                                Some(switch_ingest_args),
+                            )
+                        } else {
+                            playbook_step(
+                                "switch_workspace_via_authenticated_ingress",
+                                "If this session should intentionally switch context, rebind to an owner that hosts requested_workspace_hint, or use the served owner's authenticated ingress; the generic ingest verb is policy-disabled here.",
+                                "brain_bootstrap_consumer_not_installed: the generic ingest verb the switch step used to name is refused by policy, so recommending it would loop.",
+                                None,
+                                None,
+                            )
+                        }
+                    },
                     playbook_step(
                         "cross_repo_mode_if_needed",
                         "Use federate_auto or federate when the task genuinely needs multiple repositories at once.",
@@ -4169,30 +4203,82 @@ pub fn handle_recovery_playbook(
                 steps,
             )
         }
-        "needs_ingest" => (
-            "blocked",
-            "Populate this binding's active graph for the intended repository.",
-            "call_ingest",
-            vec![
-                playbook_step(
+        "needs_ingest" => {
+            let proposed_ingest_args = serde_json::json!({
+                "agent_id": agent_id.clone(),
+                "path": ingest_path.clone(),
+            });
+            // Never recommend a verb the server's OWN policy refuses on this
+            // binding. Generic `ingest` classifies as graph.ingest.replace
+            // (POSITIVE_SOVEREIGN) and fails closed until a typed G2/G3 consumer
+            // is installed — consult the REAL gate rather than assuming, so a
+            // future Ordinary consumer re-enables the one-call path automatically.
+            if crate::server::enforce_generic_action_policy("ingest", &proposed_ingest_args).is_ok()
+            {
+                (
+                    "blocked",
+                    "Populate this binding's active graph for the intended repository.",
                     "call_ingest",
-                    "Call ingest for the intended repository on this same binding.",
-                    "The active graph is empty or incomplete, so retrieval cannot yet be trusted.",
-                    Some("ingest"),
-                    Some(serde_json::json!({
-                        "agent_id": agent_id.clone(),
-                        "path": ingest_path,
-                    })),
-                ),
-                playbook_step(
-                    "rerun_session_handshake",
-                    "Call session_handshake again after ingest completes.",
-                    "The handshake should confirm node and edge counts before the next retrieval step.",
-                    Some("session_handshake"),
-                    Some(serde_json::json!({ "agent_id": agent_id.clone() })),
-                ),
-            ],
-        ),
+                    vec![
+                        playbook_step(
+                            "call_ingest",
+                            "Call ingest for the intended repository on this same binding.",
+                            "The active graph is empty or incomplete, so retrieval cannot yet be trusted.",
+                            Some("ingest"),
+                            Some(proposed_ingest_args),
+                        ),
+                        playbook_step(
+                            "rerun_session_handshake",
+                            "Call session_handshake again after ingest completes.",
+                            "The handshake should confirm node and edge counts before the next retrieval step.",
+                            Some("session_handshake"),
+                            Some(serde_json::json!({ "agent_id": agent_id.clone() })),
+                        ),
+                    ],
+                )
+            } else {
+                // The generic ingest verb is policy-disabled here. Recommend the
+                // honest repair instead of a call the server would reject.
+                (
+                    "blocked",
+                    "Populate this binding's graph through the served owner's authenticated ingress; the generic ingest verb is policy-disabled on this binding.",
+                    "populate_via_owner_restart_or_authenticated_ingress",
+                    vec![
+                        playbook_step(
+                            "generic_ingest_unavailable",
+                            "Do not call the generic `ingest` verb on this binding: the server refuses it (graph.ingest.replace is POSITIVE_SOVEREIGN and no typed G2/G3 bootstrap consumer is installed).",
+                            "brain_bootstrap_consumer_not_installed: recommending a verb the policy rejects would send the agent into a refusal loop.",
+                            None,
+                            Some(serde_json::json!({
+                                "code": "brain_bootstrap_consumer_not_installed",
+                                "intended_repo": ingest_path,
+                            })),
+                        ),
+                        playbook_step(
+                            "adopt_legacy_snapshot_on_owner_restart",
+                            "If this runtime just upgraded from a pre-1.5 layout, restart the served owner: a one-time legacy-snapshot adoption runs at boot and populates the runtime graph from a legacy ./graph_snapshot.json when one is present.",
+                            "A pre-1.5 snapshot left in the legacy location is adopted into the runtime root at boot, so a restart can populate the graph with no generic ingest call at all.",
+                            None,
+                            None,
+                        ),
+                        playbook_step(
+                            "use_served_owner_authenticated_ingress",
+                            "Otherwise populate the graph through the served owner's authenticated MCP ingress (the typed consumer path), not the generic REST/MCP dispatch.",
+                            "Only the served owner's authenticated ingress carries the sovereign authority the generic transport intentionally lacks.",
+                            None,
+                            None,
+                        ),
+                        playbook_step(
+                            "rerun_session_handshake",
+                            "Call session_handshake again after the graph is populated.",
+                            "The handshake should confirm node and edge counts before the next retrieval step.",
+                            Some("session_handshake"),
+                            Some(serde_json::json!({ "agent_id": agent_id.clone() })),
+                        ),
+                    ],
+                )
+            }
+        }
         "orientation_only" => (
             "warn",
             "Recover an ingest-capable binding or fall back to local file truth.",

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,8 +18,9 @@ It is intentionally host-neutral:
 
 The general agent pack carries the trained-agent loop measured in internal bug-hunt rounds:
 `north(task)` as the in-session front door (one round-trip for trust, task
-context, prior memory, sufficiency, and one `next_move`; `needs_ingest` → ingest
-→ re-north), then act on the calibrated verdicts (`act`/`reverify`/`abstain`,
+context, prior memory, sufficiency, and one `next_move`; `needs_ingest` → follow
+the `recovery_playbook`, which names `ingest` only where the mutation policy
+allows it → re-north), then act on the calibrated verdicts (`act`/`reverify`/`abstain`,
 `closure`, `trust_envelope`, `insufficient_evidence`), prove final truth
 directly, and `memorize` the durable finding at close. Recovery before absence,
 workspace-binding clarity, and evidence logging stay part of the loop.

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -135,7 +135,7 @@ merit; facts, never estimated savings (G1).
 | fresh / stale | freshness is priced per boundary (the block's scope), never vibes |
 | `full_trust` | the binding verdict (the graph covers and answers) — not a code-quality grade |
 | the bell | a call to the human (missions await landing) — never an error |
-| `needs_ingest` | "I don't know this repo yet" + its one-call repair — never a crash |
+| `needs_ingest` | "I don't know this repo yet" + the honest repair — never a crash. Follow the packet's `recovery_playbook`: where generic `ingest` is policy-allowed it names it; under the sovereign mutation policy it returns `blocked` (`brain_bootstrap_consumer_not_installed`) with the real paths (legacy snapshot adoption at owner restart, or the served owner's authenticated ingress) — never retry a verb the playbook did not name |
 | the tray | the human's door to land receipts — agents never land |
 
 **The verb families (translate by family, not tool-by-tool):**
@@ -179,7 +179,9 @@ this loop by default:
 
 1. Orient with `north(task)`. One round-trip returns binding trust, task
    context, prior cross-session memory, a sufficiency signal, one `next_move`,
-   and `honest_gaps`. `needs_ingest` → `ingest` → `north` again.
+   and `honest_gaps`. `needs_ingest` → follow the packet's `recovery_playbook`
+   (it consults the live mutation policy: generic `ingest` where allowed;
+   otherwise `blocked` with the real recovery steps) → `north` again.
 2. If trust is degraded or retrieval comes back `blocked`/empty unexpectedly,
    drop to `recovery_playbook` before interpreting absence.
    `wrong_workspace_binding` means rebind, intentional ingest, or real


### PR DESCRIPTION
## Two P0 first-run/upgrade fixes for v1.5.0

**Fix 1 — the recovery playbook stops recommending a verb the policy refuses.** On an empty brain over stdio, north's playbook emitted `call_ingest` — but generic `ingest` is G3-tombstoned (`generic_action_authority_required`, POSITIVE_SOVEREIGN), so the playbook sent agents into a refusal loop; it also suggested the RUNTIME DIR as the corpus path. The playbook now consults the real policy predicate (`enforce_generic_action_policy`) and, when refused, returns an honest blocked recovery (`brain_bootstrap_consumer_not_installed`) with the real paths (legacy adoption at restart / served-owner authenticated ingress). Property guard: no emitted step may name a policy-refused tool.

**Fix 2 — one-time legacy snapshot adoption at owner boot.** The 1.5 runtime layout boots an empty graph while the pre-1.5 legacy snapshot sits intact at the legacy cwd location — every 1.4→1.5 upgrader landed in `needs_ingest` with their brain next door. Boot now adopts the legacy snapshot into the runtime root (checkpoint-managed path) one time, journaled (`legacy_graph_adoption_v1.json`, sha256), never over a populated runtime graph, idempotent, corrupt-legacy skipped gracefully; legacy plasticity adopted only when it parses clean.

**Proof:** 8 new tests RED→GREEN (playbook honesty ×3, adoption ×5 incl. the adversarial populated-runtime case); fmt/clippy `-D warnings`/check green; full-suite flakiness (2–5 tests, checkpoint deadlines under parallel CPU) reproduced on baseline origin/main — pre-existing, unrelated.

Discovered via dogfood (guardian session 2026-07-22, field-reports filed). Must land before the `v1.5.0` tag.