### PR TITLE
fix(source-edit): relate live and durable paths in one identity domain (Windows phase-2)

### DIFF
--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -6149,6 +6149,16 @@ fn is_digest(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    /// Grace a test gives a retiring actor to land its shutdown checkpoint.
+    ///
+    /// This bounds an actor writing a graph snapshot to disk, so it is a
+    /// function of the SLOWEST machine that runs the suite, not of the work.
+    /// At two seconds it was a CI coin-flip on a loaded Windows runner
+    /// ("did not checkpoint before the shutdown deadline"). Being generous
+    /// cannot hide a defect: an actor that never checkpoints still fails the
+    /// same assertion, only later.
+    const ACTOR_SHUTDOWN_CHECKPOINT_GRACE: Duration = Duration::from_secs(60);
+
     use super::*;
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -6437,7 +6447,7 @@ mod tests {
         label: &str,
     ) {
         actor_registry
-            .shutdown(Duration::from_secs(2))
+            .shutdown(ACTOR_SHUTDOWN_CHECKPOINT_GRACE)
             .unwrap_or_else(|error| panic!("shutdown simulated dead {label} actor: {error}"));
         brain
             .lock_mut_before_actor()
@@ -7456,7 +7466,7 @@ mod tests {
                 )
                 .expect("source boot recovery");
             recovery_registry
-                .shutdown(Duration::from_secs(2))
+                .shutdown(ACTOR_SHUTDOWN_CHECKPOINT_GRACE)
                 .expect("shutdown recovered source actor before restart inspection");
             report
         }
@@ -7756,7 +7766,7 @@ mod tests {
                     .execute(&fixture.context, retry, replay_host)
                     .expect("source terminal replay");
                 replay_registry
-                    .shutdown(Duration::from_secs(2))
+                    .shutdown(ACTOR_SHUTDOWN_CHECKPOINT_GRACE)
                     .expect("shutdown source replay actor");
                 assert!(replay.graph_resync_required);
                 assert_eq!(replay.reconciliation_state, "PENDING_RECONCILIATION");
@@ -10317,7 +10327,16 @@ mod tests {
             preview.ingress_context_digest,
             context.ingress_context_digest.clone().unwrap()
         );
-        assert_eq!(preview.root_identity, fixture.repo_root.to_string_lossy());
+        // Not `to_string_lossy`: the preview's root identity is contractually
+        // `m1nd_ingest`'s own identity for the canonical root (it has to match
+        // `CodeOwnershipManifestV1::root_identity` byte-for-byte), and on Windows
+        // that normalizes `\\?\C:\...` to `//?/C:/...`. Deriving the expectation
+        // through the same function is what keeps the assertion honest instead of
+        // accidentally asserting the OS separator.
+        assert_eq!(
+            preview.root_identity,
+            m1nd_ingest::exact_path_identity(&fixture.repo_root).expect("canonical root identity")
+        );
         assert_eq!(preview.expected_graph_generation, graph_before.0);
         assert_eq!(preview.expected_source_projection_digest, graph_before.1);
         let scan_job = fixture

--- a/m1nd-mcp/src/internal_tests/project_brain_runtime.rs
+++ b/m1nd-mcp/src/internal_tests/project_brain_runtime.rs
@@ -247,7 +247,13 @@ fn multi_brain_actors_are_isolated() {
             Ok::<_, RuntimeJobFailure>(())
         })
         .expect("brain B remains readable while A actor is blocked");
-    assert!(b_read_started.elapsed() < Duration::from_secs(1));
+    // Isolation is proved by the STRUCTURE, not by this clock: A is parked
+    // inside its callback and is only released further down, on this very
+    // thread, so a B read that serialized behind A would deadlock here rather
+    // than merely run late. The bound is kept as a coarse "did not hang" net
+    // and is deliberately generous — at one second it was measuring how loaded
+    // the CI runner was, and failed on Windows for exactly that reason.
+    assert!(b_read_started.elapsed() < Duration::from_secs(60));
     release.wait();
     blocked_a
         .join()

--- a/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
+++ b/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
@@ -1699,7 +1699,21 @@ fn validate_no_symlink_components(
     let mut cursor = root.to_path_buf();
     for component in relative.components() {
         match component {
-            Component::Normal(value) => cursor.push(value),
+            Component::Normal(value) => {
+                cursor.push(value);
+                // `PathBuf::push` REPLACES the buffer when what it pushes carries
+                // a prefix — and on Windows a `Normal` component can spell one
+                // (`Path::new("C:")` is `Prefix(Disk('C'))` with no root), which
+                // would silently re-root the cursor drive-relative to the process
+                // CWD. The walk is only a containment proof if the cursor never
+                // leaves `root`, so state that invariant instead of assuming it.
+                if !cursor.starts_with(root) {
+                    return Err(SourceEditTransactionError::Preflight(format!(
+                        "path component '{}' escapes the managed root",
+                        Path::new(value).display()
+                    )));
+                }
+            }
             _ => {
                 return Err(SourceEditTransactionError::Preflight(
                     "target contains a non-normal path component".to_string(),
@@ -4660,13 +4674,16 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().canonicalize().expect("canonical root");
         fs::create_dir_all(root.join("src")).expect("tree");
-        fs::write(root.join("src/lib.rs"), BEFORE).expect("target");
+        // Never `join("src/lib.rs")` off a canonicalized root: the Windows
+        // verbatim prefix turns OFF path normalization, so `/` stops being a
+        // separator and asks NTFS for a file literally named `src/lib.rs`.
+        fs::write(root.join("src").join("lib.rs"), BEFORE).expect("target");
 
-        let walked = validate_no_symlink_components(&root, &root.join("src/lib.rs"))
+        let walked = validate_no_symlink_components(&root, &root.join("src").join("lib.rs"))
             .expect("symlink-free descent");
         assert_eq!(walked, root.join("src").join("lib.rs"));
 
-        // `..` is refused before any of it is walked, resolved spelling or not.
+        // `..` is refused when the walk reaches it, resolved spelling or not.
         let escape = root.join("src").join("..").join("..").join("passwd");
         assert!(validate_no_symlink_components(&root, &escape).is_err());
     }

--- a/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
+++ b/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
@@ -1599,6 +1599,32 @@ fn path_text(path: &Path) -> String {
     crate::scope::normalize_path_text(&path.to_string_lossy())
 }
 
+/// Component-wise position of `target` inside `root`, with both sides first
+/// projected into the single identity domain this subsystem stores paths in.
+///
+/// Every sealed record (`target_identity`, `managed_root`, `candidate_temp_path`,
+/// `transaction_directory`, ...) is written through [`path_text`], which flips
+/// separators and STRIPS the Windows verbatim prefix (`\\?\C:\repo` -> `C:/repo`).
+/// Every live path is produced by `fs::canonicalize`, which ADDS that prefix. The
+/// two domains coincide on Unix and are disjoint on Windows — `Path` compares
+/// prefix components by kind, and `VerbatimDisk('C')` never equals `Disk('C')` —
+/// so relating a live root to a durable identity could not succeed on Windows at
+/// all. Projecting both sides through `path_text` puts them in one domain.
+///
+/// The containment test itself stays `Path::strip_prefix`, i.e. component-wise:
+/// `C:/repo-evil` is still not inside `C:/repo`. This resolves a spelling, it
+/// never widens what counts as "inside".
+fn relative_within_root(root: &Path, target: &Path) -> Result<PathBuf, SourceEditTransactionError> {
+    let root_text = path_text(root);
+    let target_text = path_text(target);
+    Path::new(&target_text)
+        .strip_prefix(Path::new(&root_text))
+        .map(Path::to_path_buf)
+        .map_err(|_| {
+            SourceEditTransactionError::Preflight("target escapes managed root".to_string())
+        })
+}
+
 fn canonical_runtime_root(state: &SessionState) -> Result<PathBuf, SourceEditTransactionError> {
     let raw_metadata = fs::symlink_metadata(&state.runtime_root)
         .map_err(|error| io_error("runtime_root_lstat", error))?;
@@ -1653,17 +1679,23 @@ fn managed_target(
             target.display()
         ))
     })?;
-    validate_no_symlink_components(&managed_root, &target)?;
+    let target = validate_no_symlink_components(&managed_root, &target)?;
     Ok((managed_root, target))
 }
 
+/// Refuse any target that is not a symlink-free descent from `root`, and return
+/// the exact path that was walked.
+///
+/// The returned path is `root` plus the validated components, so a caller that
+/// then opens it touches precisely the chain that was `lstat`ed — the target can
+/// no longer be validated under one spelling and opened under another. `target`
+/// may legitimately arrive in either identity domain (see
+/// [`relative_within_root`]); the walk always proceeds from `root`.
 fn validate_no_symlink_components(
     root: &Path,
     target: &Path,
-) -> Result<(), SourceEditTransactionError> {
-    let relative = target.strip_prefix(root).map_err(|_| {
-        SourceEditTransactionError::Preflight("target escapes managed root".to_string())
-    })?;
+) -> Result<PathBuf, SourceEditTransactionError> {
+    let relative = relative_within_root(root, target)?;
     let mut cursor = root.to_path_buf();
     for component in relative.components() {
         match component {
@@ -1683,14 +1715,16 @@ fn validate_no_symlink_components(
             )));
         }
     }
-    Ok(())
+    Ok(cursor)
 }
 
 fn read_target_snapshot(
     managed_root: &Path,
     target: &Path,
 ) -> Result<SourceEditTargetSnapshotV1, SourceEditTransactionError> {
-    validate_no_symlink_components(managed_root, target)?;
+    // Read the chain that was just walked, never the caller's spelling of it.
+    let validated = validate_no_symlink_components(managed_root, target)?;
+    let target = validated.as_path();
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -2118,7 +2152,7 @@ fn validate_pre_stage_intent_for_prepared(
         descriptor_core_for_prepared(prepared, intent.core.descriptor.core.created_at_ms)?;
     let expected_directory = prepared.transaction_root.join(&prepared.transaction_id);
     if intent.core.descriptor.core != expected_descriptor
-        || Path::new(&intent.core.transaction_directory) != expected_directory
+        || intent.core.transaction_directory != path_text(&expected_directory)
     {
         return Err(SourceEditTransactionError::ContextBinding(
             "durable pre-stage intent differs from the prepared source edit".to_string(),
@@ -2677,7 +2711,7 @@ fn validate_stage_descriptor_binding(
     validate_pre_stage_intent(&intent)?;
     if intent.intent_digest != staged.core.pre_stage_intent_digest
         || intent.core.descriptor != *descriptor
-        || Path::new(&intent.core.transaction_directory) != directory
+        || intent.core.transaction_directory != path_text(directory)
     {
         return Err(SourceEditTransactionError::ContextBinding(
             "durable stage differs from its first-write pre-stage intent".to_string(),
@@ -3382,7 +3416,7 @@ fn load_pre_stage_intent_from_root(
     )?;
     validate_pre_stage_intent(&intent)?;
     if intent.core.transaction_id != transaction_id
-        || Path::new(&intent.core.transaction_directory) != transaction_root.join(transaction_id)
+        || intent.core.transaction_directory != path_text(&transaction_root.join(transaction_id))
     {
         return Err(SourceEditTransactionError::ContextBinding(
             "pre-stage intent differs from its transaction-root identity".to_string(),
@@ -3699,7 +3733,7 @@ fn cleanup_aborted_pre_stage<F: SourceEditFaults>(
     let intent = &receipt.core.pre_stage_intent;
     let transaction_id = &intent.core.transaction_id;
     let directory = root.join(transaction_id);
-    if Path::new(&intent.core.transaction_directory) != directory {
+    if intent.core.transaction_directory != path_text(&directory) {
         return Err(SourceEditTransactionError::ContextBinding(
             "pre-stage abort transaction directory escapes its canonical root".to_string(),
         ));
@@ -4021,7 +4055,7 @@ fn validate_abort_artifact_paths(
     let expected_rollback = expected_candidate.with_extension("rollback");
     if Path::new(&descriptor.core.candidate_temp_path) != expected_candidate
         || Path::new(&descriptor.core.rollback_temp_path) != expected_rollback
-        || Path::new(&descriptor.core.backup_path) != directory.join("before.bytes")
+        || descriptor.core.backup_path != path_text(&directory.join("before.bytes"))
         || Path::new(&descriptor.core.candidate_temp_path) == target
         || Path::new(&descriptor.core.rollback_temp_path) == target
     {
@@ -4047,7 +4081,7 @@ fn validate_abort_receipt_paths(
     if Path::new(&receipt.core.candidate_temp_path) != expected_candidate
         || Path::new(&receipt.core.rollback_temp_path)
             != expected_candidate.with_extension("rollback")
-        || Path::new(&receipt.core.backup_path) != directory.join("before.bytes")
+        || receipt.core.backup_path != path_text(&directory.join("before.bytes"))
         || Path::new(&receipt.core.candidate_temp_path) == target
         || Path::new(&receipt.core.rollback_temp_path) == target
     {
@@ -4590,6 +4624,69 @@ mod tests {
             SourceEditCommitAdapterV1::prepare(&fixture.cell, &fixture.request, &context)
                 .expect("prepare");
         (prepared, context)
+    }
+
+    /// Every sealed source-edit record stores its paths through [`path_text`],
+    /// which strips the Windows verbatim prefix (`\\?\C:\repo` -> `C:/repo`),
+    /// while every live path comes from `fs::canonicalize`, which ADDS it. The
+    /// two spellings name the same directory, so a live canonical root must be
+    /// able to relate a durable identity — and a sibling directory must still
+    /// be refused, because a textual prefix is not containment.
+    #[test]
+    fn a_live_canonical_root_relates_a_durable_identity_without_admitting_a_sibling() {
+        let verbatim_root = PathBuf::from(r"\\?\C:\repo");
+        assert_eq!(
+            relative_within_root(&verbatim_root, Path::new("C:/repo/src/lib.rs"))
+                .expect("one directory, two spellings"),
+            PathBuf::from("src/lib.rs")
+        );
+        for escape in [
+            "C:/repo-evil/src/lib.rs",
+            "C:/other/lib.rs",
+            r"\\?\C:\repo-evil\src\lib.rs",
+        ] {
+            assert!(
+                relative_within_root(&verbatim_root, Path::new(escape)).is_err(),
+                "a textual prefix must never be read as containment: {escape}"
+            );
+        }
+    }
+
+    /// A resolved spelling must still be the walked chain: the path
+    /// `validate_no_symlink_components` returns is what a caller opens, so it
+    /// can never validate one path and touch another.
+    #[test]
+    fn the_validated_path_is_the_chain_that_was_walked() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().canonicalize().expect("canonical root");
+        fs::create_dir_all(root.join("src")).expect("tree");
+        fs::write(root.join("src/lib.rs"), BEFORE).expect("target");
+
+        let walked = validate_no_symlink_components(&root, &root.join("src/lib.rs"))
+            .expect("symlink-free descent");
+        assert_eq!(walked, root.join("src").join("lib.rs"));
+
+        // `..` is refused before any of it is walked, resolved spelling or not.
+        let escape = root.join("src").join("..").join("..").join("passwd");
+        assert!(validate_no_symlink_components(&root, &escape).is_err());
+    }
+
+    /// The property that makes a durable identity and a live canonical path
+    /// converge at all: projecting twice is projecting once.
+    #[test]
+    fn path_text_is_the_single_identity_domain_for_stored_and_live_paths() {
+        for raw in [
+            r"\\?\C:\repo\runtime\tx",
+            "C:/repo/runtime/tx",
+            "/srv/repo/runtime/tx",
+        ] {
+            let once = path_text(Path::new(raw));
+            assert_eq!(path_text(Path::new(&once)), once, "not idempotent: {raw}");
+        }
+        assert_eq!(
+            path_text(Path::new(r"\\?\C:\repo\runtime\tx")),
+            path_text(Path::new("C:/repo/runtime/tx"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The root cause — one mismatch, ~22 red tests

Every **durable** identity in the source-edit subsystem is written through `path_text()`, which normalizes separators and **STRIPS** the Windows verbatim prefix (`\\?\C:\repo` → `C:/repo`). Every **live** path comes from `fs::canonicalize`, which **ADDS** it. `Path` compares prefix components **by kind** — and `VerbatimDisk('C')` never equals `Disk('C')`.

So the two identity domains are **identical on Unix and disjoint on Windows**. That is why the whole family passed on macOS/Linux and failed only on Windows, surfacing as `Preflight("target escapes managed root")` and `ContextBinding("pre-stage intent differs from its transaction-root identity")`.

**The CI panic was reproduced locally, word for word**, by a RED test before the fix.

## The fix

Project both sides into the single identity domain the subsystem stores in, then relate them. The containment test itself remains `Path::strip_prefix` — **component-wise**, never a string prefix, which would be weaker and defeat the point.

A second, latent wave of the same mismatch was found and fixed on the abort path, which no test ever reached because execution died earlier at stage.

## What the cross-platform review then caught — and why the second commit exists

A portability review of this branch found **two Windows-only defects**, and one of them corrected a claim this description previously made:

- **`PathBuf::push` replaces the buffer** when what it pushes carries a prefix, and on Windows a `Normal` component can spell one (`Path::new("C:")` is `Prefix(Disk('C'))` with no root) — silently re-rooting the walk cursor drive-relative to the process CWD. This mattered **more** after the first commit, not less: the cursor used to be discarded and the caller reopened its own spelling, whereas now the cursor **is** what gets opened, read and renamed over. So a malformed component moved from *validated the wrong chain* to *validated **and touched** the wrong chain*. The walk is only a containment proof if the cursor never leaves the root, so that invariant is now asserted after every push rather than assumed. Not reachable from tool input — `:` survives neither `fs::canonicalize` nor `validate_path_safety`; it needs a durable string from the owner's own runtime. **Hardening, not a live escape.**
- **The new test proving the fix could not run on the OS the fix is for**: it built paths as `canonical_root.join("src/lib.rs")`, and under the verbatim prefix Win32 turns *off* normalization — `/` stops being a separator and NTFS is asked for a file literally named `src/lib.rs` (os error 123). The assertion two lines below already used the correct form; the inconsistency lived inside a single test.

With the second commit the "as strong as before" claim holds. **Before it, it did not** — worth stating plainly rather than quietly editing.

Three further findings (a workspace-wide disagreement about what a path identity *is*, a half-closed validated-equals-touched invariant on `rename`, and MAX_PATH exposure now that the prefix-less domain is the durable one) are **named debt, not surgery for this branch** — filed in the project inbox.

## Proof

RED→GREEN with the CI panic reproduced locally; **16/16** source-edit and **47/47** external_mutation_service, independently re-run after the hardening commit; `fmt --check` and `clippy --all-targets -D warnings` clean. Frozen PRD/UML untouched.

Windows itself is proven only by this PR's advisory job — **that run is the real verdict**, and until the second commit it could not have delivered one. If it goes green, `windows-latest` can return to the blocking matrix and the `rust-gates-windows` advisory job (added 2026-07-23 as a scaffold) can be deleted.
