### PR TITLE
test(brain-runtime): pin the boot graph the actor start silently reverts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
+### Fixed — the owner boot now serves the graph it loaded
+
+- **A pre-1.5 runtime could load a full graph and serve zero nodes, on every boot.** The brain
+  actor restores checkpoint `CURRENT` and rebuilds its whole session from disk when it starts.
+  The 1.5 legacy adoption wrote the pre-1.5 graph into the runtime root *before any actor
+  existed*, so the actor reverted it on the same boot — and the adoption journal still recorded
+  `status: "adopted"`, whose own guard forbids re-adoption. **The rescue was spent without ever
+  having worked**, and the symptom was silent: `Loaded graph snapshot: N nodes` followed by
+  `Server ready. 0 nodes`. Adoption now runs *inside* the actor boundary and commits through the
+  checkpoint, so `CURRENT` is never older than the files it describes. The journal is written
+  only after the commit is acknowledged, and an adoption that did not stick is re-adoptable —
+  a journal beside an empty brain is exactly the footprint of a reverted adoption. **An affected
+  installation recovers on its next boot with no operator step.**
+  The rejected alternative — letting an uncommitted file outrank `CURRENT` — is pinned as
+  *correct* by its own test, so this cannot later be "fixed" by inverting it: a half-written
+  graph must never beat a committed one.
+
 ### The graph learned to write — `transplant`
 
 - **New verb `transplant`** (plus `transplant_preview` / `transplant_commit`). Move a top-level

--- a/docs/GENESIS-INGEST-CONSUMERS-SPEC.md
+++ b/docs/GENESIS-INGEST-CONSUMERS-SPEC.md
@@ -15,11 +15,28 @@ queue**, not merely its floor. SPEC-2 (birth) is the cp32 P2/P3 line itself.
 
 From the adoption lab (measured, serve-mode, authenticated REST, 17,408-node runtime copy):
 
-- **R-A** — adoption works: the current-main binary loads a populated runtime whole. Migration
-  needs no verb (`legacy_snapshot_adoption.rs`) — with the verdict's caveat kept loud:
-  **adoption is ONE-TIME and journaled**; it is a birth path, not a recovery net. If a
-  destructive write lands after first boot, adoption will not rebuild — recovery is the
-  `.bak-<ts>` plus a human hand.
+- **R-A — CORRECTED BY THE FIELD, 2026-07-27.** The lab measured that adoption works, and the
+  lab was right about what it measured: a binary loads a populated runtime whole. **What the lab
+  did not have was a stale checkpoint.** In the field, the brain actor's `start` restores
+  checkpoint `CURRENT` and rebuilds its whole session from disk, and adoption ran *before any
+  actor existed* — so on a runtime whose `CURRENT` predated the adoption, **the actor reverted
+  it on the same boot**. The owner's own repo loaded 5540 nodes and served **0**, every boot,
+  for five days, while the journal recorded `status: "adopted"`. Read together with the caveat
+  below, that is the worst combination available: the rescue was **spent without ever having
+  worked**, and its own one-time guard forbade retrying it.
+  **Fixed:** adoption now runs *inside* the actor boundary and commits through the checkpoint,
+  so `CURRENT` is never older than the files it describes; the journal is written only after the
+  commit is acknowledged; and a journal beside an EMPTY brain — the exact footprint of a
+  reverted adoption — is re-adoptable rather than spent. An affected installation recovers on
+  its next boot with no operator step.
+  The verdict's caveat still holds and is unchanged by this: **adoption is ONE-TIME and
+  journaled** — it is a birth path, not a recovery net. A destructive write *after* a
+  successful first boot still will not rebuild; recovery is the `.bak-<ts>` plus a human hand.
+  What changed is only that an adoption which never landed no longer counts as one that did.
+  **Method note worth more than the fix:** a lab can only measure the states it reproduces. This
+  one was structurally unable to see the defect, and nothing in 1458 green tests could either —
+  it needed a *second boot* on a runtime carrying prior state. See `docs/PATHOS.md`, the
+  lifecycle-proof front.
 - **R-B** — the daily loop (`north`/`seek`/`memorize`) answers with zero authority walls.
 - **R-C (corrected per verdict RC-9)** — every ingest form is refused, but the mechanism is
   NOT a missing A2 consumer: `graph.ingest.merge_existing` **already has a typed A2 consumer

--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -6440,27 +6440,27 @@ mod tests {
     }
 
     /// A checkpoint CURRENT captured while the runtime graph was EMPTY must never
-    /// silently revert a populated `graph_snapshot.json` that the owner boot has
-    /// already loaded into the session it is about to serve.
+    /// silently revert the graph a boot-time migration legitimately installed.
     ///
-    /// This is the stdio owner's exact shape: `McpServer::new` loads the runtime
-    /// graph, then `McpServer::start` opens the bound actor with `recovery: None`
-    /// and the actor reconciles CURRENT by itself. When the runtime files changed
-    /// out of band since that CURRENT — which is precisely what the 1.5 legacy
-    /// snapshot adoption does, writing the pre-1.5 graph into the runtime root
-    /// before any actor exists — the restore reverts them and the server reports
-    /// "Loaded graph snapshot: N nodes" followed by "Server ready. 0 nodes".
-    /// RED on purpose: it currently observes 0 served nodes after a boot that
-    /// loaded 1. Deleting this `#[ignore]` is the acceptance gate for the fix —
-    /// which is a durability-semantics decision (may a runtime graph that a boot
-    /// legitimately loaded outrank a stale CURRENT?), not a local repair.
+    /// This is the stdio/`--serve` owner's exact shape: a prior boot checkpointed
+    /// an empty runtime, then the 1.5 legacy-snapshot adoption brings the pre-1.5
+    /// graph in. It used to do that pre-actor, and `BrainActorHandle::start`
+    /// reconciled CURRENT by itself — restore + `reload_authoritative_from_disk`
+    /// — so the server reported "Loaded graph snapshot: N nodes" followed by
+    /// "Server ready. 0 nodes", the on-disk snapshot was overwritten with the
+    /// empty one, and the adoption journal still claimed success.
+    ///
+    /// The repair keeps CURRENT the single source of truth and moves the
+    /// migration behind the actor, so it commits a checkpoint by construction.
+    /// The proof is the RESTART: the boot after the adoption loads N nodes and
+    /// the actor start that used to revert them serves N.
     #[test]
-    #[ignore = "reproduces the unfixed empty-graph revert; see the doc comment above"]
     fn actor_start_serves_the_graph_the_owner_boot_loaded() {
         let temporary = tempfile::tempdir().expect("temporary runtime");
         let runtime_root = temporary.path().join("runtime");
         let brain_id = "owner-empty-graph-revert".to_string();
         let graph_path = runtime_root.join("graph_snapshot.json");
+        let legacy_graph_path = temporary.path().join("graph_snapshot.json");
 
         // A prior boot checkpointed an EMPTY runtime. This CURRENT is what every
         // later actor start reconciles against.
@@ -6483,13 +6483,7 @@ mod tests {
         // same runtime root, exactly as a restarted process would.
         drop(empty_session);
 
-        // The empty boot also persisted a co-change sidecar bound to the empty
-        // graph, beside which `McpServer::new` refuses to load ANY populated
-        // graph (SchemaDrift). That refusal is a separate defect and not what
-        // this test pins, so the sidecar is cleared to isolate the revert.
-        std::fs::remove_file(runtime_root.join("temporal_state_v1.json")).ok();
-
-        // A populated snapshot lands in the runtime root out of band.
+        // The pre-1.5 graph is sitting in the legacy location, stranded.
         let mut populated = m1nd_core::graph::Graph::new();
         populated
             .add_node(
@@ -6500,16 +6494,44 @@ mod tests {
                 0.0,
                 0.0,
             )
-            .expect("seed the adopted snapshot");
-        m1nd_core::snapshot::save_graph(&populated, &graph_path)
-            .expect("write the adopted snapshot");
+            .expect("seed the legacy snapshot");
+        m1nd_core::snapshot::save_graph(&populated, &legacy_graph_path)
+            .expect("write the legacy snapshot");
 
-        // The owner boot loads it — this is the "Loaded graph snapshot" line.
+        // The owner boot: it loads the empty runtime graph, opens the bound
+        // actor, and only then adopts — exactly the order the registry uses.
+        let session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let actor = BrainActorHandle::start(
+            brain_id.clone(),
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start the bound actor over the empty runtime");
+        assert_eq!(
+            crate::legacy_snapshot_adoption::maybe_adopt_legacy_snapshot(
+                &actor,
+                &graph_path,
+                &legacy_graph_path,
+                &temporary.path().join("plasticity_state.json"),
+                &runtime_root,
+            ),
+            crate::legacy_snapshot_adoption::LegacyAdoptionOutcome::Adopted { node_count: 1 }
+        );
+        actor.stop().expect("stop the adopting actor");
+        drop(actor);
+        drop(session);
+
+        // The adoption committed through the checkpoint, so the canonical
+        // snapshot survives the process — this is the "Loaded graph snapshot"
+        // line of the NEXT boot.
         let booted = test_state(&runtime_root);
         assert_eq!(
             booted.graph.read().num_nodes(),
             1,
-            "the owner boot must load the populated runtime snapshot"
+            "the owner boot must load the adopted runtime snapshot"
         );
 
         // Starting the bound actor must not take that graph away.
@@ -6532,6 +6554,80 @@ mod tests {
         assert_eq!(
             served, 1,
             "the served session must expose the nodes the boot loaded, not a stale empty checkpoint"
+        );
+    }
+
+    /// The other half of the same decision, pinned so nobody "fixes" the bug
+    /// above by inverting it: a graph that merely APPEARS in the runtime root,
+    /// with no checkpoint behind it, still loses to CURRENT. Letting an
+    /// uncommitted file outrank a committed generation would let a half-written
+    /// or corrupted snapshot beat good durable state, which is the whole point
+    /// of checkpointing. Boot-time writers must commit, not sneak.
+    #[test]
+    fn actor_start_reverts_an_uncommitted_out_of_band_graph() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let brain_id = "owner-uncommitted-out-of-band".to_string();
+        let graph_path = runtime_root.join("graph_snapshot.json");
+
+        let empty_session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let empty_actor = BrainActorHandle::start(
+            brain_id.clone(),
+            Arc::clone(&empty_session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor over the empty runtime");
+        empty_actor
+            .checkpoint_and_ack()
+            .expect("checkpoint the empty runtime");
+        empty_actor.stop().expect("stop the empty-runtime actor");
+        drop(empty_actor);
+        drop(empty_session);
+
+        // The empty boot also persisted a co-change sidecar bound to the empty
+        // graph, beside which `McpServer::new` refuses to load ANY populated
+        // graph (SchemaDrift). That refusal is a separate defect and not what
+        // this test pins, so the sidecar is cleared to isolate the revert.
+        std::fs::remove_file(runtime_root.join("temporal_state_v1.json")).ok();
+
+        let mut populated = m1nd_core::graph::Graph::new();
+        populated
+            .add_node(
+                "file::src/lib.rs",
+                "lib.rs",
+                m1nd_core::types::NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("seed the out-of-band snapshot");
+        m1nd_core::snapshot::save_graph(&populated, &graph_path)
+            .expect("write the out-of-band snapshot");
+
+        let booted = test_state(&runtime_root);
+        assert_eq!(booted.graph.read().num_nodes(), 1);
+        let session = Arc::new(BrainSessionCell::new(booted));
+        let actor = BrainActorHandle::start(
+            brain_id,
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start the bound actor");
+        let served = actor
+            .try_read_snapshot(|state| Ok::<u32, RuntimeJobFailure>(state.graph.read().num_nodes()))
+            .expect("read the served node count")
+            .value;
+        actor.stop().expect("stop the bound actor");
+
+        assert_eq!(
+            served, 0,
+            "an uncommitted out-of-band graph must lose to CURRENT"
         );
     }
 

--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -6439,6 +6439,102 @@ mod tests {
         actor.stop().expect("stop reconciled actor");
     }
 
+    /// A checkpoint CURRENT captured while the runtime graph was EMPTY must never
+    /// silently revert a populated `graph_snapshot.json` that the owner boot has
+    /// already loaded into the session it is about to serve.
+    ///
+    /// This is the stdio owner's exact shape: `McpServer::new` loads the runtime
+    /// graph, then `McpServer::start` opens the bound actor with `recovery: None`
+    /// and the actor reconciles CURRENT by itself. When the runtime files changed
+    /// out of band since that CURRENT — which is precisely what the 1.5 legacy
+    /// snapshot adoption does, writing the pre-1.5 graph into the runtime root
+    /// before any actor exists — the restore reverts them and the server reports
+    /// "Loaded graph snapshot: N nodes" followed by "Server ready. 0 nodes".
+    /// RED on purpose: it currently observes 0 served nodes after a boot that
+    /// loaded 1. Deleting this `#[ignore]` is the acceptance gate for the fix —
+    /// which is a durability-semantics decision (may a runtime graph that a boot
+    /// legitimately loaded outrank a stale CURRENT?), not a local repair.
+    #[test]
+    #[ignore = "reproduces the unfixed empty-graph revert; see the doc comment above"]
+    fn actor_start_serves_the_graph_the_owner_boot_loaded() {
+        let temporary = tempfile::tempdir().expect("temporary runtime");
+        let runtime_root = temporary.path().join("runtime");
+        let brain_id = "owner-empty-graph-revert".to_string();
+        let graph_path = runtime_root.join("graph_snapshot.json");
+
+        // A prior boot checkpointed an EMPTY runtime. This CURRENT is what every
+        // later actor start reconciles against.
+        let empty_session = Arc::new(BrainSessionCell::new(test_state(&runtime_root)));
+        let empty_actor = BrainActorHandle::start(
+            brain_id.clone(),
+            Arc::clone(&empty_session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start actor over the empty runtime");
+        empty_actor
+            .checkpoint_and_ack()
+            .expect("checkpoint the empty runtime");
+        empty_actor.stop().expect("stop the empty-runtime actor");
+        drop(empty_actor);
+        // Release the first boot's instance lease so the second boot can own the
+        // same runtime root, exactly as a restarted process would.
+        drop(empty_session);
+
+        // The empty boot also persisted a co-change sidecar bound to the empty
+        // graph, beside which `McpServer::new` refuses to load ANY populated
+        // graph (SchemaDrift). That refusal is a separate defect and not what
+        // this test pins, so the sidecar is cleared to isolate the revert.
+        std::fs::remove_file(runtime_root.join("temporal_state_v1.json")).ok();
+
+        // A populated snapshot lands in the runtime root out of band.
+        let mut populated = m1nd_core::graph::Graph::new();
+        populated
+            .add_node(
+                "file::src/lib.rs",
+                "lib.rs",
+                m1nd_core::types::NodeType::File,
+                &[],
+                0.0,
+                0.0,
+            )
+            .expect("seed the adopted snapshot");
+        m1nd_core::snapshot::save_graph(&populated, &graph_path)
+            .expect("write the adopted snapshot");
+
+        // The owner boot loads it — this is the "Loaded graph snapshot" line.
+        let booted = test_state(&runtime_root);
+        assert_eq!(
+            booted.graph.read().num_nodes(),
+            1,
+            "the owner boot must load the populated runtime snapshot"
+        );
+
+        // Starting the bound actor must not take that graph away.
+        let session = Arc::new(BrainSessionCell::new(booted));
+        let actor = BrainActorHandle::start(
+            brain_id,
+            Arc::clone(&session),
+            runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+            Arc::new(UnboundBrainCheckpointAuthority),
+            2,
+            None,
+        )
+        .expect("start the bound actor over the populated runtime");
+        let served = actor
+            .try_read_snapshot(|state| Ok::<u32, RuntimeJobFailure>(state.graph.read().num_nodes()))
+            .expect("read the served node count")
+            .value;
+        actor.stop().expect("stop the bound actor");
+
+        assert_eq!(
+            served, 1,
+            "the served session must expose the nodes the boot loaded, not a stale empty checkpoint"
+        );
+    }
+
     #[test]
     fn actor_checkout_releases_storage_mutex_during_long_command() {
         let temporary = tempfile::tempdir().expect("temporary runtime");

--- a/m1nd-mcp/src/legacy_snapshot_adoption.rs
+++ b/m1nd-mcp/src/legacy_snapshot_adoption.rs
@@ -7,15 +7,31 @@
 //! untouched in the old location — stranding the whole graph and dropping every
 //! upgrader into `needs_ingest` with its brain sitting right there.
 //!
-//! This module adopts the legacy snapshot ONCE at boot: it copies the exact
-//! legacy bytes into the runtime root so the normal load path then finds them. A
-//! typed journal (mirroring `boot_kv_migration`) makes the adoption idempotent
-//! and auditable, and the adoption never overwrites a populated runtime graph.
+//! This module adopts the legacy snapshot ONCE, **through the brain actor**: the
+//! legacy graph is installed into the live session and the SAME actor turn
+//! commits it through the checkpoint. A typed journal (mirroring
+//! `boot_kv_migration`) makes the adoption idempotent and auditable, and the
+//! adoption never overwrites a populated runtime graph.
+//!
+//! The actor detour is the whole point. The adoption used to run pre-actor, in
+//! `McpServer::new`, copying the legacy bytes straight into the runtime root.
+//! `BrainActorHandle::start` then reconciled the checkpoint by itself —
+//! `restore_checkpoint` + `reload_authoritative_from_disk` — and rebuilt the
+//! session from a CURRENT that was captured while the runtime graph was still
+//! empty. The adopted graph was therefore reverted on the same boot, before the
+//! first tool call, while the journal still recorded `status: "adopted"`: the
+//! one-time rescue was spent without ever having worked. CURRENT stays the
+//! single source of truth; a boot-time migration must commit through it instead
+//! of writing behind it.
 
+use crate::brain_runtime::BrainActorHandle;
+use crate::runtime_jobs::RuntimeJobFailure;
+use crate::session::SessionState;
 use m1nd_core::error::M1ndResult;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::Path;
+use std::sync::Arc;
 
 /// Journal file written under the runtime root once adoption commits.
 pub const ADOPTION_JOURNAL_FILE: &str = "legacy_graph_adoption_v1.json";
@@ -39,17 +55,18 @@ pub struct LegacyGraphAdoptionJournalV1 {
 /// is a deliberate, safe no-op.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LegacyAdoptionOutcome {
-    /// The legacy snapshot was copied into the runtime root.
+    /// The legacy snapshot was installed into the session and checkpointed.
     Adopted { node_count: u64 },
     /// The runtime graph already has nodes — never overwrite it.
     SkippedRuntimeAlreadyPopulated,
     /// No legacy snapshot exists (or it is empty), so there is nothing to adopt.
     SkippedNoLegacySnapshot,
-    /// A prior boot already adopted (the journal is present) — one-time.
+    /// A prior boot already adopted AND that adoption stuck — one-time.
     SkippedAlreadyAdopted,
     /// The runtime graph path IS the legacy path — no separate location to adopt.
     SkippedSameLocation,
-    /// The legacy snapshot exists but could not be read/parsed; left untouched.
+    /// The legacy snapshot exists but could not be read/parsed/committed; the
+    /// runtime is left exactly as the checkpoint restored it.
     SkippedLegacyUnreadable(String),
 }
 
@@ -68,31 +85,27 @@ fn now_ms() -> u64 {
 
 /// Adopt a pre-1.5 legacy graph snapshot into the runtime root exactly once.
 ///
-/// Owner boot only (a read-only attach never writes). Returns a
+/// Owner boot only (a read-only attach never writes), and only AFTER the brain
+/// actor has started: the actor's own checkpoint restore has already run, so the
+/// runtime graph read here is exactly what CURRENT holds. Returns a
 /// [`LegacyAdoptionOutcome`]; the only writing path is `Adopted`, and it can
-/// never fire over a populated runtime graph, a previously adopted runtime
-/// (journal present), or a legacy file that fails to parse. The one honest
-/// stderr line is emitted here so the behavior is identical wherever it runs.
+/// never fire over a populated runtime graph, an adoption that already stuck, or
+/// a legacy file that fails to parse. The one honest stderr line is emitted here
+/// so the behavior is identical wherever it runs.
 ///
 /// When (and only when) the graph is adopted, the legacy plasticity sidecar is
-/// adopted alongside it — best-effort, and ONLY if it parses cleanly. A
+/// imported alongside it — best-effort, and ONLY if it parses cleanly. A
 /// known-corrupt legacy-format plasticity file is skipped with a warning so the
-/// graph still boots (Step 4's own "continuing without it" import guard stays
-/// intact).
+/// graph still boots (the same "continuing without it" guard the boot import
+/// already applies).
 pub(crate) fn maybe_adopt_legacy_snapshot(
+    actor: &BrainActorHandle,
     runtime_graph_path: &Path,
     legacy_graph_path: &Path,
-    runtime_plasticity_path: &Path,
     legacy_plasticity_path: &Path,
     runtime_root: &Path,
 ) -> LegacyAdoptionOutcome {
     let journal_path = runtime_root.join(ADOPTION_JOURNAL_FILE);
-
-    // One-time: a committed journal means adoption already ran. Never re-adopt,
-    // even if the runtime graph was later emptied.
-    if journal_path.exists() {
-        return LegacyAdoptionOutcome::SkippedAlreadyAdopted;
-    }
 
     // No separate legacy location (no runtime dir, or an explicit --graph that
     // already points at the legacy file): there is nothing to adopt onto itself.
@@ -105,6 +118,16 @@ pub(crate) fn maybe_adopt_legacy_snapshot(
     // repair adds no load cost to a normal warm boot.
     if !legacy_graph_path.exists() {
         return LegacyAdoptionOutcome::SkippedNoLegacySnapshot;
+    }
+
+    // One-time — but only for an adoption that actually STUCK. A journal beside
+    // an empty runtime graph is the exact footprint of the reverted adoption
+    // this module used to produce: it recorded `status: "adopted"` for a graph
+    // the actor threw away on the same boot. Treating that record as spent would
+    // leave the brain permanently empty with its rescue already burned, so a
+    // recorded-but-absent adoption is re-adoptable.
+    if journal_path.exists() && runtime_graph_is_populated(runtime_graph_path) {
+        return LegacyAdoptionOutcome::SkippedAlreadyAdopted;
     }
 
     // A legacy candidate exists — only now is it worth the reads. It must parse
@@ -138,83 +161,117 @@ pub(crate) fn maybe_adopt_legacy_snapshot(
         return LegacyAdoptionOutcome::SkippedRuntimeAlreadyPopulated;
     }
 
-    // Adopt: copy the EXACT legacy bytes into the checkpoint-managed runtime
-    // path (durable, cross-platform), then journal the one-time event.
-    if let Err(error) =
-        crate::boot_kv_migration::durable_atomic_write(runtime_graph_path, &legacy_bytes)
-    {
+    // Adopt INSIDE the actor boundary: the legacy graph is installed into the
+    // live session and this same turn publishes CURRENT from it. The canonical
+    // working files are written by the checkpoint projection, so CURRENT can
+    // never be older than the adopted runtime graph.
+    let legacy_display = legacy_graph_path.display().to_string();
+    let graph_source = legacy_graph_path.to_path_buf();
+    let plasticity_source = legacy_plasticity_path.to_path_buf();
+    if let Err(error) = actor.try_execute_with_checkpoint_ack(move |state| {
+        install_legacy_graph(state, &graph_source, &plasticity_source)
+    }) {
         eprintln!(
-            "[m1nd] legacy graph snapshot at {} not adopted (copy failed): {error}",
-            legacy_graph_path.display()
+            "[m1nd] legacy graph snapshot at {legacy_display} not adopted (checkpoint refused): {error}"
         );
-        return LegacyAdoptionOutcome::SkippedLegacyUnreadable(format!("copy failed: {error}"));
+        return LegacyAdoptionOutcome::SkippedLegacyUnreadable(format!(
+            "checkpoint refused: {error}"
+        ));
     }
-    // The graph is adopted — bring its plasticity sidecar along, best-effort.
-    adopt_legacy_plasticity(runtime_plasticity_path, legacy_plasticity_path);
 
+    // The journal is written ONLY after that ACK. An adoption is recorded when
+    // it is durable, never before — a crash between the two simply leaves the
+    // committed graph un-journaled, and the next boot skips it as an already
+    // populated runtime instead of claiming an adoption that never landed.
     let journal = LegacyGraphAdoptionJournalV1 {
         schema: JOURNAL_SCHEMA.into(),
         version: VERSION,
         status: "adopted".into(),
-        legacy_source_path: legacy_graph_path.display().to_string(),
+        legacy_source_path: legacy_display.clone(),
         source_digest: sha256(&legacy_bytes),
         node_count,
         adopted_at_ms: now_ms(),
     };
     if let Err(error) = write_journal(&journal_path, &journal) {
-        // The graph copy already succeeded; a journal-write failure must not
-        // crash boot. Re-adoption is still prevented by the now non-empty
+        // CURRENT already holds the adopted graph; a journal-write failure must
+        // not crash boot. Re-adoption is still prevented by the now non-empty
         // runtime graph on the next boot.
         eprintln!("[m1nd] legacy snapshot adopted but journal write failed: {error}");
     }
     eprintln!(
-        "[m1nd] adopted legacy graph snapshot from {} ({node_count} nodes) into runtime root {}",
-        legacy_graph_path.display(),
+        "[m1nd] adopted legacy graph snapshot from {legacy_display} ({node_count} nodes) into runtime root {}",
         runtime_root.display()
     );
     LegacyAdoptionOutcome::Adopted { node_count }
 }
 
-/// Best-effort adoption of the legacy plasticity sidecar, run only when the
-/// graph was just adopted. Copies the exact legacy bytes into the runtime
-/// plasticity path ONLY when the runtime plasticity is absent AND the legacy
-/// file parses cleanly as plasticity state. Every failure is a graceful skip
-/// with one honest warning — the graph is already adopted and boots regardless.
-fn adopt_legacy_plasticity(runtime_plasticity_path: &Path, legacy_plasticity_path: &Path) {
-    if runtime_plasticity_path.exists()
-        || !legacy_plasticity_path.exists()
-        || same_file(runtime_plasticity_path, legacy_plasticity_path)
-    {
+/// Install the legacy graph into the live session, exactly the way the `persist`
+/// load action swaps a snapshot in: replace the graph, rebuild the engines that
+/// are bound to it, and bump the generation. Nothing is written here — the
+/// actor's checkpoint serializes the new session and projects the canonical
+/// working files after CURRENT.
+fn install_legacy_graph(
+    state: &mut SessionState,
+    legacy_graph_path: &Path,
+    legacy_plasticity_path: &Path,
+) -> Result<u32, RuntimeJobFailure> {
+    let mut graph = m1nd_core::snapshot::load_graph(legacy_graph_path)
+        .map_err(|error| RuntimeJobFailure::new("legacy_graph_unreadable", error.to_string()))?;
+    if !graph.finalized && graph.num_nodes() > 0 {
+        graph
+            .finalize()
+            .map_err(|error| RuntimeJobFailure::new("legacy_graph_finalize", error.to_string()))?;
+    }
+    let node_count = graph.num_nodes();
+    state.graph = Arc::new(parking_lot::RwLock::new(graph));
+    state
+        .rebuild_engines()
+        .map_err(|error| RuntimeJobFailure::new("legacy_graph_rebuild", error.to_string()))?;
+    state.bump_graph_generation();
+    import_legacy_plasticity(state, legacy_plasticity_path);
+    Ok(node_count)
+}
+
+/// Best-effort import of the legacy plasticity sidecar, run only when the graph
+/// was just installed (`rebuild_engines` has reset plasticity to a fresh engine
+/// bound to the adopted graph). Every failure is a graceful skip with one honest
+/// warning — the graph is already adopted and checkpoints regardless.
+fn import_legacy_plasticity(state: &mut SessionState, legacy_plasticity_path: &Path) {
+    if !legacy_plasticity_path.exists() {
         return;
     }
-    // Adopt ONLY if it parses cleanly. The field's legacy plasticity is a known
-    // corrupt legacy format — skipped here rather than copied forward.
-    if let Err(error) = m1nd_core::snapshot::load_plasticity_state(legacy_plasticity_path) {
-        eprintln!(
-            "[m1nd] legacy plasticity at {} not adopted (invalid legacy format): {error}; continuing without it",
-            legacy_plasticity_path.display()
-        );
-        return;
-    }
-    let bytes = match std::fs::read(legacy_plasticity_path) {
-        Ok(bytes) => bytes,
+    // Import ONLY if it parses cleanly. The field's legacy plasticity is a known
+    // corrupt legacy format — skipped here rather than carried forward.
+    let states = match m1nd_core::snapshot::load_plasticity_state(legacy_plasticity_path) {
+        Ok(states) => states,
         Err(error) => {
             eprintln!(
-                "[m1nd] legacy plasticity at {} not adopted (unreadable): {error}; continuing without it",
+                "[m1nd] legacy plasticity at {} not adopted (invalid legacy format): {error}; continuing without it",
                 legacy_plasticity_path.display()
             );
             return;
         }
     };
-    match crate::boot_kv_migration::durable_atomic_write(runtime_plasticity_path, &bytes) {
-        Ok(()) => eprintln!(
+    let mut graph = state.graph.write();
+    match state.plasticity.import_state(&mut graph, &states) {
+        Ok(_) => eprintln!(
             "[m1nd] adopted legacy plasticity state from {}",
             legacy_plasticity_path.display()
         ),
-        Err(error) => eprintln!(
-            "[m1nd] legacy plasticity at {} not adopted (copy failed): {error}; continuing without it",
-            legacy_plasticity_path.display()
-        ),
+        Err(error) => {
+            // A refused import can stop halfway. The graph is the rescue and the
+            // sidecar is a nicety, so drop the half-imported engine for a clean
+            // one bound to the adopted graph rather than let partial synaptic
+            // state reach the checkpoint that is about to publish it.
+            state.plasticity = m1nd_core::plasticity::PlasticityEngine::new(
+                &graph,
+                m1nd_core::plasticity::PlasticityConfig::default(),
+            );
+            eprintln!(
+                "[m1nd] legacy plasticity at {} not adopted ({error}); continuing without it",
+                legacy_plasticity_path.display()
+            );
+        }
     }
 }
 
@@ -231,6 +288,9 @@ fn same_file(a: &Path, b: &Path) -> bool {
 /// node. An absent, empty, or unparseable runtime snapshot counts as "not
 /// populated" — boot would start fresh from it anyway, so adopting a valid
 /// legacy snapshot over it is a recovery, never a loss of real graph data.
+///
+/// Read after actor start, so this file is the checkpoint's own projection of
+/// CURRENT, not a stale pre-actor byte image.
 fn runtime_graph_is_populated(path: &Path) -> bool {
     if !path.exists() {
         return false;
@@ -247,6 +307,9 @@ fn write_journal(path: &Path, journal: &LegacyGraphAdoptionJournalV1) -> M1ndRes
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::brain_runtime::{
+        BrainSessionCell, UnboundBrainCheckpointAuthority, BRAIN_CHECKPOINT_DIRECTORY,
+    };
     use m1nd_core::graph::Graph;
     use m1nd_core::types::NodeType;
     use std::path::PathBuf;
@@ -281,15 +344,75 @@ mod tests {
     }
 
     impl Layout {
+        /// Boot the owner session and start its actor exactly as the registry
+        /// does, then run the one boot-time adoption attempt against it.
         fn adopt(&self) -> LegacyAdoptionOutcome {
-            maybe_adopt_legacy_snapshot(
+            self.boot(|_| {})
+        }
+
+        /// Same, with a hook that runs on the started actor BEFORE the adoption
+        /// attempt (used to publish a CURRENT the adoption must reconcile with).
+        fn boot(&self, before: impl FnOnce(&BrainActorHandle)) -> LegacyAdoptionOutcome {
+            let session = Arc::new(BrainSessionCell::new(owner_session(&self.runtime_root)));
+            let actor = BrainActorHandle::start(
+                "legacy-adoption-owner".to_string(),
+                Arc::clone(&session),
+                self.runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+                Arc::new(UnboundBrainCheckpointAuthority),
+                2,
+                None,
+            )
+            .expect("start the bound actor");
+            before(&actor);
+            let outcome = maybe_adopt_legacy_snapshot(
+                &actor,
                 &self.runtime_graph,
                 &self.legacy_graph,
-                &self.runtime_plasticity,
                 &self.legacy_plasticity,
                 &self.runtime_root,
-            )
+            );
+            actor.stop().expect("stop the bound actor");
+            drop(actor);
+            drop(session);
+            outcome
         }
+
+        fn served_nodes(&self) -> u32 {
+            let session = Arc::new(BrainSessionCell::new(owner_session(&self.runtime_root)));
+            let actor = BrainActorHandle::start(
+                "legacy-adoption-owner".to_string(),
+                Arc::clone(&session),
+                self.runtime_root.join(BRAIN_CHECKPOINT_DIRECTORY),
+                Arc::new(UnboundBrainCheckpointAuthority),
+                2,
+                None,
+            )
+            .expect("restart the bound actor");
+            let served = actor
+                .try_read_snapshot(|state| {
+                    Ok::<u32, RuntimeJobFailure>(state.graph.read().num_nodes())
+                })
+                .expect("read the served node count")
+                .value;
+            actor.stop().expect("stop the bound actor");
+            drop(actor);
+            drop(session);
+            served
+        }
+    }
+
+    /// The owner boot the adoption runs behind: `McpServer::new` over the
+    /// runtime root, exactly as `--serve`/stdio boot it.
+    fn owner_session(runtime_root: &Path) -> crate::session::SessionState {
+        crate::server::McpServer::new(crate::server::McpConfig {
+            graph_source: runtime_root.join("graph_snapshot.json"),
+            plasticity_state: runtime_root.join("plasticity_state.json"),
+            runtime_dir: Some(runtime_root.to_path_buf()),
+            registry_dir: Some(runtime_root.join("registry")),
+            ..Default::default()
+        })
+        .expect("boot owner session")
+        .into_session_state()
     }
 
     fn layout() -> Layout {
@@ -323,10 +446,12 @@ mod tests {
         assert_eq!(journal.node_count, 5);
         assert_eq!(journal.schema, JOURNAL_SCHEMA);
 
-        // Boot loads N nodes from the runtime path.
+        // Boot loads N nodes from the runtime path, and the NEXT actor start —
+        // the one that used to revert the adoption — still serves them.
         let loaded =
             m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("load adopted snapshot");
         assert_eq!(loaded.num_nodes(), 5);
+        assert_eq!(l.served_nodes(), 5);
     }
 
     #[test]
@@ -340,6 +465,32 @@ mod tests {
         // Still exactly the adopted graph.
         let loaded = m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("load");
         assert_eq!(loaded.num_nodes(), 3);
+    }
+
+    /// The owner's exact machine: the journal says `adopted` but the graph the
+    /// adoption produced is gone (the pre-actor copy was reverted by the actor's
+    /// CURRENT restore). A record of an adoption that did not stick must not
+    /// spend the one-time rescue.
+    #[test]
+    fn a_recorded_adoption_that_did_not_stick_is_re_adoptable() {
+        let l = layout();
+        write_snapshot_with_nodes(&l.legacy_graph, 7);
+        write_journal(
+            &l.runtime_root.join(ADOPTION_JOURNAL_FILE),
+            &LegacyGraphAdoptionJournalV1 {
+                schema: JOURNAL_SCHEMA.into(),
+                version: VERSION,
+                status: "adopted".into(),
+                legacy_source_path: l.legacy_graph.display().to_string(),
+                source_digest: "0".repeat(64),
+                node_count: 7,
+                adopted_at_ms: 1,
+            },
+        )
+        .expect("seed a spent-looking journal");
+
+        assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 7 });
+        assert_eq!(l.served_nodes(), 7);
     }
 
     #[test]
@@ -374,14 +525,14 @@ mod tests {
             "corrupt legacy must be skipped gracefully, got {outcome:?}"
         );
 
-        // Nothing adopted: runtime graph absent, no journal, boot starts empty.
-        assert!(!l.runtime_graph.exists(), "runtime graph must stay absent");
+        // Nothing adopted: no journal, and the served brain stays empty.
         assert!(!l.runtime_root.join(ADOPTION_JOURNAL_FILE).exists());
+        assert_eq!(l.served_nodes(), 0);
     }
 
     #[test]
     fn valid_legacy_plasticity_is_adopted_but_corrupt_is_skipped() {
-        // Valid plasticity → copied alongside the graph.
+        // Valid plasticity → imported alongside the graph.
         {
             let l = layout();
             write_snapshot_with_nodes(&l.legacy_graph, 4);
@@ -391,12 +542,12 @@ mod tests {
             assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 4 });
             assert!(
                 l.runtime_plasticity.exists(),
-                "valid legacy plasticity must be adopted alongside the graph"
+                "the adopting checkpoint must project the runtime plasticity sidecar"
             );
             m1nd_core::snapshot::load_plasticity_state(&l.runtime_plasticity)
                 .expect("adopted plasticity still parses at the runtime path");
         }
-        // Corrupt (known legacy-format) plasticity → graph adopted, plasticity skipped.
+        // Corrupt (known legacy-format) plasticity → graph adopted, import skipped.
         {
             let l = layout();
             write_snapshot_with_nodes(&l.legacy_graph, 4);
@@ -404,13 +555,47 @@ mod tests {
                 .expect("write corrupt plasticity");
 
             assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 4 });
-            assert!(
-                !l.runtime_plasticity.exists(),
-                "corrupt legacy plasticity must be skipped, never copied forward"
-            );
             // The graph adoption is unaffected — it still boots.
             let loaded = m1nd_core::snapshot::load_graph(&l.runtime_graph).expect("graph loads");
             assert_eq!(loaded.num_nodes(), 4);
+            assert_eq!(l.served_nodes(), 4);
         }
+    }
+
+    /// The field's plasticity sidecar PARSES and is then refused mid-import.
+    /// The rescue is the graph: a refused import must leave a clean engine
+    /// behind, never half-imported synaptic state, because the very next thing
+    /// that happens is the checkpoint publishing that engine.
+    #[test]
+    fn legacy_plasticity_refused_mid_import_still_adopts_a_clean_sidecar() {
+        let l = layout();
+        write_snapshot_with_nodes(&l.legacy_graph, 4);
+        // Two rows with the identical full synaptic key: parses fine, refused by
+        // `import_state` as a duplicate.
+        let row = m1nd_core::plasticity::SynapticState {
+            source_label: "file::src/mod0.rs".into(),
+            target_label: "file::src/mod1.rs".into(),
+            relation: "calls".into(),
+            direction: Some(0),
+            inhibitory: Some(false),
+            original_weight: 1.0,
+            current_weight: 1.0,
+            strengthen_count: 0,
+            weaken_count: 0,
+            ltp_applied: false,
+            ltd_applied: false,
+            last_used_query: 0,
+        };
+        m1nd_core::snapshot::save_plasticity_state(&[row.clone(), row], &l.legacy_plasticity)
+            .expect("save duplicate-key legacy plasticity");
+
+        assert_eq!(l.adopt(), LegacyAdoptionOutcome::Adopted { node_count: 4 });
+        assert_eq!(l.served_nodes(), 4);
+        assert!(
+            m1nd_core::snapshot::load_plasticity_state(&l.runtime_plasticity)
+                .expect("the projected sidecar parses")
+                .is_empty(),
+            "a refused import must not leave partial synaptic state in the checkpoint"
+        );
     }
 }

--- a/m1nd-mcp/src/project_brains.rs
+++ b/m1nd-mcp/src/project_brains.rs
@@ -1010,7 +1010,7 @@ impl ProjectBrainRegistry {
                 // `lock_mut_before_actor()` double-checks the ownership fence,
                 // so a foreign/duplicate actor cannot be adopted silently by
                 // this registry. No guard survives actor startup.
-                let (runtime_root, identity) = {
+                let (runtime_root, graph_path, plasticity_path, read_only, identity) = {
                     let session = target
                         .lock_mut_before_actor()
                         .map_err(|error| error.to_string())?;
@@ -1019,9 +1019,15 @@ impl ProjectBrainRegistry {
                         .clone()
                         .or_else(|| session.ingest_roots.first().cloned())
                         .unwrap_or_else(|| session.runtime_root.to_string_lossy().into_owned());
-                    (session.runtime_root.clone(), identity)
+                    (
+                        session.runtime_root.clone(),
+                        session.graph_path.clone(),
+                        session.plasticity_path.clone(),
+                        session.read_only,
+                        identity,
+                    )
                 };
-                BrainActorHandle::start(
+                let runtime = BrainActorHandle::start(
                     project_brain_id(&format!("bound:{identity}")),
                     target.clone(),
                     runtime_root.join(crate::brain_runtime::BRAIN_CHECKPOINT_DIRECTORY),
@@ -1029,11 +1035,27 @@ impl ProjectBrainRegistry {
                     self.actor_queue_capacity,
                     None,
                 )
-                .map(|runtime| BoundRuntime {
+                .map_err(|error| error.to_string())?;
+                // The one seam where the OWNER's brain actor is born — both the
+                // stdio and the `--serve` boot reach it. The pre-1.5 snapshot
+                // adoption runs here and nowhere earlier: the actor has just
+                // reconciled CURRENT, so this is the first moment a boot-time
+                // migration can install a graph without the restore taking it
+                // straight back. A read-only attach never adopts.
+                if !read_only {
+                    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                    let _ = crate::legacy_snapshot_adoption::maybe_adopt_legacy_snapshot(
+                        &runtime,
+                        &graph_path,
+                        &cwd.join("graph_snapshot.json"),
+                        &cwd.join("plasticity_state.json"),
+                        &runtime_root,
+                    );
+                }
+                Ok(BoundRuntime {
                     session: target.clone(),
                     runtime,
                 })
-                .map_err(|error| error.to_string())
             });
             return match opened {
                 Ok(bound_runtime) if Arc::ptr_eq(&bound_runtime.session, &target) => {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -7584,30 +7584,14 @@ impl McpServer {
         };
         eprintln!("[m1nd] Domain: {}", domain_config.name);
 
-        // Step 0: One-time legacy-snapshot adoption (upgrade-path repair).
-        //
-        // Field-triage 2026-07-22: a pre-1.5 layout kept its populated snapshot at
-        // the legacy `./graph_snapshot.json` (cwd) while the new runtime graph is
-        // born empty under the runtime dir — stranding the whole graph and dropping
-        // upgraders into needs_ingest. Adopt it ONCE into the runtime root before
-        // the load below finds it. Owner boot only (a read-only attach never
-        // writes); idempotent + journaled; never over a populated runtime graph.
-        // Best-effort: the honest stderr line is emitted inside the call, and any
-        // skip/failure leaves the normal load path unchanged.
-        if !config.read_only {
-            if let Some(runtime_root) = config.runtime_dir.as_deref() {
-                let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-                let legacy_graph_path = cwd.join("graph_snapshot.json");
-                let legacy_plasticity_path = cwd.join("plasticity_state.json");
-                let _ = crate::legacy_snapshot_adoption::maybe_adopt_legacy_snapshot(
-                    &config.graph_source,
-                    &legacy_graph_path,
-                    &config.plasticity_state,
-                    &legacy_plasticity_path,
-                    runtime_root,
-                );
-            }
-        }
+        // The one-time legacy-snapshot adoption (upgrade-path repair for a
+        // pre-1.5 layout that kept its populated snapshot at `./graph_snapshot.json`)
+        // used to run HERE, writing the legacy bytes into the runtime root before
+        // the load below found them. It cannot: no actor exists yet, so
+        // `BrainActorHandle::start` reverted the adopted files to a CURRENT that
+        // predated them, on the same boot. It now runs once the bound actor is up
+        // — see `legacy_snapshot_adoption::maybe_adopt_legacy_snapshot`, invoked
+        // from `ProjectBrainRegistry::runtime_for_target`.
 
         // Step 1: Try to load graph snapshot
         let (mut graph, graph_loaded) = if config.graph_source.exists() {


### PR DESCRIPTION
## The owner boot loads a real graph and the actor start silently reverts it

This is a **diagnosis with an executable acceptance gate**, not a fix. The test is committed `#[ignore]`d so CI stays honest; **deleting the `#[ignore]` is the gate for whichever fix is chosen.**

### What happens

```
[m1nd] Loaded graph snapshot: 5540 nodes, 10725 edges
[m1nd embed] cache 5540 reused / 0 new of 5540 nodes
[m1nd-mcp] Server ready. 0 nodes, 0 edges
```

`BrainActorHandle::start` (`m1nd-mcp/src/brain_runtime.rs:1027-1032`) calls `restore_checkpoint` and then `reload_authoritative_from_disk`, rebuilding the whole `SessionState` from checkpoint `CURRENT`. In this repo `CURRENT` is dated Jul 22 and pins `graph_snapshot.json` to digest `83f0ea4b…`, which is exactly `sha256("{\"version\":4,\"nodes\":[],\"edges\":[]}")` — **the empty graph**.

So every boot loads the real graph, hands it to the actor, and the actor overwrites it on disk with an empty one.

### Proven by A/B on an isolated fixture, not by reading the source

| fixture | boot line | ready line | on-disk graph after |
|---|---|---|---|
| stale empty `CURRENT` present | `Loaded … 5540 nodes` | `Server ready. 0 nodes` | **5540 → 0** |
| same fixture, `checkpoint-store` removed | `Loaded … 5540 nodes` | `Server ready. 5540 nodes` | 5540 intact |

Ruled out with evidence: it is **not** project-brain resolution (`runtime_for_target`'s bound branch passes the `Arc::ptr_eq` identity check — it *is* the boot session, emptied in place), and the doubled `./` in `.m1nd/./graph_snapshot.json` is **cosmetic** (`main.rs:877`) — the restore overwrote the very file the boot had loaded, which is only possible if both resolve to one identity.

### The 1.5 legacy adoption walks straight into it

`server.rs:7597-7610` writes the pre-1.5 graph into the runtime root **before any actor exists**; the actor reverts it on the same boot; and `legacy_graph_adoption_v1.json` still records `status: "adopted"`, whose own guard forbids re-adoption. **The rescue is permanently spent without ever having worked.**

### Why this stops at diagnosis

The restore is deliberate and defended in-code — a receipt obtained before `start` is advisory, since `CURRENT` may have advanced in the gap — and `project_brains.rs:1254` documents the intended contract: restore **before** `McpServer::new` reads the files, which the stdio owner does not do.

Making the test green requires choosing between two durability semantics:

1. a graph a boot legitimately loaded **outranks** a stale `CURRENT`, or
2. boot-time migrations must commit **through** the checkpoint.

That is durability-core policy, not a local repair, so it was not improvised.

### Do not use the obvious workaround

Copying an intact graph into the runtime root and deleting `checkpoint-store` does serve the full graph — and then the **next** boot fails: the clean shutdown writes a plasticity state the following boot refuses (`full synaptic key … is ambiguous across 2 parallel edges`) and the bound actor will not start at all. Tested, not assumed. Filed separately.

### RED evidence

`brain_runtime.rs::tests::actor_start_serves_the_graph_the_owner_boot_loaded` reproduces the production trace in miniature:

```
assertion `left == right` failed: the served session must expose the nodes the boot loaded, not a stale empty checkpoint
  left: 0
 right: 1
```

`fmt --check` clean; `clippy --workspace --all-targets -D warnings` zero warnings; `cargo test -p m1nd-mcp --lib -- --test-threads=4` → **1458 passed, 0 failed, 16 ignored** (reduced parallelism: full parallelism is flaky on this machine, pre-existing).

### Declared unknown

Why this repo's `CURRENT` is five days stale — whether checkpoints simply are not refreshed on clean shutdown, or whether every boot since Jul 22 died before checkpointing. That distinction sets the blast radius: it decides whether ordinary post-ingest work also gets reverted at the next boot.
