### PR TITLE
fix(contract): re-pin M1ND-10 frozen digests after anonymization (heals main CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,9 @@ jobs:
         shell: bash
         run: |
           printf '%s  %s\n' \
-            'bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5' \
+            '2745560daf6e5cf6237b84663f895e81e2c4979de4190dfef649b032b680f87b' \
             'docs/M1ND-10-PRD.md' \
-            '8a8a5fe9b9d2a4fc62c419e160e8dc2dcb4115f58d98f3f15a2d5031881dd32b' \
+            'd5bc29776f516c300cb1a0668f0a53844286f75395fd0ad1e875b52ea3a067a5' \
             'docs/M1ND-10-UML.md' | sha256sum --check --strict
       - name: Ensure base ref is present
         if: github.event_name == 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,9 +334,9 @@ jobs:
       - name: Verify frozen ratified contracts
         run: |
           printf '%s  %s\n' \
-            'bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5' \
+            '2745560daf6e5cf6237b84663f895e81e2c4979de4190dfef649b032b680f87b' \
             'docs/M1ND-10-PRD.md' \
-            '8a8a5fe9b9d2a4fc62c419e160e8dc2dcb4115f58d98f3f15a2d5031881dd32b' \
+            'd5bc29776f516c300cb1a0668f0a53844286f75395fd0ad1e875b52ea3a067a5' \
             'docs/M1ND-10-UML.md' | sha256sum --check --strict
       - name: Rust source and release gates
         run: |

--- a/scripts/m1nd10_candidate_source_guard.py
+++ b/scripts/m1nd10_candidate_source_guard.py
@@ -268,7 +268,7 @@ def merged_violations(*groups: Iterable[dict[str, str]]) -> list[dict[str, str]]
 # never a path allowlist.
 # see docs/proofs/m1nd10-public-path-migration-ratification-20260720.md
 FROZEN_PRD_PATH = "docs/M1ND-10-PRD.md"
-FROZEN_PRD_SHA256 = "bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5"
+FROZEN_PRD_SHA256 = "2745560daf6e5cf6237b84663f895e81e2c4979de4190dfef649b032b680f87b"
 
 
 def scan_blob_for_personal_path(blob: bytes, path_text: str = "") -> str | None:

--- a/tests/test_m1nd10_ci_security_contract.py
+++ b/tests/test_m1nd10_ci_security_contract.py
@@ -126,7 +126,7 @@ class CiSecurityContractTests(unittest.TestCase):
             # the exception. see docs/proofs/
             # m1nd10-public-path-migration-ratification-20260720.md
             "FROZEN_PRD_SHA256",
-            "bf7b03c7e26ee90fe1bcad9eed4303bb9024b7dab7988251ca33834df26b81f5",
+            "2745560daf6e5cf6237b84663f895e81e2c4979de4190dfef649b032b680f87b",
         ):
             self.assertIn(token, policy, f"guard lost hardened semantics: {token}")
 


### PR DESCRIPTION
## RE-FREEZE CEREMONY — needs owner ratification (guardian prepared, did not merge)

Re-pinning a ratified frozen contract is human-sovereign. I prepared the candidate + proof; the **merge is yours**.

## The breakage (main is red; every open PR inherits it)

Commit 4ad52706 (anonymization — legitimate) rewrote the two frozen M1ND-10 docs but did not re-pin their digests: PRD bf7b03c7…→2745560d…, UML 8a8a5fe9…→d5bc2977…. So main's own CI fails on **Frozen contracts** + **Python proof harnesses**; PRs #397/#398/#400/#401 inherit that red, none introduce it.

## Proof it was cosmetic (re-pin, don't re-ratify content)

Only edits were private→neutral names (god-runner→dispatch-runner, ~/god-hud→~/cockpit). Zero semantic change. The anonymized tree carries 0 denylist terms (verified). Reverting would re-leak; re-pinning is the cure.

## This PR (6 lines, enforcement only)

Re-pins the digest in four enforcement sites: ci.yml, release.yml, m1nd10_candidate_source_guard.py, test_m1nd10_ci_security_contract.py. Historical records keep their original digests.

## Verified green locally
- CI contract-bytes sha256sum --check --strict: OK (both docs)
- python3 -m unittest discover -s tests: 143 OK
- candidate-source guard: 0 violations

Merge first → the other four PRs go green.