### PR TITLE
test(lifecycle): prove state crossing a clean shutdown and a second boot

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -92,17 +92,25 @@ Everything promised or planned and not yet done, named here rather than left in 
 Update this list in the same PR that closes one; a front that dies silently is a lie.
 
 **Blocking the product**
-- **NO END-TO-END LIFECYCLE PROOF — the front that outranks the rest.** m1nd is a CONTINUITY system: its
-  whole promise is that state crosses time. That is the one capability with no gate. On 2026-07-27 three
-  independent bricking defects were found in a single night, all in the boot path — the owner's brain had
-  been loading 5540 nodes and serving **0** for five days (#441), a clean shutdown bricked the next boot
-  (#442), and a graph-stale co-change sidecar killed all 48 tools (#442). **None of the 1458 green lib
-  tests caught any of them**, because every one is a unit and nothing tests
-  *boot → serve → mutate → clean shutdown → boot again → still serves*. They surfaced because the OWNER
-  asked whether m1nd was working. Build that gate in CI, on a real graph: it would have caught all three,
-  and it is the highest-leverage completeness work available. Read next to the traction datum in
-  checkpoint 33 — 138 registry verbs, 48 advertised, **29 ever called** — the system's problem is not
-  width.
+- **LIFECYCLE PROOF — first slice LANDED 2026-07-29; the crash half stays declared open.** m1nd is a
+  CONTINUITY system, and until this slice the property *boot → serve → mutate → clean shutdown → boot
+  again → still serves* had no proof anywhere — which is how three bricking boot defects (#441, #442)
+  lived undetected under 1458 green unit tests until the OWNER asked whether m1nd was working. The gate
+  now exists: `brain_serves_its_own_state_across_clean_shutdowns_and_second_boots` in
+  `m1nd-mcp/tests/persist_runtime_root.rs`, driving the REAL binary over stdio JSON-RPC (the harness's
+  own "faithful seam") across FOUR boots on one runtime root, covering BOTH durable-write families a
+  plain MCP client can still reach (classified `memorize`, debounce `alerts_ack` — the ack is durable to
+  nobody unless the shutdown checkpoint carries it), asserting zero sidecar refusals on captured stderr,
+  designed by an askGOD verdict (CHANGE, applied), condition-based from birth, and **proven to bite**:
+  temporarily reverting either boot fix turns it red with a message naming the regression. Cost measured:
+  ≈ +2.6s. **What remains NOT_RUN, said loudly: Cycle B — crash/kill-9 without a checkpoint — is wave 2,
+  and G4's "fault injection" claim stays open until it lands.** Two finds the build itself surfaced, both
+  filed: under the M1ND-10 authority floors **~29 mutating verbs that `tools/list` still advertises are
+  unreachable from a plain MCP client** (`generic_action_authority_required` — measured live, converges
+  with the bootstrap-instruction front and genesis P2/P3); and the light-ingest merge behind `memorize`
+  **silently erases parallel edges**, contradicting the premise of #442's fixture — needs a decision and
+  a pinned test. Read next to the traction datum in checkpoint 33 — 138 registry verbs, 48 advertised,
+  **29 ever called** — the system's problem is not width.
 - **Windows phase-2 — CLOSED 2026-07-27.** 63 test binaries green on Windows, clippy clean (#435 · #436 ·
   #437 · #438 · #440). Never needed a Windows box: a CI-driven red→green loop plus mirror probes
   (flipping `cfg(unix)`↔`cfg(windows)` locally compiles the exact branch Windows compiles) closed it.

--- a/m1nd-mcp/tests/persist_runtime_root.rs
+++ b/m1nd-mcp/tests/persist_runtime_root.rs
@@ -41,10 +41,18 @@
 //! POSIX-specific. The portable path-resolution contract itself
 //! (`anchor_persist_target`) is covered by cross-platform unit tests in
 //! `m1nd-mcp/src/main.rs`.
+//!
+//! THE SECOND TEST IN THIS FILE generalizes that subprocess seam into the
+//! LIFECYCLE GATE — `boot → serve → mutate → clean shutdown → boot again →
+//! still serves` — because the boot-path defects of 2026-07-27 all needed a
+//! second boot over prior state to exist at all. It lives here rather than in a
+//! file of its own so it reuses this harness instead of growing a second one.
+//! Its own long comment block, below, carries the reasoning and the declared
+//! wave-2 boundary.
 #![cfg(unix)]
 
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -77,12 +85,31 @@ fn write_fixture_repo(root: &Path) {
     .expect("write helper.rs");
 }
 
+/// Ingest the fixture crate through the trusted in-process library. The public
+/// generic MCP `ingest` route is fail-closed (graph replacement requires the
+/// typed G2/G3 authority consumer), so seeding goes through the library that
+/// production ingest itself uses.
+fn ingest_fixture(repo: &Path) -> m1nd_core::graph::Graph {
+    let (graph, _) = m1nd_ingest::Ingestor::new(m1nd_ingest::IngestConfig {
+        root: repo.to_path_buf(),
+        parallelism: 1,
+        ..m1nd_ingest::IngestConfig::default()
+    })
+    .ingest()
+    .expect("trusted fixture ingest");
+    graph
+}
+
 /// A live stdio JSON-RPC connection to a spawned owner process.
 struct Owner {
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
     next_id: i64,
+    /// Where this owner's stderr was redirected, when the caller asked for it.
+    /// An owner that dies mid-boot says why THERE and nowhere else, so every
+    /// panic below quotes it.
+    stderr_log: Option<PathBuf>,
 }
 
 impl Owner {
@@ -90,6 +117,24 @@ impl Owner {
     /// source, mirroring the launchd invocation (no WorkingDirectory ⇒ cwd=/,
     /// `--runtime-dir` set, default relative `./graph_snapshot.json`).
     fn spawn(cwd: &Path, runtime_dir: &Path) -> Owner {
+        Owner::start(cwd, runtime_dir, None)
+    }
+
+    /// The same spawn, keeping the owner's stderr in a file the caller can read
+    /// after the process is gone. A FILE and not a pipe on purpose: nothing here
+    /// drains the child's stderr while it runs, and a full pipe buffer would
+    /// wedge the owner mid-boot instead of failing an assertion.
+    fn spawn_logging_stderr(cwd: &Path, runtime_dir: &Path, stderr_log: &Path) -> Owner {
+        Owner::start(cwd, runtime_dir, Some(stderr_log))
+    }
+
+    fn start(cwd: &Path, runtime_dir: &Path, stderr_log: Option<&Path>) -> Owner {
+        let stderr = match stderr_log {
+            Some(path) => {
+                Stdio::from(std::fs::File::create(path).expect("create the owner stderr log"))
+            }
+            None => Stdio::null(),
+        };
         let mut child = Command::new(BIN)
             .arg("--no-gui")
             .current_dir(cwd)
@@ -103,7 +148,7 @@ impl Owner {
             .env("M1ND_NO_GUI", "1")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(stderr)
             .spawn()
             .expect("spawn m1nd-mcp stdio owner");
         let stdin = child.stdin.take().expect("child stdin");
@@ -113,6 +158,7 @@ impl Owner {
             stdin,
             stdout,
             next_id: 0,
+            stderr_log: stderr_log.map(Path::to_path_buf),
         };
         owner.initialize();
         owner
@@ -137,7 +183,11 @@ impl Owner {
             let mut line = String::new();
             let n = self.stdout.read_line(&mut line).expect("read reply line");
             if n == 0 {
-                panic!("owner stdout closed before reply id={id}");
+                panic!(
+                    "owner stdout closed before reply id={id} — the process died \
+                     instead of answering. Its stderr said:\n{}",
+                    self.owner_stderr()
+                );
             }
             let trimmed = line.trim();
             if trimmed.is_empty() {
@@ -216,13 +266,25 @@ impl Owner {
             .unwrap_or_else(|| panic!("no node_count in health body: {health}"))
     }
 
+    /// This owner's captured stderr, or an honest note when it was not captured.
+    fn owner_stderr(&self) -> String {
+        match self.stderr_log.as_deref() {
+            Some(path) => read_stderr(path),
+            None => "<stderr not captured for this owner>".to_string(),
+        }
+    }
+
     fn shutdown(mut self) {
         // Closing the transport is the stdio owner's cooperative shutdown seam.
         // It must run the real persist-before-release lifecycle; killing the
         // child would bypass the behavior this integration test exists to prove.
+        let stderr = self.owner_stderr();
         drop(self.stdin);
         let status = self.child.wait().expect("wait for graceful owner shutdown");
-        assert!(status.success(), "owner shutdown failed with {status}");
+        assert!(
+            status.success(),
+            "owner shutdown failed with {status}. Its stderr said:\n{stderr}"
+        );
     }
 }
 
@@ -243,13 +305,7 @@ fn persist_lands_under_runtime_root_and_second_process_warm_boots() {
     // public generic MCP `ingest` route is intentionally fail-closed now that
     // graph replacement requires the exact typed G2/G3 authority consumer; this
     // path-resolution test must not weaken or bypass that production contract.
-    let (seed_graph, _) = m1nd_ingest::Ingestor::new(m1nd_ingest::IngestConfig {
-        root: repo.clone(),
-        parallelism: 1,
-        ..m1nd_ingest::IngestConfig::default()
-    })
-    .ingest()
-    .expect("trusted fixture ingest");
+    let seed_graph = ingest_fixture(&repo);
     let seeded_nodes = u64::from(seed_graph.num_nodes());
     assert!(
         seeded_nodes >= 3,
@@ -301,4 +357,407 @@ fn persist_lands_under_runtime_root_and_second_process_warm_boots() {
          the persisted graph had {ingested_nodes}. A lower count means it \
          re-ingested / started fresh — the warm boot the fix restores."
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE LIFECYCLE GATE — Cycle A
+//
+// m1nd is a continuity system: its promise is state crossing time. On
+// 2026-07-27 three independent BRICKING defects were found in the boot path
+// and none of the then-green unit tests caught any of them, because each one
+// needs a SECOND boot over prior state to exist at all:
+//
+//   * the owner's brain served 0 of 5540 nodes for five days — the actor start
+//     reconciled a CURRENT captured while the runtime graph was empty and
+//     reverted the graph the boot had just loaded (#441);
+//   * a CLEAN shutdown bricked the next boot — the plasticity sidecar a
+//     shutdown writes carries two rows for a parallel edge, and the reader
+//     refused its own writer's file (#442);
+//   * a graph-stale co-change sidecar aborted `SessionState::initialize` and
+//     took all 48 MCP tools down with it (#442).
+//
+// The general property behind all three had no proof:
+//
+//   boot → serve → mutate → clean shutdown → boot again → still serves
+//
+// This is that proof, over the real binary, on ONE runtime root, across four
+// generations of it. Every boot is strictly SEQUENTIAL — the checkpoint store's
+// `WRITER.lock` allows one writer at a time, so a parallel spawn would fail the
+// lock rather than test the property.
+//
+// WHY FOUR BOOTS, each earning its place:
+//   #0 publishes the EMPTY CURRENT that a later boot's graph must survive;
+//   #1 adopts the pre-1.5 graph through the actor, serves it, makes the
+//      DEBOUNCED durable write, and shuts down cleanly;
+//   #2 is the second boot over prior state — it must come up AT ALL (the
+//      plasticity sidecar it strictly reads carries two rows under one full
+//      synaptic key), still see the debounced write, then make the CLASSIFIED
+//      durable write and shut down cleanly;
+//   #3 must still find what #2 memorized.
+// The classified write is `memorize`, which re-ingests and therefore rewrites
+// the graph; that is exactly why it lands on its own leg instead of sharing one
+// with the parallel-edge sidecar it would otherwise dedupe away.
+//
+// THE DURABLE-WRITE SURFACE IS A DECLARED BOUNDARY, not a choice. Under the
+// M1ND-10 authority floors, almost every mutating verb in
+// `READ_ONLY_DENIED_TOOLS` — `antibody_create`, `learn`, `daemon_start`,
+// `auto_ingest_start`, `calibrate_*`, `boot_memory` set/delete, `apply`,
+// `edit_commit` — now sits at SCOPED_GRANT_A2 or above and refuses generic MCP
+// dispatch outright ("generic_action_authority_required"). Of the whole list
+// only `memorize` (plus the candidate/mission verbs, which belong to M1ND-10
+// and are out of scope here) is still ORDINARY. So the CLASSIFIED family is
+// covered through `memorize`, and the DEBOUNCED family through `alerts_ack` —
+// whose own alert has to be SEEDED, because every producer of a real alert
+// (`daemon_tick`, `apply`) is above the floor too.
+//
+// Cycle B — crash / `kill -9` with no checkpoint — is deliberately NOT here.
+// It is wave 2, and until it lands the fault-injection half of this property
+// stays NOT_RUN rather than silently claimed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The agent identity every call in the lifecycle cycle carries.
+const LIFECYCLE_AGENT: &str = "lifecycle-gate-probe";
+
+/// The label of the knowledge the CLASSIFIED durable write commits. Unique
+/// enough that finding it after the restart cannot be a coincidence.
+const LIFECYCLE_MEMORY_LABEL: &str = "LifecycleGateMarkerZ7";
+
+/// The alert the DEBOUNCED durable write acknowledges. Seeded, because every
+/// producer of a real alert (`daemon_tick`, `apply`) sits above the ORDINARY
+/// authority floor — see the boundary note in the block above.
+const LIFECYCLE_ALERT_ID: &str = "alert-lifecycle-gate-0001";
+
+/// Lines a healthy SECOND boot must never print. Every one of them is a real
+/// refusal or degrade emitted on the startup path, and every one means state a
+/// clean shutdown promised to keep was dropped, reverted, or never written.
+const SIDECAR_REFUSAL_SIGNATURES: &[&str] = &[
+    // The co-change sidecar no longer binds to the loaded graph (#442). Fatal
+    // before the fix; a degrade after it — but on a warm boot over its OWN
+    // checkpoint it must not happen at all.
+    "does not match the loaded graph",
+    // Any sidecar degraded away on the boot path.
+    "continuing without it",
+    // The plasticity round trip refusing what its own writer produced (#442),
+    // in either the pre-fix ("ambiguous across") or post-fix wording.
+    "synaptic key",
+    // The launchd bug this file was born for: a relative persist target
+    // resolved against a read-only cwd.
+    "persist failed",
+    // A second boot that found nothing to warm-boot from.
+    "No graph snapshot found",
+    // The field's exact signature for #441: a boot that loads a graph and then
+    // serves an empty one.
+    "Server ready. 0 nodes",
+    // The one-time rescue must not fire twice; the runtime is populated now.
+    "adopted legacy graph snapshot",
+];
+
+/// The fixture graph plus ONE deliberate parallel edge: a second edge between
+/// the same pair with the same relation, direction, inhibitory flag and causal
+/// strength — sharing the COMPLETE synaptic key that plasticity persistence is
+/// written against.
+///
+/// This is not decoration. `export_state` writes one row per CSR slot, so a
+/// graph with a parallel edge makes every clean shutdown produce a sidecar
+/// carrying two rows under one key: the exact file whose reader used to refuse
+/// it and brick the next boot (#442). The owner's real graph carries these on
+/// `contains` edges; a three-file fixture does not grow one on its own, so the
+/// condition is planted here and then ASSERTED, never assumed.
+fn seed_graph_with_a_parallel_edge(repo: &Path) -> m1nd_core::graph::Graph {
+    let mut graph = ingest_fixture(repo);
+    let source = (0..graph.num_nodes() as usize)
+        .find(|&index| graph.csr.offsets[index + 1] > graph.csr.offsets[index])
+        .map(|index| m1nd_core::types::NodeId::new(index as u32))
+        .expect("the fixture graph must have at least one edge to twin");
+    let slot = graph.csr.offsets[source.as_usize()] as usize;
+    let target = graph.csr.targets[slot];
+    let relation = graph
+        .strings
+        .try_resolve(graph.csr.relations[slot])
+        .expect("resolve the twinned relation")
+        .to_string();
+    let direction = graph.csr.directions[slot];
+    let inhibitory = graph.csr.inhibitory[slot];
+    let causal_strength = graph.csr.causal_strengths[slot];
+    graph
+        .add_edge(
+            source,
+            target,
+            &relation,
+            m1nd_core::types::FiniteF32::new(0.5),
+            direction,
+            inhibitory,
+            causal_strength,
+        )
+        .expect("add the twin edge");
+    graph.finalize().expect("re-finalize with the twin edge");
+
+    // Precondition, not decoration: the graph must actually export two rows
+    // under one complete key, or this fixture silently stops covering #442.
+    let rows = m1nd_core::plasticity::PlasticityEngine::new(
+        &graph,
+        m1nd_core::plasticity::PlasticityConfig::default(),
+    )
+    .export_state(&graph)
+    .expect("export the seeded plasticity state");
+    let mut rows_per_key: std::collections::HashMap<_, usize> = std::collections::HashMap::new();
+    for row in &rows {
+        *rows_per_key
+            .entry((
+                row.source_label.as_str(),
+                row.target_label.as_str(),
+                row.relation.as_str(),
+                row.direction,
+                row.inhibitory,
+            ))
+            .or_default() += 1;
+    }
+    let twinned = rows_per_key.values().copied().max().unwrap_or(0);
+    assert!(
+        twinned >= 2,
+        "the seeded graph must carry a parallel edge (two rows under one full \
+         synaptic key), got {twinned} row(s) — without it this gate stops \
+         covering the plasticity round trip a clean shutdown depends on"
+    );
+    graph
+}
+
+/// Seed one unacked daemon alert into the runtime root, the way an owner that
+/// shut down with an open finding leaves one behind. `daemon_alerts` is a
+/// durable checkpoint sidecar and `alerts_ack` is its DEBOUNCED writer.
+fn seed_unacked_alert(runtime_dir: &Path) {
+    let alerts = serde_json::json!([{
+        "alert_id": LIFECYCLE_ALERT_ID,
+        "severity": "warning",
+        "kind": "lifecycle_gate",
+        "message": "seeded finding that must stay acknowledged across a restart",
+        "confidence": 0.9,
+        "evidence": [],
+        "suggested_tool": null,
+        "suggested_target": null,
+        "file_path": null,
+        "node_id": null,
+        "created_at_ms": 1_700_000_000_000u64,
+        "acked": false,
+        "acked_at_ms": null
+    }]);
+    std::fs::write(
+        runtime_dir.join("daemon_alerts.json"),
+        serde_json::to_vec_pretty(&alerts).expect("encode seeded alerts"),
+    )
+    .expect("seed daemon alerts");
+}
+
+/// Read a captured stderr log; an owner that never wrote one reads as empty.
+fn read_stderr(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_default()
+}
+
+#[test]
+fn brain_serves_its_own_state_across_clean_shutdowns_and_second_boots() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("mk runtime dir");
+    let repo = tmp.path().join("repo");
+    write_fixture_repo(&repo);
+    seed_unacked_alert(&runtime_dir);
+
+    // The owner's working directory across every boot — the one a restart keeps.
+    let cwd = tmp.path().join("cwd");
+    std::fs::create_dir_all(&cwd).expect("mk owner cwd");
+
+    let boot0_stderr = tmp.path().join("boot0.stderr");
+    let boot1_stderr = tmp.path().join("boot1.stderr");
+    let boot2_stderr = tmp.path().join("boot2.stderr");
+    let boot3_stderr = tmp.path().join("boot3.stderr");
+
+    // ── Boot #0: the empty brain that publishes an EMPTY CURRENT ─────────────
+    // Not scaffolding — this generation is half the defect. #441 happened
+    // because a CURRENT captured while the runtime graph was still empty
+    // outranked the graph the NEXT boot legitimately loaded. Without a prior
+    // generation on this root there is nothing for the next boot to be reverted
+    // by, and the whole class becomes invisible.
+    let cold = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot0_stderr);
+    cold.shutdown();
+
+    // The pre-1.5 graph now appears in the legacy location beside an empty
+    // runtime that already has a committed generation: the field's exact
+    // upgrade footprint.
+    let seed_graph = seed_graph_with_a_parallel_edge(&repo);
+    let seeded_nodes = u64::from(seed_graph.num_nodes());
+    assert!(
+        seeded_nodes >= 3,
+        "fixture ingest should create several nodes, got {seeded_nodes}"
+    );
+    m1nd_core::snapshot::save_graph(&seed_graph, &cwd.join("graph_snapshot.json"))
+        .expect("seed the legacy graph snapshot");
+
+    // ── Boot #1: serve, make the DEBOUNCED durable write, shut down cleanly ──
+    let mut owner1 = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot1_stderr);
+    let served = owner1.node_count();
+    assert!(
+        served >= seeded_nodes,
+        "the first boot must SERVE the graph it adopted: expected at least \
+         {seeded_nodes} nodes, got {served}. Serving fewer is the field's exact \
+         signature — a graph the boot loaded and the actor's CURRENT \
+         reconciliation then reverted."
+    );
+
+    // `alerts_ack` is NOT classified a mutation. It reaches the persist choke
+    // point `persist_daemon_alerts`, which under an actor stage writes nothing
+    // and only joins the staged-persist debounce. The default interval is 50
+    // deferring turns, so the debounce cannot flush inside this cycle: the ack
+    // is durable to NOBODY unless the clean shutdown checkpoint carries it.
+    let acked = owner1.call(
+        "alerts_ack",
+        serde_json::json!({ "agent_id": LIFECYCLE_AGENT, "alert_ids": [LIFECYCLE_ALERT_ID] }),
+    );
+    assert_eq!(
+        acked.get("acked").and_then(|value| value.as_u64()),
+        Some(1),
+        "the seeded alert must be acknowledged in memory before the shutdown: {acked}"
+    );
+
+    // The cooperative stdio seam, not a kill: closing the transport runs the
+    // real persist-before-release lifecycle.
+    owner1.shutdown();
+
+    let boot1_log = read_stderr(&boot1_stderr);
+    assert!(
+        boot1_log.contains("adopted legacy graph snapshot"),
+        "the first boot must reach its graph THROUGH the actor-boundary \
+         adoption — that seam is what stops the actor's CURRENT reconciliation \
+         from reverting it on the same boot. stderr was:\n{boot1_log}"
+    );
+
+    // ── Boot #2: the second boot over prior state ────────────────────────────
+    // Booting AT ALL is the first assertion here. The plasticity sidecar this
+    // boot is about to read strictly is the one the clean shutdown just wrote,
+    // and it carries two rows under one full synaptic key (the seeded parallel
+    // edge). A reader that refuses its own writer's file dies on this line.
+    let mut owner2 = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot2_stderr);
+    let rebooted = owner2.node_count();
+    assert!(
+        rebooted >= served,
+        "the second boot must serve the state the first one checkpointed: \
+         booted with {rebooted} nodes but the first boot served {served}"
+    );
+
+    // The DEBOUNCED durable write survived, read back through a public verb.
+    let alerts = owner2.call(
+        "alerts_list",
+        serde_json::json!({ "agent_id": LIFECYCLE_AGENT, "include_acked": true, "limit": 50 }),
+    );
+    let still_acked = alerts
+        .get("alerts")
+        .and_then(|list| list.as_array())
+        .and_then(|list| {
+            list.iter()
+                .find(|entry| {
+                    entry.get("alert_id").and_then(|id| id.as_str()) == Some(LIFECYCLE_ALERT_ID)
+                })
+                .and_then(|entry| entry.get("acked"))
+                .and_then(|acked| acked.as_bool())
+        });
+    assert_eq!(
+        still_acked,
+        Some(true),
+        "the DEBOUNCED durable write must survive the restart: `alerts_ack` \
+         acked {LIFECYCLE_ALERT_ID} before a clean shutdown and this boot reads \
+         it back unacknowledged. The staged-persist drift never reached the \
+         shutdown checkpoint — a loss window a clean shutdown must not have. \
+         Read back: {alerts}"
+    );
+
+    // ── Boot #2: make the CLASSIFIED durable write, shut down cleanly ────────
+    // `memorize` sits in `READ_ONLY_DENIED_TOOLS`, so the actor classifies the
+    // turn a mutation and publishes CURRENT on the turn it acks. It writes a
+    // `.light.md` under the runtime root AND ingests it, so the commitment
+    // lands in the graph itself. It is also the only mutating verb in that list
+    // a plain MCP client can still reach — see the boundary note at the top.
+    let memorized = owner2.call(
+        "memorize",
+        serde_json::json!({
+            "agent_id": LIFECYCLE_AGENT,
+            "node_label": LIFECYCLE_MEMORY_LABEL,
+            "claims": [ { "label": LIFECYCLE_MEMORY_LABEL, "text": "knowledge that must cross a restart" } ]
+        }),
+    );
+    assert_eq!(
+        memorized.get("ingested").and_then(|value| value.as_bool()),
+        Some(true),
+        "memorize must write its light file AND ingest it — an un-ingested \
+         memory never reaches the graph this gate follows: {memorized}"
+    );
+    let after_memorize = owner2.node_count();
+    assert!(
+        after_memorize > rebooted,
+        "memorize must actually grow the graph it will be asked to remember: \
+         {rebooted} -> {after_memorize}"
+    );
+    owner2.shutdown();
+
+    // ── Boot #3: the classified write is still there ─────────────────────────
+    let mut owner3 = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot3_stderr);
+    let final_nodes = owner3.node_count();
+    assert!(
+        final_nodes >= after_memorize,
+        "the third boot must serve what the second one memorized: booted with \
+         {final_nodes} nodes, the checkpointed graph had {after_memorize}"
+    );
+    let found = owner3.call(
+        "search",
+        serde_json::json!({
+            "agent_id": LIFECYCLE_AGENT,
+            "query": LIFECYCLE_MEMORY_LABEL,
+            "mode": "literal",
+            "top_k": 20
+        }),
+    );
+    // Look inside `results` and nowhere else: `search` echoes the query back in
+    // its own `query` field, so matching the whole payload would pass on zero
+    // hits.
+    let hits = found
+        .get("results")
+        .and_then(|results| results.as_array())
+        .map(|entries| {
+            entries
+                .iter()
+                .filter(|entry| entry.to_string().contains(LIFECYCLE_MEMORY_LABEL))
+                .count()
+        })
+        .unwrap_or(0);
+    assert!(
+        hits > 0,
+        "the CLASSIFIED durable write must survive the restart: `memorize` \
+         acked {LIFECYCLE_MEMORY_LABEL} before a clean shutdown and the \
+         rebooted brain cannot find it. Read back: {found}"
+    );
+    owner3.shutdown();
+
+    // ── ZERO sidecar refusals on every boot that had prior state to read ─────
+    // The strongest observable available: the owner's own stderr, which is
+    // where each of the three 2026-07-27 defects announced itself — or, for
+    // #441, announced the graph it was about to throw away.
+    for (label, log) in [
+        ("second", read_stderr(&boot2_stderr)),
+        ("third", read_stderr(&boot3_stderr)),
+    ] {
+        // An absence check over an empty file proves nothing. Pin that this log
+        // is the real one, from a boot that actually came up, first.
+        assert!(
+            log.contains("Server ready."),
+            "the {label} boot's captured stderr must carry its ready banner, \
+             otherwise the refusal scan below is checking an empty file. Log \
+             was:\n{log}"
+        );
+        for signature in SIDECAR_REFUSAL_SIGNATURES {
+            assert!(
+                !log.contains(signature),
+                "the {label} boot refused or degraded a sidecar it wrote itself \
+                 ({signature:?}). A warm boot over its own clean checkpoint must \
+                 adopt every sidecar exactly. stderr was:\n{log}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## The property that had no proof

m1nd is a continuity system. Its whole promise is state crossing time, and on
2026-07-27 three independent **bricking** defects were found in the boot path:

- the owner's brain served **0 of 5540 nodes for five days** — the actor start
  reconciled a CURRENT captured while the runtime graph was empty and reverted
  the graph the boot had just loaded (#441);
- a **clean shutdown bricked the next boot** — the plasticity sidecar a shutdown
  writes carries two rows for a parallel edge, and the reader refused its own
  writer's file (#442);
- a graph-stale co-change sidecar **aborted `SessionState::initialize`** and took
  all 48 MCP tools down with it (#442).

The whole green unit suite caught none of them, for one reason: every one of
these needs a **second boot over prior state** to exist at all. The general
property

```
boot → serve → mutate → clean shutdown → boot again → still serves
```

had no proof anywhere in the repo. This PR is that proof.

## What landed

One new test, `brain_serves_its_own_state_across_clean_shutdowns_and_second_boots`,
in the existing `m1nd-mcp/tests/persist_runtime_root.rs` — the harness that
already drives the **real binary over stdio JSON-RPC** and whose own comment
calls that subprocess seam "the faithful seam". No new test file, no new
harness: `Owner::spawn`, `call`, `node_count`, `shutdown`, `read_reply` and the
fixture writer are reused unchanged.

Three additions to the harness, each because the lifecycle needed it and
nothing else did:

- **the owner's stderr is capturable** (`spawn_logging_stderr`, to a *file* —
  nothing drains a pipe while the owner runs, and a full pipe buffer would wedge
  it mid-boot). The "zero sidecar refusals" assertion has no other observable,
  and every panic now quotes the dead owner's stderr instead of reporting a
  closed pipe. That change alone turned `owner stdout closed before reply id=1`
  into a message naming the exact regression;
- **`ingest_fixture`** — the seed ingest lifted out of the existing test so both
  use one seeding path;
- **`seed_graph_with_a_parallel_edge` / `seed_unacked_alert`** — the two fixture
  conditions, both asserted rather than assumed.

It walks one runtime root across four generations, each earning its place:

| boot | what it does | what it pins |
|---|---|---|
| **#0** | cold, empty brain, clean shutdown | publishes the **empty CURRENT** a later boot's graph must survive — without it, #441's class is invisible |
| **#1** | adopts the pre-1.5 graph through the actor, serves it, makes the **DEBOUNCED** durable write, clean shutdown | the actor-boundary adoption seam; the staged-persist drift reaching the shutdown checkpoint |
| **#2** | must **come up at all**, serve the same graph, still see the debounced write; then makes the **CLASSIFIED** durable write, clean shutdown | the plasticity sidecar it strictly reads carries two rows under one full synaptic key |
| **#3** | still finds what #2 memorized; zero sidecar refusals | the classified write crossing a restart |

Boots are strictly **sequential** — the checkpoint store's `WRITER.lock` allows
one writer at a time, so a parallel spawn would fail the lock rather than test
the property.

**Zero wall-clock assertions.** No sleeps, no deadlines. Every step is a
condition (a JSON-RPC reply, a process exit, a readback), with generous
watchdog ceilings so a real hang still fails instead of hanging forever.

## The two durable-write families, and one declared boundary

- **CLASSIFIED route** — `memorize`. It sits in `READ_ONLY_DENIED_TOOLS`, so the
  actor classifies the turn a mutation and publishes CURRENT on the turn it
  acks. Read back on boot #3 with `search`.
- **DEBOUNCE route** — `alerts_ack`. It is *not* classified; it reaches the
  persist choke point `persist_daemon_alerts`, which under an actor stage writes
  nothing and only joins the staged-persist debounce. The default interval is
  **50 deferring turns**, so the debounce cannot flush inside the cycle: the ack
  is durable to nobody unless the clean shutdown checkpoint carries it. Read
  back on boot #2 with `alerts_list`.

**The boundary, declared rather than faked:** under the M1ND-10 authority floors,
almost every mutating verb in `READ_ONLY_DENIED_TOOLS` — `antibody_create`,
`learn`, `daemon_start`, `auto_ingest_start`, `calibrate_*`, `boot_memory`
set/delete, `apply`, `edit_commit` — now sits at `SCOPED_GRANT_A2` or above and
refuses generic MCP dispatch outright (`generic_action_authority_required`).
Measured live, not inferred: the first draft of this test used
`antibody_create` and got the refusal back instead of an antibody. Of that whole
list only `memorize` is still `ORDINARY` (plus candidate/mission verbs, which
belong to M1ND-10 and are out of scope here). The alert `alerts_ack`
acknowledges therefore has to be **seeded**, because every producer of a real
one (`daemon_tick`, `apply`) is above the floor too. Both facts are written into
the test's own comments so the next reader does not rediscover them. A separate
mailbox letter carries the wider question: `tools/list` still advertises all of
those verbs as usable.

## Proven to bite

The boot fixes are on this base, so the gate was made red by temporarily
reverting them (scaffolding only — nothing reverted is committed).

**#441 — the adoption seam.** Restoring the pre-fix byte copy in
`McpServer::new` (legacy bytes written into the runtime root *before* any actor
exists) and disabling the actor-boundary adoption in `project_brains.rs`:

```
thread 'brain_serves_its_own_state_across_clean_shutdowns_and_second_boots' panicked at
m1nd-mcp/tests/persist_runtime_root.rs:562:5:
the first boot must SERVE the graph it adopted: expected at least 10 nodes, got 0.
Serving fewer is the field's exact signature — a graph the boot loaded and the
actor's CURRENT reconciliation then reverted.
```

**#442 — the plasticity round trip.** Restoring the pre-fix reader in
`m1nd-core/src/plasticity.rs::import_state` (refuse a full synaptic key owned by
more than one parallel edge). The second boot does not fail an assertion — it
**dies**, and now says why:

```
owner stdout closed before reply id=1 — the process died instead of answering. Its stderr said:
[m1nd] Domain: code
[m1nd] Loaded graph snapshot: 10 nodes, 16 edges
[m1nd] Failed to import plasticity state (corrupt persistence state: full synaptic key for
       file::Cargo.toml -> file::Cargo.toml::struct::package (contains, direction=0,
       inhibitory=false) is ambiguous across 2 parallel edges), continuing without it
[m1nd-mcp] Failed to start server: persistence failed: bound brain actor refused: brain
       persistence failed: corrupt persistence state: full synaptic key for ... is ambiguous
       across 2 parallel edges
```

Both restored; the tree in this PR is the fixed one and green.

## Cost

Measured on this machine, same target dir, by swapping the file back to `HEAD`
and running the target three times each:

- `persist_runtime_root` **before**: 10.75s / 8.10s / 7.97s
- `persist_runtime_root` **after**: 10.72s / 10.83s / 10.33s
- the new test alone: 11.17s / 11.13s / 10.97s

**≈ +2.6s** to the target's wall clock (the two tests run concurrently, so the
new test's four boots overlap the old test's two). The fixture stays tiny: a
three-file crate, 10 nodes, 16 edges.

## Two honest boundaries

1. **Cycle B — crash / `kill -9` with no checkpoint — is NOT in this PR.** It is
   wave 2. Until it lands, G4's "fault injection" claim remains **NOT_RUN**. The
   test says so in its own header rather than letting the green tick imply it.
2. The parallel-edge fixture is **planted and then asserted**, never assumed —
   the owner's real graph carries parallel `contains` edges, a three-file fixture
   does not grow one on its own, and a fixture that silently stopped carrying it
   would silently stop covering #442.

## This is not a ceremony gate

This is **product CI hygiene** entering the existing
`cargo test --workspace --all-targets` gate. It adds no new gate, no new
workflow, no new required check, and it does not touch M1ND-10 candidate purity
or any frozen contract. The unlock for building it now is the reproduced-P0
exception: three reproduced bricking defects in one day, none of them reachable
without a second boot.

## No vacuous assertion

Two checks were audited for teeth rather than trusted:

- the `search` readback looks inside `results` only — `search` echoes the query
  back in its own `query` field, so matching the whole payload would have passed
  on zero hits. Probed: searching a label that was never memorized fails;
- the "zero sidecar refusals" scan is an *absence* check, so each captured log
  must first show its `Server ready.` banner. An absence check over an empty
  file proves nothing.

## Gates

```
cargo fmt --check                                        clean
cargo clippy --workspace --all-targets -- -D warnings    clean
cargo test -p m1nd-mcp --test persist_runtime_root
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.89s
cargo test -p m1nd-mcp --lib -- --test-threads=4
  test result: ok. 1462 passed; 0 failed; 15 ignored; 0 measured; 0 filtered out; finished in 495.44s
```

The agent-docs gate is **not armed** by this diff (`GATE_FILES=m1nd-mcp/tests/persist_runtime_root.rs`
→ "not armed (no agent-workflow surfaces touched). PASS."), and no frozen
contract is touched.
