### PR TITLE
test(m1nd-mcp): bound lifecycle tests by condition, not by a clock CI cannot meet

### DIFF
--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -4079,6 +4079,16 @@ pub type BrainPrepare<P, S> =
 mod tests {
     use super::*;
 
+    /// Upper bound for polling a lifecycle FACT into view — a health status
+    /// flipping, an actor fence dropping, a heartbeat landing. Every loop that uses
+    /// it exits on the first matching observation, so this caps a stuck run and
+    /// nothing else: a healthy run returns in milliseconds and pays nothing for the
+    /// headroom. Deliberately generous — at two and five seconds these budgets were
+    /// measuring how loaded the machine is (the m1nd-mcp lib suite measures ~1001s
+    /// on the two-core Windows runner against ~440-700s on a developer Mac), which
+    /// is the same failure mode that makes the shutdown-deadline tests rotate red.
+    const OBSERVE_BUDGET: Duration = Duration::from_secs(60);
+
     fn add_consistent_test_node(
         state: &mut SessionState,
         id: &str,
@@ -4513,7 +4523,7 @@ mod tests {
         )
         .expect("decode candidate CURRENT");
         assert_ne!(current.current_checkpoint_id, baseline);
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status != "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -4540,7 +4550,7 @@ mod tests {
         assert!(session.is_actor_active());
 
         injector.enabled.store(false, Ordering::SeqCst);
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status == "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -4594,7 +4604,7 @@ mod tests {
         assert!(session.try_lock().is_none());
         injector.enabled.store(false, Ordering::SeqCst);
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while session.is_actor_active() && std::time::Instant::now() < deadline {
             thread::sleep(Duration::from_millis(20));
         }
@@ -4637,7 +4647,7 @@ mod tests {
             })
             .expect_err("post-CURRENT adapter panic cannot yield an ACK");
         assert_eq!(error.code(), "brain_checkpoint_committed_unconfirmed");
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status != "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -4651,7 +4661,7 @@ mod tests {
         assert!(session.try_lock().is_none());
 
         injector.enabled.store(false, Ordering::SeqCst);
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status == "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -4691,7 +4701,7 @@ mod tests {
         assert!(session.try_lock().is_none());
 
         injector.enabled.store(false, Ordering::SeqCst);
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status == "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -6302,7 +6312,7 @@ mod tests {
         std::fs::remove_file(graph_path.join("rollback-blocker"))
             .expect("remove temporary rollback blocker");
         std::fs::remove_dir(&graph_path).expect("clear temporary rollback obstruction");
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status == "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -6420,7 +6430,7 @@ mod tests {
         assert!(session.try_lock().is_none());
 
         fail_validation.store(false, Ordering::SeqCst);
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         while actor.health_snapshot().status == "reconciling"
             && std::time::Instant::now() < deadline
         {
@@ -6721,7 +6731,7 @@ mod tests {
     }
 
     fn wait_for_matching_heartbeat(entry_path: &Path, lease_path: &Path) -> u64 {
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
         loop {
             let entry = std::fs::read(entry_path).ok().and_then(|bytes| {
                 serde_json::from_slice::<crate::instance_registry::InstanceRegistryEntry>(&bytes)

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -10502,8 +10502,10 @@ mod tests {
             .expect("preview worker joined")
             .expect_err("cancelled scan cannot publish a preview");
         assert_eq!(cancelled.code(), "graph_ingest_scan_job_failed");
+        // Condvar-based: returns the instant the job finishes, so the budget only
+        // caps a stuck run and can be generous enough for a loaded two-core runner.
         let terminal = limited_jobs
-            .wait_terminal(&job_id, Duration::from_secs(2))
+            .wait_terminal(&job_id, Duration::from_secs(60))
             .expect("cancelled scan terminal");
         let RuntimeJobWait::Terminal(terminal) = terminal else {
             panic!("cancelled scan remained non-terminal")

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -5728,8 +5728,11 @@ mod tests {
             .install_read_snapshot_test_hook(snapshot_entered_tx, release_rx);
 
         let request = tokio::spawn(request);
+        // Waits FOR the seam to be reached and returns the instant it is, so the
+        // budget only caps a stuck run; two seconds was measuring how long a loaded
+        // runner takes to schedule the spawned request.
         snapshot_entered_rx
-            .recv_timeout(Duration::from_secs(2))
+            .recv_timeout(Duration::from_secs(60))
             .expect("request reached actor snapshot seam");
         assert!(
             !request.is_finished(),
@@ -5748,7 +5751,7 @@ mod tests {
         );
 
         release_tx.send(()).expect("release graph analysis");
-        tokio::time::timeout(Duration::from_secs(10), request)
+        tokio::time::timeout(Duration::from_secs(60), request)
             .await
             .expect("request completed after graph release")
             .expect("request task joined")
@@ -5916,6 +5919,13 @@ mod tests {
             .iter()
             .filter(|latency| **latency >= Duration::from_millis(100))
             .count();
+        // DO NOT widen these two to appease a slow runner: unlike every other
+        // wall-clock budget in this suite, 100ms here is a PRODUCT contract, frozen
+        // in docs/M1ND-10-PRD.md ("/health p99 abaixo de 100 ms durante uma operação
+        // de 30 s", and the same row in its acceptance matrix). The bound is the
+        // guarantee, not the test's tolerance, so a red here is either a real
+        // regression or evidence that the runner class cannot host the SLO — a
+        // decision for the PRD, not for this assertion.
         assert!(
             p99 < Duration::from_millis(100),
             "busy health p99 was {p99:?} across {SAMPLE_COUNT} samples during a measured {measured_stall:?} owner stall"

--- a/m1nd-mcp/src/instance_registry.rs
+++ b/m1nd-mcp/src/instance_registry.rs
@@ -2098,12 +2098,16 @@ mod tests {
 
         // Drive the sweep through the boot entry point. `spawn_boot_gc` must
         // return the handle promptly (fire-and-forget) rather than block on the
-        // sweep — a 25k-file dir at boot must not stall the handshake.
+        // sweep — a 25k-file dir at boot must not stall the handshake. This bound is
+        // a coarse "returned rather than joined the sweep" net only: with a fixture
+        // this small the sweep itself is milliseconds, so the number can be generous
+        // without giving anything up, and a one-second ceiling on a bare
+        // `thread::spawn` was measuring machine load.
         let started = std::time::Instant::now();
         let handle = spawn_boot_gc(live.registry_root());
         let spawn_elapsed = started.elapsed();
         assert!(
-            spawn_elapsed < std::time::Duration::from_secs(1),
+            spawn_elapsed < std::time::Duration::from_secs(30),
             "spawn_boot_gc must return immediately (non-blocking); took {:?}",
             spawn_elapsed,
         );

--- a/m1nd-mcp/src/internal_tests/delegation_slices.rs
+++ b/m1nd-mcp/src/internal_tests/delegation_slices.rs
@@ -326,8 +326,10 @@ impl Owner {
             .project_brains
             .runtime_job_registry()
             .map_err(|error| error.to_string())?;
+        // Condvar-based: returns the instant the job finishes, so the budget only
+        // caps a stuck run and can be generous enough for a loaded two-core runner.
         let terminal = jobs
-            .wait_terminal(&submitted, Duration::from_secs(5))
+            .wait_terminal(&submitted, Duration::from_secs(60))
             .map_err(|error| error.to_string())?;
         let job = match terminal {
             RuntimeJobWait::Terminal(job) => job,
@@ -336,7 +338,7 @@ impl Owner {
             }
         };
         let dispatched = result_rx
-            .recv_timeout(Duration::from_secs(1))
+            .recv_timeout(Duration::from_secs(30))
             .map_err(|error| format!("debrief fixture result missing: {error}"))?;
         if job.state != RuntimeJobState::Succeeded {
             return dispatched.and_then(|_| {

--- a/m1nd-mcp/src/internal_tests/file_view_brain_root.rs
+++ b/m1nd-mcp/src/internal_tests/file_view_brain_root.rs
@@ -167,8 +167,10 @@ fn set_hosted_workspace_root(
     let jobs = registry
         .runtime_job_registry()
         .expect("runtime job registry");
+    // Condvar-based: returns the instant the job finishes, so the budget only caps a
+    // stuck run and can be generous enough for a loaded two-core runner.
     match jobs
-        .wait_terminal(&submitted, Duration::from_secs(5))
+        .wait_terminal(&submitted, Duration::from_secs(60))
         .expect("wait for hosted fixture mutation")
     {
         RuntimeJobWait::Terminal(job) => assert_eq!(

--- a/m1nd-mcp/src/internal_tests/per_brain_open.rs
+++ b/m1nd-mcp/src/internal_tests/per_brain_open.rs
@@ -419,10 +419,14 @@ async fn warm_boots_dormant_store_on_first_selector() {
     let (warm_sess, _e) =
         resolve_brain(&owner.app, Some(&project_repo.to_string_lossy())).expect("warm resolves");
     let warm_n = owner.graph_node_count(Some(&project_repo)).await;
+    // The grace is this caller's tolerance for a slow machine, not the guarantee:
+    // shutdown returns the instant the last ACK lands, and still fails closed if a
+    // real checkpoint never arrives. Three seconds was too tight for a hosted brain
+    // doing real checkpoint I/O on a loaded two-core runner.
     let shutdown_acks = owner
         .app
         .project_brains
-        .shutdown(std::time::Duration::from_secs(3))
+        .shutdown(std::time::Duration::from_secs(60))
         .expect("graceful owner shutdown checkpoints and releases hosted brains");
     assert!(
         !shutdown_acks.is_empty(),

--- a/m1nd-mcp/src/internal_tests/project_brain_runtime.rs
+++ b/m1nd-mcp/src/internal_tests/project_brain_runtime.rs
@@ -16,6 +16,24 @@ use m1nd_mcp::runtime_jobs::{
     RUNTIME_JOB_BINDING_SCHEMA,
 };
 
+/// Upper bound for awaiting a runtime job's TERMINAL state. `wait_terminal` is
+/// condvar-based and returns the instant the job finishes, so this only caps a
+/// stuck run: a healthy run pays nothing for the headroom. Generous on purpose —
+/// on the loaded two-core Windows runner the m1nd-mcp lib suite measures ~1001s
+/// against ~440-700s on a developer Mac, so a five-second wait was measuring the
+/// runner rather than the job.
+const TERMINAL_BUDGET: Duration = Duration::from_secs(60);
+
+/// Grace handed to `ProjectBrainRegistry::shutdown`. The product contract is
+/// "fail closed unless every actor checkpoints within the grace the CALLER gave";
+/// this constant is only the test's tolerance for a slow machine. Shutdown returns
+/// the instant the last ACK lands, so the headroom costs nothing when healthy.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(60);
+
+/// Upper bound for waiting on a condition (a refusal arriving, a health status
+/// flipping) rather than timing a single look. Bounds a stuck run only.
+const OBSERVE_BUDGET: Duration = Duration::from_secs(30);
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -185,14 +203,14 @@ fn stale_concurrent_worker_never_mutates_and_only_one_write_commits() {
     let fast_id = submit_root_append(&registry, &root, "fast-winner", "winner-marker");
     let jobs = registry.runtime_job_registry().expect("job registry");
     let fast = terminal(
-        jobs.wait_terminal(&fast_id, Duration::from_secs(5))
+        jobs.wait_terminal(&fast_id, TERMINAL_BUDGET)
             .expect("wait fast"),
     );
     assert_eq!(fast.state, RuntimeJobState::Succeeded);
 
     release_tx.send(()).expect("release stale worker");
     let slow = terminal(
-        jobs.wait_terminal(&slow_id, Duration::from_secs(5))
+        jobs.wait_terminal(&slow_id, TERMINAL_BUDGET)
             .expect("wait slow"),
     );
     assert_eq!(slow.state, RuntimeJobState::Failed);
@@ -211,7 +229,7 @@ fn stale_concurrent_worker_never_mutates_and_only_one_write_commits() {
         .value;
     assert!(roots.iter().any(|root| root == "winner-marker"));
     assert!(!roots.iter().any(|root| root == "stale-marker"));
-    registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+    registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
 }
 
 #[test]
@@ -263,11 +281,7 @@ fn multi_brain_actors_are_isolated() {
     let job_a = submit_root_append(&registry, &root_a, "brain-a-job", "only-a");
     let jobs = registry.runtime_job_registry().expect("jobs");
     assert_eq!(
-        terminal(
-            jobs.wait_terminal(&job_a, Duration::from_secs(5))
-                .expect("wait A")
-        )
-        .state,
+        terminal(jobs.wait_terminal(&job_a, TERMINAL_BUDGET).expect("wait A")).state,
         RuntimeJobState::Succeeded
     );
     let roots_a = registry
@@ -288,7 +302,7 @@ fn multi_brain_actors_are_isolated() {
         registry.brain_id_for(&root_a.to_string_lossy()),
         registry.brain_id_for(&root_b.to_string_lossy())
     );
-    let acks = registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+    let acks = registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
     assert_eq!(acks.len(), 2);
     assert_ne!(acks[0].brain_id, acks[1].brain_id);
 }
@@ -302,7 +316,17 @@ fn ten_thousand_multi_project_actor_operations_are_isolated_and_bounded() {
     const WRITES_PER_BRAIN: usize = OPERATIONS_PER_BRAIN / WRITE_EVERY;
     const TOTAL_WRITES: usize = BRAIN_COUNT * WRITES_PER_BRAIN;
     const TOTAL_READS: usize = TOTAL_OPERATIONS - TOTAL_WRITES;
-    const COMPLETION_BOUND: Duration = Duration::from_secs(60);
+    // A LIVELOCK / LOST-WORKER net, not a throughput SLO: nothing in the product
+    // promises 10,000 actor operations inside any wall-clock window, and the proof
+    // this test carries is isolation plus the exact read/write ledger below. At
+    // sixty seconds the bound was measuring the runner instead — eight worker
+    // threads doing real OCC submissions on a loaded two-core box (the m1nd-mcp lib
+    // suite measures ~1001s there against ~440-700s on a developer Mac) blew it and
+    // reported "exceeded 60s or lost a worker". Five minutes still catches a real
+    // hang in minutes, and a healthy run neither waits for it nor hides behind it:
+    // the true elapsed time is asserted-on-nothing but PRINTED below, so a genuine
+    // throughput regression stays visible in the log.
+    const COMPLETION_BOUND: Duration = Duration::from_secs(300);
 
     let temp = tempfile::tempdir().expect("tempdir");
     let registry = Arc::new(
@@ -360,13 +384,13 @@ fn ten_thousand_multi_project_actor_operations_are_isolated_and_bounded() {
                         let job = match registry
                             .runtime_job_registry()
                             .map_err(|error| format!("open stress job registry: {error}"))?
-                            .wait_terminal(&job_id, Duration::from_secs(15))
+                            .wait_terminal(&job_id, TERMINAL_BUDGET)
                             .map_err(|error| format!("wait stress job {job_id}: {error}"))?
                         {
                             RuntimeJobWait::Terminal(job) => job,
                             RuntimeJobWait::ObservableNonTerminal(job) => {
                                 return Err(format!(
-                                    "stress job {job_id} did not terminate before its 15s wait: {:?}",
+                                    "stress job {job_id} did not terminate before its {TERMINAL_BUDGET:?} wait: {:?}",
                                     job.state
                                 ));
                             }
@@ -426,7 +450,7 @@ fn ten_thousand_multi_project_actor_operations_are_isolated_and_bounded() {
         let remaining = deadline.saturating_duration_since(Instant::now());
         worker_results.push(result_rx.recv_timeout(remaining).unwrap_or_else(|error| {
             panic!(
-                "10,000-operation stress exceeded {COMPLETION_BOUND:?} or lost a worker: {error}"
+                "10,000-operation stress hung past {COMPLETION_BOUND:?} or lost a worker: {error}"
             )
         }));
     }
@@ -445,7 +469,7 @@ fn ten_thousand_multi_project_actor_operations_are_isolated_and_bounded() {
     let stress_elapsed = started.elapsed();
     assert!(
         stress_elapsed < COMPLETION_BOUND,
-        "10,000 logical actor operations exceeded {COMPLETION_BOUND:?}"
+        "10,000 logical actor operations hung past {COMPLETION_BOUND:?}"
     );
     assert_eq!(completed.load(Ordering::SeqCst), TOTAL_OPERATIONS);
     assert_eq!(reads.load(Ordering::SeqCst), TOTAL_READS);
@@ -473,7 +497,7 @@ fn ten_thousand_multi_project_actor_operations_are_isolated_and_bounded() {
     }
 
     let acks = registry
-        .shutdown(Duration::from_secs(15))
+        .shutdown(SHUTDOWN_GRACE)
         .expect("bounded stress shutdown");
     assert_eq!(acks.len(), BRAIN_COUNT);
     assert_eq!(
@@ -531,7 +555,7 @@ fn actor_queue_and_global_worker_limit_fail_fast_under_pressure() {
         }));
     }
     let refused = result_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(OBSERVE_BUDGET)
         .expect("one contender must fail fast while actor+queue are occupied");
     assert!(refused
         .expect_err("one contender must be refused")
@@ -542,7 +566,7 @@ fn actor_queue_and_global_worker_limit_fail_fast_under_pressure() {
         .expect("blocker thread")
         .expect("blocker read");
     let accepted = result_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(OBSERVE_BUDGET)
         .expect("queued contender completes");
     assert!(accepted.is_ok());
     for contender in contenders {
@@ -578,7 +602,13 @@ fn actor_queue_and_global_worker_limit_fail_fast_under_pressure() {
         |_state, ()| Ok(RuntimeJobSuccess::new("unexpected", "must not commit")),
     );
     assert!(overload.is_err());
-    assert!(overload_started.elapsed() < Duration::from_secs(1));
+    // Fail-fast is proved by the STRUCTURE, not by this clock: the only worker slot
+    // is parked inside `prepare` waiting on `prepare_release_tx`, which is only sent
+    // further down on THIS thread — so an overload submission that queued for a slot
+    // instead of refusing would deadlock here rather than merely run late. The bound
+    // is kept as a coarse "did not block" net and is deliberately generous; at one
+    // second it was measuring how loaded the runner was.
+    assert!(overload_started.elapsed() < OBSERVE_BUDGET);
     assert!(overload
         .expect_err("overload")
         .to_string()
@@ -587,13 +617,13 @@ fn actor_queue_and_global_worker_limit_fail_fast_under_pressure() {
     let jobs = registry.runtime_job_registry().expect("jobs");
     assert_eq!(
         terminal(
-            jobs.wait_terminal(&first_job, Duration::from_secs(5))
+            jobs.wait_terminal(&first_job, TERMINAL_BUDGET)
                 .expect("wait first")
         )
         .state,
         RuntimeJobState::Succeeded
     );
-    registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+    registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
 }
 
 #[test]
@@ -636,7 +666,7 @@ fn persistence_failure_closes_admission_marks_reconciling_and_checkpoint_retry_r
     );
     let jobs = registry.runtime_job_registry().expect("jobs");
     let failed = terminal(
-        jobs.wait_terminal(&failed_job, Duration::from_secs(5))
+        jobs.wait_terminal(&failed_job, TERMINAL_BUDGET)
             .expect("wait persistence failure"),
     );
     assert_eq!(failed.state, RuntimeJobState::Failed);
@@ -701,7 +731,9 @@ fn persistence_failure_closes_admission_marks_reconciling_and_checkpoint_retry_r
 
     std::fs::remove_file(graph_path.join("projection-blocker")).expect("remove projection blocker");
     std::fs::remove_dir(&graph_path).expect("clear projection obstruction");
-    let deadline = Instant::now() + Duration::from_secs(5);
+    // Poll the reconciliation OUT of the health surface; the loop exits on the first
+    // non-reconciling read, so the budget only caps a stuck run.
+    let deadline = Instant::now() + OBSERVE_BUDGET;
     while registry
         .runtime_health(&root.to_string_lossy())
         .expect("poll recovery health")
@@ -754,14 +786,14 @@ fn persistence_failure_closes_admission_marks_reconciling_and_checkpoint_retry_r
     );
     assert_eq!(
         terminal(
-            jobs.wait_terminal(&post_recovery_job, Duration::from_secs(5))
+            jobs.wait_terminal(&post_recovery_job, TERMINAL_BUDGET)
                 .expect("wait post-recovery write")
         )
         .state,
         RuntimeJobState::Succeeded
     );
     std::fs::remove_file(graph_backup).expect("remove test-only graph backup");
-    registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+    registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
 }
 
 #[test]
@@ -780,16 +812,10 @@ fn shutdown_ack_and_exact_current_restore_overwrite_corrupt_canonical_files() {
         replay_job_id = job.clone();
         let jobs = registry.runtime_job_registry().expect("jobs");
         assert_eq!(
-            terminal(
-                jobs.wait_terminal(&job, Duration::from_secs(5))
-                    .expect("wait")
-            )
-            .state,
+            terminal(jobs.wait_terminal(&job, TERMINAL_BUDGET).expect("wait")).state,
             RuntimeJobState::Succeeded
         );
-        let acks = registry
-            .shutdown(Duration::from_secs(5))
-            .expect("shutdown ACK");
+        let acks = registry.shutdown(SHUTDOWN_GRACE).expect("shutdown ACK");
         assert_eq!(acks.len(), 1);
         assert_eq!(acks[0].brain_id, registry.brain_id_for(&canonical_root));
         store_dir = registry.store_dir_for(&canonical_root);
@@ -828,7 +854,7 @@ fn shutdown_ack_and_exact_current_restore_overwrite_corrupt_canonical_files() {
             .state,
         RuntimeJobState::Succeeded
     );
-    registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+    registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
 }
 
 #[test]
@@ -846,15 +872,11 @@ fn corrupt_latest_checkpoint_recovers_only_with_degraded_fallback_receipt() {
         for (job_id, marker) in [("fallback-first", "first"), ("fallback-second", "second")] {
             let job = submit_root_append(&registry, &root, job_id, marker);
             assert_eq!(
-                terminal(
-                    jobs.wait_terminal(&job, Duration::from_secs(5))
-                        .expect("wait")
-                )
-                .state,
+                terminal(jobs.wait_terminal(&job, TERMINAL_BUDGET).expect("wait")).state,
                 RuntimeJobState::Succeeded
             );
         }
-        registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+        registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
         checkpoint_root = registry
             .store_dir_for(&canonical_root)
             .join(BRAIN_CHECKPOINT_DIRECTORY);
@@ -928,7 +950,7 @@ fn corrupt_latest_checkpoint_recovers_only_with_degraded_fallback_receipt() {
         registry
             .runtime_job_registry()
             .expect("jobs")
-            .wait_terminal(&job_id, Duration::from_secs(5))
+            .wait_terminal(&job_id, TERMINAL_BUDGET)
             .expect("wait degraded refusal"),
     );
     assert_eq!(job.state, RuntimeJobState::Failed);
@@ -954,14 +976,10 @@ fn corrupt_current_pointer_fails_closed_instead_of_fresh_boot() {
         let job = submit_root_append(&registry, &root, "pointer-write", "pointer-root");
         let jobs = registry.runtime_job_registry().expect("jobs");
         assert_eq!(
-            terminal(
-                jobs.wait_terminal(&job, Duration::from_secs(5))
-                    .expect("wait")
-            )
-            .state,
+            terminal(jobs.wait_terminal(&job, TERMINAL_BUDGET).expect("wait")).state,
             RuntimeJobState::Succeeded
         );
-        registry.shutdown(Duration::from_secs(5)).expect("shutdown");
+        registry.shutdown(SHUTDOWN_GRACE).expect("shutdown");
         checkpoint_root = registry
             .store_dir_for(&canonical_root)
             .join(BRAIN_CHECKPOINT_DIRECTORY);

--- a/m1nd-mcp/src/internal_tests/test_auto_ingest.rs
+++ b/m1nd-mcp/src/internal_tests/test_auto_ingest.rs
@@ -57,9 +57,16 @@ fn actor_call(
         .expect("actor tool call")
 }
 
+/// Retries the queue-depth polls below are allowed before they call a run stuck.
+/// Both loops exit on the FIRST observation that meets the bar, so this only caps a
+/// stuck run: a healthy run pays one poll. At 50 retries (≈1s of sleep) it was a bet
+/// on how fast the machine drains a scan — the same bet that makes the shutdown
+/// deadlines rotate red on the loaded two-core runner.
+const QUEUE_POLL_RETRIES: usize = 1_500;
+
 fn wait_for_actor_queue(actor: &BrainActorHandle, expected_min: usize) {
     let mut last_queue_depth = 0;
-    for _ in 0..50 {
+    for _ in 0..QUEUE_POLL_RETRIES {
         let status = actor_call(
             actor,
             "auto_ingest_status",
@@ -77,8 +84,8 @@ fn wait_for_actor_queue(actor: &BrainActorHandle, expected_min: usize) {
         thread::sleep(Duration::from_millis(20));
     }
     panic!(
-        "timed out waiting for actor auto-ingest queue depth to reach at least {}; last observed queue depth was {} after 50 retries with 20ms sleep",
-        expected_min, last_queue_depth
+        "timed out waiting for actor auto-ingest queue depth to reach at least {}; last observed queue depth was {} after {} retries with 20ms sleep",
+        expected_min, last_queue_depth, QUEUE_POLL_RETRIES
     );
 }
 
@@ -129,7 +136,7 @@ fn search_file_paths(state: &mut SessionState, query: &str) -> Vec<String> {
 
 fn wait_for_queue(state: &mut SessionState, expected_min: usize) {
     let mut last_queue_depth = 0;
-    for _ in 0..50 {
+    for _ in 0..QUEUE_POLL_RETRIES {
         let status = call(state, "auto_ingest_status", json!({ "agent_id": "tester" }));
         let queue_depth = status
             .get("queue_depth")
@@ -142,9 +149,10 @@ fn wait_for_queue(state: &mut SessionState, expected_min: usize) {
         thread::sleep(Duration::from_millis(20));
     }
     panic!(
-        "timed out waiting for auto-ingest queue depth to reach at least {}; last observed queue depth was {} after 50 retries with 20ms sleep",
+        "timed out waiting for auto-ingest queue depth to reach at least {}; last observed queue depth was {} after {} retries with 20ms sleep",
         expected_min,
-        last_queue_depth
+        last_queue_depth,
+        QUEUE_POLL_RETRIES
     );
 }
 

--- a/m1nd-mcp/src/internal_tests/universe_endpoint.rs
+++ b/m1nd-mcp/src/internal_tests/universe_endpoint.rs
@@ -364,29 +364,40 @@ async fn universe_is_sidecar_only_while_a_legacy_session_guard_is_held() {
     let root = write_dormant_brain(&app, &repo, 64, 128, now_ms());
 
     // Simulate the gardener tick: a background holder grabs the session lock and
-    // keeps it far longer than any acceptable panorama latency (the real tick holds
-    // it across a re-ingest + rebuild_engines — minutes).
+    // keeps it held across the WHOLE panorama read (the real tick holds it across a
+    // re-ingest + rebuild_engines — minutes). The holder only lets go once this
+    // thread reports the read is done, so "the panorama did not queue behind graph
+    // work" is proved by the STRUCTURE — a panorama that took the session lock would
+    // wait out the watchdog — instead of by racing a fixed two-second sleep against a
+    // 500ms ceiling, which is a bet on how loaded the machine is. The watchdog keeps
+    // a real regression FAILING rather than hanging, and the ceiling below stays far
+    // under it so the verdict is unambiguous.
+    const HOLD_WATCHDOG: std::time::Duration = std::time::Duration::from_secs(120);
+    const PANORAMA_CEILING: std::time::Duration = std::time::Duration::from_secs(20);
     let held = app.session.clone();
     let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
     let holder = std::thread::spawn(move || {
         let _guard = held.lock();
         tx.send(()).unwrap(); // the lock is provably HELD now
-        std::thread::sleep(std::time::Duration::from_secs(2));
+        let _ = release_rx.recv_timeout(HOLD_WATCHDOG);
     });
     rx.recv().unwrap(); // only drive the read once the lock is held
 
-    // The panorama must answer within a tight ceiling DESPITE the held lock.
+    // The panorama must answer while that lock is STILL held.
     let start = std::time::Instant::now();
     let (status, body) = get_universe(&app).await;
     let elapsed = start.elapsed();
+    let _ = release_tx.send(());
 
     assert_eq!(
         status, 200,
         "the panorama serves 200 even under a held lock: {body}"
     );
     assert!(
-        elapsed < std::time::Duration::from_millis(500),
-        "the panorama must NEVER queue behind graph work: took {elapsed:?} (ceiling 500ms)"
+        elapsed < PANORAMA_CEILING,
+        "the panorama must NEVER queue behind graph work: took {elapsed:?} while the session \
+         lock was held (ceiling {PANORAMA_CEILING:?}, holder watchdog {HOLD_WATCHDOG:?})"
     );
 
     // The dormant world is still served from its on-disk manifest (the sidecar path

--- a/m1nd-mcp/src/project_brains.rs
+++ b/m1nd-mcp/src/project_brains.rs
@@ -2079,10 +2079,26 @@ pub struct StoreFacts {
 }
 
 #[cfg(test)]
-// Persistence fixtures exercise real embedding-cache/checkpoint I/O. Match the
-// owner's five-second shutdown budget so workspace stress cannot turn scheduler
-// delay into a false lifecycle failure; dedicated deadline tests stay tighter.
-const TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+// Wall-clock grace every lifecycle test hands to `shutdown`. The PRODUCT contract
+// is "fail closed unless every actor checkpoints within the grace the CALLER gave"
+// — the number below is only this caller's tolerance for a slow machine, never the
+// guarantee. Persistence fixtures do real embedding-cache/checkpoint I/O, so on a
+// loaded two-core runner (the m1nd-mcp lib suite measures ~1001s there against
+// ~440-700s on a developer Mac) a five-second grace was measuring the runner rather
+// than the shutdown fence: `hosted_actor_binding_survives_restart_...`,
+// `concurrent_dormant_resolve_...` and `shutdown_releases_hosted_instance_...` went
+// red on a ROTATING basis with "did not checkpoint before the shutdown deadline",
+// while the other 63 test binaries stayed green. A minute is generous on purpose —
+// a healthy shutdown returns the instant the last ACK lands and pays nothing for
+// the headroom, and a genuinely stuck checkpoint still fails closed with exactly
+// the same message.
+const TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE: Duration = Duration::from_secs(60);
+
+#[cfg(test)]
+// Upper bound for polling a lifecycle FACT into view (today: the admission fence
+// closing). Only caps a stuck run — a healthy run breaks on the first matching
+// poll, in milliseconds — so it can be generous without costing wall-clock time.
+const TEST_LIFECYCLE_OBSERVE_BUDGET: Duration = Duration::from_secs(30);
 
 #[cfg(test)]
 mod external_mutation_actor_binding_tests {
@@ -2216,7 +2232,7 @@ mod external_mutation_actor_binding_tests {
             "an erroring command cannot checkpoint its partial postimage"
         );
         registry
-            .shutdown(Duration::from_secs(2))
+            .shutdown(TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE)
             .expect("shutdown rollback fixture");
     }
 }
@@ -2367,13 +2383,16 @@ mod lifecycle_shutdown_tests {
 
         let (shutdown_tx, shutdown_rx) = std::sync::mpsc::sync_channel(1);
         let shutdown_registry = Arc::clone(&registry);
+        // This grace starts ticking HERE, but the inflight callback below is only
+        // released after several intervening assertions — so the budget has to
+        // cover this thread's own scheduling too, not just the drain.
         let shutdown = std::thread::spawn(move || {
             shutdown_tx
-                .send(shutdown_registry.shutdown(Duration::from_secs(3)))
+                .send(shutdown_registry.shutdown(TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE))
                 .expect("report shutdown");
         });
 
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let deadline = Instant::now() + TEST_LIFECYCLE_OBSERVE_BUDGET;
         loop {
             if !registry.lifecycle.lock().accepting {
                 break;
@@ -2456,7 +2475,7 @@ mod lifecycle_shutdown_tests {
             .expect("capture hosted lifecycle facts");
 
         let acks = first
-            .shutdown(Duration::from_secs(3))
+            .shutdown(TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE)
             .expect("shutdown hosted owner");
         assert_eq!(acks.len(), 1);
         assert!(
@@ -2500,7 +2519,7 @@ mod lifecycle_shutdown_tests {
             "revoked permit cannot overwrite a successor owner"
         );
         successor
-            .shutdown(Duration::from_secs(3))
+            .shutdown(TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE)
             .expect("shutdown successor");
     }
 }


### PR DESCRIPTION
## Four agents filed the same defect — a clock CI cannot meet

The Windows advisory leg keeps failing on a ROTATING set of tests, always from one family: wall-clock deadlines written for a developer machine. Measured: the `m1nd-mcp` lib suite takes **1001s on the Windows runner** vs 362–440s on a dev Mac. A prior run of an identical commit was fully green — the flake signature. Four independent letters in the project inbox name this family; a flaky gate teaches agents to re-run instead of investigate, which is how the same defect got filed four times.

This repo has solved this class three times before (`e855c36d`, the `:250` note, `ACTOR_SHUTDOWN_CHECKPOINT_GRACE`). This is the fourth pass, applied **systematically** instead of one test at a time — a full inventory of every wall-clock gate in `m1nd-mcp --lib`.

## What changed, per test (the full inventory is in the commit)

- **Converted to a condition (mechanism replaced), 2 tests:** the universe sidecar-only probe now holds the lock until the read RETURNS (structural, and *faster* — an unconditional 2s sleep is gone); the overload fail-fast restates its 1s elapsed assert as a deadlock-vs-ran distinction.
- **Budget widened (test tolerance only), ~30 sites:** shutdown graces 2–5s → 60s via shared consts; observe/poll budgets 1–2s → 30–60s; the 10k-op stress bound 60s → 300s **renamed in intent** — it is a livelock net, not a throughput SLO, and the true elapsed still prints.
- **Left alone deliberately:** negative waits (slow runner makes them MORE likely to pass), opposite-polarity `slow == true` asserts, 5s loopback timeouts with ~5000× headroom, printed-not-asserted benches.

## Product guarantees: none changed

Every widened number is a **caller-supplied test budget**. `shutdown(grace)` still fails closed with the identical message; `wait_terminal` is condvar-based and returns the instant a job finishes; every poll breaks on first observation. A healthy run pays nothing.

**The one bound deliberately NOT touched:** `/health` p99 < 100ms — that is a frozen PRD contract (`docs/M1ND-10-PRD.md:282`), the bound IS the guarantee. Widening it here would silently weaken a product promise. It carries a `DO NOT widen` comment and its own inbox letter; resolving it is a PRD-owner decision.

## Proof

`cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test -p m1nd-mcp --lib` at **DEFAULT parallelism, twice**: `1458 passed; 0 failed` in 381.28s and 362.24s. (Run pre-rebase onto #441/#442; the rebase was conflict-free and this PR's CI validates the merged result.)
