### PR TITLE
release: ship 1.5.0 for macOS + Linux (drop Windows binary, phase-2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,11 +501,6 @@ jobs:
             archive: m1nd-mcp-macos-aarch64.tar.gz
             artifact: m1nd-mcp-macos-aarch64
             raw: m1nd-mcp-macos-aarch64
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            archive: m1nd-mcp-windows-x86_64.zip
-            artifact: m1nd-mcp-windows-x86_64
-            raw: m1nd-mcp-windows-x86_64.exe
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -538,20 +533,12 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: cp "target/${{ matrix.target }}/release/${BINARY_NAME}" "${{ matrix.raw }}"
-      - name: Stage updater-facing Windows runtime
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Copy-Item "target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe" "${{ matrix.raw }}"
       - name: Archive Unix runtime
         if: runner.os != 'Windows'
         shell: bash
         run: |
           tar -C "target/${{ matrix.target }}/release" \
             -czf "${{ matrix.archive }}" "${BINARY_NAME}"
-      - name: Archive Windows runtime
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Compress-Archive -Path "target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe" -DestinationPath "${{ matrix.archive }}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.artifact }}
@@ -588,12 +575,6 @@ jobs:
             archive: m1nd-mcp-macos-aarch64.tar.gz
             binary: runtime/m1nd-mcp
             raw: m1nd-mcp-macos-aarch64
-          - target: windows-x86_64
-            os: windows-latest
-            artifact: m1nd-mcp-windows-x86_64
-            archive: m1nd-mcp-windows-x86_64.zip
-            binary: runtime/m1nd-mcp.exe
-            raw: m1nd-mcp-windows-x86_64.exe
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -610,10 +591,6 @@ jobs:
         run: |
           mkdir runtime
           tar -xzf "${{ matrix.archive }}" -C runtime
-      - name: Install Windows archive bytes
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Expand-Archive -Path "${{ matrix.archive }}" -DestinationPath runtime
       - name: Restore raw Unix executable permission
         if: runner.os != 'Windows'
         shell: bash
@@ -712,7 +689,6 @@ jobs:
             --expected-target linux-x86_64 \
             --expected-target macos-x86_64 \
             --expected-target macos-aarch64 \
-            --expected-target windows-x86_64 \
             --compatibility-output canonical-inputs/RELEASE-COMPATIBILITY.json \
             --rollback-output canonical-inputs/M1ND10-ROLLBACK.json \
             --digest-output canonical-inputs/CANONICAL-OPERATIONAL-DIGESTS.json
@@ -727,7 +703,6 @@ jobs:
             --expected-target linux-x86_64 \
             --expected-target macos-x86_64 \
             --expected-target macos-aarch64 \
-            --expected-target windows-x86_64 \
             --required-job tag-guard \
             --required-job release-gate \
             --required-job build \
@@ -792,7 +767,6 @@ jobs:
             release-bins/m1nd-mcp-linux-x86_64
             release-bins/m1nd-mcp-macos-x86_64
             release-bins/m1nd-mcp-macos-aarch64
-            release-bins/m1nd-mcp-windows-x86_64.exe
             release-bins/*.json
             release-bins/SHA256SUMS
       - name: GitHub Sigstore SBOM attestation
@@ -806,7 +780,6 @@ jobs:
             release-bins/m1nd-mcp-linux-x86_64
             release-bins/m1nd-mcp-macos-x86_64
             release-bins/m1nd-mcp-macos-aarch64
-            release-bins/m1nd-mcp-windows-x86_64.exe
             release-bins/CANDIDATE.json
             release-bins/GATE-RECEIPT.json
             release-bins/ROLLBACK.json
@@ -847,9 +820,6 @@ jobs:
           - target: macos-aarch64
             os: macos-latest
             raw: m1nd-mcp-macos-aarch64
-          - target: windows-x86_64
-            os: windows-latest
-            raw: m1nd-mcp-windows-x86_64.exe
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -2109,6 +2109,16 @@ function githubReleaseAvailability(
       error: available ? null : "test override reported unavailable",
     };
   }
+  if (platform === "win32") {
+    return {
+      ok: false,
+      available: false,
+      asset,
+      url,
+      source: "windows-phase-2",
+      error: `m1nd ${version} does not ship a Windows binary; Windows support is phase-2`,
+    };
+  }
   const curl = trustedUpdateTool("curl");
   if (!curl) {
     return {
@@ -4800,6 +4810,7 @@ module.exports = {
   runtimeBinaryName,
   commandLooksLikeRuntime,
   githubReleaseAssetName,
+  githubReleaseAvailability,
   canonicalJson,
   canonicalJsonV1,
   parseIntegerJson,

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -16,6 +16,7 @@ const {
   hostStatus,
   hostRecipe,
   githubReleaseAssetName,
+  githubReleaseAvailability,
   canonicalJsonV1,
   parseIntegerJson,
   domainSeparatedDigest,
@@ -128,6 +129,28 @@ assert.strictEqual(
   "m1nd-mcp-windows-x86_64.exe"
 );
 assert.strictEqual(githubReleaseAssetName("win32", "arm64"), null);
+{
+  // Windows is phase-2: the release ships no Windows binary, so runtime
+  // acquisition on win32 must refuse with a clear message instead of a later
+  // ENOENT on a m1nd-mcp.exe that was never downloaded. Clear the availability
+  // override so the guard, not a test fixture, decides — and prove it returns
+  // before any network probe.
+  const savedAvailable = process.env.M1ND_TEST_GITHUB_RELEASE_AVAILABLE;
+  delete process.env.M1ND_TEST_GITHUB_RELEASE_AVAILABLE;
+  const windowsAvailability = githubReleaseAvailability("1.5.0", "win32", "x64");
+  assert.strictEqual(windowsAvailability.ok, false);
+  assert.strictEqual(windowsAvailability.available, false);
+  assert.strictEqual(windowsAvailability.source, "windows-phase-2");
+  assert.strictEqual(
+    windowsAvailability.error,
+    "m1nd 1.5.0 does not ship a Windows binary; Windows support is phase-2"
+  );
+  if (savedAvailable === undefined) {
+    delete process.env.M1ND_TEST_GITHUB_RELEASE_AVAILABLE;
+  } else {
+    process.env.M1ND_TEST_GITHUB_RELEASE_AVAILABLE = savedAvailable;
+  }
+}
 assert.strictEqual(
   commandLooksLikeRuntime("/Us" + "ers/alice/.m1nd/bin/" + runtimeBinaryName() + " --stdio"),
   true

--- a/scripts/m1nd10_crates_io_upload.py
+++ b/scripts/m1nd10_crates_io_upload.py
@@ -352,7 +352,11 @@ def inspect_crate(path: Path) -> dict[str, Any]:
         raise CratePackageError("crate VCS source identity is not valid JSON") from error
     git = vcs.get("git") if isinstance(vcs, dict) else None
     source_commit = git.get("sha1") if isinstance(git, dict) else None
-    source_dirty = git.get("dirty") if isinstance(git, dict) else None
+    # Cargo only emits `dirty` in .cargo_vcs_info.json when the tree was dirty at
+    # package time; on a clean tagged commit the field is absent. Treat absent as
+    # not-dirty rather than rejecting it (the field being present-but-non-bool is
+    # still an integrity failure).
+    source_dirty = git.get("dirty", False) if isinstance(git, dict) else None
     if not isinstance(source_commit, str) or not SHA1_RE.fullmatch(source_commit):
         raise CratePackageError("crate VCS source commit is missing or invalid")
     if not isinstance(source_dirty, bool):


### PR DESCRIPTION
Fixes the failed 1.5.0 release run (nothing published — recoverable). Three release-machinery fixes, no product code:

1. **VCS-dirty guard** (`m1nd10_crates_io_upload.py`): cargo omits the `dirty` flag in `.cargo_vcs_info.json` on a clean tagged commit; the guard rejected the absence as "missing or invalid" and failed crate packaging. Absent now means not-dirty.
2. **Drop Windows from the release pipeline** (`release.yml`, 7 sites, actionlint clean): the Windows build failed on a non-reproducible UI-bundle digest attestation that can't be fixed without Windows hardware. Windows is declared phase-2 and its binary has red tests — shipping an attested-but-broken `.exe` would be worse than none. macOS + Linux (3 targets) ship cleanly.
3. **npm graceful on win32** (`cli.js`): the wrapper downloads the runtime from the GitHub Release; with no Windows asset, `m1nd update` on win32 now returns a clear "does not ship a Windows binary; Windows support is phase-2" instead of an obscure ENOENT.

The Windows source-edit path-canon suite (ci.yml) remains a tracked phase-2 follow-up; the release no longer depends on Windows.