### PR TITLE
build(mcp): make getrandom non-optional and gate the lean edge in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,15 @@ jobs:
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
       - name: Verify formatting
         run: cargo fmt --all --check
+      # `--workspace` UNIFIES features, so every gate above builds m1nd-mcp with
+      # `serve` on no matter who asked for it. That hid a real break: m1nd-runnerd
+      # declares `default-features = false`, and m1nd-mcp had not compiled that way
+      # since an ungated `getrandom` call entered `external_mutation_service` — it
+      # only linked because a sibling in the same build widened it. A declared lean
+      # edge that nothing builds is not an edge. This is the one gate that asks for
+      # a crate ALONE, and it is cheap (~20s) precisely because nothing else does.
+      - name: Build the lean edge nothing else builds
+        run: cargo check --locked -p m1nd-mcp --no-default-features
       # Release-profile build runs on main pushes only (2026-07-24): on a PR it
       # proved nothing tests+clippy don't, at ~half the round's wall-clock, and
       # the signed release pipeline rebuilds --release at tag time anyway. A

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 # `embed` is ON by default so the shipped server has semantic recall out of the
 # box. Build a lean, embeddings-free binary with `--no-default-features --features serve`.
 default = ["serve", "embed"]
-serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:tokio-stream", "dep:futures", "dep:reqwest", "dep:getrandom"]
+serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:tokio-stream", "dep:futures", "dep:reqwest"]
 # Real local static embeddings in `seek` (semantic recall by meaning), forwarded
 # to m1nd-core. The model (~29 MB, model2vec/potion-base-8M) is fetched on first
 # use and cached; if it cannot load, `seek` falls back to trigram matching
@@ -62,7 +62,12 @@ mime_guess = { version = "2", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"], optional = true }
 futures = { version = "0.3", optional = true }
 reqwest = { version = "0.13", features = ["json", "stream"], optional = true }
-getrandom = { version = "0.3", optional = true }
+# NOT optional: `external_mutation_service` is compiled unconditionally (`lib.rs`,
+# ungated) and mints its scan-job ids with `getrandom::fill`. The other three
+# callers — http_security, http_server, mcp_http — ARE behind `serve`, which is
+# why this read as a serve-only dep for so long. `--workspace` unifies features,
+# so CI never built m1nd-mcp without `serve` and never saw the break.
+getrandom = { version = "0.3" }
 
 # Already present transitively (via sysinfo/tokio); declared directly ONLY to call
 # `libc::flock` for the per-slug supersession lock (see light_author_handlers.rs).


### PR DESCRIPTION
## A declared edge that nothing builds is not an edge

`m1nd-mcp` has not compiled with `--no-default-features` since an ungated `getrandom::fill` entered `external_mutation_service` — a module `lib.rs` compiles unconditionally. The dependency was declared serve-only because its **other three** callers genuinely are behind `serve`:

| caller | gated by `serve`? |
|---|---|
| `http_security.rs:473` | yes |
| `http_server.rs` | yes |
| `mcp_http.rs:386` | yes |
| **`external_mutation_service.rs:105`** | **no** |

`m1nd-runnerd` declares `m1nd-mcp = { …, default-features = false }`, so its lean edge was already broken. It only linked because a sibling in the same `--workspace` build widened the feature set on its behalf.

## Why nothing caught it, and the part that matters

Every existing gate builds the whole workspace, and **`--workspace` unifies features** — so `m1nd-mcp` is never built without `serve` anywhere in CI. The break was invisible by construction, not by oversight.

So the fix ships with the gate that holds it: one `cargo check --locked -p m1nd-mcp --no-default-features`, the only step in the pipeline that asks for a crate **alone**. It costs ~20s precisely because nothing else does this.

**The guard is proven to bite, not merely present**: restoring `optional = true` turns it red (2 errors) — checked, then reverted.

## Proof

- `cargo check -p m1nd-mcp --no-default-features` → Finished (was: `E0433 cannot find module or crate getrandom`)
- `cargo check -p m1nd-runnerd` alone → Finished
- `cargo check -p m1nd-mcp` (normal) → Finished
- **`Cargo.lock` does not move** — `getrandom` was already in the build graph; this only changes which feature owns it.

Found while closing the Windows front: it surfaced from a subagent's report, was filed to the project inbox, and is fixed here rather than left as a note.
