### PR TITLE
ci: keep grouped dependabot bumps off known-poison majors (bincode 3.x, typescript 7.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,14 @@ updates:
       ui:
         patterns: ["*"]
     ignore:
+      # TypeScript 7 is the native-port era: typescript-eslint 8.x refuses it as
+      # a peer, so a grouped bump that carries it can never `npm ci` (proven on
+      # the recreated ui group: ERESOLVE, typescript@7.0.2 vs
+      # typescript-eslint@8.65.0). Migrating to TS 7 is a deliberate project —
+      # drop this entry when that project happens, never inside a grouped ride.
+      - dependency-name: typescript
+        versions: ["7.x"]
+    ignore:
       # TypeScript 7 is the ground-up native (Go) compiler — a migration, not a
       # bump. The grouped ui update (#421) pulled typescript 7.0.2 into the same
       # group as typescript-eslint 8.65.0, whose peer range rejects it, so

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
     groups:
       rust:
         patterns: ["*"]
+    ignore:
+      # bincode 3.x is not a release: the published crate's lib.rs is a single
+      # `compile_error!("https://xkcd.com/2347/")`, so any tree that resolves it
+      # fails to build. Dependabot proposed it inside the grouped rust bump
+      # (PR #392) and took the whole 33-crate group down with it. We are on the
+      # 1.3 line; when a real 3.x ships, drop this entry deliberately rather
+      # than letting a grouped bump decide.
+      - dependency-name: bincode
+        versions: ["3.x"]
 
   - package-ecosystem: npm
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,12 @@ updates:
     groups:
       ui:
         patterns: ["*"]
+    ignore:
+      # TypeScript 7 is the ground-up native (Go) compiler — a migration, not a
+      # bump. The grouped ui update (#421) pulled typescript 7.0.2 into the same
+      # group as typescript-eslint 8.65.0, whose peer range rejects it, so
+      # `npm ci` dies on ERESOLVE and the whole 19-bump group cannot install.
+      # Adopting TS 7 is an owner decision with its own PR; keep it out of
+      # grouped rides until then.
+      - dependency-name: typescript
+        versions: ["7.x"]


### PR DESCRIPTION
## What took #392 down

The grouped rust bump (33 crates) failed `cargo check --locked --workspace --all-targets` on one line — and the line is not ours:

```
error: https://xkcd.com/2347/
 --> /home/runner/.cargo/registry/.../bincode-3.0.0/src/lib.rs:1:1
  |
1 | compile_error!("https://xkcd.com/2347/");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

**`bincode` 3.0.0 as published is not a release.** Its entire `lib.rs` is that `compile_error!`, so any tree that resolves it cannot build. ([xkcd 2347](https://xkcd.com/2347/) is the dependency-tower comic.)

One crate this repo does not even depend on directly — `m1nd-core` pins `bincode = "1.3"`, and the lockfile on main is `1.3.3` — took the whole 33-crate group down. Worth stating plainly: **a blind auto-merge of a grouped dependency bump would have broken main outright.** Auto-merge on #392 has been disarmed.

## The fix, where it survives

Pinned in `dependabot.yml` rather than a PR comment, so it holds across the next weekly run and every `recreate`:

```yaml
    ignore:
      - dependency-name: bincode
        versions: ["3.x"]
```

When a real 3.x ships, that entry gets dropped **deliberately** — a major of the serialization crate sitting under the graph snapshot deserves its own decision, not a ride inside a 33-crate grouped bump.

## Follow-up on #392

It needs a `@dependabot recreate` after this lands so the group regenerates without bincode. Leaving that to after the merge so the recreate sees the new config.