### PR TITLE
fix(boot): make the plasticity round trip real and stop a stale co-change sidecar from killing the session

### DIFF
--- a/m1nd-core/src/plasticity.rs
+++ b/m1nd-core/src/plasticity.rs
@@ -34,8 +34,10 @@ pub struct SynapticState {
     pub source_label: String,
     pub target_label: String,
     pub relation: String,
-    /// Complete edge identity for current sidecars. `None` marks a legacy
-    /// triple-only row and is accepted only when that triple is unambiguous.
+    /// Complete edge identity for current sidecars — complete, but not unique:
+    /// parallel edges share it, and [`PlasticityEngine::import_state`] resolves
+    /// those positionally. `None` marks a legacy triple-only row and is accepted
+    /// only when that triple is unambiguous.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub direction: Option<u8>,
     /// Complete edge identity for current sidecars. See [`Self::direction`].
@@ -791,8 +793,13 @@ impl PlasticityEngine {
     /// Import synaptic state from persistence.
     /// FM-PL-007 fix: validates JSON schema, wraps in try/catch.
     /// Current sidecars match the complete structural identity
-    /// `(source, target, relation, direction, inhibitory)`. Legacy triple-only
-    /// rows are migrated only when exactly one live edge owns that triple.
+    /// `(source, target, relation, direction, inhibitory)`. Parallel edges share
+    /// that identity, so the rows owning one are consumed in file order against
+    /// that identity's CSR slots in slot order — the same order `export_state`
+    /// wrote them in — and only while those slots are interchangeable. More rows
+    /// than slots is corruption; a parallel group that disagrees on causal
+    /// strength is dropped instead of guessed. Legacy triple-only rows are
+    /// migrated only when exactly one live edge owns that triple.
     /// Replaces: plasticity.py PlasticityEngine.import_state()
     pub fn import_state(&mut self, graph: &mut Graph, states: &[SynapticState]) -> M1ndResult<u32> {
         let n = graph.num_nodes() as usize;
@@ -881,7 +888,9 @@ impl PlasticityEngine {
         }
 
         // Resolve and validate the entire sidecar before mutating one slot.
-        let mut seen_full_keys = HashSet::<FullKey>::new();
+        // Rows are consumed in file order, so the cursor walks each identity's
+        // parallel edges in the same CSR order `export_state` wrote them in.
+        let mut full_key_cursor = HashMap::<FullKey, usize>::new();
         let mut selected_slots = HashSet::<usize>::new();
         let mut plans = Vec::with_capacity(states.len());
 
@@ -922,29 +931,46 @@ impl PlasticityEngine {
                         direction,
                         inhibitory,
                     );
-                    if !seen_full_keys.insert(key.clone()) {
+                    let slots = match full_to_edges.get(&key).map(Vec::as_slice) {
+                        None | Some([]) => continue,
+                        Some(slots) => slots,
+                    };
+                    // Parallel edges share every persisted identity field, so
+                    // `export_state` necessarily writes one row per slot with the
+                    // same key: rejecting that would refuse the file the previous
+                    // clean shutdown wrote. Bind positionally instead — but only
+                    // while the candidate slots are interchangeable. Causal
+                    // strength is the one structural column outside the persisted
+                    // key, so a group that disagrees on it is dropped rather than
+                    // guessed: losing relearnable weights beats binding a record
+                    // to an edge it did not come from.
+                    let cursor = full_key_cursor.entry(key).or_insert(0);
+                    if slots.len() > 1 && !parallel_slots_are_interchangeable(graph, slots) {
+                        if *cursor == 0 {
+                            eprintln!(
+                                "[m1nd] WARNING: {} parallel edges for {} -> {} ({}) differ outside the persisted synaptic key; their learned weights are dropped and relearned",
+                                slots.len(),
+                                state.source_label,
+                                state.target_label,
+                                state.relation
+                            );
+                        }
+                        *cursor += 1;
+                        continue;
+                    }
+                    let Some(&slot) = slots.get(*cursor) else {
                         return Err(M1ndError::CorruptState {
                             reason: format!(
-                                "duplicate full synaptic key for {} -> {} ({}, direction={direction}, inhibitory={inhibitory})",
-                                state.source_label, state.target_label, state.relation
+                                "duplicate full synaptic key for {} -> {} ({}, direction={direction}, inhibitory={inhibitory}): more rows than the {} parallel edge(s) that own it",
+                                state.source_label,
+                                state.target_label,
+                                state.relation,
+                                slots.len()
                             ),
                         });
-                    }
-                    match full_to_edges.get(&key).map(Vec::as_slice) {
-                        None | Some([]) => continue,
-                        Some([slot]) => *slot,
-                        Some(matches) => {
-                            return Err(M1ndError::CorruptState {
-                                reason: format!(
-                                    "full synaptic key for {} -> {} ({}) is ambiguous across {} parallel edges",
-                                    state.source_label,
-                                    state.target_label,
-                                    state.relation,
-                                    matches.len()
-                                ),
-                            });
-                        }
-                    }
+                    };
+                    *cursor += 1;
+                    slot
                 }
                 (None, None) => match triple_to_edges.get(&triple).map(Vec::as_slice) {
                     None | Some([]) => continue,
@@ -1029,6 +1055,26 @@ impl PlasticityEngine {
     pub fn top_node_access_frequencies(&self, n: usize) -> Vec<(NodeId, u32)> {
         self.memory.top_node_frequencies(n)
     }
+}
+
+/// Parallel edges (same source, target, relation, direction and inhibitory flag)
+/// can only be restored positionally, so they must first be proven mutually
+/// substitutable: causal strength is the one structural column outside the
+/// persisted synaptic key. A column that cannot be read counts as disagreement —
+/// dropping relearnable weights is cheaper than binding a record to an edge it
+/// did not come from.
+fn parallel_slots_are_interchangeable(graph: &Graph, slots: &[usize]) -> bool {
+    let Some(reference) = graph.csr.causal_strengths.get(slots[0]) else {
+        return false;
+    };
+    let reference = reference.get().to_bits();
+    slots.iter().all(|&slot| {
+        graph
+            .csr
+            .causal_strengths
+            .get(slot)
+            .is_some_and(|value| value.get().to_bits() == reference)
+    })
 }
 
 #[cfg(test)]

--- a/m1nd-core/tests/plasticity_persist_roundtrip.rs
+++ b/m1nd-core/tests/plasticity_persist_roundtrip.rs
@@ -69,6 +69,36 @@ fn parallel_graph() -> Graph {
     graph
 }
 
+/// Two structurally identical edges between the same pair: same relation, same
+/// direction, same inhibitory flag, same causal strength. Ingest emits these for
+/// a duplicated relation (the owner's graph carries them on `contains` edges),
+/// and `export_state` writes one row per CSR slot — so the sidecar a clean
+/// shutdown produces necessarily contains two rows with the same complete key.
+fn twin_edge_graph() -> Graph {
+    let mut graph = Graph::new();
+    let alpha = graph
+        .add_node("alpha", "alpha", NodeType::File, &[], 0.0, 0.0)
+        .unwrap();
+    let beta = graph
+        .add_node("beta", "beta", NodeType::Struct, &[], 0.0, 0.0)
+        .unwrap();
+    for _ in 0..2 {
+        graph
+            .add_edge(
+                alpha,
+                beta,
+                "contains",
+                FiniteF32::new(0.5),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::ZERO,
+            )
+            .unwrap();
+    }
+    graph.finalize().unwrap();
+    graph
+}
+
 fn edge_slot(graph: &Graph, source: NodeId, target: NodeId, inhibitory: bool) -> usize {
     graph
         .csr
@@ -236,6 +266,122 @@ fn complete_identity_disambiguates_parallel_edges() {
     );
     assert_eq!(restored.edge_plasticity.last_used_query[excitatory], 11);
     assert_eq!(restored.edge_plasticity.last_used_query[inhibitory], 72);
+}
+
+#[test]
+fn twin_parallel_edges_survive_persist_then_import() {
+    // The boot-after-clean-shutdown contract: whatever `export_state` writes must
+    // be re-importable by the very next boot. Twin edges share every persisted
+    // identity field, so the sidecar holds two rows with the same complete key;
+    // rejecting that file bricks a brain that shut down cleanly.
+    let source_graph = twin_edge_graph();
+    let source_engine = PlasticityEngine::new(&source_graph, PlasticityConfig::default());
+    let mut states = source_engine.export_state(&source_graph).unwrap();
+    assert_eq!(states.len(), 2, "twin edges must occupy two CSR slots");
+    states[0].original_weight = 0.10;
+    states[0].current_weight = 0.11;
+    states[0].last_used_query = 11;
+    states[1].original_weight = 0.70;
+    states[1].current_weight = 0.72;
+    states[1].last_used_query = 72;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("plasticity_state.json");
+    save_plasticity_state(&states, &path).unwrap();
+    let persisted = load_plasticity_state(&path).unwrap();
+
+    let mut restored = twin_edge_graph();
+    let mut engine = PlasticityEngine::new(&restored, PlasticityConfig::default());
+    assert_eq!(
+        engine.import_state(&mut restored, &persisted).unwrap(),
+        2,
+        "both twin rows must bind to their own CSR slot"
+    );
+    let alpha = restored.resolve_id("alpha").unwrap();
+    let slots: Vec<usize> = restored.csr.out_range(alpha).collect();
+    assert_eq!(slots.len(), 2);
+    assert_eq!(
+        restored.edge_plasticity.original_weight[slots[0]].get(),
+        0.10
+    );
+    assert_eq!(
+        restored.edge_plasticity.current_weight[slots[0]].get(),
+        0.11
+    );
+    assert_eq!(restored.edge_plasticity.last_used_query[slots[0]], 11);
+    assert_eq!(
+        restored.edge_plasticity.original_weight[slots[1]].get(),
+        0.70
+    );
+    assert_eq!(
+        restored.edge_plasticity.current_weight[slots[1]].get(),
+        0.72
+    );
+    assert_eq!(restored.edge_plasticity.last_used_query[slots[1]], 72);
+    assert_eq!(
+        restored
+            .csr
+            .read_weight(EdgeIdx::new(slots[1] as u32))
+            .get(),
+        0.72
+    );
+}
+
+#[test]
+fn parallel_edges_disagreeing_outside_the_key_are_dropped_not_guessed() {
+    // Same complete key, different causal strength: the two slots are NOT
+    // interchangeable and nothing in the sidecar says which row came from which.
+    // Positional binding would be a coin flip, so the group is dropped — the
+    // boot still proceeds and the two slots keep their bootstrap weights.
+    let mut graph = Graph::new();
+    let alpha = graph
+        .add_node("alpha", "alpha", NodeType::File, &[], 0.0, 0.0)
+        .unwrap();
+    let beta = graph
+        .add_node("beta", "beta", NodeType::Struct, &[], 0.0, 0.0)
+        .unwrap();
+    for causal in [0.1_f32, 0.9_f32] {
+        graph
+            .add_edge(
+                alpha,
+                beta,
+                "contains",
+                FiniteF32::new(0.5),
+                EdgeDirection::Forward,
+                false,
+                FiniteF32::new(causal),
+            )
+            .unwrap();
+    }
+    graph.finalize().unwrap();
+
+    let engine = PlasticityEngine::new(&graph, PlasticityConfig::default());
+    let mut states = engine.export_state(&graph).unwrap();
+    assert_eq!(states.len(), 2);
+    states[0].current_weight = 0.11;
+    states[1].current_weight = 0.72;
+    let before: Vec<f32> = graph
+        .edge_plasticity
+        .current_weight
+        .iter()
+        .map(|weight| weight.get())
+        .collect();
+
+    let mut importer = PlasticityEngine::new(&graph, PlasticityConfig::default());
+    assert_eq!(
+        importer.import_state(&mut graph, &states).unwrap(),
+        0,
+        "an unresolvable parallel group must apply nothing, not guess"
+    );
+    assert_eq!(
+        graph
+            .edge_plasticity
+            .current_weight
+            .iter()
+            .map(|weight| weight.get())
+            .collect::<Vec<_>>(),
+        before
+    );
 }
 
 #[test]

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -2002,11 +2002,24 @@ impl SessionState {
         )?;
         let mut temporal = TemporalEngine::build(&graph)?;
         let temporal_state_path = runtime_root.join(crate::temporal_state::TEMPORAL_STATE_FILE);
-        if let Some((primary, orchestrator_matrix)) =
-            crate::temporal_state::load_temporal_state(&temporal_state_path, &graph)?
-        {
-            temporal.co_change = primary;
-            orchestrator.temporal.co_change = orchestrator_matrix;
+        match crate::temporal_state::load_temporal_state(&temporal_state_path, &graph) {
+            Ok(Some((primary, orchestrator_matrix))) => {
+                temporal.co_change = primary;
+                orchestrator.temporal.co_change = orchestrator_matrix;
+            }
+            Ok(None) => {}
+            // A co-change matrix is indexed by the graph it was learned on, so a
+            // sidecar bound to a different graph must never be adopted. Refusing
+            // the whole boot over it is the wrong consequence: it takes every MCP
+            // tool down and leaves hand-deleting the file as the only recovery.
+            // Drop it like every other stale sidecar on this path and relearn.
+            Err(M1ndError::SchemaDrift { reason }) => {
+                eprintln!(
+                    "[m1nd] WARNING: co-change state at {} does not match the loaded graph ({reason}); continuing without it — the matrix will be relearned and rewritten on the next persist",
+                    temporal_state_path.display()
+                );
+            }
+            Err(error) => return Err(error),
         }
         let counterfactual = CounterfactualEngine::with_defaults();
         let topology = TopologyAnalyzer::with_defaults();

--- a/m1nd-mcp/tests/boot_temporal_state_drift.rs
+++ b/m1nd-mcp/tests/boot_temporal_state_drift.rs
@@ -1,0 +1,126 @@
+//! A co-change sidecar bound to a DIFFERENT graph must not kill the boot.
+//!
+//! `temporal_state_v1.json` is one sidecar among many on the startup path, and
+//! every other one degrades ("continuing without it") when it no longer matches
+//! the loaded graph. This one used to abort `SessionState::initialize`, which
+//! takes the whole MCP server — all its tools — down with it, and the only
+//! recovery was deleting the file by hand.
+//!
+//! The binding check itself is correct and stays: a matrix whose rows are
+//! indexed by another graph's nodes would predict nonsense. What changes is the
+//! consequence — the stale matrix is dropped and relearned, loudly.
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_core::temporal::CoChangeMatrix;
+use m1nd_core::types::{NodeId, NodeType};
+use m1nd_mcp::server::McpConfig;
+use m1nd_mcp::session::SessionState;
+use m1nd_mcp::temporal_state::{save_temporal_state, TEMPORAL_STATE_FILE};
+use std::path::Path;
+
+fn graph_of(node_count: usize, prefix: &str) -> Graph {
+    let mut graph = Graph::new();
+    for index in 0..node_count {
+        let id = format!("{prefix}_{index}");
+        graph
+            .add_node(&id, &id, NodeType::File, &[], 0.0, 0.0)
+            .expect("add node");
+    }
+    graph.finalize().expect("finalize");
+    graph
+}
+
+fn learned_matrix(graph: &Graph) -> CoChangeMatrix {
+    let mut matrix = CoChangeMatrix::bootstrap(graph, 128).expect("bootstrap");
+    for _ in 0..4 {
+        matrix.note_node_appearance(NodeId::new(0));
+        matrix.note_node_appearance(NodeId::new(1));
+        matrix
+            .record_co_change(NodeId::new(0), NodeId::new(1), 0.0)
+            .expect("learn");
+    }
+    matrix
+}
+
+fn config_for(root: &Path) -> McpConfig {
+    McpConfig {
+        graph_source: root.join("graph_snapshot.json"),
+        plasticity_state: root.join("plasticity_state.json"),
+        runtime_dir: Some(root.to_path_buf()),
+        registry_dir: Some(root.join("registry")),
+        ..McpConfig::default()
+    }
+}
+
+#[test]
+fn boot_survives_a_co_change_sidecar_bound_to_another_graph() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let written_for = graph_of(3, "alpha");
+    let matrix = learned_matrix(&written_for);
+    save_temporal_state(
+        &root.join(TEMPORAL_STATE_FILE),
+        &written_for,
+        &matrix,
+        &matrix,
+    )
+    .expect("save sidecar bound to graph A");
+
+    // Boot against a different graph: same shape, different node identities.
+    let loaded = graph_of(3, "beta");
+    let state = SessionState::initialize(loaded, &config_for(root), DomainConfig::code())
+        .expect("a stale co-change sidecar must not abort the boot");
+
+    assert_eq!(
+        state.temporal.co_change.num_entries(),
+        0,
+        "the stale matrix must be dropped, not bound to the new graph"
+    );
+    assert_eq!(
+        state.orchestrator.temporal.co_change.num_entries(),
+        0,
+        "the orchestrator fallback matrix must be dropped too"
+    );
+    assert!(
+        state
+            .temporal
+            .co_change
+            .predict(NodeId::new(0), 8)
+            .is_empty(),
+        "a dropped matrix must predict nothing until it is relearned"
+    );
+}
+
+#[test]
+fn boot_still_adopts_a_co_change_sidecar_bound_to_the_loaded_graph() {
+    // The degrade must not become a shrug: a sidecar that DOES match is still
+    // adopted exactly, otherwise every restart would silently forget.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let graph = graph_of(3, "alpha");
+    let matrix = learned_matrix(&graph);
+    let expected = matrix.predict(NodeId::new(0), 8);
+    assert!(!expected.is_empty(), "fixture must have learned something");
+    save_temporal_state(&root.join(TEMPORAL_STATE_FILE), &graph, &matrix, &matrix)
+        .expect("save sidecar");
+
+    let state = SessionState::initialize(
+        graph_of(3, "alpha"),
+        &config_for(root),
+        DomainConfig::code(),
+    )
+    .expect("boot");
+    assert_eq!(
+        state.temporal.co_change.predict(NodeId::new(0), 8),
+        expected
+    );
+    assert_eq!(
+        state
+            .orchestrator
+            .temporal
+            .co_change
+            .predict(NodeId::new(0), 8),
+        expected
+    );
+}


### PR DESCRIPTION
## Two boot defects that brick a working brain, both found by dogfooding

Neither was caught by the 1458 green tests, because both need a **second boot** to appear.

## 1 — plasticity `persist → import` was not a round trip

`export_state` emits one row per CSR slot, keyed by `(source, target, relation, direction, inhibitory)`. **Parallel edges** — two slots agreeing on all five — were written as two rows with the same key, and `import_state` then found 2 matches and refused:

```
full synaptic key for … -> … (contains) is ambiguous across 2 parallel edges
```

**The writer was persisting a file its own reader rejects.** The friendly boot degrades, but `prepare_strict_recovery_state` propagates it — so a checkpointed brain could not restart. Reproduced on the real 5540-node graph: boot N served and checkpointed, **boot N+1 could not start.**

Where the twins come from is already fixed upstream: `m1nd-openclaw/Cargo.toml` carries two `[[bin]]` tables, and an older TOML extractor gave both the same node id, emitting `contains` twice. Current ingest de-duplicates. **But snapshots on disk still carry the twins until a re-ingest** — which is exactly why the reader has to survive them.

**Fix:** a per-identity cursor. Rows owning one key are consumed in file order against that key's slots in slot order — the same order `export_state` wrote them — so the round trip is exact.

**Can a record now bind to the wrong parallel edge? No.** Binding never crosses identity groups. Inside a group, positional binding happens only after `parallel_slots_are_interchangeable` proves every candidate agrees on causal strength — the one structural column outside the persisted key — so a swap between them is an automorphism of the graph's structural data. When slots are *not* substitutable, **nothing is bound**: the group is dropped with a warning and relearned. More rows than slots is still `CorruptState` before any mutation.

**An existing `plasticity_state.json` still imports — do not discard it.** No serialized schema change; the reader is strictly more permissive. Every file the old reader accepted takes an identical path; the only changes turn previous *errors* into successes or skips.

**Field-scale check:** an ingest of this worktree (17,186 nodes / 72,047 edges / 967 files) exported a 30.9 MB sidecar and re-imported it — `applied 72047 of 72047 CSR edges`.

## 2 — a graph-stale co-change sidecar killed the whole session

`CoChangeMatrix::from_state` correctly returns `SchemaDrift` when the binding differs. `SessionState::initialize` used `?` on it — so **`McpServer::new` died and all 48 MCP tools vanished from the host.** The only recovery was deleting the sidecar by hand. Every sibling sidecar on that path degrades with "continuing without it"; only this one was fatal.

This bit the owner for real today.

**Fix: one hunk at the boot site.** `SchemaDrift` warns and keeps the bootstrap matrices; the next persist rewrites the file against the live graph. **Detection is untouched** — `load_temporal_state` stays strict, so checkpoint recovery still fails closed, and corruption, digest mismatch and unknown versions remain fatal. A silently-wrong co-change matrix is never bound; dropping it is the honest outcome.

## Proof

Both born RED with the field's exact messages, green after:

- `twin_parallel_edges_survive_persist_then_import` + `parallel_edges_disagreeing_outside_the_key_are_dropped_not_guessed` → RED `FAILED. 8 passed; 2 failed` with the owner's verbatim error; GREEN `ok. 10 passed; 0 failed`
- `boot_temporal_state_drift` → RED with `SchemaDrift { … }`; GREEN `ok. 2 passed`. The second test is a **positive control**: a sidecar that *does* match is still adopted exactly, so the degrade cannot rot into a shrug.

`fmt --check` clean · `clippy --workspace --all-targets -D warnings` zero warnings · `cargo test -p m1nd-mcp --lib -- --test-threads=4` → **1458 passed, 0 failed** (reduced parallelism: full parallelism is flaky on this machine, pre-existing) · `cargo test -p m1nd-core` no failures.

**Declared limit on that last one:** the m1nd-core run was captured through `tail`, so every visible line is `ok` and no failure line appears, but a grand total cannot be quoted from that capture.

## Footprint outside m1nd-core, stated plainly

The fatal was only expressible at the caller, so this touches **exactly one hunk** in `m1nd-mcp/src/session.rs::initialize` (+18/−5) plus one new test file. `m1nd-mcp/src/temporal_state.rs` is untouched — its doc ("a graph-stale file is an error") stays true of the function; only the consequence moved to the caller.
