### PR TITLE
M1ND-10: re-freeze the PRD at the cleaned-canon digest (owner-ratified)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           printf '%s  %s\n' \
-            '00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38' \
+            'bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5' \
             'docs/M1ND-10-PRD.md' \
             '8a8a5fe9b9d2a4fc62c419e160e8dc2dcb4115f58d98f3f15a2d5031881dd32b' \
             'docs/M1ND-10-UML.md' | sha256sum --check --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
       - name: Verify frozen ratified contracts
         run: |
           printf '%s  %s\n' \
-            '00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38' \
+            'bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5' \
             'docs/M1ND-10-PRD.md' \
             '8a8a5fe9b9d2a4fc62c419e160e8dc2dcb4115f58d98f3f15a2d5031881dd32b' \
             'docs/M1ND-10-UML.md' | sha256sum --check --strict

--- a/docs/M1ND-10-HANDOFF-20260719.md
+++ b/docs/M1ND-10-HANDOFF-20260719.md
@@ -154,8 +154,15 @@ The frozen contracts must not be edited in place:
 
 | Contract | SHA-256 |
 |---|---|
-| `docs/M1ND-10-PRD.md` | `00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38` |
+| `docs/M1ND-10-PRD.md` | `bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5` |
 | `docs/M1ND-10-UML.md` | `8a8a5fe9b9d2a4fc62c419e160e8dc2dcb4115f58d98f3f15a2d5031881dd32b` |
+
+> PRD digest amendment (2026-07-23, owner-ratified): the owner replaced machine-local
+> absolute paths in the PRD with home shorthand (`531ca750`, the no-leak rule applied to
+> the public canon) and re-froze it at the digest above (previous:
+> `00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38`). Historical proof
+> documents keep the digest that was ratified at their date. Record:
+> `docs/proofs/m1nd10-prd-refreeze-20260723.md`.
 
 The ratified implementation posture is:
 

--- a/docs/proofs/m1nd10-prd-refreeze-20260723.md
+++ b/docs/proofs/m1nd10-prd-refreeze-20260723.md
@@ -1,0 +1,43 @@
+# M1ND-10 — PRD re-freeze amendment — 2026-07-23
+
+> The owner edited the frozen PRD to remove machine-local absolute paths (the no-leak rule
+> applied to the public canon) and ratified re-freezing it at the new digest. This record is
+> the amendment's paper trail; historical proof documents are untouched and keep the digest
+> that was ratified at their date.
+
+## What changed
+
+- Commit `531ca750` (author: the owner, direct to main, 2026-07-23): every machine-local
+  absolute path in `docs/M1ND-10-PRD.md` replaced with home shorthand (`~/…`). Zero personal
+  paths remain in the public canon. No semantic contract content changed.
+
+## Digests
+
+| | SHA-256 |
+|---|---|
+| Previous frozen PRD | `00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38` |
+| **Re-frozen PRD (this amendment)** | `bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5` |
+| UML (unchanged) | `8a8a5fe9b9d2a4fc62c419e160e8dc2dcb4115f58d98f3f15a2d5031881dd32b` |
+
+## Ratification
+
+- The content edit itself was the owner's hand (`531ca750`).
+- The re-freeze at the new digest was explicitly confirmed by the owner in the 2026-07-23
+  guardian session ("confirmo") after the guardian surfaced the frozen-contract divergence
+  (the release tag-guard caught it — the enforcement worked exactly as designed).
+
+## Enforcement points updated (this amendment's commit)
+
+- `.github/workflows/release.yml` (tag-guard `sha256sum --check`)
+- `.github/workflows/ci.yml` (frozen-contracts gate)
+- `scripts/m1nd10_candidate_source_guard.py` (`FROZEN_PRD_SHA256`, the digest-bound
+  `personal_path_content` exception — now moot in effect, since the PRD no longer contains
+  personal paths; the mechanism is kept)
+- `tests/test_m1nd10_ci_security_contract.py` (the semantic assertion that exists precisely
+  to force this conscious amendment step)
+- `docs/M1ND-10-HANDOFF-20260719.md` (living frozen-contracts table + amendment note)
+
+## Not touched (history keeps its own digest)
+
+`docs/proofs/*` (ratification, gate, review receipts dated ≤2026-07-22),
+`docs/benchmarks/*` result/spec JSONs, `docs/M1ND-10-PUBLIC-PATH-MIGRATION-PLAN-20260719.md`.

--- a/scripts/m1nd10_candidate_source_guard.py
+++ b/scripts/m1nd10_candidate_source_guard.py
@@ -268,7 +268,7 @@ def merged_violations(*groups: Iterable[dict[str, str]]) -> list[dict[str, str]]
 # never a path allowlist.
 # see docs/proofs/m1nd10-public-path-migration-ratification-20260720.md
 FROZEN_PRD_PATH = "docs/M1ND-10-PRD.md"
-FROZEN_PRD_SHA256 = "00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38"
+FROZEN_PRD_SHA256 = "bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5"
 
 
 def scan_blob_for_personal_path(blob: bytes, path_text: str = "") -> str | None:

--- a/tests/test_m1nd10_candidate_source_guard.py
+++ b/tests/test_m1nd10_candidate_source_guard.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -278,19 +279,29 @@ class CandidateSourceGuardTests(unittest.TestCase):
             )
 
     def test_frozen_prd_digest_exception_is_bound_to_exact_bytes(self) -> None:
-        # The owner-ratified C6 exception lets the frozen PRD's documented
-        # machine-local paths pass the content gate, but ONLY at its exact
-        # SHA-256. One byte of drift kills the exception and restores the normal
-        # personal_path_content refusal, in both the worktree projection and the
-        # enforced exact-commit mode. The real PRD bytes are read at runtime so
-        # this test source never embeds a personal path.
-        # see docs/proofs/m1nd10-public-path-migration-ratification-20260720.md
+        # The owner-ratified C6 exception exempts the canonical PRD from the
+        # content gate ONLY at its exact SHA-256. Since the 2026-07-23 re-freeze
+        # (docs/proofs/m1nd10-prd-refreeze-20260723.md) the real PRD carries no
+        # machine-local paths, so the exception is moot in effect; the binding
+        # mechanism is kept and proven here with synthetic canon bytes whose
+        # digest is patched in as the frozen one.
         prd_bytes = (ROOT / "docs" / "M1ND-10-PRD.md").read_bytes()
         self.assertEqual(
             hashlib.sha256(prd_bytes).hexdigest(),
             GUARD.FROZEN_PRD_SHA256,
             "the real PRD bytes must match the ratified frozen digest",
         )
+        # The cleaned canon must STAY clean: reintroducing a machine-local path
+        # into the public PRD is a regression, exception or not. The needles are
+        # assembled at runtime so this test source never embeds a personal path
+        # (the guard scans this file too).
+        macos_home = b"/" + b"Users" + b"/"
+        linux_home = b"/" + b"home" + b"/"
+        self.assertNotIn(macos_home, prd_bytes)
+        self.assertNotIn(linux_home, prd_bytes)
+
+        synthetic = b"# PRD\ncheckout at " + macos_home + b"example-operator/m1nd\n"
+        synthetic_digest = hashlib.sha256(synthetic).hexdigest()
         with tempfile.TemporaryDirectory() as temporary:
             repo = pathlib.Path(temporary)
             subprocess.run(["git", "init", "-q", str(repo)], check=True)
@@ -324,25 +335,10 @@ class CandidateSourceGuardTests(unittest.TestCase):
 
             prd = repo / "docs" / "M1ND-10-PRD.md"
             prd.parent.mkdir(parents=True)
+            prd.write_bytes(synthetic)
 
-            # (a) Exact frozen bytes → the digest-bound exception makes the guard
-            # PASS in both inspection modes, even though the PRD embeds documented
-            # machine-local paths.
-            prd.write_bytes(prd_bytes)
-            self.assertEqual("PASS", GUARD.inspect_worktree_projection(repo)["status"])
-            subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
-            subprocess.run(
-                ["git", "-C", str(repo), "commit", "-qm", "frozen-prd"], check=True
-            )
-            self.assertEqual("PASS", GUARD.inspect_candidate(repo, "HEAD")["status"])
-
-            # (b) One byte of drift → the exception dies and the machine-local
-            # path inside the now non-canonical document is refused again.
-            prd.write_bytes(prd_bytes + b"\n")
-            self.assertNotEqual(
-                hashlib.sha256(prd.read_bytes()).hexdigest(),
-                GUARD.FROZEN_PRD_SHA256,
-            )
+            # (a) Without a matching frozen digest, the machine-local path in
+            # the PRD is refused like any other content.
             projection = GUARD.inspect_worktree_projection(repo)
             self.assertEqual("FAIL", projection["status"])
             self.assertEqual(
@@ -353,16 +349,44 @@ class CandidateSourceGuardTests(unittest.TestCase):
                 {"personal_path_content"},
                 {row["reason"] for row in projection["violations"]},
             )
-            subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
-            subprocess.run(
-                ["git", "-C", str(repo), "commit", "-qm", "prd-drift"], check=True
-            )
-            report = GUARD.inspect_candidate(repo, "HEAD")
-            self.assertEqual("FAIL", report["status"])
-            self.assertEqual(
-                {"personal_path_content"},
-                {row["reason"] for row in report["violations"]},
-            )
+
+            # (b) With the frozen digest bound to EXACTLY these bytes, the
+            # exception fires in both inspection modes.
+            with unittest.mock.patch.object(
+                GUARD, "FROZEN_PRD_SHA256", synthetic_digest
+            ):
+                self.assertEqual(
+                    "PASS", GUARD.inspect_worktree_projection(repo)["status"]
+                )
+                subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+                subprocess.run(
+                    ["git", "-C", str(repo), "commit", "-qm", "frozen-prd"],
+                    check=True,
+                )
+                self.assertEqual(
+                    "PASS", GUARD.inspect_candidate(repo, "HEAD")["status"]
+                )
+
+                # (c) One byte of drift kills the exception and restores the
+                # normal personal_path_content refusal in both modes.
+                prd.write_bytes(synthetic + b"\n")
+                drifted = GUARD.inspect_worktree_projection(repo)
+                self.assertEqual("FAIL", drifted["status"])
+                self.assertEqual(
+                    {"personal_path_content"},
+                    {row["reason"] for row in drifted["violations"]},
+                )
+                subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+                subprocess.run(
+                    ["git", "-C", str(repo), "commit", "-qm", "prd-drift"],
+                    check=True,
+                )
+                report = GUARD.inspect_candidate(repo, "HEAD")
+                self.assertEqual("FAIL", report["status"])
+                self.assertEqual(
+                    {"personal_path_content"},
+                    {row["reason"] for row in report["violations"]},
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_m1nd10_ci_security_contract.py
+++ b/tests/test_m1nd10_ci_security_contract.py
@@ -126,7 +126,7 @@ class CiSecurityContractTests(unittest.TestCase):
             # the exception. see docs/proofs/
             # m1nd10-public-path-migration-ratification-20260720.md
             "FROZEN_PRD_SHA256",
-            "00658cd88ce9dc5866f9b1fc6b9fbe594923e32fb900bde5bbc7740894c25c38",
+            "bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5",
         ):
             self.assertIn(token, policy, f"guard lost hardened semantics: {token}")
 


### PR DESCRIPTION
The owner cleaned machine-local paths out of the frozen PRD (`531ca750`, no-leak applied to the public canon) and ratified re-freezing at the new digest `bf7b03c7…`. The release tag-guard caught the divergence exactly as designed — this amendment updates every enforcement point (release.yml, ci.yml, candidate source guard, the semantic contract test, the living HANDOFF table) and records the ratification in `docs/proofs/m1nd10-prd-refreeze-20260723.md`. Historical proofs keep their dated digest. Proven: 22/22 contract+guard tests; guard exact-commit PASS 0 violations; the guard's digest-binding mechanism now exercised with runtime-assembled synthetic bytes (the canon itself carries no personal paths anymore).