### PR TITLE
ci(release): sign and notarize the macOS runtime with Developer ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,6 +529,65 @@ jobs:
           key: release-${{ matrix.target }}
       - name: Build target exactly once
         run: cargo build --locked --release --bin m1nd-mcp --target ${{ matrix.target }}
+      # macOS distribution gate: an unsigned, un-notarized 69MB binary makes the
+      # FIRST run on a user's Mac block in Gatekeeper verification (observed
+      # 2026-07-26: process stuck in uninterruptible `UE` state). Sign with
+      # Developer ID + notarize so the check is fast and trusted. Honest posture:
+      # when the Apple secrets are absent the step SKIPS loudly (today's
+      # behaviour, unsigned); when they are present any failure FAILS the build —
+      # it never silently ships an unsigned binary claiming to be signed.
+      - name: Sign and notarize the macOS runtime
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          BIN_PATH: target/${{ matrix.target }}/release/m1nd-mcp
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_CERT_P12_BASE64:-}" ] || [ -z "${APPLE_API_KEY_P8_BASE64:-}" ]; then
+            echo "::warning title=Unsigned macOS runtime::Apple signing secrets absent — shipping UNSIGNED. First run on a user Mac may block in Gatekeeper. Configure APPLE_* secrets to enable signing + notarization."
+            exit 0
+          fi
+
+          # 1) ephemeral keychain holding only the Developer ID certificate
+          KEYCHAIN="$RUNNER_TEMP/m1nd-signing.keychain-db"
+          KEYCHAIN_PASS="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          printf '%s' "$APPLE_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN" >/dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+          # 2) sign with hardened runtime + secure timestamp (notarization requires both)
+          codesign --force --timestamp --options runtime \
+            --sign "$APPLE_SIGNING_IDENTITY" "$BIN_PATH"
+          codesign --verify --strict --verbose=2 "$BIN_PATH"
+
+          # 3) notarize (a bare executable is submitted zipped; stapling is not
+          #    possible for a raw binary, so Gatekeeper resolves the ticket online)
+          printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          ditto -c -k --keepParent "$BIN_PATH" "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait --timeout 30m
+          rm -f "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/notarize.zip"
+
+          # 4) prove the shipped bytes carry a Developer ID signature
+          codesign -dv --verbose=4 "$BIN_PATH" 2>&1 | grep -q "Authority=Developer ID Application" \
+            || { echo "signed binary does not carry a Developer ID authority" >&2; exit 1; }
+          security delete-keychain "$KEYCHAIN" || true
+          echo "macOS runtime signed + notarized"
       - name: Stage updater-facing Unix runtime
         if: runner.os != 'Windows'
         shell: bash


### PR DESCRIPTION
## The finding (live, on the owner's Mac, 2026-07-26)

Installing the **published 1.5.0** macOS asset the way a user would: SHA-256 verified against the release `SHA256SUMS` ✓ — then the first run **parked in uninterruptible `UE` state**. Neither `timeout` nor SIGTERM could interrupt it. `codesign -dv` confirms the shipped binary is ad-hoc only: `Format=Mach-O thin (arm64)`, no Developer ID authority.

**The release publishes, but it does not install well.** Every macOS user hits this on first run.

(Also surfaced: `m1nd update apply` correctly refuses without `cosign` — the product behaved exactly as designed, but the cosign requirement is undocumented in the install path. Separate follow-up.)

## The fix

Sign each macOS target with a **Developer ID Application** certificate (hardened runtime + secure timestamp) and **notarize** via `notarytool`, placed between the build and the staging steps so **both** the raw updater-facing binary and the tarball carry the signature.

**Honest posture — the part that matters:**
- Secrets **absent** → the step **skips with a loud warning**, shipping unsigned exactly as today. No release breaks while the credentials are being set up.
- Secrets **present** → any failure **fails the build**, and a final check proves an `Authority=Developer ID Application` is actually on the shipped bytes. It never ships unsigned bytes claiming to be signed.
- The signing certificate lives in an **ephemeral keychain** deleted at the end; the API key is written and removed inside the step.
- A raw executable **cannot be stapled** (only .app/.dmg/.pkg can), so Gatekeeper resolves the notarization ticket online — stated, not hidden.

## Secrets required (owner)

`APPLE_CERT_P12_BASE64` · `APPLE_CERT_PASSWORD` · `APPLE_SIGNING_IDENTITY` · `APPLE_API_KEY_ID` · `APPLE_API_ISSUER_ID` · `APPLE_API_KEY_P8_BASE64`

actionlint clean; CI security-contract tests 14/14.