### PR TITLE
fix(clippy): drop three needless returns the Unix leg cannot see

### DIFF
--- a/m1nd-mcp/src/authority_runtime.rs
+++ b/m1nd-mcp/src/authority_runtime.rs
@@ -4981,7 +4981,7 @@ fn sync_parent(path: &Path) -> Result<(), AuthorityRuntimeError> {
     #[cfg(windows)]
     {
         let _ = parent;
-        return Ok(());
+        Ok(())
     }
     #[cfg(not(windows))]
     File::open(parent)

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -6134,7 +6134,7 @@ fn sync_parent(path: &Path) -> std::io::Result<()> {
     #[cfg(windows)]
     {
         let _ = path;
-        return Ok(());
+        Ok(())
     }
     #[cfg(not(windows))]
     std::fs::File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()

--- a/m1nd-mcp/src/http_security.rs
+++ b/m1nd-mcp/src/http_security.rs
@@ -531,7 +531,7 @@ fn sync_parent(path: &Path) -> Result<(), HttpSecurityError> {
     #[cfg(windows)]
     {
         let _ = parent;
-        return Ok(());
+        Ok(())
     }
     #[cfg(not(windows))]
     fs::File::open(parent)


### PR DESCRIPTION
## Windows has zero failing tests

The first `--no-fail-fast` advisory run reports the whole surface at once, and the number is: **63 test binaries, all green on Windows.** The phase-2 test debt — declared as "~22 source-edit path-canon tests" and revealed to be three masked layers — is closed.

What still fails the Windows leg is **clippy, and only clippy**: three `needless_return` errors.

```
m1nd-mcp/src/authority_runtime.rs:4984
m1nd-mcp/src/external_mutation_service.rs:6137
m1nd-mcp/src/http_security.rs:534
```

All three are `return Ok(());` inside a `#[cfg(windows)]` block. The ubuntu and macOS legs never compile those lines, so their clippy never lints them — **a green Unix clippy says nothing at all about a cfg-gated branch.** This is precisely the defect class a platform-conditional gate exists to catch.

## Verified, not reasoned

I cannot compile a Windows branch here, so I did not want to ship this on reasoning about tail expressions. The three blocks were temporarily flipped to `cfg(unix)` — which makes this machine compile the exact branch Windows compiles — and the `Ok(())` tail form builds clean, with the lint gone. The probe was then reverted.

The diff is **exactly three lines**. `fmt --check` and `clippy --workspace --all-targets -D warnings` clean.

## What this means for the advisory leg

If the Windows job goes green here, there is nothing left blocking `windows-latest` from returning to the required matrix, and the `rust-gates-windows` advisory job (added 2026-07-23 as a scaffold, kept as an honest red) can be deleted.

That flip is deliberately **not** in this PR. It should be made against a Windows run that is already green — the same discipline that kept it out of the two PRs before this one.
