### PR TITLE
docs: ratify squash as the merge standard; guard the checkpoint store from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ m1nd-ui/test-results/
 m1nd-ui/playwright-report/
 m1nd-ui/e2e/artifacts/
 .vitals-due
+
+# Content-addressed brain store minted at the repo root by another profile's
+# runtime — a runtime artifact, never source. One `git add -A` away from
+# publishing a brain; keep it invisible to git. (Salvaged from PR #398.)
+checkpoint-store/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,13 @@ owner on port `1338` — all tests use temp dirs.
   as the maintainer, complete any gate the agent missed (docs coupling above all), then land.
   State the groundwork's provenance honestly in the commit body — never claim an authorship
   the platform did not produce.
+- **How PRs merge (owner-ratified 2026-07-24): squash is the default.** One PR = one
+  conventional commit on main — the changelog is generated from commit subjects, branch noise
+  (WIP commits, conflict-resolution merges) never lands individually, and any PR reverts as one
+  gesture. **Merge commits are reserved** for ceremonies where the commit LINEAGE is itself the
+  artifact — the M1ND-10 candidate freezes, where each preserved commit carries its own guard
+  PASS (squash would destroy the proof). Auto-merge (squash) is armed on a PR once it has a
+  review verdict; never arm what nobody read.
 - The universal **documentation gate**: a behaviour/API/architecture change updates the repo's
   `docs/`, wiki, `README`, and `docs/PATHOS.md` **in the same PR** — a feature is not done until
   the docs reflect it.


### PR DESCRIPTION
Two small guardian items, both owner-ratified today.

## The merge standard, written down

Measured before writing: the last 30 merges to main are **14 merge commits × 16 squashes** — two eras, two needs, no written rule. Now stated in `AGENTS.md`:

- **Squash is the default**: one PR = one conventional commit on main. The changelog is generated from commit subjects (existing doctrine), branch noise (WIP commits, conflict-resolution merges) never lands individually, and any PR reverts as one gesture.
- **Merge commits are reserved** for ceremonies where the commit **lineage is itself the artifact** — the M1ND-10 candidate freezes, where each preserved commit carries its own guard PASS and squashing would destroy the proof. That is why the release era (#388–#402) looks different from the auto-merge era (#404→), and both were right.
- Auto-merge is armed only on PRs with a review verdict — never arm what nobody read.

## The salvaged leak guard

`checkpoint-store/` at the repo root is an untracked, content-addressed **brain store** minted by another profile's runtime — a runtime artifact one `git add -A` away from publication in a public repo. PR #398 flagged it; the fix should not wait on that PR's larger discussion, so it lands here with credit. Gitignored like every other runtime artifact.

Docs + one ignore line.