### PR TITLE
ci: react to merge_group so the merge queue can be turned on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  # Required for the merge queue: without this event the same gates never run on
+  # the queued `gh-readonly-queue/*` ref, so every PR would enter the queue and
+  # hang forever. The aggregator `Test` job runs here too and is the single check
+  # the queue waits on. (2026-07-24 — restoring throughput without strict serial
+  # rebasing.)
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
First of two steps to replace strict serial rebasing with a merge queue.

## Why

Branch protection is `strict: true` — every merge marks all other PRs out-of-date, and with auto-merge armed they don't self-update, so the queue drains one 25-minute CI round at a time. A **merge queue** tests each PR against the *projected* post-merge result, in order, keeping the guarantee without the serial cost. The repo already has `merge_queue: true` available.

## The ordering trap this PR avoids

A merge queue builds a temporary `gh-readonly-queue/*` ref and runs CI on it. A workflow that doesn't listen for the `merge_group` event **never runs there**, so every PR would enter the queue and hang forever. So the event has to be on `main` **before** the queue is enabled — this PR does only that, nothing else.

## Safety

- **Inert until the queue is turned on:** the `merge_group` event cannot fire without an active queue, so this changes nothing today.
- The aggregator `Test` job runs on `merge_group` too, and stays the one required check the queue waits on.
- Pull-request-only steps (the doc-coupling gate, dependency review, base-ref fetch) skip in the queue context by their existing `if: github.event_name == 'pull_request'` — they already ran on the PR itself.

Once this is on main, step 2 is enabling the queue in branch protection (no code).