### PR TITLE
build(deps): pin sha2 to 0.10 until the RustCrypto majors land together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,23 @@ updates:
       # than letting a grouped bump decide.
       - dependency-name: bincode
         versions: ["3.x"]
+      # sha2 0.11 cannot arrive alone. It moves to `digest` 0.11, which swaps
+      # `generic-array` for `hybrid-array` — and `hybrid-array::Array` drops the
+      # `LowerHex` impl the whole repo hashes through (~26 `format!("{:x}", ..)`
+      # sites over letter ids, content digests and WAL record hashes). Worse, it
+      # buys nothing on its own: `ed25519-dalek` 2.2.0 and `p256` 0.13.2 both
+      # require `sha2 = "0.10"`, so 0.10 stays in the graph either way and the
+      # workspace merely straddles both majors (measured: with m1nd-core on
+      # 0.11, `cargo tree -i sha2@0.10.9` still resolves via m1nd-control).
+      # The coherent move is the whole RustCrypto sweep — ed25519-dalek 3.0,
+      # p256 0.14, ecdsa 0.17, elliptic-curve 0.14, curve25519-dalek 5.0,
+      # signature 3.0, all of which DO want sha2 0.11 — as one deliberate,
+      # security-reviewed PR against the authority/enclave signing paths.
+      # Drop this entry as part of that sweep, never as a lone sha2 bump.
+      # (The hash OUTPUT is stable across the majors: sha2 0.11 reproduces the
+      # pinned NIST vectors for sha256("") and sha256("abc") byte for byte.)
+      - dependency-name: sha2
+        versions: ["0.11.x"]
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## #430 cannot land as a lone sha2 bump — measured, and pinned so it stops re-litigating itself

sha2 0.11 is not a bump: it moves to `digest` 0.11, which swaps `generic-array` for `hybrid-array`. Two measurements close the case:

1. **Migrating our call sites buys nothing.** `ed25519-dalek 2.2.0` and `p256 0.13.2` both require `sha2 = "0.10"` in their published manifests — with `m1nd-core` moved to 0.11, `cargo tree -i sha2@0.10.9` still resolves it via m1nd-control. The workspace would merely straddle both majors. (sha2 0.11 is in fact **already in `Cargo.lock`** via `rust-embed-utils` — dual coexistence is the status quo; a solo migration adds nothing but churn.)
2. **The rewrite cost lands in the worst place.** `hybrid-array::Array` drops `LowerHex`, and ~26 `format!("{:x}", …)` sites hash letter ids, content digests and WAL record hashes — confirmed by compiler error, reaching `build.rs` via `ui_bundle_support.rs`.

**Hash stability was proven anyway** (the part that matters if anyone ever does migrate): sha2 0.11 produces byte-identical digests to the vectors the repo already pins in `content_sha256_is_a_real_sha256_digest` — the risk in the eventual sweep is signature/DER semantics, never the hash bytes.

## What this PR does

One file, YAML only: a `sha2 0.11.x` **ignore entry in dependabot.yml**, following the repo's existing curated idiom (bincode 3.x, typescript 7.x), with the full rationale in the comment — so dependabot stops re-opening this weekly and the analysis lives where the next bump reads.

**The real path forward is filed, not lost:** the whole RustCrypto sweep (`ed25519-dalek` 3.0, `p256` 0.14, `ecdsa` 0.17, `elliptic-curve` 0.14, `curve25519-dalek` 5) as ONE security-reviewed PR that proves persisted authority-WAL signatures still verify, and drops this ignore entry in the same gesture. Letter in the project inbox.

## Gates

fmt clean · `clippy --workspace --all-targets -D warnings` exit 0 · m1nd-core **292 passed, 0 failed** · m1nd-mcp lib **all 1477 covered, 0 failures** (run in two balanced chunks + stragglers).

**A finding that corrects this week's narrative:** the lib suite is not flaky — it is *slow*. Every apparent "failure" under load was `SIGTERM` from a harness timeout killing the runner mid-green (>560s full run). Split into chunks, everything passes deterministically.
