### PR TITLE
build(scripts): give every checkout its own cargo target dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,22 @@ Always run `cargo fmt` and `cargo clippy --workspace -- -D warnings` before fini
 If a test flakes under parallel build-cache contention (e.g. `retrobuilder_real`), re-run
 it in isolation (`cargo test -p m1nd-core --test retrobuilder_real`) before concluding.
 
+**A gate is evidence only about the tree it ran in.** Cargo's metadata hash does not encode
+the source path, so two checkouts sharing one `CARGO_TARGET_DIR` emit the same artifact name
+and one can link the other's binary. Measured across parallel worktrees on 2026-07-27/28: a
+checkout whose `m1nd-control/src/action_catalog.rs` held 169 entries linked a sibling's 172
+and failed 47 tests with `CatalogDrift` — cured by `touch` alone, with no code change. The
+red is the harmless half; a gate that PASSES on another checkout's binary makes the claim
+unfalsifiable. So before running gates anywhere parallel checkouts exist, take this one's
+own directory:
+
+```bash
+export CARGO_TARGET_DIR="$(scripts/cargo_target_dir.sh)"   # deterministic, per-checkout
+```
+
+Deliberately not a checked-in `.cargo/config.toml`: CI and a lone clone already build in
+isolation, and no contributor should inherit this machine's build layout.
+
 **MCP tool-schema contract:** every advertised tool's `inputSchema` MUST declare a top-level
 `"type": "object"` (MCP spec). Strict clients (Claude Code) reject the ENTIRE `tools/list`
 when a single tool violates it — the 2026-07-22 incident (a bare top-level `oneOf` on

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -1292,8 +1292,9 @@ levers above capture the waste without that risk.
   maintainer-reviewed PR remains the promotion boundary; hosted execution is still `NOT_RUN` here.
 - **Multi-session hygiene.** A served owner holds the live brain and sibling worktrees may hold
   parallel work — `git fetch` before acting, confirm `git branch --show-current` before commit, do
-  feature work in an isolated worktree with the shared `CARGO_TARGET_DIR`
-  (`$HOME/.m1nd-build-cache/target`), and `git worktree remove` it when done.
+  feature work in an isolated worktree under that worktree's OWN `CARGO_TARGET_DIR`
+  (`export CARGO_TARGET_DIR="$(scripts/cargo_target_dir.sh)"` — sharing one lets a gate link a
+  sibling's binary, checkpoint 36), and `git worktree remove` it when done.
 
 ## Proof Standard
 Done = `cargo test --workspace` green + clippy `-D warnings` + `cargo fmt` clean + the BATTERY
@@ -1352,7 +1353,8 @@ mid-mission; `honesty` class is calibration ground truth; a triage session START
 mailbox, and a confirmed bug becomes a battery case BEFORE the fix); the **UNIVERSAL DOC GATE incl.
 agent surfaces** (docs/wiki/README/PATHOS current before "done"; any change to HOW agents work
 updates the agent-read surfaces in the SAME PR — the agent-docs CI gate enforces this); the **DISK
-HYGIENE rule** (shared `CARGO_TARGET_DIR` + worktree sweeps).
+HYGIENE rule** (per-checkout `CARGO_TARGET_DIR` under one auto-deletable cache root + worktree
+sweeps).
 
 ---
 

--- a/scripts/cargo_target_dir.sh
+++ b/scripts/cargo_target_dir.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Print the CARGO_TARGET_DIR that belongs to the checkout this is run from.
+#
+#   export CARGO_TARGET_DIR="$(scripts/cargo_target_dir.sh)"
+#
+# WHY THIS EXISTS
+# ---------------
+# Cargo's metadata hash does not encode the source path, so two checkouts of
+# this repo building into ONE target dir produce artifacts with the SAME name.
+# Measured twice on 2026-07-27/28 across parallel worktrees: two of them emitted
+# the identical test binary path, one worktree's gate linked the other's
+# artifact, and one executor killed the other's test process believing it a
+# duplicate. The visible half was a red run — a worktree whose
+# `m1nd-control/src/action_catalog.rs` held 169 entries linked a sibling's 172
+# and failed 47 tests with `CatalogDrift`, cured by `touch` alone, with no code
+# change. The dangerous half is the false GREEN: a gate that passes on another
+# checkout's binary makes every "proved" claim in a parallel burst unfalsifiable.
+#
+# A gate is only evidence about the tree it was run in. This makes that
+# mechanical instead of remembered.
+#
+# WHAT IT DOES NOT DO
+# -------------------
+# It is not wired into a checked-in `.cargo/config.toml`. That would impose a
+# machine-specific build layout on every contributor and every CI runner (which
+# already build in isolated checkouts and have no such collision). This is a
+# workflow mechanism for parallel local worktrees; the wiring is the export
+# above.
+#
+# Everything stays under `~/.m1nd-build-cache/`, so the disk rule that names
+# that one directory as the auto-deletable build cache still covers all of it.
+set -euo pipefail
+
+cache_root="$HOME/.m1nd-build-cache"
+
+# Outside a git checkout there is nothing to separate: keep the historical path.
+if ! toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || [ -z "$toplevel" ]; then
+  printf '%s\n' "$cache_root/target"
+  exit 0
+fi
+
+# Resolve through symlinks so one checkout can never hash to two directories.
+toplevel="$(CDPATH='' cd -- "$toplevel" && pwd -P)"
+
+# The checkout PATH is the discriminator — a linked worktree has its own, while
+# branch, HEAD state (detached included) and the shared object store do not
+# distinguish builds and must not enter the digest. Hashing via git keeps this
+# dependency-free: `shasum` and `sha256sum` are not both present on every OS
+# this repo is developed on, and git is already required to have gotten here.
+digest="$(printf '%s' "$toplevel" | git hash-object --stdin)"
+
+printf '%s\n' "$cache_root/target-${digest:0:12}"

--- a/tests/test_cargo_target_dir.py
+++ b/tests/test_cargo_target_dir.py
@@ -1,0 +1,123 @@
+"""The build-artifact separation contract of `scripts/cargo_target_dir.sh`.
+
+Two checkouts of this repo building into ONE `CARGO_TARGET_DIR` emit artifacts
+with the SAME name — cargo's metadata hash does not encode the source path. The
+red half of that is a gate failing on a sibling's binary; the dangerous half is a
+gate PASSING on one. The helper separates them by checkout path; these are the
+properties that separation has to keep.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "cargo_target_dir.sh"
+
+
+def target_dir(cwd: pathlib.Path, home: pathlib.Path) -> str:
+    """Run the helper from `cwd` with a hermetic HOME and no inherited git env."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["HOME"] = str(home)
+    completed = subprocess.run(
+        ["bash", str(HELPER)],
+        cwd=str(cwd),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def init_repo(path: pathlib.Path) -> None:
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "cache@example.invalid"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Target Dir Fixture"],
+        check=True,
+    )
+
+
+class CargoTargetDirTests(unittest.TestCase):
+    def test_one_checkout_resolves_to_one_stable_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = pathlib.Path(temporary) / "home"
+            repo = pathlib.Path(temporary) / "repo-alpha"
+            repo.mkdir(parents=True)
+            home.mkdir()
+            init_repo(repo)
+            nested = repo / "crate" / "src"
+            nested.mkdir(parents=True)
+
+            first = target_dir(repo, home)
+            second = target_dir(repo, home)
+
+            self.assertEqual(first, second, "same checkout must be deterministic")
+            self.assertEqual(
+                first,
+                target_dir(nested, home),
+                "a subdirectory belongs to its checkout, not to a directory of its own",
+            )
+            self.assertTrue(
+                first.startswith(str(home / ".m1nd-build-cache")),
+                f"must stay inside the auto-deletable build cache, got {first}",
+            )
+
+    def test_two_checkouts_never_share_a_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = pathlib.Path(temporary) / "home"
+            home.mkdir()
+            alpha = pathlib.Path(temporary) / "repo-alpha"
+            beta = pathlib.Path(temporary) / "repo-beta"
+            for repo in (alpha, beta):
+                repo.mkdir()
+                init_repo(repo)
+
+            self.assertNotEqual(target_dir(alpha, home), target_dir(beta, home))
+
+    def test_a_linked_worktree_never_shares_its_parent_checkout_directory(self) -> None:
+        """The case that bit: worktrees share an object store, not a build."""
+        with tempfile.TemporaryDirectory() as temporary:
+            home = pathlib.Path(temporary) / "home"
+            home.mkdir()
+            repo = pathlib.Path(temporary) / "repo-alpha"
+            repo.mkdir()
+            init_repo(repo)
+            (repo / "file.txt").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)
+            subprocess.run(["git", "-C", str(repo), "commit", "-qm", "seed"], check=True)
+
+            linked = pathlib.Path(temporary) / "worktree-b"
+            subprocess.run(
+                ["git", "-C", str(repo), "worktree", "add", "-q", str(linked), "HEAD"],
+                check=True,
+            )
+
+            # Detached HEAD, same branchless commit, same object store: only the
+            # checkout path may decide, and it must.
+            self.assertNotEqual(target_dir(repo, home), target_dir(linked, home))
+
+    def test_outside_a_checkout_it_keeps_the_historical_shared_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = pathlib.Path(temporary) / "home"
+            home.mkdir()
+            loose = pathlib.Path(temporary) / "not-a-repo"
+            loose.mkdir()
+
+            self.assertEqual(
+                target_dir(loose, home),
+                str(home / ".m1nd-build-cache" / "target"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## A gate is evidence only about the tree it ran in — and today it wasn't

Cargo's metadata hash does not encode the source path. Two checkouts sharing one `CARGO_TARGET_DIR` emit the **same artifact name**, and one links the other's binary. Measured in the field twice this week (169-entry catalog linking a sibling's 172 → 47 `CatalogDrift` failures, cured by `touch` alone; two parallel executors producing the identical `m1nd_mcp-665b60f7…` path).

The red is the harmless half. **This PR reproduces the dangerous half live — the false green:**

```
### worktree A, whose source contains no match for `selfproof` anywhere:
    Finished `test` profile … in 0.07s     ← cargo found the SIBLING's artifact fresh
running 1 test
test action_catalog::tests::compiled_in_worktree_b_selfproof ... ok
```

Worktree A's gate enumerated 138 tests where A has 137, **ran a test that exists in no file of A, and reported `ok`.** Every "proved" claim from a parallel burst under a shared dir is unfalsifiable.

## The mechanism

`scripts/cargo_target_dir.sh` (52 lines, shellcheck-clean): prints `$HOME/.m1nd-build-cache/target-<12hex>`, keyed on the **checkout path** (symlink-resolved `git rev-parse --show-toplevel`, hashed with `git hash-object` — no new tool dependency). Deterministic: same checkout → same dir; different checkouts → different dirs; outside git → the historical shared path, unchanged. Everything stays under the one auto-deletable cache root, so the disk-hygiene rule keeps covering it.

Deliberately **not** a checked-in `.cargo/config.toml`: CI and a lone clone already build in isolation, and no contributor should inherit this machine's parallel-burst layout. The wiring surface is `AGENTS.md`, where agents actually read — inserted beside the existing build-cache-contention advice, with the one-line export.

Proof with the mechanism on: A and B resolve different dirs, each `cargo check` sees only its own tree (137 vs 138 tests — the incident's 169 vs 172 in miniature).

## Guarded in CI

`tests/test_cargo_target_dir.py` joins the required `python-gates` job — 150 tests OK (146 before). Falsified: removing the per-checkout suffix from the helper turns 2 of the 4 red.

Also swept in the same commit (the "sweep the prose" law): two `docs/PATHOS.md` lines that *instructed* the shared-dir hazard now teach the per-checkout export.

## Declared limits

Nothing forces the export — an agent that forgets still gets the shared dir; the forcing lever is machine doctrine (owner's amendment, filed separately). The self-host refresh script's default dir is deliberately untouched (changing it costs a cold `--release` rebuild — owner's call; letter filed).
