### PR TITLE
perf(brain): stop every read from publishing a whole-brain checkpoint

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -110,6 +110,40 @@ Update this list in the same PR that closes one; a front that dies silently is a
 - `m1nd-viz` was listed as a workspace member in the repo's agent guides — `AGENTS.md` (corrected in
   PR #407, in queue) and the local gitignored build notes (corrected the same day) — but no such crate
   exists anywhere in the tree and `Cargo.toml` never declared it.
+- **Durability is now a WINDOW for verbs the witness cannot see (2026-07-25, PR #426).** The brain actor
+  stopped answering "did this turn change durable state?" with a SHA-256 of the whole ~100 MB state and
+  now answers with `DurableWitnessV1` (`Graph::generation` + session generations, O(1)) — the fix that took
+  a warm `seek` from 5.0s to 0.40s. The witness sees graph STRUCTURE and session generations, nothing else,
+  so a verb that writes only a durable SIDECAR is invisible to it. Two declared routes now carry those:
+  a mutating classification (`READ_ONLY_DENIED_TOOLS` → published on the acked turn — `antibody_create`,
+  `ingest`, `learn`, `daemon_start`, `auto_ingest_start`), or a persist choke point that enters the
+  staged-persist debounce. **Debounce route = a real `kill -9` loss window of up to
+  `auto_persist_interval` (50) deferring turns**: `alerts_ack`, `daemon_stop`, `daemon_tick`,
+  `boot_memory`, `antibody_scan`, `calibrate_envelope`, `calibrate_predict`, `document_bindings`,
+  `document_drift`, `document_resolve`, `auto_ingest_tick`, `auto_ingest_stop`. An acked `daemon_stop` or
+  `auto_ingest_stop` inside that window can therefore RESURRECT as running after a hard kill — note that
+  `daemon_start` IS a classified mutation while `daemon_stop` is not, an asymmetry that predates this
+  change and now has a durability consequence.
+  **Worse for pure learning drift:** plasticity raises no persist request at all, so it does not even
+  advance the debounce counter — on a read-only workload with the daemon stopped and auto-ingest idle,
+  a `kill -9` loses the entire session's learning. The only backstop is the graceful shutdown checkpoint,
+  which is **single-attempt and refusable** (`m1nd-mcp/src/project_brains.rs::shutdown` — terminal
+  lifecycle, refuses a second attempt, and can time out with 0 checkpoint ACKs). Not a guarantee.
+  Open: decide whether plasticity drift should tick the debounce (bounded loss) or stay free (cheapest
+  reads), and whether the debounce-route verbs above deserve promotion to classified mutations. The
+  classification itself is mechanically guarded — `session.rs` freezes the sidecar inventory and scans
+  the shipped source, so a new sidecar writer that declares no route fails CI loudly. Doctrine in
+  `docs/UML-ORGANISM.md` § "Who pays the checkpoint".
+- **The strict `read_snapshot` still deep-clones the graph on EVERY transport call.** Brain resolution asks
+  the actor whether the bound brain covers the caller root, so `read_snapshot` runs per call, and it ends
+  with an UNCONDITIONAL `rebind_after_callback` — a full `encode_graph_json` + `decode_graph_json` of the
+  whole graph. Read from the code, NOT measured here (the perf lab was deleted); the PR's own
+  `M1ND_BRAIN_TIMING=1` prints `rebind_detached_graph` as its own stage, so the number is one lab run away.
+  The deferring `execute` branch already proves the cheap shape: rebind only when a second owner of the
+  graph Arc exists (`strong_count > 1` or a live `Weak`), i.e. only when a callback actually kept a handle
+  (`execute_read_without_an_escaped_arc_does_not_rebind_the_graph`). Applying the same gate to the strict
+  path is deliberately NOT done here — it is the hardened fence and deserves its own verdict and its own
+  A/B, not a drive-by. Measured claim, unmeasured fix.
 
 **Process debt**
 - The PR queue needs review, not just rebasing — `#401` ("the graph learned to write") is substantial and

--- a/docs/UML-ORGANISM.md
+++ b/docs/UML-ORGANISM.md
@@ -225,21 +225,60 @@ rejected by the production loader; h4nd is a caller of the ceremony, never an au
 
 ## Who pays the checkpoint (brain actor, corrected 2026-07-25)
 
-An actor turn publishes a durable checkpoint when it is a CLASSIFIED MUTATION, when the
-`DurableWitnessV1` (`Graph::generation` + the session generations, all O(1)) moved — i.e.
-STRUCTURE changed under a read-classified callback — or when the staged-persist debounce
-elapses. Every read routinely dirties small regenerable sidecars: plasticity Step 8 rewrites
-edge weights on every graph verb, and the freshness-by-traffic daemon tick persists daemon
-state on nearly every dispatch. That drift is DEFERRED — drained by the debounce
-(`SessionState::auto_persist_interval`, 50), by the next real mutation, or by the shutdown
-checkpoint — never by turning each read into a durable whole-brain write.
+An actor turn publishes a durable checkpoint on exactly four conditions: the command is a
+CLASSIFIED MUTATION (`server::READ_ONLY_DENIED_TOOLS`); the `DurableWitnessV1`
+(`Graph::generation` + the session generations, all O(1)) moved, i.e. graph STRUCTURE changed
+under a read-classified callback; a post-CURRENT effect is queued (only the checkpoint path
+drains one, so it can never be deferred); or the staged-persist debounce comes due.
 
 The actor used to decide this by byte-digest of the serialized state, which serialized
 ~100 MB twice per call (once BEFORE argument validation) and published a ~113 MB checkpoint
 per read. Measured in the lab (17,415 nodes): 87% of a warm `seek` turn was that machinery,
-and 10 reads produced 10 checkpoints (+1.1 GB of store). The strict `read_snapshot` (which
-refuses ANY change) keeps the byte-digest. (`m1nd-mcp/src/brain_runtime.rs`; the perf hunt
-of 2026-07-25 — seek 5.0s → 0.40s warm, mutation checkpoints unchanged at exactly one.)
+and 10 reads produced 10 checkpoints (+1.1 GB of store). Post-fix: seek 5.0s → 0.40s warm,
+70 reads → 0 checkpoints, a real mutation → exactly one.
+(`m1nd-mcp/src/brain_runtime.rs`; the perf hunt of 2026-07-25.)
+
+**What the strict `read_snapshot` fence actually promises.** It compares the same
+`DurableWitnessV1`, not a byte digest, and it refuses a change to graph STRUCTURE or to the
+session generations — not "any change". An interior column write (a tag, a provenance row, an
+edge weight) does NOT move the witness and is admitted. That is deliberate: this path runs on
+EVERY transport call, so it cannot serialize the world to answer, and the digest it used to
+take was unsound here — `rebind_detached_graph` rebuilds `edge_plasticity` from the current
+weights, so once plasticity had drifted a weight the postimage could never match and honest
+reads were refused as mutation attempts. The compensating control is CLASSIFICATION, not the
+witness: every verb that writes a graph tag or provenance column (`xray_retag`, `xray_paint`,
+`xray_apply`, `ingest`, `apply`) is on the mutating deny-list, so its durability is carried by
+the classification. Pinned by
+`read_snapshot_fence_refuses_structure_and_admits_interior_column_drift`.
+
+**The deferring branch still pays the isolation fence.** A turn that publishes nothing rebinds
+the graph when — and only when — a second owner of the graph Arc exists (`strong_count > 1` or
+any live `Weak`), i.e. a callback kept a handle. Skipping it would let that handle alias
+actor-owned state BETWEEN turns, where
+mutations arrive with no classification at all. When nothing escaped, the fence is O(1) and the
+turn pays no deep clone. Pinned by
+`escaped_execute_read_graph_arc_is_detached_from_actor_owner` and
+`execute_read_without_an_escaped_arc_does_not_rebind_the_graph`.
+
+**Durable sidecars are NOT witnessed, and that is the sharp edge.** The witness watches graph
+structure and session generations only. A verb that writes the antibody store, the trust
+ledger, daemon state or the document cache moves neither, so its durability must come from one
+of two declared routes: a mutating classification (published on the acked turn), or a persist
+choke point (`SessionState::persist`, `persist_daemon_*`, `persist_boot_memory`, or
+`note_durable_sidecar_drift`) that enters the staged-persist debounce. Verbs on the debounce
+route are durable within a WINDOW, not on their turn. `READ_ONLY_DENIED_TOOLS` was designed as
+the read-only-attach gate and became, by accident, the durability classifier; the accident is
+now explicit and mechanically guarded — `session.rs` freezes the sidecar inventory, cross-checks
+every declared writer against the live classification, and SCANS the shipped source so a new
+writer that forgets to declare a route fails loudly (`no_undeclared_durable_sidecar_writer_exists`).
+
+**Honest limit of the debounce.** Nothing about plasticity drift raises a persist request, so
+pure learning drift does NOT advance the debounce counter. On a read-only workload with the
+daemon stopped and auto-ingest idle, no turn requests a persist, the counter never moves, and a
+`kill -9` loses the whole session's learning. Plasticity drift is flushed only when something
+ELSE publishes: a classified mutation, a debounce that some other request drove to term, or the
+graceful shutdown checkpoint — which is single-attempt and refusable
+(`project_brains.rs::shutdown`), so it is not a guarantee.
 
 ---
 

--- a/docs/UML-ORGANISM.md
+++ b/docs/UML-ORGANISM.md
@@ -272,6 +272,17 @@ now explicit and mechanically guarded — `session.rs` freezes the sidecar inven
 every declared writer against the live classification, and SCANS the shipped source so a new
 writer that forgets to declare a route fails loudly (`no_undeclared_durable_sidecar_writer_exists`).
 
+**The drift note is guarded at the source, not at runtime.** `note_durable_sidecar_drift` is a
+deliberate NO-OP outside an actor stage, so a caller reached from boot, a CLI path or a spawned
+task would lose its drift in silence. That cannot be caught by asserting a live stage inside the
+function: a pre-actor session is indistinguishable from a bare one, and the bare shape is
+legitimate and tested — with a stage open `persist` records intent instead of writing, which is
+exactly the unstaged path the auto-ingest and document tests reload from disk to prove. A second
+scan (`no_undeclared_staged_drift_caller_exists`) instead requires every shipped caller of the
+note to appear in `DURABLE_SIDECAR_WRITERS`, whose rows must name a real routed verb. A
+boot/CLI/spawn caller has no verb to name, so it fails when it is WRITTEN rather than only if
+some test happens to run it.
+
 **The guard is closed on one side only.** Sidecar writers are scanned; INTERIOR COLUMN writers
 are a hand-kept list. The strict fence admits interior drift (tags, provenance, edge weights) by
 design — the transport path runs on every call and a content-sensitive fence would have to

--- a/docs/UML-ORGANISM.md
+++ b/docs/UML-ORGANISM.md
@@ -272,6 +272,18 @@ now explicit and mechanically guarded — `session.rs` freezes the sidecar inven
 every declared writer against the live classification, and SCANS the shipped source so a new
 writer that forgets to declare a route fails loudly (`no_undeclared_durable_sidecar_writer_exists`).
 
+**The guard is closed on one side only.** Sidecar writers are scanned; INTERIOR COLUMN writers
+are a hand-kept list. The strict fence admits interior drift (tags, provenance, edge weights) by
+design — the transport path runs on every call and a content-sensitive fence would have to
+serialize, which is the tasteless digest this change removed. The compensating control is
+classification, and the five known column-writing verbs (`xray_retag`, `xray_paint`,
+`xray_apply`, `ingest`, `apply`) are pinned as a literal list, not discovered by scan. So a NEW
+verb that writes a tag and forgets its classification passes the fence as an honest read and
+seals in the next checkpoint without a receipt — the residue of that decision, named here so it
+is a known limit rather than a surprise. Closing this side means either a column-writer scan of
+the same shape as the sidecar one, or a witness that covers interior columns; both are their own
+verdict.
+
 **Honest limit of the debounce.** Nothing about plasticity drift raises a persist request, so
 pure learning drift does NOT advance the debounce counter. On a read-only workload with the
 daemon stopped and auto-ingest idle, no turn requests a persist, the counter never moves, and a

--- a/docs/UML-ORGANISM.md
+++ b/docs/UML-ORGANISM.md
@@ -223,6 +223,24 @@ record each have a separate domain-signature boundary; REST/MCP transport sessio
 correlation labels and never authenticate the subject. Software fixture backends are test-only and
 rejected by the production loader; h4nd is a caller of the ceremony, never an authority or key source.
 
+## Who pays the checkpoint (brain actor, corrected 2026-07-25)
+
+An actor turn publishes a durable checkpoint when it is a CLASSIFIED MUTATION, when the
+`DurableWitnessV1` (`Graph::generation` + the session generations, all O(1)) moved — i.e.
+STRUCTURE changed under a read-classified callback — or when the staged-persist debounce
+elapses. Every read routinely dirties small regenerable sidecars: plasticity Step 8 rewrites
+edge weights on every graph verb, and the freshness-by-traffic daemon tick persists daemon
+state on nearly every dispatch. That drift is DEFERRED — drained by the debounce
+(`SessionState::auto_persist_interval`, 50), by the next real mutation, or by the shutdown
+checkpoint — never by turning each read into a durable whole-brain write.
+
+The actor used to decide this by byte-digest of the serialized state, which serialized
+~100 MB twice per call (once BEFORE argument validation) and published a ~113 MB checkpoint
+per read. Measured in the lab (17,415 nodes): 87% of a warm `seek` turn was that machinery,
+and 10 reads produced 10 checkpoints (+1.1 GB of store). The strict `read_snapshot` (which
+refuses ANY change) keeps the byte-digest. (`m1nd-mcp/src/brain_runtime.rs`; the perf hunt
+of 2026-07-25 — seek 5.0s → 0.40s warm, mutation checkpoints unchanged at exactly one.)
+
 ---
 
 *Atlas curated at the design seat from twenty-two code-grounded system maps; diagrams mechanically drafted from those maps and parser-validated; every load-bearing claim carries a file:line hint in its sheet. Where a sheet and reality diverge tomorrow, trust reality, re-anchor the sheet, and log a letter.*

--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -47,7 +47,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use parking_lot::{Condvar, Mutex as ParkingMutex, MutexGuard as ParkingMutexGuard};
 use serde::de::DeserializeOwned;
@@ -1144,6 +1144,7 @@ impl BrainActorHandle {
             pending_rollback: None,
             active_checkpoint_stage: None,
             managed_working_paths,
+            deferred_read_publishes: 0,
             admission: Arc::clone(&admission),
             health: actor_health,
         };
@@ -1638,6 +1639,36 @@ type StateTransactionStartV1 = (
     (u64, u64, u64),
 );
 
+/// O(1) witness of the durable shape of a session, captured on both sides of an
+/// actor callback.
+///
+/// The actor used to answer "did this turn change durable state?" by serializing
+/// the whole world twice and comparing SHA-256 digests. That question is asked on
+/// every call, and the answer for a graph verb is *always yes* — plasticity Step 8
+/// legitimately rewrites edge weights on every read (`query()` calls
+/// `plasticity.update(graph, ..)`), so the byte digest always moves and every read
+/// published a full durable checkpoint of the entire state.
+///
+/// These counters answer the question the fence actually cares about — did the
+/// callback change the *structure* of the graph, or the session's own generations —
+/// without touching a byte of the state. `Graph::generation` is incremented by
+/// `add_node`/`add_edge` and deliberately NOT by plasticity (FM-PL-006 only asserts
+/// it), which is exactly the read-versus-mutation line.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct DurableWitnessV1 {
+    session_generations: (u64, u64, u64),
+    graph_generation: m1nd_core::types::Generation,
+}
+
+impl DurableWitnessV1 {
+    fn capture(state: &SessionState) -> Self {
+        Self {
+            session_generations: session_generation_tuple(state),
+            graph_generation: state.graph.read().generation,
+        }
+    }
+}
+
 struct BrainActorState {
     brain_id: String,
     session: Arc<BrainSessionCell>,
@@ -1663,6 +1694,9 @@ struct BrainActorState {
     /// candidate attempted by this actor. Post-CURRENT projection removes
     /// entries absent from the new explicit PRESENT/ABSENT inventory.
     managed_working_paths: BTreeSet<String>,
+    /// Read turns whose only durable claim was a routine staged persist, held
+    /// back from publishing a whole-brain checkpoint. Reset by every checkpoint.
+    deferred_read_publishes: u32,
     admission: Arc<Mutex<BrainActorAdmission>>,
     health: Arc<Mutex<BrainRuntimeHealthState>>,
 }
@@ -2153,10 +2187,15 @@ impl BrainActorState {
         }
     }
 
-    fn begin_state_transaction(
+    /// Open the candidate-first persistence stage and arm the authoritative
+    /// rollback packet. Deliberately serializes NOTHING: a turn that ends up
+    /// changing no durable state must not pay for a preimage nobody reads, and an
+    /// argument-validation refusal must not pay for one before it is even allowed
+    /// to refuse.
+    fn begin_state_stage(
         &mut self,
         state: &mut SessionState,
-    ) -> Result<StateTransactionStartV1, BrainRuntimeError> {
+    ) -> Result<CheckpointPersistenceStage, BrainRuntimeError> {
         let stage = state
             .begin_checkpoint_staging()
             .map_err(|error| BrainRuntimeError::Persistence(error.to_string()))?;
@@ -2166,6 +2205,14 @@ impl BrainActorState {
             version_before: self.version,
             stage: Some(stage.clone()),
         });
+        Ok(stage)
+    }
+
+    fn begin_state_transaction(
+        &mut self,
+        state: &mut SessionState,
+    ) -> Result<StateTransactionStartV1, BrainRuntimeError> {
+        let stage = self.begin_state_stage(state)?;
         match Self::candidate_with_panic_fence(state, &stage) {
             Ok(candidate) => {
                 let generations = session_generation_tuple(state);
@@ -2184,12 +2231,14 @@ impl BrainActorState {
         }
     }
 
-    fn post_callback_candidate(
-        state: &mut SessionState,
-        stage: &CheckpointPersistenceStage,
-    ) -> Result<SessionCheckpointCandidate, BrainRuntimeError> {
-        match catch_unwind(AssertUnwindSafe(|| state.rebind_detached_graph())) {
-            Ok(Ok(())) => Self::candidate_with_panic_fence(state, stage),
+    /// Replace the live graph with a deep clone so an Arc a callback escaped can
+    /// no longer reach actor-owned state. This is the isolation fence, kept
+    /// independent of candidate serialization so a turn can pay for the fence
+    /// without paying to serialize the whole brain.
+    fn rebind_after_callback(state: &mut SessionState) -> Result<(), BrainRuntimeError> {
+        let rebind_started = Instant::now();
+        let result = match catch_unwind(AssertUnwindSafe(|| state.rebind_detached_graph())) {
+            Ok(Ok(())) => Ok(()),
             Ok(Err(error)) => Err(BrainRuntimeError::Persistence(format!(
                 "could not detach actor-owned graph after callback: {error}"
             ))),
@@ -2197,20 +2246,37 @@ impl BrainActorState {
                 "detaching actor-owned graph panicked: {}",
                 panic_payload_detail(payload)
             ))),
-        }
+        };
+        log_brain_stage("  rebind_detached_graph", rebind_started);
+        result
+    }
+
+    fn post_callback_candidate(
+        state: &mut SessionState,
+        stage: &CheckpointPersistenceStage,
+    ) -> Result<SessionCheckpointCandidate, BrainRuntimeError> {
+        Self::rebind_after_callback(state)?;
+        let candidate_started = Instant::now();
+        let candidate = Self::candidate_with_panic_fence(state, stage);
+        log_brain_stage("  checkpoint_candidate", candidate_started);
+        candidate
     }
 
     // Each argument is independent rollback evidence captured at a different
     // boundary; keeping them explicit avoids an ambiguously partially-filled packet.
     #[allow(clippy::too_many_arguments)]
+    /// Close out a refused callback by restoring the authoritative preimage.
+    ///
+    /// A refused command is always rolled back, including in-memory state the
+    /// checkpoint inventory does not carry (`queries_processed` and friends):
+    /// reloading from the authoritative checkpoint is the only mechanism that
+    /// reverts those, and `domain_error_is_returned_exactly_and_partial_mutation_is_rolled_back`
+    /// holds that line.
     fn callback_failure(
         &mut self,
         mut state: CheckedOutSession,
         version_before: BrainVersionV1,
         stage: CheckpointPersistenceStage,
-        baseline_digest: &str,
-        baseline_generations: (u64, u64, u64),
-        force_rollback: bool,
         callback_error: BrainRuntimeError,
     ) -> BrainRuntimeError {
         let post = match Self::post_callback_candidate(&mut state, &stage) {
@@ -2226,25 +2292,6 @@ impl BrainActorState {
                 return self.rollback_callback_state(state, version_before, stage, callback_error);
             }
         };
-        if !force_rollback
-            && post.state_digest == baseline_digest
-            && session_generation_tuple(&state) == baseline_generations
-            && !post.persist_requested
-        {
-            return match Self::finish_stage_with_panic_fence(&mut state, stage) {
-                Ok(_) => {
-                    self.clear_rollback_packet();
-                    callback_error
-                }
-                Err(close_error) => self.quarantine_failed_state(
-                    state,
-                    version_before,
-                    BrainRuntimeError::Persistence(format!(
-                        "{callback_error}; unchanged callback stage could not close: {close_error}"
-                    )),
-                ),
-            };
-        }
 
         self.managed_working_paths
             .extend(post.files.iter().map(|file| file.relative_path.clone()));
@@ -2314,71 +2361,45 @@ impl BrainActorState {
         let mut state = session.checkout()?;
         self.refresh_external_generation(&state);
         let version_before = self.version;
-        let (stage, baseline, baseline_generations) = match self.begin_state_transaction(&mut state)
-        {
-            Ok(transaction) => transaction,
+        let stage = match self.begin_state_stage(&mut state) {
+            Ok(stage) => stage,
             Err(error) => {
                 return Err(self.quarantine_failed_state(state, version_before, error));
             }
         };
+        let baseline_witness = DurableWitnessV1::capture(&state);
         let value = match catch_unwind(AssertUnwindSafe(|| read(&state))) {
             Ok(Ok(value)) => value,
             Ok(Err(failure)) => {
                 let error = BrainRuntimeError::SnapshotRead(failure);
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
             Err(payload) => {
                 let error = BrainRuntimeError::Worker(format!(
                     "read snapshot callback panicked: {}",
                     panic_payload_detail(payload)
                 ));
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
         };
-        let post = match Self::post_callback_candidate(&mut state, &stage) {
-            Ok(candidate) => candidate,
-            Err(error) => {
-                return Err(self.rollback_callback_state(
-                    state,
-                    version_before,
-                    stage,
-                    BrainRuntimeError::Worker(format!(
-                        "read snapshot callback produced an invalid actor-owned state: {error}"
-                    )),
-                ));
-            }
-        };
-        if post.state_digest != baseline.state_digest
-            || session_generation_tuple(&state) != baseline_generations
-        {
+        // This runs on EVERY transport call (brain resolution asks the actor
+        // whether the bound brain covers the caller root), so it must not
+        // serialize the world to answer. The byte digest it used to compare was
+        // also unsound here: `rebind_detached_graph` rebuilds `edge_plasticity`
+        // from the current weights, so once a graph verb had drifted a weight the
+        // postimage could never match the preimage and an honest read was refused
+        // as a mutation attempt.
+        if DurableWitnessV1::capture(&state) != baseline_witness {
             let error = BrainRuntimeError::Worker(
                 "read snapshot callback attempted to mutate actor-owned durable state".to_string(),
             );
-            return Err(self.callback_failure(
-                state,
-                version_before,
-                stage,
-                &baseline.state_digest,
-                baseline_generations,
-                true,
-                error,
-            ));
+            return Err(self.callback_failure(state, version_before, stage, error));
+        }
+        // The mutation verdict is about what the CALLBACK did, so it is decided
+        // above, before this fence rebuilds the graph. Any Arc the callback
+        // escaped now points at a detached clone.
+        if let Err(error) = Self::rebind_after_callback(&mut state) {
+            return Err(self.rollback_callback_state(state, version_before, stage, error));
         }
         if let Err(error) = Self::finish_stage_with_panic_fence(&mut state, stage) {
             return Err(self.quarantine_failed_state(state, version_before, error));
@@ -2412,17 +2433,21 @@ impl BrainActorState {
         if mutating {
             self.ensure_writable()?;
         }
+        let turn_started = Instant::now();
         let session = Arc::clone(&self.session);
         let mut state = session.checkout()?;
         self.refresh_external_generation(&state);
         let version_before = self.version;
-        let (stage, baseline, baseline_generations) = match self.begin_state_transaction(&mut state)
-        {
-            Ok(transaction) => transaction,
+        let staged = Instant::now();
+        let stage = match self.begin_state_stage(&mut state) {
+            Ok(stage) => stage,
             Err(error) => {
                 return Err(self.quarantine_failed_state(state, version_before, error));
             }
         };
+        let baseline_witness = DurableWitnessV1::capture(&state);
+        log_brain_stage("begin_state_transaction", staged);
+        let callback_started = Instant::now();
         let output = match catch_unwind(AssertUnwindSafe(|| execute(&mut state))) {
             Ok(Ok(output)) => output,
             Ok(Err(failure)) => {
@@ -2431,9 +2456,6 @@ impl BrainActorState {
                     state,
                     version_before,
                     stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
                     error,
                 ));
             }
@@ -2446,62 +2468,88 @@ impl BrainActorState {
                     state,
                     version_before,
                     stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
                     error,
                 ));
             }
         };
+
+        log_brain_stage("callback", callback_started);
 
         if let Err(error) = self.ensure_checkpointable() {
             return Err(self.callback_failure(
                 state,
                 version_before,
                 stage,
-                &baseline.state_digest,
-                baseline_generations,
-                true,
                 error,
             ));
         }
 
-        let candidate = match Self::post_callback_candidate(&mut state, &stage) {
-            Ok(candidate) => candidate,
+        // Decide whether this turn owes a durable checkpoint BEFORE serializing
+        // anything, and separate the two reasons it might.
+        //
+        // A read turn routinely dirties small, regenerable sidecars: plasticity
+        // Step 8 rewrites edge weights on every graph verb, and the
+        // freshness-by-traffic daemon tick calls `persist_daemon_state` on nearly
+        // every dispatch. Publishing a whole-brain checkpoint for that is what made
+        // a warm `seek` cost seconds and grew the store by ~113 MB per read. That
+        // drift is DEFERRED here and flushed by the debounce below, by the next
+        // real mutation, or by the shutdown checkpoint.
+        //
+        // A structural change is different: if a callback classified read-only
+        // actually moved the graph or a session generation, it is sealed on the
+        // spot, exactly as before.
+        let publish_requested = match state.checkpoint_publish_required(&stage) {
+            Ok(requested) => requested,
             Err(error) => {
-                return Err(self.rollback_callback_state(
+                return Err(self.quarantine_failed_state(
                     state,
                     version_before,
-                    stage,
-                    BrainRuntimeError::Worker(format!(
-                        "brain command callback produced an invalid actor-owned state: {error}"
-                    )),
+                    BrainRuntimeError::Persistence(error.to_string()),
                 ));
             }
         };
-        let durable_state_changed = candidate.state_digest != baseline.state_digest
-            || session_generation_tuple(&state) != baseline_generations
-            || candidate.persist_requested;
+        let witness_moved = DurableWitnessV1::capture(&state) != baseline_witness;
+        let debounce = state.auto_persist_interval.max(1);
+        let debounce_due = publish_requested && self.deferred_read_publishes + 1 >= debounce;
+        let durable_state_changed = mutating || witness_moved || debounce_due;
+        if publish_requested && !durable_state_changed {
+            self.deferred_read_publishes = self.deferred_read_publishes.saturating_add(1);
+        }
         if durable_state_changed && !mutating {
             if let Err(error) = self.ensure_writable() {
                 return Err(self.callback_failure(
                     state,
                     version_before,
                     stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
                     error,
                 ));
             }
         }
-        if mutating || durable_state_changed {
+        if durable_state_changed {
+            let post_started = Instant::now();
+            let candidate = match Self::post_callback_candidate(&mut state, &stage) {
+                Ok(candidate) => candidate,
+                Err(error) => {
+                    return Err(self.rollback_callback_state(
+                        state,
+                        version_before,
+                        stage,
+                        BrainRuntimeError::Worker(format!(
+                            "brain command callback produced an invalid actor-owned state: {error}"
+                        )),
+                    ));
+                }
+            };
+            log_brain_stage("post_callback_candidate", post_started);
             let observed = session_generation(&state);
             self.version.generation = self.version.generation.saturating_add(1).max(observed);
             self.version.revision = self.version.revision.saturating_add(1);
+            let checkpoint_started = Instant::now();
             if let Err(error) = self.checkpoint_with_panic_fence(&mut state, stage, candidate) {
                 return Err(self.quarantine_failed_state(state, version_before, error));
             }
+            log_brain_stage("checkpoint", checkpoint_started);
+            self.deferred_read_publishes = 0;
             self.clear_persistence_failure();
         } else {
             if let Err(error) = Self::finish_stage_with_panic_fence(&mut state, stage) {
@@ -2509,6 +2557,14 @@ impl BrainActorState {
             }
             self.clear_rollback_packet();
         }
+        log_brain_stage(
+            if mutating {
+                "TURN(mutating)"
+            } else {
+                "TURN(read)"
+            },
+            turn_started,
+        );
 
         Ok(output)
     }
@@ -2536,42 +2592,18 @@ impl BrainActorState {
             Ok(Ok(output)) => output,
             Ok(Err(failure)) => {
                 let error = BrainRuntimeError::SnapshotRead(failure);
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
             Err(payload) => {
                 let error = BrainRuntimeError::Worker(format!(
                     "checkpointed brain callback panicked: {}",
                     panic_payload_detail(payload)
                 ));
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
         };
         if let Err(error) = self.ensure_checkpointable() {
-            return Err(self.callback_failure(
-                state,
-                version_before,
-                stage,
-                &baseline.state_digest,
-                baseline_generations,
-                true,
-                error,
-            ));
+            return Err(self.callback_failure(state, version_before, stage, error));
         }
         let candidate = match Self::post_callback_candidate(&mut state, &stage) {
             Ok(candidate) => candidate,
@@ -2631,42 +2663,18 @@ impl BrainActorState {
             Ok(Ok(success)) => success,
             Ok(Err(failure)) => {
                 let error = BrainRuntimeError::SnapshotRead(failure);
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
             Err(payload) => {
                 let error = BrainRuntimeError::Worker(format!(
                     "brain proposal apply callback panicked: {}",
                     panic_payload_detail(payload)
                 ));
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    &baseline.state_digest,
-                    baseline_generations,
-                    true,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
         };
         if let Err(error) = self.ensure_checkpointable() {
-            return Err(self.callback_failure(
-                state,
-                version_before,
-                stage,
-                &baseline.state_digest,
-                baseline_generations,
-                true,
-                error,
-            ));
+            return Err(self.callback_failure(state, version_before, stage, error));
         }
         let candidate = match Self::post_callback_candidate(&mut state, &stage) {
             Ok(candidate) => candidate,
@@ -3929,6 +3937,29 @@ fn validate_relative_path(value: &str) -> Result<(), BrainRuntimeError> {
         )));
     }
     Ok(())
+}
+
+/// Per-stage actor timing, opt-in via `M1ND_BRAIN_TIMING=1`. The read path is
+/// the hottest code in the product and its cost is invisible from the outside:
+/// one HTTP duration cannot tell a slow retrieval from a slow checkpoint. This
+/// prints the actual boundary each turn crossed, so a regression is diagnosed
+/// with numbers instead of a guess.
+fn brain_timing_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("M1ND_BRAIN_TIMING")
+            .map(|value| !matches!(value.as_str(), "" | "0" | "false"))
+            .unwrap_or(false)
+    })
+}
+
+fn log_brain_stage(stage: &str, started: Instant) {
+    if brain_timing_enabled() {
+        eprintln!(
+            "[m1nd brain-timing] {stage} {:.3}s",
+            started.elapsed().as_secs_f64()
+        );
+    }
 }
 
 fn session_generation(state: &SessionState) -> u64 {
@@ -5561,6 +5592,113 @@ mod tests {
                 Ok::<(), RuntimeJobFailure>(())
             })
             .expect("later valid mutation remains admitted");
+        actor.stop().expect("stop actor");
+    }
+
+    /// A graph verb legitimately rewrites non-structural node/edge numbers on
+    /// every call (plasticity Step 8). That drift must NOT publish a durable
+    /// checkpoint of the whole brain: before this was fixed, every single warm
+    /// `seek` wrote a ~113 MB checkpoint, the store grew by one checkpoint per
+    /// read, and a warm read cost seconds instead of milliseconds.
+    #[test]
+    fn execute_false_with_only_non_structural_drift_publishes_no_checkpoint() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "read-drift-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        actor
+            .try_execute(true, |state| {
+                add_consistent_test_node(state, "drift::anchor", "drift anchor")
+            })
+            .expect("seed a node to drift");
+        let baseline = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("CURRENT after the seeding mutation");
+
+        for _ in 0..3 {
+            actor
+                .try_execute(false, |state| {
+                    let mut graph = state.graph.write();
+                    let previous = graph.nodes.change_frequency[0].get();
+                    graph.nodes.change_frequency[0] =
+                        m1nd_core::types::FiniteF32::new(previous + 0.125);
+                    Ok::<(), RuntimeJobFailure>(())
+                })
+                .expect("non-structural drift on a read turn is admitted");
+        }
+
+        assert_eq!(
+            actor.health_snapshot().current_checkpoint_id.as_deref(),
+            Some(baseline.as_str()),
+            "read turns must not publish a durable checkpoint for learning drift"
+        );
+        actor.stop().expect("stop actor");
+    }
+
+    /// The freshness-by-traffic daemon tick calls `persist_daemon_state` on
+    /// nearly every dispatch, and under the old rule that single staged flag
+    /// published a whole-brain checkpoint per read. The request is now debounced:
+    /// it accumulates and flushes once, not once per call.
+    #[test]
+    fn read_turn_staged_persist_is_debounced_instead_of_published_per_call() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "read-debounce-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        let debounce = actor
+            .try_read_snapshot(|state| Ok::<u32, RuntimeJobFailure>(state.auto_persist_interval))
+            .expect("read the debounce interval")
+            .value
+            .max(1);
+        let baseline = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("baseline CURRENT");
+
+        for turn in 1..debounce {
+            actor
+                .try_execute(false, |state| {
+                    state
+                        .persist_daemon_state()
+                        .map_err(|error| RuntimeJobFailure::new("daemon_state", error.to_string()))
+                })
+                .expect("read turn with a routine staged persist");
+            assert_eq!(
+                actor.health_snapshot().current_checkpoint_id.as_deref(),
+                Some(baseline.as_str()),
+                "turn {turn} must not publish its own checkpoint"
+            );
+        }
+
+        actor
+            .try_execute(false, |state| {
+                state
+                    .persist_daemon_state()
+                    .map_err(|error| RuntimeJobFailure::new("daemon_state", error.to_string()))
+            })
+            .expect("the debounced turn");
+        assert_ne!(
+            actor.health_snapshot().current_checkpoint_id.as_deref(),
+            Some(baseline.as_str()),
+            "the accumulated drift must be flushed once the debounce is due"
+        );
         actor.stop().expect("stop actor");
     }
 

--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -1633,12 +1633,6 @@ struct PendingAuthoritativeRollback {
     stage: Option<CheckpointPersistenceStage>,
 }
 
-type StateTransactionStartV1 = (
-    CheckpointPersistenceStage,
-    SessionCheckpointCandidate,
-    (u64, u64, u64),
-);
-
 /// O(1) witness of the durable shape of a session, captured on both sides of an
 /// actor callback.
 ///
@@ -2208,16 +2202,21 @@ impl BrainActorState {
         Ok(stage)
     }
 
-    fn begin_state_transaction(
+    /// Open the stage AND serialize the current state as the candidate.
+    ///
+    /// Only [`Self::checkpoint_current`] needs this: it publishes the state as it
+    /// stands, with no callback in between, so its candidate IS the preimage.
+    /// Every callback path uses [`Self::begin_state_stage`] and serializes once,
+    /// at the end, if it turns out to owe a checkpoint — the pre-callback
+    /// "baseline" those paths used to take was read by nothing and cost a full
+    /// ~100 MB serialization of the brain per call.
+    fn begin_state_stage_with_candidate(
         &mut self,
         state: &mut SessionState,
-    ) -> Result<StateTransactionStartV1, BrainRuntimeError> {
+    ) -> Result<(CheckpointPersistenceStage, SessionCheckpointCandidate), BrainRuntimeError> {
         let stage = self.begin_state_stage(state)?;
         match Self::candidate_with_panic_fence(state, &stage) {
-            Ok(candidate) => {
-                let generations = session_generation_tuple(state);
-                Ok((stage, candidate, generations))
-            }
+            Ok(candidate) => Ok((stage, candidate)),
             Err(error) => match Self::finish_stage_with_panic_fence(state, stage) {
                 Ok(_) => {
                     self.active_checkpoint_stage = None;
@@ -2249,6 +2248,27 @@ impl BrainActorState {
         };
         log_brain_stage("  rebind_detached_graph", rebind_started);
         result
+    }
+
+    /// The isolation fence for turns that do NOT serialize a candidate.
+    ///
+    /// A deep clone of a 17k-node graph is not free, and a turn that publishes
+    /// nothing is exactly the turn that must stay cheap. The fence is only needed
+    /// when a second owner of the graph Arc actually exists: the only way a
+    /// callback can reach actor-owned state after its boundary is by having kept
+    /// an `Arc` clone alive, and that is precisely what `strong_count > 1` reports.
+    /// If both counts are at their floor the actor is the sole owner, nothing can
+    /// alias it, and rebinding would only burn a full encode/decode. Racing the
+    /// check is not possible in the direction that matters: a new strong clone can
+    /// only be minted FROM a live strong clone or by upgrading a `Weak`, and both
+    /// are counted here BEFORE the stage closes.
+    fn rebind_if_callback_escaped_graph(state: &mut SessionState) -> Result<(), BrainRuntimeError> {
+        // `weak_count` matters as much as `strong_count`: a callback that escaped a
+        // `Weak` can upgrade it after this check and reach the live graph again.
+        if Arc::strong_count(&state.graph) > 1 || Arc::weak_count(&state.graph) > 0 {
+            return Self::rebind_after_callback(state);
+        }
+        Ok(())
     }
 
     fn post_callback_candidate(
@@ -2452,40 +2472,25 @@ impl BrainActorState {
             Ok(Ok(output)) => output,
             Ok(Err(failure)) => {
                 let error = BrainRuntimeError::SnapshotRead(failure);
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
             Err(payload) => {
                 let error = BrainRuntimeError::Worker(format!(
                     "brain command callback panicked: {}",
                     panic_payload_detail(payload)
                 ));
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
         };
 
         log_brain_stage("callback", callback_started);
 
         if let Err(error) = self.ensure_checkpointable() {
-            return Err(self.callback_failure(
-                state,
-                version_before,
-                stage,
-                error,
-            ));
+            return Err(self.callback_failure(state, version_before, stage, error));
         }
 
         // Decide whether this turn owes a durable checkpoint BEFORE serializing
-        // anything, and separate the two reasons it might.
+        // anything, keeping the reasons it might apart.
         //
         // A read turn routinely dirties small, regenerable sidecars: plasticity
         // Step 8 rewrites edge weights on every graph verb, and the
@@ -2495,9 +2500,16 @@ impl BrainActorState {
         // drift is DEFERRED here and flushed by the debounce below, by the next
         // real mutation, or by the shutdown checkpoint.
         //
-        // A structural change is different: if a callback classified read-only
-        // actually moved the graph or a session generation, it is sealed on the
-        // spot, exactly as before.
+        // Everything else is sealed on the spot: a classified mutation, a
+        // structural change under a callback that claimed to be read-only, and a
+        // queued post-CURRENT effect.
+        //
+        // NOTE what this decision CANNOT see. The witness watches graph structure
+        // and the session generations; a verb that writes only a durable SIDECAR
+        // (the antibody store, the trust ledger, daemon state, the document cache)
+        // moves neither. Such a verb owes its durability to being classified a
+        // mutation or to reaching a persist choke point — `session.rs` holds that
+        // invariant mechanically (`no_undeclared_durable_sidecar_writer_exists`).
         let publish_requested = match state.checkpoint_publish_required(&stage) {
             Ok(requested) => requested,
             Err(error) => {
@@ -2508,21 +2520,26 @@ impl BrainActorState {
                 ));
             }
         };
+        // A queued post-CURRENT effect is the one persist reason that CANNOT be
+        // deferred: `finish_checkpoint_staging` refuses to close a stage while one
+        // is outstanding, and only the checkpoint path drains it. Folding it into
+        // the deferrable `publish_requested` would send the turn down the debounce
+        // branch and straight into `quarantine_failed_state`. No PRODUCTION verb
+        // reaches it today — `persist`, the only verb that queues one, is a
+        // classified mutation — but ANY read-classified callback that queues an
+        // effect does, and the quarantine is one line of code away.
+        let staged_effect_pending = state.has_unresolved_staged_effects();
         let witness_moved = DurableWitnessV1::capture(&state) != baseline_witness;
         let debounce = state.auto_persist_interval.max(1);
         let debounce_due = publish_requested && self.deferred_read_publishes + 1 >= debounce;
-        let durable_state_changed = mutating || witness_moved || debounce_due;
+        let durable_state_changed =
+            mutating || witness_moved || staged_effect_pending || debounce_due;
         if publish_requested && !durable_state_changed {
             self.deferred_read_publishes = self.deferred_read_publishes.saturating_add(1);
         }
         if durable_state_changed && !mutating {
             if let Err(error) = self.ensure_writable() {
-                return Err(self.callback_failure(
-                    state,
-                    version_before,
-                    stage,
-                    error,
-                ));
+                return Err(self.callback_failure(state, version_before, stage, error));
             }
         }
         if durable_state_changed {
@@ -2552,6 +2569,17 @@ impl BrainActorState {
             self.deferred_read_publishes = 0;
             self.clear_persistence_failure();
         } else {
+            // The deferring branch still owes the ISOLATION FENCE. Before this
+            // branch existed every turn rebound through `post_callback_candidate`;
+            // skipping it here would let an Arc a callback escaped keep aliasing
+            // the live actor graph BETWEEN turns — mutations through it would land
+            // with no classification at all, and would race the next turn's
+            // witness capture. `rebind_if_callback_escaped_graph` keeps the fence
+            // and keeps the turn O(1) when nothing escaped, which is every honest
+            // read.
+            if let Err(error) = Self::rebind_if_callback_escaped_graph(&mut state) {
+                return Err(self.rollback_callback_state(state, version_before, stage, error));
+            }
             if let Err(error) = Self::finish_stage_with_panic_fence(&mut state, stage) {
                 return Err(self.quarantine_failed_state(state, version_before, error));
             }
@@ -2581,9 +2609,8 @@ impl BrainActorState {
         let mut state = session.checkout()?;
         self.refresh_external_generation(&state);
         let version_before = self.version;
-        let (stage, baseline, baseline_generations) = match self.begin_state_transaction(&mut state)
-        {
-            Ok(transaction) => transaction,
+        let stage = match self.begin_state_stage(&mut state) {
+            Ok(stage) => stage,
             Err(error) => {
                 return Err(self.quarantine_failed_state(state, version_before, error));
             }
@@ -2651,9 +2678,8 @@ impl BrainActorState {
                 observed: self.version,
             });
         }
-        let (stage, baseline, baseline_generations) = match self.begin_state_transaction(&mut state)
-        {
-            Ok(transaction) => transaction,
+        let stage = match self.begin_state_stage(&mut state) {
+            Ok(stage) => stage,
             Err(error) => {
                 return Err(self.quarantine_failed_state(state, version_before, error));
             }
@@ -2706,13 +2732,12 @@ impl BrainActorState {
         let mut state = session.checkout()?;
         self.refresh_external_generation(&state);
         let version_before = self.version;
-        let (stage, candidate, _baseline_generations) =
-            match self.begin_state_transaction(&mut state) {
-                Ok(transaction) => transaction,
-                Err(error) => {
-                    return Err(self.quarantine_failed_state(state, version_before, error));
-                }
-            };
+        let (stage, candidate) = match self.begin_state_stage_with_candidate(&mut state) {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                return Err(self.quarantine_failed_state(state, version_before, error));
+            }
+        };
         match self.checkpoint_with_panic_fence(&mut state, stage, candidate) {
             Ok(ack) => {
                 self.clear_persistence_failure();
@@ -5699,6 +5724,382 @@ mod tests {
             Some(baseline.as_str()),
             "the accumulated drift must be flushed once the debounce is due"
         );
+        actor.stop().expect("stop actor");
+    }
+
+    fn single_node_antibody_pattern() -> crate::protocol::layers::AntibodyPatternInput {
+        crate::protocol::layers::AntibodyPatternInput {
+            nodes: vec![crate::protocol::layers::PatternNodeInput {
+                role: "suspect".into(),
+                node_type: Some("concept".into()),
+                required_tags: Vec::new(),
+                label_contains: Some("antibody-durability".into()),
+            }],
+            edges: Vec::new(),
+            negative_edges: Vec::new(),
+        }
+    }
+
+    /// `antibody_create` writes the `antibodies` checkpoint sidecar and NOTHING
+    /// else: no node, no edge, no session generation. The actor's O(1) witness is
+    /// blind to that by construction, so the verb's durability rests entirely on
+    /// being classified a mutation. Before that classification existed the ack said
+    /// "created" while the antibody lived only in memory — a `kill -9` lost it, or
+    /// resurrected one that had been deleted.
+    ///
+    /// The `mutating` flag here comes from the REAL classifier, not a literal, so
+    /// dropping `antibody_create` from `READ_ONLY_DENIED_TOOLS` fails this test.
+    #[test]
+    fn antibody_create_is_durable_on_the_turn_it_is_acked() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "antibody-durability-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        let baseline = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("baseline CURRENT");
+
+        let mutating = crate::server::read_only_denied(
+            "antibody_create",
+            &serde_json::json!({ "action": "create" }),
+        );
+        assert!(
+            mutating,
+            "antibody_create writes the antibodies sidecar, so the classifier must call it a mutation"
+        );
+        let created = actor
+            .try_execute(mutating, |state| {
+                crate::layer_handlers::handle_antibody_create(
+                    state,
+                    crate::protocol::layers::AntibodyCreateInput {
+                        agent_id: "durability-test".into(),
+                        action: "create".into(),
+                        antibody_id: None,
+                        name: Some("durability probe".into()),
+                        description: Some("pins sidecar durability".into()),
+                        severity: "warning".into(),
+                        pattern: Some(single_node_antibody_pattern()),
+                    },
+                )
+                .map_err(|error| RuntimeJobFailure::new("antibody_create", error.to_string()))
+            })
+            .expect("antibody_create is admitted");
+        assert!(
+            created.get("antibody_id").is_some(),
+            "the ack claims creation"
+        );
+
+        let after_create = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("CURRENT after antibody_create");
+        assert_ne!(
+            after_create, baseline,
+            "an acked antibody_create must be sealed in a durable checkpoint on its own turn"
+        );
+        let durable = actor
+            .try_read_snapshot(|state| Ok::<usize, RuntimeJobFailure>(state.antibodies.len()))
+            .expect("read the antibody store")
+            .value;
+        assert_eq!(durable, 1, "the created antibody is in the live store");
+        actor.stop().expect("stop actor");
+    }
+
+    /// The isolation fence must survive the branch that publishes nothing. Every
+    /// turn used to rebind through `post_callback_candidate`; the deferring read
+    /// branch skips that, so without an explicit fence an `Arc` a callback escaped
+    /// keeps aliasing the live actor graph BETWEEN turns. This is the execute-read
+    /// mirror of `escaped_read_graph_arc_is_detached_from_actor_owner`.
+    #[test]
+    fn escaped_execute_read_graph_arc_is_detached_from_actor_owner() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "execute-arc-detach-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        let escaped: Arc<Mutex<Option<m1nd_core::graph::SharedGraph>>> = Arc::new(Mutex::new(None));
+        let escaped_from_callback = Arc::clone(&escaped);
+        actor
+            .try_execute(false, move |state| {
+                *lock_unpoisoned(&escaped_from_callback) = Some(Arc::clone(&state.graph));
+                Ok::<(), RuntimeJobFailure>(())
+            })
+            .expect("a read turn that escapes its graph Arc is admitted");
+        let old_graph = lock_unpoisoned(&escaped)
+            .take()
+            .expect("callback escaped its old graph Arc");
+        old_graph
+            .write()
+            .add_node(
+                "execute-escaped-arc::sentinel",
+                "execute escaped arc sentinel",
+                m1nd_core::types::NodeType::Concept,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("mutate detached old graph");
+        let visible = actor
+            .try_read_snapshot(|state| {
+                Ok::<bool, RuntimeJobFailure>(
+                    state
+                        .graph
+                        .read()
+                        .resolve_id("execute-escaped-arc::sentinel")
+                        .is_some(),
+                )
+            })
+            .expect("read live actor graph")
+            .value;
+        assert!(
+            !visible,
+            "an Arc escaped by a read-classified execute still mutated actor-owned graph"
+        );
+        actor.stop().expect("stop actor");
+    }
+
+    /// The fence above must stay O(1) on the hot path. An honest read leaves no
+    /// second owner of the graph Arc, so nothing can alias the actor and the deep
+    /// clone is skipped entirely — the graph the next turn sees is the SAME
+    /// allocation. This is what keeps the deferring branch cheap; if it starts
+    /// rebinding unconditionally, a warm read pays a full encode/decode again.
+    #[test]
+    fn execute_read_without_an_escaped_arc_does_not_rebind_the_graph() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "execute-no-rebind-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        fn graph_identity(state: &SessionState) -> usize {
+            Arc::as_ptr(&state.graph) as usize
+        }
+        let before = actor
+            .try_execute(false, |state| {
+                Ok::<usize, RuntimeJobFailure>(graph_identity(state))
+            })
+            .expect("first read turn");
+        let after = actor
+            .try_execute(false, |state| {
+                Ok::<usize, RuntimeJobFailure>(graph_identity(state))
+            })
+            .expect("second read turn");
+        assert_eq!(
+            before, after,
+            "a read turn with no escaped Arc must not pay for a graph deep clone"
+        );
+        actor.stop().expect("stop actor");
+    }
+
+    /// A queued post-CURRENT effect is the one persist reason that cannot be
+    /// deferred: only the checkpoint path drains it and `finish_checkpoint_staging`
+    /// refuses to close a stage while one is outstanding. Folding it into the
+    /// deferrable persist request would send the turn into `quarantine_failed_state`
+    /// instead of publishing.
+    #[test]
+    fn execute_read_with_an_unresolved_staged_effect_publishes_instead_of_deferring() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "staged-effect-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        let baseline = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("baseline CURRENT");
+
+        actor
+            .try_execute(false, |state| {
+                state
+                    .persist_binary_snapshot()
+                    .map(|_| ())
+                    .map_err(|error| {
+                        RuntimeJobFailure::new("persist_binary_snapshot", error.to_string())
+                    })
+            })
+            .expect("a read turn that queues a derived export must still close cleanly");
+
+        assert_ne!(
+            actor.health_snapshot().current_checkpoint_id.as_deref(),
+            Some(baseline.as_str()),
+            "a queued post-CURRENT effect must publish on its own turn, never wait for the debounce"
+        );
+        assert!(
+            !actor.health_snapshot().degraded_persistence,
+            "the turn must publish, not quarantine"
+        );
+        actor.stop().expect("stop actor");
+    }
+
+    /// The perf contract of this change, held as an assertion instead of a lab
+    /// note: a long run of honest reads publishes NOTHING, and the mutation that
+    /// follows publishes EXACTLY ONE checkpoint.
+    #[test]
+    fn a_long_run_of_reads_publishes_nothing_and_one_mutation_publishes_exactly_one() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "read-volume-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        actor
+            .try_execute(true, |state| {
+                add_consistent_test_node(state, "volume::anchor", "volume anchor")
+            })
+            .expect("seed the brain");
+        let baseline = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("CURRENT after the seeding mutation");
+
+        for _ in 0..70 {
+            actor
+                .try_execute(false, |state| {
+                    let mut graph = state.graph.write();
+                    let previous = graph.nodes.change_frequency[0].get();
+                    graph.nodes.change_frequency[0] =
+                        m1nd_core::types::FiniteF32::new(previous + 0.001);
+                    Ok::<(), RuntimeJobFailure>(())
+                })
+                .expect("warm read turn");
+        }
+        assert_eq!(
+            actor.health_snapshot().current_checkpoint_id.as_deref(),
+            Some(baseline.as_str()),
+            "70 reads must publish 0 checkpoints"
+        );
+
+        actor
+            .try_execute(true, |state| {
+                add_consistent_test_node(state, "volume::real", "a real mutation")
+            })
+            .expect("the real mutation");
+        let after = actor
+            .health_snapshot()
+            .current_checkpoint_id
+            .expect("CURRENT after the mutation");
+        assert_ne!(after, baseline, "a real mutation publishes");
+
+        for _ in 0..10 {
+            actor
+                .try_execute(false, |state| {
+                    Ok::<u64, RuntimeJobFailure>(state.graph.read().generation.0)
+                })
+                .expect("read after the mutation");
+        }
+        assert_eq!(
+            actor.health_snapshot().current_checkpoint_id.as_deref(),
+            Some(after.as_str()),
+            "the mutation published exactly one checkpoint and the reads after it published none"
+        );
+        actor.stop().expect("stop actor");
+    }
+
+    /// What the strict `read_snapshot` fence actually promises, pinned so the doc
+    /// cannot drift from it again.
+    ///
+    /// It refuses a change to durable STRUCTURE (nodes, edges) and to the session
+    /// generations. It does NOT refuse an interior column write — a tag, a
+    /// provenance row, an edge weight — because answering that question needs a
+    /// content digest, and this path runs on EVERY transport call. The digest it
+    /// used to take was also unsound here: plasticity legitimately rewrites weights
+    /// on every read, so honest reads were refused as mutation attempts.
+    ///
+    /// The compensating control is classification, not the witness: every verb that
+    /// writes a graph tag or provenance column (`xray_retag`, `xray_paint`,
+    /// `xray_apply`, `ingest`, `apply`) is in `READ_ONLY_DENIED_TOOLS`, so its
+    /// durability comes from being a declared mutation.
+    #[test]
+    fn read_snapshot_fence_refuses_structure_and_admits_interior_column_drift() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            "read-fence-contract-brain".to_string(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor");
+        actor
+            .try_execute(true, |state| {
+                add_consistent_test_node(state, "fence::anchor", "fence anchor")
+            })
+            .expect("seed a node to tag");
+
+        let refused = actor
+            .try_read_snapshot(|state| {
+                state
+                    .graph
+                    .write()
+                    .add_node(
+                        "fence::structural",
+                        "structural change",
+                        m1nd_core::types::NodeType::Concept,
+                        &[],
+                        0.0,
+                        0.0,
+                    )
+                    .map(|_| ())
+                    .map_err(|error| RuntimeJobFailure::new("add_node", error.to_string()))
+            })
+            .expect_err("a structural change under the strict fence is refused");
+        assert_eq!(refused.code(), "brain_worker_failed");
+
+        let tagged = actor
+            .try_read_snapshot(|state| {
+                let mut graph = state.graph.write();
+                let node = graph.resolve_id("fence::anchor").ok_or_else(|| {
+                    RuntimeJobFailure::new("resolve", "anchor missing".to_string())
+                })?;
+                Ok::<usize, RuntimeJobFailure>(graph.add_node_tags(node, &["fence:interior"]))
+            })
+            .expect("an interior column write is ADMITTED — the fence is structural, by design");
+        assert_eq!(tagged.value, 1);
+
+        for verb in ["xray_retag", "xray_paint", "xray_apply", "ingest", "apply"] {
+            assert!(
+                crate::server::read_only_denied(verb, &serde_json::json!({})),
+                "{verb} writes graph columns the witness cannot see, so classification must carry its durability"
+            );
+        }
         actor.stop().expect("stop actor");
     }
 

--- a/m1nd-mcp/src/layer_handlers.rs
+++ b/m1nd-mcp/src/layer_handlers.rs
@@ -8562,6 +8562,16 @@ pub fn handle_antibody_scan(
         g.generation.0
     };
 
+    // A scan is a READ verb, but `scan_antibodies` writes back into the antibody
+    // store: match counters, `last_match_at`, and the auto-disable of an antibody
+    // that timed out. That is durable sidecar drift with no classification behind
+    // it, so it joins the staged-persist debounce rather than forcing a
+    // whole-brain checkpoint per scan. Declared window: up to
+    // `auto_persist_interval` deferring turns, then flushed — see PATHOS.
+    if !result.matches.is_empty() || !result.auto_disabled_antibodies.is_empty() {
+        state.note_durable_sidecar_drift();
+    }
+
     Ok(serde_json::json!({
         "matches": result.matches,
         "antibodies_checked": result.antibodies_checked,
@@ -8610,7 +8620,14 @@ pub fn handle_antibody_create(
 
     state.track_agent(&input.agent_id);
 
-    match input.action.as_str() {
+    // Every arm below rewrites `state.antibodies`, the in-memory owner of the
+    // `antibodies` checkpoint sidecar. The actor decides durability from an O(1)
+    // witness of graph structure + session generations, so a sidecar-only write is
+    // invisible to it: without the persist request here (and without
+    // `antibody_create` sitting in `READ_ONLY_DENIED_TOOLS`) the ack would say
+    // "created" while the antibody lived only in memory — a `kill -9` would lose it,
+    // or resurrect one that was deleted.
+    let acted: M1ndResult<serde_json::Value> = match input.action.as_str() {
         "disable" => {
             let ab_id =
                 input
@@ -8787,7 +8804,15 @@ pub fn handle_antibody_create(
                 "warning": warning
             }))
         }
-    }
+    };
+    let outcome = acted?;
+    // Deliberate durability through the actor-aware persistence choke point, the
+    // same stance `handle_calibrate_envelope` takes for `calibration_table`. Under
+    // an actor stage this raises the staged-persist flag; the mutating
+    // classification is what turns it into a checkpoint on this very turn. A
+    // refused action returns above and persists nothing.
+    state.persist()?;
+    Ok(outcome)
 }
 
 /// Handle m1nd.flow_simulate — concurrent flow simulation for race detection.

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -4093,6 +4093,15 @@ const READ_ONLY_DENIED_TOOLS: &[&str] = &[
     // promote writes a medulla copy + a witness stamp to disk (MEDULLA M6).
     "promote",
     "learn",
+    // antibody_create is the antibody store's writer: create/delete/enable/disable
+    // all rewrite `state.antibodies`, which the checkpoint inventory carries as the
+    // `antibodies` sidecar. A read-only attach must refuse it on its own merits,
+    // and the classification is ALSO what makes the write durable the turn it is
+    // acked — the actor's O(1) witness watches graph structure and session
+    // generations, so a sidecar-only write is invisible to it. `antibody_scan` and
+    // `antibody_list` stay ABSENT: scan's counter drift joins the staged-persist
+    // debounce instead (see `handle_antibody_scan`), list is a pure read.
+    "antibody_create",
     "daemon_start",
     "auto_ingest_start",
     // xray_retag commits tag mutations to graph_path on disk, so a read-only
@@ -7473,8 +7482,14 @@ impl McpServer {
         self.actor_execute(false, move |state| {
             if !state.read_only {
                 if let Some(dropped) = dropped {
-                    state.daemon_state.watch_events_dropped =
-                        state.daemon_state.watch_events_dropped.max(dropped);
+                    let previous = state.daemon_state.watch_events_dropped;
+                    state.daemon_state.watch_events_dropped = previous.max(dropped);
+                    if state.daemon_state.watch_events_dropped != previous {
+                        // `daemon_state` is a durable checkpoint file and this turn
+                        // is read-classified, so the actor's witness cannot see the
+                        // write. Join the staged-persist debounce.
+                        state.note_durable_sidecar_drift();
+                    }
                 }
             }
             Ok(DaemonLoopView {

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -2624,6 +2624,24 @@ impl SessionState {
         true
     }
 
+    /// Declare that a durable sidecar owner changed in a way only the checkpoint
+    /// inventory carries, without demanding an immediate whole-brain write.
+    ///
+    /// This is the floor for a verb that is NOT classified a mutation but still
+    /// dirties durable state (an antibody scan bumping match counters, a document
+    /// verb refreshing its cache row). Without it the drift is invisible: the
+    /// actor's witness only sees graph structure and session generations, no
+    /// persist flag is raised, the staged-persist debounce never advances, and
+    /// the change survives only until the process dies. With it the turn joins the
+    /// debounce and is flushed by it, by the next real mutation, or by the
+    /// shutdown checkpoint.
+    ///
+    /// Outside an actor stage this is deliberately a no-op — those owners have no
+    /// eager writer of their own anyway, exactly as before.
+    pub(crate) fn note_durable_sidecar_drift(&self) {
+        let _ = self.note_staged_persist();
+    }
+
     /// Serialize the fixed candidate inventory directly from live in-memory
     /// owners. Kept stage-agnostic so strict recovery can produce the same state
     /// witness without manufacturing a persistence capability.
@@ -4380,6 +4398,519 @@ mod tests {
                 },
             }
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // The durability class guard
+    //
+    // The brain actor decides "does this turn owe a durable checkpoint?" from an
+    // O(1) witness of GRAPH STRUCTURE plus the session generations, from the
+    // command's read/write CLASSIFICATION, and from the staged-persist debounce.
+    // A verb that writes a durable SIDECAR — the antibody store, the trust
+    // ledger, daemon state, the document cache — moves none of those on its own.
+    // If it is neither classified a mutation nor routed through a persist choke
+    // point, its write is durable to nobody: the ack returns, the debounce
+    // counter never advances, and `kill -9` loses it (or resurrects what it
+    // deleted). That is exactly how `antibody_create` slipped through.
+    //
+    // `READ_ONLY_DENIED_TOOLS` was designed as the read-only-attach gate and
+    // became, by accident, the durability classifier. These three tests make the
+    // accident explicit and make the next omission fail LOUD instead of silent:
+    //   1. the sidecar inventory is frozen — a new durable file forces a verdict;
+    //   2. every declared writer's route agrees with the live classification;
+    //   3. the source is scanned for writers, so a NEW one that forgets the
+    //      table fails here instead of shipping a silent durability hole.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// In-memory owners on `SessionState` whose ONLY durability channel is an
+    /// explicit persist request or a mutating classification.
+    ///
+    /// Deliberately excluded, each because it already has a channel of its own:
+    /// `graph` (watched by `DurableWitnessV1`), `plasticity` and `temporal`
+    /// (regenerable learning drift, excluded by design — FM-PL-006),
+    /// `auto_ingest` (owns `checkpoint_persist_requested`), and the boot-KV
+    /// inventory (rebuilt from `boot_memory`, which IS listed).
+    const DURABLE_SIDECAR_OWNERS: &[&str] = &[
+        "antibodies",
+        "tremor_registry",
+        "trust_ledger",
+        "calibration_table",
+        "daemon_alerts",
+        "daemon_state",
+        "ingest_roots",
+        "document_cache",
+        "document_artifacts",
+        "boot_memory",
+    ];
+
+    /// The fixed logical names a checkpoint candidate carries for a brain with no
+    /// migrated boot-KV lights and no ingested documents. Adding a durable file
+    /// without classifying its writers fails `durable_sidecar_inventory_is_frozen`.
+    const FROZEN_CHECKPOINT_INVENTORY: &[&str] = &[
+        "antibodies",
+        "auto_ingest_state",
+        "binary_graph_snapshot",
+        "boot_config",
+        "boot_kv_migration",
+        "boot_kv_migration_journal",
+        "boot_memory_state",
+        "calibration_state",
+        "daemon_alerts",
+        "daemon_state",
+        "document_artifact_inventory",
+        "document_cache_index",
+        "embeddings_cache",
+        "graph_snapshot",
+        "ingest_roots",
+        "plasticity_state",
+        "temporal_state",
+        "tremor_state",
+        "trust_state",
+    ];
+
+    /// How a durable-sidecar writer earns its place in a checkpoint.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    enum DurabilityRoute {
+        /// The verb is in `READ_ONLY_DENIED_TOOLS`: the actor classifies the turn
+        /// a mutation and publishes on that very turn.
+        ClassifiedMutation,
+        /// The write reaches a persist choke point (`persist`,
+        /// `persist_daemon_state`, `persist_daemon_alerts`, `persist_boot_memory`,
+        /// `AutoIngestState::persist`, or `note_durable_sidecar_drift`), so it
+        /// joins the staged-persist debounce. Declared loss window: up to
+        /// `auto_persist_interval` deferring turns before the flush.
+        StagedPersistDebounce,
+        /// Not reached through verb dispatch at all — an owner-side loop whose
+        /// writes ride the enclosing tick's own persist.
+        OwnerLoop,
+    }
+
+    /// Every function outside `#[cfg(test)]` that writes a durable sidecar owner,
+    /// with the verb it serves and how that verb earns durability. Kept in lockstep
+    /// with the source by `no_undeclared_durable_sidecar_writer_exists`.
+    const DURABLE_SIDECAR_WRITERS: &[(&str, &str, DurabilityRoute)] = &[
+        // ── classified mutations: published on the turn they are acked ──
+        (
+            "start",
+            "auto_ingest_start",
+            DurabilityRoute::ClassifiedMutation,
+        ),
+        (
+            "handle_daemon_start",
+            "daemon_start",
+            DurabilityRoute::ClassifiedMutation,
+        ),
+        (
+            "handle_antibody_create",
+            "antibody_create",
+            DurabilityRoute::ClassifiedMutation,
+        ),
+        (
+            "finalize_ingest_with_inventory",
+            "ingest",
+            DurabilityRoute::ClassifiedMutation,
+        ),
+        ("handle_learn", "learn", DurabilityRoute::ClassifiedMutation),
+        // ── debounced: durable within the staged-persist window, not on the turn ──
+        (
+            "tick",
+            "auto_ingest_tick",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_boot_memory",
+            "boot_memory",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_alerts_ack",
+            "alerts_ack",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_daemon_stop",
+            "daemon_stop",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_daemon_tick",
+            "daemon_tick",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "run_auto_reconcile",
+            "daemon_tick",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "settle_auto_reconcile_outcome",
+            "daemon_tick",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_antibody_scan",
+            "antibody_scan",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_calibrate_envelope",
+            "calibrate_envelope",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "handle_calibrate_predict",
+            "calibrate_predict",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "document_bindings",
+            "document_bindings",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "document_drift",
+            "document_drift",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "refresh_document_cache_entry",
+            "document_resolve",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "ensure_cache_root_in_ingest_roots",
+            "document_resolve",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        (
+            "daemon_loop_view",
+            "daemon_status",
+            DurabilityRoute::StagedPersistDebounce,
+        ),
+        // ── owner-side loops: no verb, covered by the enclosing tick's persist ──
+        (
+            "persist_daemon_alerts_from_insights",
+            "(apply/apply_batch/daemon_tick)",
+            DurabilityRoute::OwnerLoop,
+        ),
+        (
+            "refresh_daemon_watcher",
+            "(owner daemon loop)",
+            DurabilityRoute::OwnerLoop,
+        ),
+        (
+            "run_daemon_tick",
+            "(owner daemon loop)",
+            DurabilityRoute::OwnerLoop,
+        ),
+        ("serve", "(owner daemon loop)", DurabilityRoute::OwnerLoop),
+    ];
+
+    /// Drop every `#[cfg(test)]` item so the scan only sees shipped code.
+    fn strip_cfg_test_items(lines: &[&str]) -> Vec<String> {
+        let mut kept = Vec::new();
+        let mut index = 0usize;
+        while index < lines.len() {
+            let trimmed = lines[index].trim_start();
+            if trimmed.starts_with("#[cfg(test)]") || trimmed.starts_with("#[cfg(all(test") {
+                let mut item = index + 1;
+                while item < lines.len()
+                    && (lines[item].trim().is_empty() || lines[item].trim_start().starts_with("#["))
+                {
+                    item += 1;
+                }
+                if item >= lines.len() {
+                    break;
+                }
+                if lines[item].contains('{') {
+                    let mut depth = 0i32;
+                    let mut cursor = item;
+                    while cursor < lines.len() {
+                        depth += lines[cursor].matches('{').count() as i32;
+                        depth -= lines[cursor].matches('}').count() as i32;
+                        cursor += 1;
+                        if depth <= 0 {
+                            break;
+                        }
+                    }
+                    index = cursor;
+                } else {
+                    index = item + 1;
+                }
+                continue;
+            }
+            kept.push(lines[index].to_string());
+            index += 1;
+        }
+        kept
+    }
+
+    fn collapse_for_scan(text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut pending_space = false;
+        for ch in text.chars() {
+            if ch.is_whitespace() {
+                pending_space = !out.is_empty();
+                continue;
+            }
+            if pending_space && ch != '.' && !out.ends_with('.') {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.push(ch);
+        }
+        out
+    }
+
+    fn declared_fn_name(line: &str) -> Option<String> {
+        let mut rest = line.trim_start();
+        for prefix in ["pub(crate) ", "pub(super) ", "pub(in crate) ", "pub "] {
+            if let Some(stripped) = rest.strip_prefix(prefix) {
+                rest = stripped.trim_start();
+            }
+        }
+        for prefix in ["const ", "async ", "unsafe ", "extern \"C\" "] {
+            if let Some(stripped) = rest.strip_prefix(prefix) {
+                rest = stripped.trim_start();
+            }
+        }
+        let rest = rest.strip_prefix("fn ")?;
+        let name = rest
+            .split(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .next()?;
+        (!name.is_empty()).then(|| name.to_string())
+    }
+
+    /// True when the text right after `state.<owner>` is a write: an assignment
+    /// into the owner (or a field of it), or a mutating call anywhere along its
+    /// field chain. The chain walk stops at the first call, so
+    /// `state.ingest_roots.iter().map(..).collect()` is a read and
+    /// `state.document_cache.entries.get_mut(..)` is a write.
+    fn is_write_after_owner(rest_of_window: &str, rest_of_line: &str) -> bool {
+        const MUTATORS: &[&str] = &[
+            "push",
+            "retain",
+            "insert",
+            "remove",
+            "clear",
+            "pop",
+            "extend",
+            "truncate",
+            "drain",
+            "sort",
+            "sort_by",
+            "sort_unstable",
+            "iter_mut",
+            "get_mut",
+            "values_mut",
+            "entry",
+            "append",
+            "dedup",
+            "set",
+            "record_defect",
+            "record_false_alarm",
+            "record_partial",
+            "record_observation",
+        ];
+        let mut cursor = rest_of_window;
+        while let Some(after_dot) = cursor.strip_prefix('.') {
+            let end = after_dot
+                .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .unwrap_or(after_dot.len());
+            if end == 0 {
+                break;
+            }
+            let (name, tail) = after_dot.split_at(end);
+            if tail.starts_with('(') {
+                return MUTATORS.contains(&name);
+            }
+            cursor = tail;
+        }
+        // Assignment is single-line by construction: `owner.field = value;`.
+        let statement = rest_of_line.split(';').next().unwrap_or("");
+        let bytes = statement.as_bytes();
+        for (index, byte) in bytes.iter().enumerate() {
+            if *byte != b'=' {
+                continue;
+            }
+            if matches!(bytes.get(index + 1), Some(b'=') | Some(b'>')) {
+                continue;
+            }
+            if index > 0 && matches!(bytes[index - 1], b'=' | b'!' | b'<' | b'>') {
+                continue;
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Scan the shipped source for functions that write a durable sidecar owner.
+    /// `session.rs` and `brain_runtime.rs` are excluded: they ARE the durability
+    /// machinery, not consumers of it.
+    fn scan_durable_sidecar_writers() -> BTreeMap<String, String> {
+        // Recursive on purpose: real handler code lives in `surgical_handlers/`,
+        // `external_mutation_service/`, `protocol/` and `perspective/` too, and a
+        // scan that only saw the top level would miss a writer placed there.
+        fn collect_rust_sources(directory: &Path, found: &mut Vec<PathBuf>) {
+            let mut entries = std::fs::read_dir(directory)
+                .expect("read crate source directory")
+                .map(|entry| entry.expect("source dir entry").path())
+                .collect::<Vec<_>>();
+            entries.sort();
+            for path in entries {
+                if path.is_dir() {
+                    // `internal_tests` is `#[cfg(test)]` at every declaration site.
+                    if path
+                        .file_name()
+                        .is_some_and(|name| name == "internal_tests")
+                    {
+                        continue;
+                    }
+                    collect_rust_sources(&path, found);
+                } else if path.extension().is_some_and(|ext| ext == "rs") {
+                    found.push(path);
+                }
+            }
+        }
+
+        let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut writers = BTreeMap::new();
+        let mut files = Vec::new();
+        collect_rust_sources(&source_root, &mut files);
+        for path in files {
+            let name = path
+                .strip_prefix(&source_root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .to_string();
+            // These two ARE the durability machinery, not consumers of it.
+            if name == "session.rs" || name == "brain_runtime.rs" {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("read crate source file");
+            let raw = text.lines().collect::<Vec<_>>();
+            let lines = strip_cfg_test_items(&raw);
+            let mut current = String::from("<file scope>");
+            for index in 0..lines.len() {
+                if let Some(declared) = declared_fn_name(&lines[index]) {
+                    current = declared;
+                }
+                let window_end = (index + 3).min(lines.len());
+                let window = collapse_for_scan(&lines[index..window_end].join(" "));
+                let line = collapse_for_scan(&lines[index]);
+                for owner in DURABLE_SIDECAR_OWNERS {
+                    let key = format!("state.{owner}");
+                    let borrowed = format!("&mut {key}");
+                    let hit = window.contains(&borrowed)
+                        || window.find(&key).is_some_and(|at| {
+                            let after_window = &window[at + key.len()..];
+                            let after_line = line
+                                .find(&key)
+                                .map(|at| &line[at + key.len()..])
+                                .unwrap_or("");
+                            is_write_after_owner(after_window, after_line)
+                        });
+                    if hit {
+                        writers
+                            .entry(current.clone())
+                            .or_insert_with(|| format!("{name}:{owner}"));
+                        break;
+                    }
+                }
+            }
+        }
+        writers
+    }
+
+    /// A new durable file in the checkpoint inventory must not slip in without a
+    /// verdict on who writes it and how that write becomes durable.
+    #[test]
+    fn durable_sidecar_inventory_is_frozen() {
+        let (_temp, _runtime, _registry, state) = strict_recovery_fixture();
+        let mut observed = state
+            .checkpoint_candidate_files()
+            .expect("candidate inventory")
+            .into_iter()
+            .map(|file| file.logical_name)
+            .collect::<Vec<_>>();
+        observed.sort();
+        let expected = FROZEN_CHECKPOINT_INVENTORY
+            .iter()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            observed, expected,
+            "the durable checkpoint inventory changed. Classify every writer of the \
+             new/renamed file in DURABLE_SIDECAR_WRITERS (and add its owner field to \
+             DURABLE_SIDECAR_OWNERS) before updating this list"
+        );
+    }
+
+    /// The declared route of every writer must agree with the live read-only
+    /// classification. Dropping a verb from `READ_ONLY_DENIED_TOOLS` — or adding
+    /// one and forgetting the table — fails here.
+    #[test]
+    fn durable_writer_routes_agree_with_the_read_only_classification() {
+        for (function, verb, route) in DURABLE_SIDECAR_WRITERS {
+            match route {
+                DurabilityRoute::ClassifiedMutation => {
+                    assert!(
+                        crate::server::read_only_denied(verb, &serde_json::json!({})),
+                        "{function} writes a durable sidecar and is declared a classified \
+                         mutation, but '{verb}' is not in READ_ONLY_DENIED_TOOLS — the write \
+                         would be durable to nobody"
+                    );
+                }
+                DurabilityRoute::StagedPersistDebounce => {
+                    assert!(
+                        !crate::server::read_only_denied(verb, &serde_json::json!({})),
+                        "{function} is declared debounced but '{verb}' is now a classified \
+                         mutation — promote the row to ClassifiedMutation"
+                    );
+                    assert!(
+                        crate::action_routes::MCP_TOOL_ROUTE_NAMES.contains(verb),
+                        "{function} names '{verb}', which is not a routed MCP tool"
+                    );
+                }
+                DurabilityRoute::OwnerLoop => {}
+            }
+        }
+    }
+
+    /// The guard that closes the class: the shipped source is scanned for durable
+    /// sidecar writers, and every one must be declared. A new verb that writes a
+    /// sidecar and forgets its durability fails HERE, loudly, instead of shipping
+    /// an ack that promises a persistence nobody performed.
+    #[test]
+    fn no_undeclared_durable_sidecar_writer_exists() {
+        let observed = scan_durable_sidecar_writers();
+        let declared = DURABLE_SIDECAR_WRITERS
+            .iter()
+            .map(|(function, ..)| *function)
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let undeclared = observed
+            .iter()
+            .filter(|(function, _)| !declared.contains(function.as_str()))
+            .map(|(function, evidence)| format!("{function} ({evidence})"))
+            .collect::<Vec<_>>();
+        assert!(
+            undeclared.is_empty(),
+            "these functions write a durable checkpoint sidecar but are absent from \
+             DURABLE_SIDECAR_WRITERS: {undeclared:?}. Decide how each write becomes durable \
+             — a mutating classification in READ_ONLY_DENIED_TOOLS, or a persist choke point \
+             (`state.persist()` / `note_durable_sidecar_drift()`) — then declare it"
+        );
+
+        let stale = declared
+            .iter()
+            .filter(|function| !observed.contains_key(**function))
+            .collect::<Vec<_>>();
+        assert!(
+            stale.is_empty(),
+            "these DURABLE_SIDECAR_WRITERS rows no longer write a durable sidecar: {stale:?}. \
+             Remove them so the table keeps meaning something"
+        );
     }
 
     fn strict_recovery_fixture() -> (tempfile::TempDir, PathBuf, PathBuf, SessionState) {

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -2639,19 +2639,34 @@ impl SessionState {
     /// Outside an actor stage this is deliberately a no-op — those owners have no
     /// eager writer of their own anyway, exactly as before.
     ///
-    /// CALLERS MUST RUN INSIDE AN ACTOR STAGE. Every caller today does (verb
-    /// handlers, and the pull-based `auto_ingest::tick`, which has no spawn of its
-    /// own), so the no-op never fires in production. But it is SILENT: a future
-    /// caller from boot, a CLI path, or a spawned task would lose its drift with
-    /// no alarm at all. The `debug_assert` makes that mistake loud in test and
-    /// debug builds without changing release behaviour, since the release no-op
-    /// is the historically correct fallback.
+    /// Every SHIPPED caller runs inside an actor stage. A `&mut SessionState` is
+    /// reachable only through `BrainSessionCell::checkout`, whose call sites are
+    /// the five actor turn primitives — `read_snapshot`, `execute`,
+    /// `execute_with_checkpoint_ack`, `commit`, `checkpoint_current` — each of
+    /// which opens the stage before the callback runs, plus actor startup, which
+    /// runs no verb. Every transport seam dispatches inside one of the five, and
+    /// so do the pull-based `auto_ingest::tick` and the owner daemon loop, whose
+    /// every branch is wrapped in `actor_execute`. The drift is therefore never
+    /// dropped in production. But it IS silent, and a future caller from boot, a
+    /// CLI path, or a spawned task would lose its drift with no alarm.
+    ///
+    /// That guard cannot live here as a runtime assert. A pre-actor session and a
+    /// session the actor simply has not staged yet are the SAME shape at this
+    /// level, and the unstaged shape is legitimate and tested: with a stage open
+    /// both `Self::persist` and `AutoIngestState::persist` record intent instead
+    /// of writing, so the tests that drive these handlers against a bare
+    /// `SessionState` and then reload from disk are exercising exactly the
+    /// unstaged fallback. Asserting a stage here fails those, and would say
+    /// nothing about the caller that actually escapes the actor.
+    ///
+    /// The guard is instead a source-level one, in the same registry that already
+    /// classifies durable writers: `no_undeclared_staged_drift_caller_exists`
+    /// requires every shipped caller of this function to be declared in
+    /// `DURABLE_SIDECAR_WRITERS`, and `durable_writer_routes_agree_with_the_read_only_classification`
+    /// requires that row to name a real routed verb. A boot/CLI/spawn caller has
+    /// no such verb, so it cannot be declared quietly — it fails at the moment it
+    /// is written, not only if some test happens to run it.
     pub(crate) fn note_durable_sidecar_drift(&self) {
-        debug_assert!(
-            self.persistence_stage.get().is_some(),
-            "note_durable_sidecar_drift called outside an actor stage: the drift is \
-             silently dropped. Route this writer through a staged actor turn."
-        );
         let _ = self.note_staged_persist();
     }
 
@@ -4757,35 +4772,35 @@ mod tests {
         false
     }
 
+    /// Recursive on purpose: real handler code lives in `surgical_handlers/`,
+    /// `external_mutation_service/`, `protocol/` and `perspective/` too, and a
+    /// scan that only saw the top level would miss a writer placed there.
+    fn collect_rust_sources(directory: &Path, found: &mut Vec<PathBuf>) {
+        let mut entries = std::fs::read_dir(directory)
+            .expect("read crate source directory")
+            .map(|entry| entry.expect("source dir entry").path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        for path in entries {
+            if path.is_dir() {
+                // `internal_tests` is `#[cfg(test)]` at every declaration site.
+                if path
+                    .file_name()
+                    .is_some_and(|name| name == "internal_tests")
+                {
+                    continue;
+                }
+                collect_rust_sources(&path, found);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                found.push(path);
+            }
+        }
+    }
+
     /// Scan the shipped source for functions that write a durable sidecar owner.
     /// `session.rs` and `brain_runtime.rs` are excluded: they ARE the durability
     /// machinery, not consumers of it.
     fn scan_durable_sidecar_writers() -> BTreeMap<String, String> {
-        // Recursive on purpose: real handler code lives in `surgical_handlers/`,
-        // `external_mutation_service/`, `protocol/` and `perspective/` too, and a
-        // scan that only saw the top level would miss a writer placed there.
-        fn collect_rust_sources(directory: &Path, found: &mut Vec<PathBuf>) {
-            let mut entries = std::fs::read_dir(directory)
-                .expect("read crate source directory")
-                .map(|entry| entry.expect("source dir entry").path())
-                .collect::<Vec<_>>();
-            entries.sort();
-            for path in entries {
-                if path.is_dir() {
-                    // `internal_tests` is `#[cfg(test)]` at every declaration site.
-                    if path
-                        .file_name()
-                        .is_some_and(|name| name == "internal_tests")
-                    {
-                        continue;
-                    }
-                    collect_rust_sources(&path, found);
-                } else if path.extension().is_some_and(|ext| ext == "rs") {
-                    found.push(path);
-                }
-            }
-        }
-
         let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut writers = BTreeMap::new();
         let mut files = Vec::new();
@@ -4932,6 +4947,88 @@ mod tests {
             stale.is_empty(),
             "these DURABLE_SIDECAR_WRITERS rows no longer write a durable sidecar: {stale:?}. \
              Remove them so the table keeps meaning something"
+        );
+    }
+
+    /// Scan the shipped source for functions that call `note_durable_sidecar_drift`.
+    /// Only `session.rs` is excluded — it DEFINES and documents the function, so
+    /// every mention there is machinery, not a caller.
+    fn scan_staged_drift_callers() -> BTreeMap<String, String> {
+        const DRIFT_CALL: &str = "note_durable_sidecar_drift(";
+
+        let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut callers = BTreeMap::new();
+        let mut files = Vec::new();
+        collect_rust_sources(&source_root, &mut files);
+        for path in files {
+            let name = path
+                .strip_prefix(&source_root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .to_string();
+            if name == "session.rs" {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("read crate source file");
+            let raw = text.lines().collect::<Vec<_>>();
+            let lines = strip_cfg_test_items(&raw);
+            let mut current = String::from("<file scope>");
+            for line in &lines {
+                if let Some(declared) = declared_fn_name(line) {
+                    current = declared;
+                }
+                if collapse_for_scan(line).contains(DRIFT_CALL) {
+                    // File only, like the sibling scan: `lines` is the cfg(test)-stripped
+                    // view, so its index is NOT the line number in the real file.
+                    callers
+                        .entry(current.clone())
+                        .or_insert_with(|| name.clone());
+                }
+            }
+        }
+        callers
+    }
+
+    /// The oracle for the drift note itself, and the reason it is not a runtime
+    /// assert inside `note_durable_sidecar_drift`.
+    ///
+    /// Outside an actor stage that function is a deliberate no-op, so a caller
+    /// reached from boot, a CLI path, or a spawned task would lose its drift in
+    /// silence. A stage check at the call site cannot catch that: a pre-actor
+    /// session is indistinguishable from a bare one, and the bare shape is
+    /// legitimate — the crate's own tests drive these handlers without an actor
+    /// precisely to exercise the unstaged direct-persist path.
+    ///
+    /// So the guard is here instead, and it is stronger: every shipped caller must
+    /// be declared in `DURABLE_SIDECAR_WRITERS`, which
+    /// `durable_writer_routes_agree_with_the_read_only_classification` forces to
+    /// name a real routed verb. A boot/CLI/spawn caller has no verb to name, so it
+    /// fails when it is WRITTEN rather than only if some test happens to run it.
+    #[test]
+    fn no_undeclared_staged_drift_caller_exists() {
+        let observed = scan_staged_drift_callers();
+        assert!(
+            !observed.is_empty(),
+            "the drift-caller scan found nothing — it has gone blind (renamed function \
+             or moved call shape), which would make this guard silently useless"
+        );
+
+        let declared = DURABLE_SIDECAR_WRITERS
+            .iter()
+            .map(|(function, ..)| *function)
+            .collect::<std::collections::BTreeSet<_>>();
+        let undeclared = observed
+            .iter()
+            .filter(|(function, _)| !declared.contains(function.as_str()))
+            .map(|(function, evidence)| format!("{function} ({evidence})"))
+            .collect::<Vec<_>>();
+        assert!(
+            undeclared.is_empty(),
+            "these functions note durable sidecar drift but are absent from \
+             DURABLE_SIDECAR_WRITERS: {undeclared:?}. The note is a NO-OP outside an actor \
+             stage, so declare the verb this runs under — if there is none, this caller is \
+             reached from boot, a CLI path, or a spawned task and its drift is lost: route it \
+             through a staged actor turn instead"
         );
     }
 

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -2926,6 +2926,37 @@ impl SessionState {
         })
     }
 
+    /// Cheap, stage-preserving answer to "must this transaction publish a
+    /// checkpoint?". It reports exactly the two persist flags
+    /// [`Self::checkpoint_candidate`] folds into `persist_requested`, plus any
+    /// queued post-CURRENT effect (which only the checkpoint path can drain),
+    /// WITHOUT serializing the ~100 MB candidate to find out.
+    ///
+    /// The read path asks this question on every single call. Answering it by
+    /// serializing graph + temporal + plasticity is what turned a warm `seek`
+    /// into seconds of work.
+    /// A derived post-CURRENT effect is queued and only the checkpoint path can
+    /// drain it. Unlike a routine persist request, this cannot be deferred: the
+    /// stage refuses to close while one is outstanding.
+    pub(crate) fn has_unresolved_staged_effects(&self) -> bool {
+        !self.staged_binary_snapshot_effects.is_empty()
+    }
+
+    pub(crate) fn checkpoint_publish_required(
+        &self,
+        stage: &CheckpointPersistenceStage,
+    ) -> M1ndResult<bool> {
+        self.verify_checkpoint_stage(stage)?;
+        if self.has_unresolved_staged_effects() {
+            return Ok(true);
+        }
+        let session_requested = self
+            .persistence_stage
+            .get()
+            .is_some_and(|active| active.persist_requested);
+        Ok(session_requested || self.auto_ingest.checkpoint_persist_requested(stage.id)?)
+    }
+
     /// Stage-free witness of the currently rebuilt authoritative in-memory
     /// working set. The brain actor compares this with the digest stored in the
     /// checkpoint working-set envelope after rollback/reconciliation. An active

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -2638,7 +2638,20 @@ impl SessionState {
     ///
     /// Outside an actor stage this is deliberately a no-op — those owners have no
     /// eager writer of their own anyway, exactly as before.
+    ///
+    /// CALLERS MUST RUN INSIDE AN ACTOR STAGE. Every caller today does (verb
+    /// handlers, and the pull-based `auto_ingest::tick`, which has no spawn of its
+    /// own), so the no-op never fires in production. But it is SILENT: a future
+    /// caller from boot, a CLI path, or a spawned task would lose its drift with
+    /// no alarm at all. The `debug_assert` makes that mistake loud in test and
+    /// debug builds without changing release behaviour, since the release no-op
+    /// is the historically correct fallback.
     pub(crate) fn note_durable_sidecar_drift(&self) {
+        debug_assert!(
+            self.persistence_stage.get().is_some(),
+            "note_durable_sidecar_drift called outside an actor stage: the drift is \
+             silently dropped. Route this writer through a staged actor turn."
+        );
         let _ = self.note_staged_persist();
     }
 
@@ -4881,6 +4894,15 @@ mod tests {
     /// sidecar writers, and every one must be declared. A new verb that writes a
     /// sidecar and forgets its durability fails HERE, loudly, instead of shipping
     /// an ack that promises a persistence nobody performed.
+    ///
+    /// HONEST LIMIT — this is a TEXTUAL heuristic, not semantic analysis. It sees
+    /// the direct `state.<owner>` write shape that every writer uses today (and
+    /// this crate has no `macro_rules!`, so nothing hides behind expansion). It
+    /// would NOT see a rebinding writer (`let s = &mut state; s.antibodies…`), a
+    /// write behind a differently-named helper, or anything outside
+    /// `m1nd-mcp/src`. None of those shapes exists today; if one appears, this
+    /// guard goes quiet rather than red. Do not read a green here as proof of
+    /// total coverage — read it as proof that the shape we do write is declared.
     #[test]
     fn no_undeclared_durable_sidecar_writer_exists() {
         let observed = scan_durable_sidecar_writers();

--- a/m1nd-mcp/src/universal_docs.rs
+++ b/m1nd-mcp/src/universal_docs.rs
@@ -147,6 +147,10 @@ pub fn ensure_cache_root_in_ingest_roots(state: &mut SessionState) {
     } else {
         state.ingest_roots.push(cache_root);
     }
+    // `ingest_roots` is a durable checkpoint file. Reordering or appending the
+    // cache root is routine, so it joins the staged-persist debounce rather than
+    // forcing a checkpoint of its own.
+    state.note_durable_sidecar_drift();
 }
 
 pub fn load_document_cache(runtime_root: &Path) -> DocumentCacheState {
@@ -1158,6 +1162,10 @@ fn refresh_document_cache_entry(state: &mut SessionState, source_path: &str) -> 
         entry.drift_summary = drift.summary;
         entry.last_binding_refresh_generation = state.graph_generation;
         entry.last_drift_refresh_generation = state.graph_generation;
+        // `document_cache` is the in-memory owner of the `document_cache_index`
+        // sidecar. The refresh is routine and regenerable, so it joins the
+        // staged-persist debounce instead of forcing a whole-brain checkpoint.
+        state.note_durable_sidecar_drift();
     }
     Ok(())
 }
@@ -1235,6 +1243,7 @@ pub fn document_bindings(
         cache_entry.last_binding_count = bindings.len();
         cache_entry.binding_preview = bindings.iter().take(8).cloned().collect();
         cache_entry.last_binding_refresh_generation = state.graph_generation;
+        state.note_durable_sidecar_drift();
     }
     serde_json::to_value(DocumentBindingsOutput {
         source_path,
@@ -1263,6 +1272,7 @@ pub fn document_drift(
         cache_entry.drift_summary = drift.summary.clone();
         cache_entry.last_binding_refresh_generation = state.graph_generation;
         cache_entry.last_drift_refresh_generation = state.graph_generation;
+        state.note_durable_sidecar_drift();
     }
     serde_json::to_value(drift).map_err(M1ndError::Serde)
 }


### PR DESCRIPTION
## The culprit, named with numbers

Instrumented actor-turn stages (`M1ND_BRAIN_TIMING=1`, new) on a copy of the real runtime (17,415 nodes / 70,384 edges), serve-warm:

| stage | time |
|---|---|
| `begin_state_transaction` (preimage — runs **before** argument validation) | 0.55s |
| `callback` (the actual retrieval) | 0.50s |
| `post_callback_candidate` | 0.73s |
| **`checkpoint` (durable publication)** | **2.1–4.1s** |

**87% of a warm `seek` was checkpoint machinery.** Independent confirmation: 10 successful reads → exactly **10 new checkpoints** (+1.1 GB of store, ~113 MB each).

Two causes, one disease — routine, regenerable side-effects forcing a durable whole-brain write:
1. `durable_state_changed` decided by SHA-256 digest of the serialized state (~100 MB, **twice per call**) — and plasticity Step 8 rewrites edge weights on every graph verb, so the digest always moved.
2. The freshness-by-traffic daemon tick persists daemon state on nearly every dispatch; that flag alone demanded a checkpoint (`#[track_caller]` probe pointing at the exact line).

Refuted on the way: per-call embed-cache re-verification (boot-only — 11 calls, zero extra passes).

## The fix

`DurableWitnessV1` = `Graph::generation` + the session generations — all O(1). `Graph::generation` is bumped by `add_node`/`add_edge` and deliberately **not** by plasticity (FM-PL-006): exactly the read/mutation line. A checkpoint publishes when the turn is a classified mutation, when the witness moved (structure changed under a read-classified callback), or when the staged-persist debounce elapses. The strict `read_snapshot` fence keeps the byte-digest.

## A/B (same machine, same brain)

| verb | before | after | 1.4.0 baseline |
|---|---|---|---|
| warm seek | 5.02s | **0.26–0.54s** (avg 0.40s over 60 rounds) | 0.12s |
| north | 5.18s | **0.88s** | 2.40s |
| 70 reads | 70 checkpoints | **0** | — |
| real mutation (`memorize`) | 1 checkpoint | **1 checkpoint** | — |

No degradation across rounds. `north` is now **faster than the 1.4.0 deployed owner**.

## Declared, not hidden

- **Invalid-argument `memorize` still refuses in ~6s** (target <1s). The shortcut tried broke `domain_error_is_returned_exactly_and_partial_mutation_is_rolled_back` — a partial in-memory mutation must be rolled back and disk-reload is today's only mechanism — so it was reverted. Cheap refusals need a session-state copy-on-write transaction design: declared debt, out of scope here.
- Two real bugs of the first attempt were found and fixed before this landed: an escaped-Arc fence in `read_snapshot`, and an unconditional rollback on refusal.
- Two out-of-scope findings filed as letters in the repo box: the boot builds the orchestrator twice (first pass re-embeds all ~17.4k vectors, `cache 0 reused`), and a family of clock-assert tests that cannot report honest green/red under load.
- The doctrine paragraph ("who pays the checkpoint") lives in `docs/UML-ORGANISM.md` — the living atlas. The first draft touched the **frozen** `docs/M1ND-10-UML.md`; that was reverted byte-exact (digest verified `d5bc2977…`) before this PR.

## Gates

`cargo fmt --check` green · `clippy --locked -p m1nd-mcp --all-targets -- -D warnings` green · `cargo test --locked -p m1nd-mcp --lib`: **1437 passed / 0 failed serial** (`--test-threads=1`). In parallel there are ~6 clock-sensitive flakes with a changing set — baseline HEAD already fails one of them in parallel; this fix makes reads ~20× faster so the suite stresses wall-clock asserts harder. Semantically green; the flaky family is filed in the box. Two new regression tests pin the contract: a read-only turn with only non-structural drift publishes no checkpoint, and staged persist debounces instead of publishing per call.

Groundwork by a session executor under the guardian's spec; verified, the frozen-contract violation corrected, rebased and landed by the maintainer loop. Unblocks the genesis binary swap (this was the last measured blocker).