### PR TITLE
fix(ingest): keep the parallel edges the memorize merge was erasing

### DIFF
--- a/m1nd-ingest/src/merge.rs
+++ b/m1nd-ingest/src/merge.rs
@@ -418,21 +418,49 @@ pub fn merge_graphs(base: &Graph, overlay: &Graph) -> M1ndResult<Graph> {
         }
     }
 
-    let mut edge_records: HashMap<EdgeKey, EdgeRecord> = HashMap::new();
+    // Parallel edges — two edges between the same pair carrying the same
+    // relation, direction and inhibitory flag — are legal graph content, not
+    // noise to fold away. `Graph::add_edge` admits them; the snapshot round trip
+    // writes and reads back one row per CSR slot (`edge_slot_queues` /
+    // `pop_unconsumed_slot` exist for exactly that); and plasticity binds the
+    // rows a clean shutdown persisted to those slots POSITIONALLY (#442). A
+    // merge that collapsed a key's occurrences onto one edge would erase real
+    // structure and leave the sidecar's rows pointing at slots it just deleted —
+    // reintroducing, from the writer, the ambiguity #442 hardened the reader
+    // against.
+    //
+    // So the merge is positional too: the Nth occurrence of a key in the base
+    // pairs with the Nth in the overlay, and the side with more occurrences sets
+    // the multiplicity. Re-ingesting the same source therefore still cannot
+    // double an edge (max(1, 1) == 1), which is what the old fold bought.
+    let mut edge_records: HashMap<EdgeKey, Vec<EdgeRecord>> = HashMap::new();
     let (base_edges, skipped_base_edges) = collect_edges(base);
     let (overlay_edges, skipped_overlay_edges) = collect_edges(overlay);
 
-    for record in base_edges.into_iter().chain(overlay_edges) {
+    for record in base_edges {
         edge_records
             .entry(record.key.clone())
-            .and_modify(|existing| {
-                existing.weight = existing.weight.max(record.weight);
-                existing.causal_strength = existing.causal_strength.max(record.causal_strength);
-            })
-            .or_insert(record);
+            .or_default()
+            .push(record);
     }
 
-    for record in edge_records.values() {
+    let mut overlay_occurrences: HashMap<EdgeKey, usize> = HashMap::new();
+    for record in overlay_edges {
+        let occurrence = *overlay_occurrences
+            .entry(record.key.clone())
+            .and_modify(|seen| *seen += 1)
+            .or_insert(0);
+        let slots = edge_records.entry(record.key.clone()).or_default();
+        match slots.get_mut(occurrence) {
+            Some(existing) => {
+                existing.weight = existing.weight.max(record.weight);
+                existing.causal_strength = existing.causal_strength.max(record.causal_strength);
+            }
+            None => slots.push(record),
+        }
+    }
+
+    for record in edge_records.values().flatten() {
         let source = merged.resolve_id(&record.key.source).unwrap();
         let target = merged.resolve_id(&record.key.target).unwrap();
         merged.add_edge(
@@ -545,6 +573,84 @@ mod tests {
             .resolve_id("memory::memory::entry::batman-mode")
             .is_some());
         assert!(merged.num_edges() >= 2);
+    }
+
+    /// Build a graph whose one file node `contains` one struct node over
+    /// `twins` edges that share their COMPLETE synaptic key — the shape a
+    /// clean shutdown turns into `twins` plasticity rows under one key (#442).
+    fn graph_with_parallel_contains(twins: usize) -> Graph {
+        let mut graph = Graph::with_capacity(2, twins);
+        let file = graph
+            .add_node(
+                "file::Cargo.toml",
+                "Cargo.toml",
+                NodeType::File,
+                &["code"],
+                10.0,
+                0.3,
+            )
+            .unwrap();
+        let table = graph
+            .add_node(
+                "file::Cargo.toml::struct::package",
+                "package",
+                NodeType::Struct,
+                &["code"],
+                10.0,
+                0.3,
+            )
+            .unwrap();
+        for _ in 0..twins {
+            graph
+                .add_edge(
+                    file,
+                    table,
+                    "contains",
+                    FiniteF32::new(0.8),
+                    EdgeDirection::Forward,
+                    false,
+                    FiniteF32::new(0.4),
+                )
+                .unwrap();
+        }
+        graph.finalize().unwrap();
+        graph
+    }
+
+    /// The merge must preserve parallel edges — and must still not breed them.
+    ///
+    /// RED before the positional merge: the fold keyed on `EdgeKey` collapsed
+    /// every occurrence of a key onto one edge, so the merge behind `memorize`
+    /// silently deleted a slot the snapshot and the plasticity sidecar both
+    /// address by position (#442). The three legs pin the whole rule, because
+    /// preserving the pair is only correct if re-ingesting a source still
+    /// cannot double its edges.
+    #[test]
+    fn merge_graphs_preserves_parallel_edges_without_breeding_them() {
+        let twinned = graph_with_parallel_contains(2);
+        let single = graph_with_parallel_contains(1);
+
+        assert_eq!(
+            merge_graphs(&twinned, &twinned).unwrap().num_edges(),
+            2,
+            "a parallel pair re-ingested from the same source must stay a pair"
+        );
+        assert_eq!(
+            merge_graphs(&twinned, &single).unwrap().num_edges(),
+            2,
+            "an overlay carrying one edge must not erase the base's second slot"
+        );
+        assert_eq!(
+            merge_graphs(&single, &twinned).unwrap().num_edges(),
+            2,
+            "an overlay carrying a pair must bring its second slot into the merge"
+        );
+        assert_eq!(
+            merge_graphs(&single, &single).unwrap().num_edges(),
+            1,
+            "one edge merged with itself must stay one edge — the merge must \
+             never breed a parallel edge out of a plain re-ingest"
+        );
     }
 
     #[test]

--- a/m1nd-mcp/src/light_author_handlers.rs
+++ b/m1nd-mcp/src/light_author_handlers.rs
@@ -1556,6 +1556,174 @@ mod tests {
         );
     }
 
+    /// External id of a node, the way every other reader here spells it.
+    fn external_id(graph: &Graph, node: m1nd_core::types::NodeId) -> String {
+        graph
+            .id_to_node
+            .iter()
+            .find_map(|(interned, &nid)| {
+                (nid == node).then(|| graph.strings.resolve(*interned).to_string())
+            })
+            .expect("every node in the graph carries an external id")
+    }
+
+    /// Count the CSR slots carrying `relation` from `source_ext` to
+    /// `target_ext`. Two is a parallel edge; one is a parallel edge some writer
+    /// erased.
+    fn parallel_slots(graph: &Graph, source_ext: &str, target_ext: &str, relation: &str) -> usize {
+        let (Some(source), Some(target)) =
+            (graph.resolve_id(source_ext), graph.resolve_id(target_ext))
+        else {
+            return 0;
+        };
+        graph
+            .csr
+            .out_range(source)
+            .filter(|&slot| {
+                graph.csr.targets[slot] == target
+                    && graph.strings.resolve(graph.csr.relations[slot]) == relation
+            })
+            .count()
+    }
+
+    // -----------------------------------------------------------------------
+    // #442's premise defended at the WRITER. `memorize` is the only mutating
+    // verb a plain MCP client can reach under the authority floors, and it
+    // re-ingests — so its merge decides whether a parallel edge survives the
+    // session at all. Measured RED before the positional merge in
+    // `m1nd_ingest::merge`: a runtime graph carrying a parallel pair (the shape
+    // a legacy adoption hands the runtime, and the shape the owner's real graph
+    // carries on `contains`) came back from ONE `memorize` call with a single
+    // slot. The plasticity sidecar a clean shutdown writes binds one row per
+    // slot POSITIONALLY, so the reader #442 hardened was being handed a graph
+    // whose second slot the writer had already deleted.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn memorize_preserves_a_parallel_edge_and_its_plasticity_rows() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let proj = temp.path().join("proj");
+        std::fs::create_dir_all(&proj).expect("proj dir");
+        std::fs::write(proj.join("auth.rs"), "pub fn f() -> bool { true }\n").expect("write");
+
+        let runtime_dir = temp.path().join("runtime");
+        std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+
+        let config = McpConfig {
+            graph_source: runtime_dir.join("graph.json"),
+            plasticity_state: runtime_dir.join("plasticity.json"),
+            runtime_dir: Some(runtime_dir),
+            ..Default::default()
+        };
+        let mut state = SessionState::initialize(Graph::new(), &config, DomainConfig::code())
+            .expect("init session");
+
+        crate::tools::handle_ingest(
+            &mut state,
+            IngestInput {
+                path: proj.to_string_lossy().to_string(),
+                agent_id: "test".into(),
+                incremental: false,
+                adapter: "code".into(),
+                mode: "replace".into(),
+                namespace: None,
+                include_dotfiles: false,
+                dotfile_patterns: vec![],
+                project_root: None,
+            },
+        )
+        .expect("code ingest");
+
+        // Plant the condition, then ASSERT it — a fixture that quietly stops
+        // carrying a parallel edge would pass while covering nothing.
+        let (source_ext, target_ext, relation) = {
+            let mut graph = state.graph.write();
+            let source = (0..graph.num_nodes() as usize)
+                .find(|&index| graph.csr.offsets[index + 1] > graph.csr.offsets[index])
+                .map(|index| m1nd_core::types::NodeId::new(index as u32))
+                .expect("the ingested graph must have at least one edge to twin");
+            let slot = graph.csr.offsets[source.as_usize()] as usize;
+            let target = graph.csr.targets[slot];
+            let relation = graph.strings.resolve(graph.csr.relations[slot]).to_string();
+            let direction = graph.csr.directions[slot];
+            let inhibitory = graph.csr.inhibitory[slot];
+            let causal_strength = graph.csr.causal_strengths[slot];
+            graph
+                .add_edge(
+                    source,
+                    target,
+                    &relation,
+                    m1nd_core::types::FiniteF32::new(0.5),
+                    direction,
+                    inhibitory,
+                    causal_strength,
+                )
+                .expect("plant the twin edge");
+            graph.finalize().expect("re-finalize with the twin edge");
+
+            let source_ext = external_id(&graph, source);
+            let target_ext = external_id(&graph, target);
+            assert_eq!(
+                parallel_slots(&graph, &source_ext, &target_ext, &relation),
+                2,
+                "precondition: the runtime graph must carry a parallel edge before memorize"
+            );
+            (source_ext, target_ext, relation)
+        };
+
+        let mut input = make_input(vec![LightClaim {
+            label: "Fact".into(),
+            text: Some("A durable fact.".into()),
+            kind: Some("entity".into()),
+            confidence: Some("0.9".into()),
+            ambiguity: None,
+            evidence: vec![],
+            depends_on: vec![],
+        }]);
+        input.ingest_after = true;
+        input.mode = "merge".into();
+        handle_light_author(&mut state, input).expect("memorize ok");
+
+        let mut graph = state.graph.write();
+        assert_eq!(
+            parallel_slots(&graph, &source_ext, &target_ext, &relation),
+            2,
+            "memorize's merge must not erase a parallel edge — the plasticity \
+             rows a clean shutdown writes are bound to those slots by position"
+        );
+
+        // ...and the surviving graph must still round-trip its own sidecar, the
+        // exact property #442 restored on the reader.
+        let rows = m1nd_core::plasticity::PlasticityEngine::new(
+            &graph,
+            m1nd_core::plasticity::PlasticityConfig::default(),
+        )
+        .export_state(&graph)
+        .expect("export the merged graph's plasticity state");
+        let mut rows_per_key = std::collections::HashMap::<_, usize>::new();
+        for row in &rows {
+            *rows_per_key
+                .entry((
+                    row.source_label.clone(),
+                    row.target_label.clone(),
+                    row.relation.clone(),
+                    row.direction,
+                    row.inhibitory,
+                ))
+                .or_default() += 1;
+        }
+        assert_eq!(
+            rows_per_key.values().copied().max().unwrap_or(0),
+            2,
+            "the merged graph must still export two rows under one full synaptic key"
+        );
+        m1nd_core::plasticity::PlasticityEngine::new(
+            &graph,
+            m1nd_core::plasticity::PlasticityConfig::default(),
+        )
+        .import_state(&mut graph, &rows)
+        .expect("the merged graph must re-import the sidecar it just wrote (#442)");
+    }
+
     // -----------------------------------------------------------------------
     // Test 3: provenance frontmatter (Created + Source-Agent) is stamped
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## The one mutating verb a plain client can reach was silently lossy

The light-ingest merge behind `memorize` **erased parallel edges**: measured, a graph carrying 16 rows with a parallel-edge twin came out of a memorize-triggered merge with the twin gone. This directly contradicted the premise of #442, whose plasticity round-trip exists *because* the owner's real graph legitimately carries parallel edges (the extractor deliberately keeps them distinct — `toml_repeated_array_tables_receive_distinct_ids`), and whose positional binding assigns synaptic rows to those twin slots. A writer quietly dropping one twin reintroduces the exact ambiguity family #442 hardened the reader against.

**Verdict (A): parallel edges are legitimate graph content — the merge must preserve them.** The reader fix (#442), the extractor behaviour, and the plasticity binding all agree; the merge was the one dissenter, and it was wrong.

## The fix and its guards

The merge now keys edges by their full identity including multiplicity, preserving twins without breeding duplicates on re-merge:

- `merge_graphs_preserves_parallel_edges_without_breeding_them` (m1nd-ingest) — twins survive one merge and do not multiply across repeated merges
- `memorize_preserves_a_parallel_edge_and_its_plasticity_rows` (m1nd-mcp) — end-to-end through the verb: the twin survives AND the plasticity rows bound to both slots still import cleanly after

## Proven against the lifecycle gate

The lifecycle gate (#447) plants a parallel edge and drives `memorize` across real subprocess boots — the exact interaction this changes. On the rebased tree: **2/2 green**, independently re-run by the orchestrator.

## Provenance, stated plainly

The executor committed and then the host process restarted before it could report its full gate lines. Orchestrator verification post-restart: rebase onto main clean, both new tests green in their crates, lifecycle gate 2/2, `fmt --check` clean, `clippy --lib -D warnings` zero issues. The full-workspace gate is this PR's CI.
