### PR TITLE
fix: deterministic Windows failures in the actor family + A2 path-semantics security tightening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,18 @@ UI changes (`m1nd-ui/`) additionally:
 cd m1nd-ui && npm ci && npm test && npm run build && npm run lint:soft
 ```
 
+**Cross-platform fs & path contract (Windows is a first-class CI OS):**
+- Never `set_len`/truncate on an append-mode handle — on Windows it lacks `FILE_WRITE_DATA`
+  (os error 5). Route tail-truncation through `windows_durable_fs::truncate_no_follow`.
+- Never hold long-lived lock files opened with `share_mode(0)` — read-only tree snapshots then
+  die with sharing violations (os error 32). Share reads (`FILE_SHARE_READ`); write access stays
+  unshared so single-owner collision detection is unchanged.
+- Never screen operator-supplied paths with `Path::is_absolute` alone — `"/x"`, `"\x"` and
+  `"C:\x"` are not absolute under the other OS's semantics. Use the shared helpers
+  (`is_safe_relative_discovery_pattern`, `m1nd_ingest::exact_path_identity`) so security screens
+  and identity stamps agree on every OS (2026-07-22 incident: a rooted discovery pattern escaped
+  the scanned root on Windows).
+
 Always run `cargo fmt` and `cargo clippy --workspace -- -D warnings` before finishing.
 If a test flakes under parallel build-cache contention (e.g. `retrobuilder_real`), re-run
 it in isolation (`cargo test -p m1nd-core --test retrobuilder_real`) before concluding.

--- a/m1nd-ingest/src/lib.rs
+++ b/m1nd-ingest/src/lib.rs
@@ -110,7 +110,16 @@ pub(crate) fn relative_source_path(root: &Path, path: &Path) -> String {
     relative
 }
 
-fn exact_path_identity(path: &Path) -> M1ndResult<String> {
+/// The canonical, cross-platform identity string for an **already-canonicalized**
+/// managed path. This is the exact value stamped into
+/// [`ownership::CodeOwnershipManifestV1::root_identity`] and every managed source
+/// key, so any consumer that must compare against a bundle's `root_identity`
+/// (e.g. the graph-ingest admission path in `m1nd-mcp`) has to derive its own
+/// root string through this same function — Windows `canonicalize` yields a
+/// `\\?\C:\...` verbatim path, which is normalized here to `//?/C:/...` so the
+/// identity never depends on the OS separator. Callers pass a path they have
+/// already run through [`std::fs::canonicalize`]; this does not canonicalize.
+pub fn exact_path_identity(path: &Path) -> M1ndResult<String> {
     let identity = path.to_str().ok_or_else(|| M1ndError::InvalidParams {
         tool: "ingest_identity".into(),
         detail: format!("managed path is not valid UTF-8: {}", path.display()),

--- a/m1nd-mcp/src/authority_wal.rs
+++ b/m1nd-mcp/src/authority_wal.rs
@@ -609,8 +609,7 @@ impl AuthorityWal {
             })
             .transpose()?;
         if recovery.truncated_tail_bytes != 0 {
-            file.set_len(complete_len)?;
-            file.sync_all()?;
+            truncate_journal_tail(&file, &path, complete_len)?;
         }
         Ok(Self {
             path,
@@ -945,6 +944,28 @@ fn open_journal_no_follow(_path: &Path) -> io::Result<File> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "AuthorityWAL no-follow durable open is not proven on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn truncate_journal_tail(file: &File, _path: &Path, complete_len: u64) -> io::Result<()> {
+    file.set_len(complete_len)?;
+    file.sync_all()
+}
+
+#[cfg(windows)]
+fn truncate_journal_tail(_file: &File, path: &Path, complete_len: u64) -> io::Result<()> {
+    // The journal handle is append-only on Windows (no `FILE_WRITE_DATA`), so it
+    // cannot `SetEndOfFile`; truncate the torn tail through a dedicated write
+    // handle instead.
+    crate::windows_durable_fs::truncate_no_follow(path, complete_len)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn truncate_journal_tail(_file: &File, _path: &Path, _complete_len: u64) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "AuthorityWAL torn-tail truncation is not proven on this platform",
     ))
 }
 

--- a/m1nd-mcp/src/external_mutation_journal.rs
+++ b/m1nd-mcp/src/external_mutation_journal.rs
@@ -368,12 +368,12 @@ impl ExternalMutationJournalV1 {
             tail_digest = Some(record.record_digest);
         }
         if complete_len != bytes.len() {
-            file.set_len(complete_len as u64)
-                .and_then(|()| file.sync_all())
-                .map_err(|source| ExternalMutationJournalError::Io {
+            truncate_journal_tail(&file, &path, complete_len as u64).map_err(|source| {
+                ExternalMutationJournalError::Io {
                     operation: "truncate_torn_external_mutation_journal_tail",
                     source,
-                })?;
+                }
+            })?;
         }
         let protected_head = protected_head_backend
             .as_ref()
@@ -1410,6 +1410,27 @@ fn open_journal_no_follow(_path: &Path) -> std::io::Result<File> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "external mutation journal no-follow durable open is not proven on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn truncate_journal_tail(file: &File, _path: &Path, complete_len: u64) -> std::io::Result<()> {
+    file.set_len(complete_len)?;
+    file.sync_all()
+}
+
+#[cfg(windows)]
+fn truncate_journal_tail(_file: &File, path: &Path, complete_len: u64) -> std::io::Result<()> {
+    // Append-only Windows journal handles cannot `SetEndOfFile`; truncate the
+    // torn tail through a dedicated write handle instead.
+    crate::windows_durable_fs::truncate_no_follow(path, complete_len)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn truncate_journal_tail(_file: &File, _path: &Path, _complete_len: u64) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "external mutation journal torn-tail truncation is not proven on this platform",
     ))
 }
 

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -7057,7 +7057,18 @@ mod tests {
     const SOURCE_MATRIX_BEFORE: &str = "pub fn before() -> u8 { 1 }\n";
     const SOURCE_MATRIX_AFTER: &str = "pub fn after() -> u8 { 2 }\n";
 
+    /// The source recovery matrix spawns real brain-actor threads and drives
+    /// restart cycles whose previous owner releases *asynchronously* — the actor
+    /// thread must drain and drop before `actor_active` clears. Running several of
+    /// these fixtures at once starves that drain on a loaded CI runner, so the
+    /// restart bind in `host_for_brain` can miss even its 30s wait. Serialize the
+    /// family so only one source matrix fixture is live at a time: each cycle's
+    /// actor is free to release before the next one binds. A poisoned latch is
+    /// irrelevant (it carries no state), so recover from it.
+    static SOURCE_MATRIX_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     struct SourceMatrixFixture {
+        _serial: std::sync::MutexGuard<'static, ()>,
         _temp: TempDir,
         repo_root: PathBuf,
         runtime_root: PathBuf,
@@ -7096,6 +7107,9 @@ mod tests {
         }
 
         fn new() -> Self {
+            let serial = SOURCE_MATRIX_SERIAL
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let temp = tempfile::tempdir().expect("source matrix tempdir");
             let repo_root = temp.path().join("repo");
             let runtime_root = temp.path().join("runtime");
@@ -7256,6 +7270,7 @@ mod tests {
                 runtime_root,
                 target_path,
                 _temp: temp,
+                _serial: serial,
             }
         }
 

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -7068,7 +7068,6 @@ mod tests {
     static SOURCE_MATRIX_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     struct SourceMatrixFixture {
-        _serial: std::sync::MutexGuard<'static, ()>,
         _temp: TempDir,
         repo_root: PathBuf,
         runtime_root: PathBuf,
@@ -7089,6 +7088,10 @@ mod tests {
         operation_object_digest: String,
         actor_calls: Arc<AtomicU64>,
         checkpoint_acks: Arc<Mutex<Vec<BrainPromoteCheckpointAckV1>>>,
+        // Declared LAST so it drops LAST: the latch must outlive the host /
+        // actor-registry teardown above (fields drop in declaration order), or
+        // the next fixture binds while this one's actor is still draining.
+        _serial: std::sync::MutexGuard<'static, ()>,
     }
 
     impl SourceMatrixFixture {

--- a/m1nd-mcp/src/external_mutation_service/graph_ingest_a2.rs
+++ b/m1nd-mcp/src/external_mutation_service/graph_ingest_a2.rs
@@ -121,11 +121,11 @@ impl GraphIngestA2InputV1 {
                 "owner preview id, full-root path, and exact current source-projection digest are required",
             ));
         }
-        if self.dotfile_patterns.iter().any(|pattern| {
-            pattern.trim().is_empty()
-                || pattern != pattern.trim()
-                || Path::new(pattern).is_absolute()
-        }) {
+        if self
+            .dotfile_patterns
+            .iter()
+            .any(|pattern| !is_safe_relative_discovery_pattern(pattern))
+        {
             return Err(GraphIngestA2Error::new(
                 "graph_ingest_discovery_controls_invalid",
                 "dotfile patterns must be non-empty trimmed relative patterns",
@@ -1751,11 +1751,33 @@ fn canonical_root(root: &str) -> Result<String, GraphIngestA2Error> {
             "A2 code ingestion requires a canonical directory root",
         ));
     }
-    Ok(canonical.to_string_lossy().into_owned())
+    // The identity MUST match `CodeOwnershipManifestV1.root_identity` byte-for-byte
+    // or a full-root bundle looks foreign (on Windows `canonicalize` yields
+    // `\\?\C:\...`, which ingest normalizes to `//?/C:/...`). Reuse ingest's own
+    // normalizer instead of re-deriving it here so the two can never drift.
+    m1nd_ingest::exact_path_identity(&canonical).map_err(|error| {
+        GraphIngestA2Error::new("graph_ingest_root_unavailable", error.to_string())
+    })
 }
 
 fn is_digest(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// A discovery dotfile pattern must be a non-empty, whitespace-trimmed, RELATIVE
+/// pattern. `Path::is_absolute` alone is platform-dependent: on Windows a
+/// leading-separator (`/x`, `\x`) or drive-relative root (`C:\x`) is NOT reported
+/// as absolute, so an operator-supplied pattern could escape the scanned root on
+/// Windows while being refused on POSIX. This rejects the leading-separator and
+/// drive-letter forms on every OS, mirroring the separator/drive rules
+/// `m1nd_ingest::is_valid_relative_file_path` already enforces for source keys.
+fn is_safe_relative_discovery_pattern(pattern: &str) -> bool {
+    !pattern.is_empty()
+        && pattern == pattern.trim()
+        && !pattern.starts_with('/')
+        && !pattern.starts_with('\\')
+        && pattern.as_bytes().get(1) != Some(&b':')
+        && !Path::new(pattern).is_absolute()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1845,6 +1867,13 @@ mod tests {
             vec!["".to_string()],
             vec![" .env".to_string()],
             vec!["/absolute".to_string()],
+            // Windows-rooted forms that `Path::is_absolute` does NOT classify as
+            // absolute on POSIX: a leading backslash, a drive-letter root, and a
+            // verbatim prefix must all be refused on every OS so an operator
+            // pattern can never escape the scanned root.
+            vec!["\\rooted".to_string()],
+            vec!["C:\\drive".to_string()],
+            vec!["\\\\?\\C:\\verbatim".to_string()],
             vec![".env".to_string(), ".env".to_string()],
         ] {
             let mut request = input(None);
@@ -1857,6 +1886,32 @@ mod tests {
                 "graph_ingest_discovery_controls_invalid"
             );
         }
+    }
+
+    #[test]
+    fn canonical_root_identity_matches_ingested_bundle_root_identity() {
+        // Admission compares `bundle.ownership.root_identity` against the
+        // request's `canonical_root(...)`. That only holds cross-platform when
+        // canonical_root normalizes the path exactly like the ingest crate: on
+        // Windows `canonicalize` returns `\\?\C:\...`, which ingest stamps as
+        // `//?/C:/...`. Before the fix canonical_root kept the backslashes, so
+        // every full-root A2 operation was misread as foreign and refused with
+        // `graph_ingest_full_root_required`.
+        let temp = tempfile::tempdir().expect("A2 identity root");
+        std::fs::write(temp.path().join("lib.rs"), "pub fn a2() {}\n").expect("A2 source");
+        let raw_root = temp
+            .path()
+            .canonicalize()
+            .expect("canonical root")
+            .to_string_lossy()
+            .into_owned();
+
+        let identity = canonical_root(&raw_root).expect("canonical identity");
+        let bundle = build_complete_bundle(&identity, false, &[]).expect("full-root bundle");
+        assert_eq!(
+            identity, bundle.ownership.root_identity,
+            "canonical_root must match the identity ingest stamps into the bundle"
+        );
     }
 
     #[test]

--- a/m1nd-mcp/src/external_mutation_service/graph_ingest_a2.rs
+++ b/m1nd-mcp/src/external_mutation_service/graph_ingest_a2.rs
@@ -1778,6 +1778,9 @@ fn is_safe_relative_discovery_pattern(pattern: &str) -> bool {
         && !pattern.starts_with('\\')
         && pattern.as_bytes().get(1) != Some(&b':')
         && !Path::new(pattern).is_absolute()
+        && !pattern
+            .split(['/', '\\'])
+            .any(|segment| segment == "." || segment == "..")
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1874,6 +1877,14 @@ mod tests {
             vec!["\\rooted".to_string()],
             vec!["C:\\drive".to_string()],
             vec!["\\\\?\\C:\\verbatim".to_string()],
+            // Dot segments must be refused on every OS (mirror of
+            // `is_valid_relative_file_path`): a future consumer that joins a
+            // pattern to the root must never inherit a traversal vector.
+            vec!["..".to_string()],
+            vec!["../escape".to_string()],
+            vec!["a/../b".to_string()],
+            vec!["a\\..\\b".to_string()],
+            vec![".".to_string()],
             vec![".env".to_string(), ".env".to_string()],
         ] {
             let mut request = input(None);

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -27,6 +27,18 @@ const LEASE_DIR_NAME: &str = "leases";
 const DEFAULT_REGISTRY_SUBDIR: &str = ".m1nd/registry";
 const STALE_AFTER_MS: u64 = 30_000;
 
+/// Windows share mode for the crash-released lock files (`*.owner.lock`,
+/// `.lease-mutations.guard`). Sharing READ lets read-only registry inspection —
+/// `list_instances`, `doctor`, and durable-tree snapshots — open a lock while it
+/// is held, matching Unix `flock`, which never blocks readers. A competing
+/// WRITER still collides because its write access is not shared, so single-owner
+/// exclusion is unchanged: `acquire_os`/`LeaseMutationGuard` still see
+/// `ERROR_SHARING_VIOLATION` (32) from a second acquirer and treat it as "held".
+/// Opening these files fully exclusive (`share_mode(0)`) is what made a Windows
+/// reader fail with error 32 where the Unix reader succeeds.
+#[cfg(windows)]
+const LOCK_FILE_SHARE_MODE: u32 = windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InstanceRegistryEntry {
     pub instance_id: String,
@@ -767,7 +779,7 @@ impl OwnerLifetimeGuard {
             .read(true)
             .write(true)
             .create(true)
-            .share_mode(0)
+            .share_mode(LOCK_FILE_SHARE_MODE)
             .open(&path)
         {
             Ok(file) => Ok(Self { path, file }),
@@ -869,7 +881,7 @@ impl LeaseMutationGuard {
                     .read(true)
                     .write(true)
                     .create(true)
-                    .share_mode(0)
+                    .share_mode(LOCK_FILE_SHARE_MODE)
                     .open(&guard_path)
                 {
                     Ok(file) => {

--- a/m1nd-mcp/src/owner_authorization_broker.rs
+++ b/m1nd-mcp/src/owner_authorization_broker.rs
@@ -539,12 +539,12 @@ impl OwnerAuthorizationBrokerV1 {
             })
             .transpose()?;
         if complete_len != bytes.len() {
-            file.set_len(complete_len as u64)
-                .and_then(|()| file.sync_all())
-                .map_err(|source| OwnerAuthorizationBrokerError::Io {
+            truncate_broker_tail(&file, &path, complete_len as u64).map_err(|source| {
+                OwnerAuthorizationBrokerError::Io {
                     operation: "truncate_torn_broker_tail",
                     source,
-                })?;
+                }
+            })?;
         }
         Ok(Self {
             config,
@@ -1715,6 +1715,20 @@ fn sync_parent(path: &Path) -> std::io::Result<()> {
 #[cfg(not(unix))]
 fn sync_parent(_path: &Path) -> std::io::Result<()> {
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn truncate_broker_tail(file: &File, _path: &Path, complete_len: u64) -> std::io::Result<()> {
+    file.set_len(complete_len)?;
+    file.sync_all()
+}
+
+#[cfg(windows)]
+fn truncate_broker_tail(_file: &File, path: &Path, complete_len: u64) -> std::io::Result<()> {
+    // The broker journal handle is append-only on Windows (no `FILE_WRITE_DATA`),
+    // so it cannot `SetEndOfFile`; truncate the torn tail through a dedicated
+    // write handle instead.
+    crate::windows_durable_fs::truncate_no_follow(path, complete_len)
 }
 
 #[cfg(test)]

--- a/m1nd-mcp/src/perspective/peek_security.rs
+++ b/m1nd-mcp/src/perspective/peek_security.rs
@@ -256,7 +256,72 @@ fn open_beneath_root(canonical_root: &Path, canonical: &Path) -> M1ndResult<fs::
     unreachable!("non-empty component list returns on its final component")
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn open_beneath_root(canonical_root: &Path, canonical: &Path) -> M1ndResult<fs::File> {
+    // Windows analog of the Unix descriptor walk. Every open refuses reparse
+    // points (`FILE_FLAG_OPEN_REPARSE_POINT`, the `O_NOFOLLOW` equivalent) and
+    // every child is opened relative to the parent's handle through
+    // `NtCreateFile`'s `RootDirectory` binding (the `openat` equivalent), so a
+    // same-user reparse-point swap mid-walk cannot redirect the later read
+    // outside the allow-root. This mirrors the anchored walk `graph_ingest_a2`
+    // already performs with the same `windows_durable_fs` primitives.
+    let root_metadata = fs::metadata(canonical_root).map_err(M1ndError::Io)?;
+    if root_metadata.is_file() {
+        if canonical != canonical_root {
+            return Err(M1ndError::InvalidParams {
+                tool: "perspective.peek".into(),
+                detail: "a file allow-root only authorizes that exact file".into(),
+            });
+        }
+        return crate::windows_durable_fs::open_read_no_follow(canonical_root)
+            .map_err(M1ndError::Io);
+    }
+    if !root_metadata.is_dir() {
+        return Err(M1ndError::InvalidParams {
+            tool: "perspective.peek".into(),
+            detail: "allow-root is neither a regular file nor directory".into(),
+        });
+    }
+
+    let relative =
+        canonical
+            .strip_prefix(canonical_root)
+            .map_err(|_| M1ndError::InvalidParams {
+                tool: "perspective.peek".into(),
+                detail: format!("path '{}' is outside allowed root", canonical.display()),
+            })?;
+    let components = relative.components().collect::<Vec<_>>();
+    if components.is_empty() {
+        return Err(M1ndError::InvalidParams {
+            tool: "perspective.peek".into(),
+            detail: "a directory allow-root is not itself readable as a file".into(),
+        });
+    }
+
+    let mut current = crate::windows_durable_fs::open_directory_no_follow(canonical_root)
+        .map_err(M1ndError::Io)?;
+    for (index, component) in components.iter().enumerate() {
+        let name = match component {
+            std::path::Component::Normal(name) => *name,
+            _ => {
+                return Err(M1ndError::InvalidParams {
+                    tool: "perspective.peek".into(),
+                    detail: "canonical relative path contains a non-normal component".into(),
+                });
+            }
+        };
+        let last = index + 1 == components.len();
+        if last {
+            return crate::windows_durable_fs::open_relative_read_no_follow(&current, name)
+                .map_err(M1ndError::Io);
+        }
+        current = crate::windows_durable_fs::open_relative_directory_no_follow(&current, name)
+            .map_err(M1ndError::Io)?;
+    }
+    unreachable!("non-empty component list returns on its final component")
+}
+
+#[cfg(all(not(unix), not(windows)))]
 fn open_beneath_root(_canonical_root: &Path, _canonical: &Path) -> M1ndResult<fs::File> {
     Err(M1ndError::InvalidParams {
         tool: "perspective.peek".into(),

--- a/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
+++ b/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
@@ -3789,9 +3789,16 @@ fn cleanup_aborted_pre_stage<F: SourceEditFaults>(
 
     if managed_entry_exists(&directory)? {
         validate_private_directory(&directory)?;
-        let mut entries = fs::read_dir(&directory)
-            .map_err(|error| io_error("pre_stage_abort_directory_read", error))?;
-        if entries.next().is_some() {
+        // Scope the ReadDir so its directory handle is closed before removal.
+        // Windows `RemoveDirectoryW` fails with ERROR_SHARING_VIOLATION while any
+        // handle to the directory is open, and a live `ReadDir` holds exactly such
+        // a handle; POSIX tolerates rmdir with an open DIR* so unix never noticed.
+        let directory_is_empty = {
+            let mut entries = fs::read_dir(&directory)
+                .map_err(|error| io_error("pre_stage_abort_directory_read", error))?;
+            entries.next().is_none()
+        };
+        if !directory_is_empty {
             return Err(SourceEditTransactionError::RecoveryRequired {
                 transaction_id: transaction_id.clone(),
                 detail: "pre-stage transaction directory contains an unknown artifact".to_string(),

--- a/m1nd-mcp/src/windows_durable_fs.rs
+++ b/m1nd-mcp/src/windows_durable_fs.rs
@@ -74,6 +74,21 @@ pub(crate) fn open_write_no_follow(path: &Path) -> io::Result<File> {
     validate_opened_target(options.open(path)?, path)
 }
 
+/// Durably truncates a torn journal tail on Windows.
+///
+/// A journal opened with [`open_read_append_create_no_follow`] carries only
+/// `FILE_APPEND_DATA` (Rust drops `FILE_WRITE_DATA` for append handles), so
+/// `File::set_len` on that handle is refused with `ERROR_ACCESS_DENIED`.
+/// Recovery therefore truncates through a dedicated no-follow write handle,
+/// which does hold `FILE_WRITE_DATA`, exactly as `evidence_spine` already does
+/// for its own tail repair. The append handle keeps writing at end-of-file, so
+/// the next record still lands immediately after the truncation point.
+pub(crate) fn truncate_no_follow(path: &Path, len: u64) -> io::Result<()> {
+    let file = open_write_no_follow(path)?;
+    file.set_len(len)?;
+    file.sync_all()
+}
+
 pub(crate) fn open_read_append_create_no_follow(path: &Path) -> io::Result<File> {
     let mut options = OpenOptions::new();
     options


### PR DESCRIPTION
## P0 — main is red on Windows since 2026-07-21; this heals it (4 classes)

**Class A — append-handle `set_len` (os error 5).** Journals open in append mode; on Windows that handle lacks `FILE_WRITE_DATA`, so torn-tail recovery's `File::set_len` gets `ERROR_ACCESS_DENIED`. Fixed via new `windows_durable_fs::truncate_no_follow` routed through per-file platform-split helpers (mirrors what `evidence_spine.rs` already did): `authority_wal`, `external_mutation_journal`, `owner_authorization_broker`.

**Class B — registry lock share mode (os error 32).** `*.owner.lock` opened with `share_mode(0)`; the lifetime guard holds it, so read-only tree snapshots hit sharing violations. Fixed with `FILE_SHARE_READ` — a second acquirer still collides (write access unshared), single-owner exclusion unchanged; readers behave like unix flock.

**Class C — A2 path semantics (SECURITY).** Discovery patterns were screened with `Path::is_absolute` alone — on Windows `"/x"`, `"\x"`, `"C:\x"` return `false` and a rooted operator pattern escaped the scanned root. New `is_safe_relative_discovery_pattern` rejects leading separators + drive letters on EVERY OS (RED→GREEN proven on macOS). Also `canonical_root` now reuses `m1nd_ingest::exact_path_identity` so admission's root identity can never drift from ingest (`\\?\C:\` vs `//?/C:/` mismatch failed the whole graph_ingest_* family); contract test pins the comparison.

**Class D — macOS actor-owner contention flake.** `SourceMatrixFixture` cycles real brain actors whose previous owner releases asynchronously; under CPU contention the 30s poll starved. Serialized the source-matrix family via a static latch (mirrors the existing `LEASE_MUTATION_MUTEX` pattern); full 43-test source family green locally.

**Proof state (honest):** fmt/clippy `-D warnings`/check green; `x86_64-pc-windows-gnu` cross-compile of all targets (incl. Windows test arms) exit 0; macOS no-regression on lock semantics + source family. The Windows-only paths (error-5/32 elimination, `\\?\` normalization) are provable ONLY by this PR's Windows CI — that run is the definitive gate. source_* deterministic failures attributed to Class A by strong static analysis (their recovery hits the exact fixed path); Windows CI confirms.

Blocks: #389, #390, and the v1.5.0 tag (#388) — all inherit red main until this lands.