### PR TITLE
ci: keep majors out of grouped dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,24 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+        # Majors get their own deliberate PR — see the note above the cargo group.
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    # Grouped bumps carry MINOR and PATCH only. A major inside a group has broken
+    # this repo four times in one week: bincode 3.0 (a published `compile_error!`),
+    # bincode 2.0 (API rewrite), the ecdsa/p256 family (crypto API break in
+    # m1nd-control), and typescript 7 (peer-rejected, npm ci impossible). One
+    # unmigratable crate takes the whole 33-crate group down and the other 32
+    # wanted bumps wait behind it. Majors still get their OWN PR from dependabot,
+    # where the migration is the point of the change rather than a passenger.
     groups:
       rust:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       # bincode 3.x is not a release: the published crate's lib.rs is a single
       # `compile_error!("https://xkcd.com/2347/")`, so any tree that resolves it
@@ -38,6 +48,8 @@ updates:
     groups:
       ui:
         patterns: ["*"]
+        # Majors get their own deliberate PR — see the note above the cargo group.
+        update-types: ["minor", "patch"]
     ignore:
       # TypeScript 7 is the native-port era: typescript-eslint 8.x refuses it as
       # a peer, so a grouped bump that carries it can never `npm ci` (proven on


### PR DESCRIPTION
## Four breaks in one week, one pattern

| what | how it broke the group |
|---|---|
| `bincode` 3.0.0 | the published crate is a single `compile_error!("https://xkcd.com/2347/")` — no tree that resolves it can build |
| `bincode` 2.0 | API rewrite against a codebase pinned to `1.3` |
| `ecdsa` / `p256` family | crypto API break in `m1nd-control` — `to_encoded_point` gone, `Array<u8, _>: LowerHex` unsatisfied |
| `typescript` 7 | peer-rejected by `typescript-eslint` 8.x — `npm ci` cannot install the tree |

Each time, **one unmigratable major held 30+ wanted bumps hostage** and burned a full CI round to tell us. Per-version ignores (already landed for bincode 3.x and typescript 7.x) only patch the case *after* it happens.

## The fix

All three groups (`actions`, `rust`, `ui`) now carry **minor and patch only**:

```yaml
    groups:
      rust:
        patterns: ["*"]
        update-types: ["minor", "patch"]
```

Dependabot **still proposes majors** — as their own individual PRs, where the migration is the point of the change rather than a passenger nobody signed up for. That is the correct shape for a major: read it, do the migration, prove it.

The two version-specific ignores stay in place; they document crates whose *named versions* must never be proposed at all (a `compile_error!` release is not a migration question).

Immediate effect: #392 can regenerate as a clean 30-ish-crate minor/patch group, and the `bincode` 2.0 / `ecdsa` majors it currently carries become separate, honest PRs.