### PR TITLE
test(transplant): key the harness snapshot in one path identity domain

### DIFF
--- a/m1nd-mcp/tests/transplant_harness.rs
+++ b/m1nd-mcp/tests/transplant_harness.rs
@@ -202,11 +202,17 @@ fn snapshot_src(root: &Path) -> BTreeMap<String, String> {
     let mut out = BTreeMap::new();
     let src = root.join("src");
     for entry in walk_rs(&src) {
+        // These keys are matched against expectations that spell paths with
+        // '/' (`src_rel: "src/alpha.rs"`), so they must arrive in that one
+        // identity domain. On Windows `strip_prefix` hands back '\', no key
+        // ever matches, and the certificate silently grades the source file of
+        // a move as "unrelated" — asserting it must not change, when changing
+        // is precisely its job.
         let rel = entry
             .strip_prefix(root)
             .unwrap()
             .to_string_lossy()
-            .to_string();
+            .replace('\\', "/");
         out.insert(rel, std::fs::read_to_string(&entry).unwrap());
     }
     out


### PR DESCRIPTION
## The last red test on Windows — and the product was never wrong

With the source-edit path-canon fix landed, the Windows advisory job went from **~22 failures to exactly one**: `harness_certificate_canonical_move_changes_only_expected_regions`.

That one is **not a product defect**. Read what the Windows log actually reports:

```
unrelated/referencer file src\alpha.rs must not gain or lose items
  left:  {"move_me", "private_helper", "shared_helper", "stay_here"}
  right: {"shared_helper", "stay_here"}
```

`alpha.rs` went from four functions to two — losing exactly `move_me` and `private_helper`. **That is the transplant working correctly.** The failure is that the harness graded `alpha.rs` under its *"every OTHER file keeps its exact fn set"* branch, i.e. it did not recognize the source file of the move as the source file of the move.

## Why

`snapshot_src` builds its map keys with `to_string_lossy()`, which spells separators the platform way. The expectations they are matched against spell them with `/`:

```rust
if *rel == exp.src_rel        // "src\alpha.rs"  vs  "src/alpha.rs"
```

On Windows no key ever matches, every file falls through to the unrelated branch, and the certificate asserts that a file whose whole purpose is to change must not change.

## The fix

One line: key the snapshot in the same identity domain the expectations use.

This is the **same lesson** as the path-canon fix that just landed — paths compared across a boundary need one identity domain. There the boundary was between `path_text()` and `fs::canonicalize`; here it is between the walker and the test's own expectations. Worth noting that a *test harness* had the identical defect class as the subsystem it certifies.

## Proof

`transplant_harness` **15/15** green, `fmt` clean. Windows is proven only by this PR's advisory job.

If it goes green, Windows has **no known failures left** and `windows-latest` can return to the blocking matrix — with the `rust-gates-windows` advisory scaffold (added 2026-07-23) deleted. That flip is deliberately **not** in this PR: it should be made against a Windows run that is already green, not one hoping to be.
