### PR TITLE
test(runnerd): spell fixture repo roots the way Windows means absolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,15 @@ jobs:
           key: rust-gates-windows-latest
       # Mirrors the required gate exactly: no standalone check (clippy subsumes
       # it), release-profile build on main pushes only.
+      #
+      # `--no-fail-fast` ONLY here, and deliberately. Cargo stops after the first
+      # test binary that fails, so on a leg carrying known debt every fix reveals
+      # the next failure one CI round at a time — the source-edit family masked a
+      # transplant-harness bug, which was in turn masking runnerd's. An advisory
+      # leg exists to MEASURE the debt, so it has to report all of it in one run.
+      # The required gate keeps failing fast.
       - name: Test every target
-        run: cargo test --locked --workspace --all-targets
+        run: cargo test --locked --workspace --all-targets --no-fail-fast
       - name: Deny clippy warnings
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
       - name: Verify formatting

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -89,11 +89,23 @@ Everything promised or planned and not yet done, named here rather than left in 
 Update this list in the same PR that closes one; a front that dies silently is a lie.
 
 **Blocking the product**
-- **Windows phase-2** — the ~22 source-edit path-canon tests. Single diagnosed cause (`fs::canonicalize`
-  emits the `\\?\` verbatim prefix; stored/constructed identities lack it, so every preflight refuses
-  "target escapes managed root"). Security-sensitive and not locally verifiable (no mingw C++ toolchain).
-  This is the root of the CI pain, now advisory rather than blocking. Needs a real Windows box or CI-driven
-  red→green loop, not a guess.
+- **Windows phase-2** — the source-edit path-canon suite is FIXED (`d8668591`, #435): the two identity
+  domains are related in one spelling, the containment test stays component-wise `strip_prefix`, and a
+  latent `PathBuf::push` re-root was closed with it. The CI-driven red→green loop this entry asked for is
+  what closed it — no Windows box was needed.
+  **But "~22" was never the size of this front, and the number itself was the lie.** `cargo test` stops at
+  the first test binary that fails, so the source-edit family was MASKING the rest: fixing it revealed one
+  transplant-harness failure (#436 — where the product was correct and the harness's own path keys were
+  not), and fixing that revealed four `m1nd-runnerd` fixtures that spell absolute paths the Unix way only
+  (`/abs/repo` has a root but no prefix on Windows, so it is not absolute — the product is right to refuse
+  it). Each fix cost a full CI round to learn the next layer, so the advisory leg now runs `--no-fail-fast`:
+  an advisory job exists to MEASURE debt, and one that reports a layer at a time measures nothing.
+  **The true remaining surface is therefore still unknown** and will be known for the first time on the next
+  advisory run. Two latent items already found on the way, both filed: `config::workspace_allowed` carries
+  the same verbatim-prefix split `d8668591` just fixed (fail-closed, so a legitimate workspace is refused on
+  Windows and allowed on Unix — same input, opposite verdict), and `m1nd-mcp` does not compile with `serve`
+  off (an ungated `getrandom::fill` against an optional dep), which `--workspace` feature unification hides
+  from CI entirely.
 - **Genesis P2 and P3** — P1 (medulla-only read fallback so a brainless repo is served doctrine instead of
   blindness) is implemented in PR #403, in the merge queue and NOT yet on main — checkpoint 32's "0 code
   hits" above described the tree before that PR existed, and holds for main until it lands; **P2** (the birth ceremony: `m1nd init` is today only `installSkills`, and the PRD

--- a/m1nd-runnerd/src/config.rs
+++ b/m1nd-runnerd/src/config.rs
@@ -314,9 +314,38 @@ fn read_valid_secret(path: &Path) -> std::io::Result<String> {
     Ok(secret)
 }
 
+/// Test support: spell an absolute path the way the CURRENT platform means it.
+///
+/// The platforms genuinely disagree here, and the obvious literal gets it wrong:
+/// `Path::new("/abs/repo").is_absolute()` is `true` on Unix and **`false` on
+/// Windows**. There a leading `/` carries a root but no prefix, which leaves the
+/// path drive-RELATIVE — "that directory on whichever drive happens to be
+/// current" — so it is ambiguous, [`validate`] is right to refuse it, and it must
+/// keep refusing it. A fixture that needs a root the validator ACCEPTS therefore
+/// has to carry a drive letter on Windows; forward slashes stay legal separators
+/// there, so gluing `C:` in front is the whole fix and the TOML needs no
+/// backslash escaping.
+#[cfg(test)]
+pub(crate) fn abs_path(unix_path: &str) -> String {
+    if cfg!(windows) {
+        format!("C:{unix_path}")
+    } else {
+        unix_path.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Render a config fixture: `{abs_root}` becomes a repo root the validator
+    /// accepts on the platform running the test. It cannot be written as a literal
+    /// — see [`abs_path`]. Fixtures that spell a DELIBERATELY relative entry
+    /// (`not/absolute`, the ones proving the refusal) carry no token and go
+    /// straight to [`parse`].
+    fn fixture(toml: &str) -> String {
+        toml.replace("{abs_root}", &abs_path("/abs/repo"))
+    }
 
     const GOOD: &str = r#"
 [[runner]]
@@ -324,19 +353,19 @@ id = "build-1"
 capability = "build-runner"
 command = ["agent-cli", "run", "{packet_file}"]
 gate_command = ["cargo", "test"]
-workspace_allowlist = ["/abs/repo"]
+workspace_allowlist = ["{abs_root}"]
 
 [[runner]]
 id = "name-1"
 capability = "naming-runner"
 command = ["namer", "{packet_file}"]
 gate_command = ["true"]
-workspace_allowlist = ["/abs/repo"]
+workspace_allowlist = ["{abs_root}"]
 "#;
 
     #[test]
     fn valid_config_parses_both_runners() {
-        let cfg = parse(GOOD).expect("valid config parses");
+        let cfg = parse(&fixture(GOOD)).expect("valid config parses");
         assert_eq!(cfg.runners.len(), 2);
         assert_eq!(cfg.runners[0].parsed_capability(), Capability::BuildRunner);
         assert_eq!(cfg.runners[1].timeout_secs, DEFAULT_TIMEOUT_SECS);
@@ -357,9 +386,9 @@ id = "x"
 capability = "loop-runner"
 command = ["c", "{packet_file}"]
 gate_command = ["t"]
-workspace_allowlist = ["/abs"]
+workspace_allowlist = ["{abs_root}"]
 "#;
-        let err = parse(toml).expect_err("loop-runner is out of the MVP");
+        let err = parse(&fixture(toml)).expect_err("loop-runner is out of the MVP");
         match err {
             ConfigError::Field { field, .. } => assert_eq!(field, "capability"),
             other => panic!("expected a capability field error, got {other}"),
@@ -374,9 +403,9 @@ id = "x"
 capability = "build-runner"
 command = ["agent-cli", "run"]
 gate_command = ["t"]
-workspace_allowlist = ["/abs"]
+workspace_allowlist = ["{abs_root}"]
 "#;
-        let err = parse(toml).expect_err("no {packet_file} token");
+        let err = parse(&fixture(toml)).expect_err("no {packet_file} token");
         assert!(err.to_string().contains("packet_file"), "got {err}");
     }
 
@@ -388,10 +417,10 @@ workspace_allowlist = ["/abs"]
 id = "x"
 capability = "build-runner"
 command = ["c", "{packet_file}"]
-workspace_allowlist = ["/abs"]
+workspace_allowlist = ["{abs_root}"]
 "#;
         assert!(matches!(
-            parse(no_gate).unwrap_err(),
+            parse(&fixture(no_gate)).unwrap_err(),
             ConfigError::Field {
                 field: "gate_command",
                 ..
@@ -422,16 +451,16 @@ id = "x"
 capability = "build-runner"
 command = ["c", "{packet_file}"]
 gate_command = ["t"]
-workspace_allowlist = ["/abs"]
+workspace_allowlist = ["{abs_root}"]
 [[runner]]
 id = "x"
 capability = "naming-runner"
 command = ["c", "{packet_file}"]
 gate_command = ["t"]
-workspace_allowlist = ["/abs"]
+workspace_allowlist = ["{abs_root}"]
 "#;
         assert!(matches!(
-            parse(dup).unwrap_err(),
+            parse(&fixture(dup)).unwrap_err(),
             ConfigError::DuplicateId(_)
         ));
     }
@@ -463,12 +492,14 @@ id = "b"
 capability = "build-runner"
 command = ["agent-cli"]
 gate_command = ["t"]
-workspace_allowlist = ["/abs"]
+workspace_allowlist = ["{abs_root}"]
 "#;
-        assert!(
-            parse(build_no_token).is_err(),
-            "a build-runner still requires the packet_file token"
-        );
+        // Assert the REASON, not merely that something failed: a bare `is_err()`
+        // would stay green if the refusal ever came from an unrelated field, and
+        // this test's whole claim is about the token.
+        let err = parse(&fixture(build_no_token))
+            .expect_err("a build-runner still requires the packet_file token");
+        assert!(err.to_string().contains("packet_file"), "got {err}");
 
         // A zero per-block naming timeout is refused honestly by field.
         let zero = r#"
@@ -569,12 +600,21 @@ command = ["c"]
 
     #[test]
     fn workspace_allowlist_prefix_and_alias() {
-        let cfg = parse(GOOD).unwrap();
+        let cfg = parse(&fixture(GOOD)).unwrap();
         let r = find(&cfg, "build-1").unwrap();
-        assert!(workspace_allowed(r, "/abs/repo"), "exact root");
-        assert!(workspace_allowed(r, "/abs/repo/sub/dir"), "under the root");
-        assert!(!workspace_allowed(r, "/abs/other"), "outside the root");
-        assert!(!workspace_allowed(r, "/abs"), "the parent is not allowed");
+        assert!(workspace_allowed(r, &abs_path("/abs/repo")), "exact root");
+        assert!(
+            workspace_allowed(r, &abs_path("/abs/repo/sub/dir")),
+            "under the root"
+        );
+        assert!(
+            !workspace_allowed(r, &abs_path("/abs/other")),
+            "outside the root"
+        );
+        assert!(
+            !workspace_allowed(r, &abs_path("/abs")),
+            "the parent is not allowed"
+        );
     }
 
     #[test]

--- a/m1nd-runnerd/src/mission.rs
+++ b/m1nd-runnerd/src/mission.rs
@@ -1010,32 +1010,38 @@ mod tests {
 
     #[test]
     fn validate_run_pins_and_allowlists() {
+        // The allowlist takes only paths the platform agrees are ABSOLUTE, and
+        // `/allowed/repo` is not one on Windows — see `crate::config::abs_path`.
+        // Substituted rather than `format!`ed in: the fixture carries a literal
+        // `{packet_file}` token that a format string would try to expand.
+        let allowed = crate::config::abs_path("/allowed/repo");
         let cfg = crate::config::parse(
-            r#"
+            &r#"
 [[runner]]
 id = "build-1"
 capability = "build-runner"
 command = ["c", "{packet_file}"]
 gate_command = ["t"]
-workspace_allowlist = ["/allowed/repo"]
-"#,
+workspace_allowlist = ["{allowed_root}"]
+"#
+            .replace("{allowed_root}", &allowed),
         )
         .unwrap();
 
         // Unpinned runner id → 403 unpinned_runner.
-        let mut r = req("/allowed/repo");
+        let mut r = req(&allowed);
         r.runner_id = "ghost".to_string();
         let err = validate_run(&cfg, &r).expect_err("unpinned");
         assert_eq!(err.keyword(), "unpinned_runner");
         assert_eq!(err.status(), 403);
 
         // Workspace outside the allowlist → 403 workspace_not_allowed.
-        let r = req("/somewhere/else");
+        let r = req(&crate::config::abs_path("/somewhere/else"));
         let err = validate_run(&cfg, &r).expect_err("outside allowlist");
         assert_eq!(err.keyword(), "workspace_not_allowed");
 
         // In-allowlist → the pinned runner.
-        let r = req("/allowed/repo");
+        let r = req(&allowed);
         assert_eq!(validate_run(&cfg, &r).unwrap().id, "build-1");
     }
 


### PR DESCRIPTION
## Windows: the next layer, and why there was a next layer

`cargo test` stops at the first test binary that fails. The source-edit path-canon family was therefore **masking** everything behind it. Fixing it (#435) revealed one transplant-harness failure (#436); fixing that revealed these four:

```
config::tests::valid_config_parses_both_runners
config::tests::each_required_field_is_checked
config::tests::workspace_allowlist_prefix_and_alias
mission::tests::validate_run_pins_and_allowlists
```

All from one cause: `'/abs/repo' is not an absolute path`. On Windows a leading `/` carries a root but **no prefix**, which makes the path drive-relative and ambiguous. **The product is right to refuse it** — no product code is touched here. The fixtures spell absolute paths the Unix way only.

## The premise I brought to this was wrong for 3 of the 4

I expected the neighbouring tests to be "passing for the wrong reason" on Windows. Measured, not assumed: `validate` is a straight-line sequential check — capability → command → `{packet_file}` token → `gate_command` → allowlist non-empty → **allowlist absolute**. Everything those tests intend is checked *before* the absolute-path rule, so their intended error fires first even on Windows.

Two real defects did surface from looking:

- **`dup`** genuinely got the wrong error: runner 1's allowlist is validated before runner 2's id is reached, so it never got to `DuplicateId`. That is what made `each_required_field_is_checked` fail.
- **`build_no_token`** asserted a bare `is_err()` — **unfalsifiable**: it proved nothing about *which* field failed. Now asserts the reason, like its sibling.

## Executed evidence for a claim about a platform we cannot run

`cfg!(windows)` was flipped to `true` on macOS — where `C:/abs/repo` is likewise not absolute, the mirror image of the real bug. **Exactly the four reported tests went red, no more and no fewer.** That is evidence both that the model of the platform split is complete and that the substitution reaches every fixture site.

Reasoned but **not executed** (no Windows here): that `C:/abs/repo` satisfies `is_absolute` on Windows, and that `workspace_allowed`'s prefix algebra holds with `Disk` prefixes.

## `--no-fail-fast`, on the advisory leg only

Each fix above cost a full CI round just to learn what the next layer was. An advisory job exists to **measure** debt; one that reports a layer at a time measures nothing. The required gate keeps failing fast.

`docs/PATHOS.md` is corrected in the same PR: it scoped this front to "the ~22 source-edit path-canon tests", and that number was taken behind fail-fast — the first layer reported as the total. It now says the true remaining surface is unknown until the next advisory run, rather than claiming a size it has not measured.

## Two latent defects found on the way — filed, not fixed here

- **`config::workspace_allowed` carries the same verbatim-prefix split `d8668591` just fixed.** An existing allowlist root canonicalizes to `\\?\C:\repos` while a not-yet-existing workspace stays `C:/repos/proj`; the prefix kinds never compare equal, so a legitimate workspace is refused. Same input, opposite verdict per OS. Fail-closed, so not a hole — and invisible to the suite because every fixture takes the fallback on both sides.
- **`m1nd-mcp` does not compile with `serve` off** — an ungated `getrandom::fill` against an optional dep. `--workspace` feature unification hides this from CI completely, and it makes m1nd-runnerd's declared lean edge unachievable: it only links because a sibling widens it.

## Gates

`cargo test -p m1nd-runnerd --features m1nd-mcp/serve` → **34 passed, 0 failed** (independently re-run). Full CI-equivalent `cargo test --locked --workspace --all-targets --no-fail-fast` → exit 0, **2440 passed across 63 binaries**. clippy `-D warnings` and `fmt --check` clean. The helper is `#[cfg(test)]` — absent from the shipped binary.
