### PR TITLE
fix(release): let the update smoke find cosign in a trusted path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -829,6 +829,17 @@ jobs:
           node-version: "22"
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Place cosign in a trusted fixed path for the updater
+        shell: bash
+        # The updater resolves cosign only from fixed system directories (never
+        # an arbitrary PATH), but cosign-installer drops it in the runner
+        # tool-cache. Copy the just-installed, signature-verified cosign into a
+        # trusted directory so the updater's own resolver finds it.
+        run: |
+          set -euo pipefail
+          src="$(command -v cosign)"
+          sudo install -m 0755 "$src" /usr/local/bin/cosign
+          /usr/local/bin/cosign version >/dev/null
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: m1nd-release-candidate-${{ github.sha }}


### PR DESCRIPTION
Third and final release-machinery fix for the 1.5.0 ship (nothing published — recoverable). The `verified-update-smoke` failed with "cosign not found": the updater resolves cosign only from fixed system dirs (hardening), but cosign-installer uses the runner tool-cache. Copy the signature-verified cosign into `/usr/local/bin` so the updater finds it. Keeps the whole signed-verification tail intact and blocking (no advisory downgrade — the npm publish depends on release-verification's outputs). actionlint clean.