### PR TITLE
fix(openclaw): gate the two helpers behind unix, like their only caller

### DIFF
--- a/m1nd-openclaw/src/main.rs
+++ b/m1nd-openclaw/src/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use m1nd_mcp::server::{McpConfig, McpServer, McpToolClient};
 #[cfg(unix)]
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
 use serde_json::Value;
 #[cfg(unix)]
 use std::path::{Path, PathBuf};
@@ -62,10 +63,12 @@ struct BridgeResponse {
     elapsed_ms: f64,
 }
 
+#[cfg(unix)]
 fn normalize_tool_name(tool: &str) -> &str {
     tool.strip_prefix("m1nd.").unwrap_or(tool)
 }
 
+#[cfg(unix)]
 fn inject_default_agent_id(arguments: &Value, default_agent_id: &str) -> Value {
     let mut next = arguments.clone();
     if let Some(map) = next.as_object_mut() {
@@ -312,7 +315,7 @@ fn main() {
     std::process::exit(2);
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::{inject_default_agent_id, normalize_tool_name};
     use serde_json::json;


### PR DESCRIPTION
## The Windows test surface is green — this is the last clippy layer

A re-run of the **identical commit** (`e29a0e86`) settled the open question from the previous round: **63 test suites, zero failures on Windows.** The two `project_brains` shutdown/checkpoint failures seen once were a flake — same code, same runner, green on re-run. They are not a `#426` regression.

What still fails the Windows leg is clippy, and this is the last of it:

```
error: function `inject_default_agent_id` is never used
error: function `normalize_tool_name` is never used
```

## Why

`m1nd-openclaw` is a Unix-domain-socket bridge — its own Windows `main` says exactly that and exits 2. Everything meaningful is already `#[cfg(unix)]`. But these two helpers were not, while their **only production caller**, `build_response`, is. On Windows the caller compiles out and the helpers become dead code.

The Unix legs cannot see this: they compile the caller, so the functions are live there. **Same blind spot as the three `needless_return`s in `e29a0e86`** — a green Unix clippy says nothing about a cfg-gated branch. That is now three separate defects from one blind spot, which is the argument for the advisory leg existing at all.

Gated along with them: the `Value` import (whose only remaining users are these two) and the test module (which exercises only these two).

## Verified, not reasoned

Swapping `unix`↔`windows` in this file makes macOS compile the exact branch Windows compiles. Clippy is clean there under `-D warnings`, and the Unix build stays clean unchanged. The probe was reverted; the diff is **four lines**.

A first probe attempt using `#[cfg(all())]` was discarded — it tripped a clippy lint of its own (`unneeded sub cfg`) and would have proven nothing about the real code.

## What this closes

If Windows goes green here, the phase-2 front is **done**: tests were already green, and this is the last clippy error. `windows-latest` can return to the required matrix and the `rust-gates-windows` advisory job — added 2026-07-23 as a scaffold — can be deleted.

That flip stays out of this PR, as it has out of every one before it: it should be made against a Windows run that is already green.
