### PR TITLE
fix(mcp): mark every verb the authority floors refuse, instead of advertising it

### DIFF
--- a/m1nd-mcp/src/help_guidance.rs
+++ b/m1nd-mcp/src/help_guidance.rs
@@ -83,8 +83,13 @@ pub fn catalog_entries() -> Vec<HelpCatalogEntry> {
             let (category, glyph) = manual
                 .map(|doc| (doc.category.to_string(), doc.glyph.to_string()))
                 .unwrap_or_else(|| infer_category_and_glyph(&schema.name));
+            // The manual's curated one-liner SHADOWS the schema description, so
+            // the floor annotation has to travel with it — otherwise `help`
+            // keeps advertising as callable the verbs `tools/list` now marks
+            // POLICY-DISABLED. The schema description already carries the long
+            // form, so it passes through untouched.
             let one_liner = manual
-                .map(|doc| doc.one_liner.to_string())
+                .map(|doc| crate::server::annotate_floor_gated_summary(&schema.name, doc.one_liner))
                 .unwrap_or_else(|| schema.description.clone());
             let returns = manual
                 .map(|doc| doc.returns.to_string())

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -57,6 +57,22 @@ brain). Do not attempt a write from this mismatched session. The honest recovery
 `brain_bootstrap_consumer_not_installed`; no public one-call bootstrap or overlap escape hatch \
 is advertised while that sovereign consumer is absent.
 
+**ADVERTISED ≠ CALLABLE — the authority floors.** Bootstrap is not the only closed door. Every \
+semantic action carries an M1ND-10 authority floor and generic MCP/REST dispatch admits only \
+`ORDINARY`; a verb above it (`SCOPED_GRANT_A2` / `POSITIVE_SOVEREIGN` / `SERVICE_IDENTITY`) \
+refuses with `generic_action_authority_required`. No payload shape, capability claim or retry \
+lifts that — only an exact typed G2/G3 consumer (an authority lease), and none is installed for \
+those actions yet. 40 of the 141 advertised verbs are affected today, INCLUDING ones this \
+document teaches: `learn`, `debrief`, `promote`, `calibrate_predict` / `calibrate_envelope`, \
+`ghost_edges`, `runtime_overlay`, `apply` / `apply_batch` / `edit_commit`, `daemon_start` / \
+`_stop` / `_tick`, `auto_ingest_start` / `_stop` / `_tick` (their `_status` reads stay open), \
+the `xray_*` commit branch, `boot_memory` set/delete, \
+`mission_close write_light_memory:true`, and every system-blocks writer. `tools/list` marks each \
+one: its description is prefixed `POLICY-DISABLED (authority floor …)`. READ THAT before planning \
+around a verb, and do not spend turns retrying a refusal. Still ORDINARY and genuinely callable: \
+every read, `memorize`, `delegate`, `trail_save`, the perspective family, plain `mission_start` / \
+`mission_event` / `mission_verify` / `mission_handoff` / `mission_close`.
+
 ## 1. PRE-ORIENT — never start cold
 
 Call `north(task)` FIRST, before reading or editing anything. One round-trip returns: \
@@ -3197,7 +3213,203 @@ fn all_tool_schemas_inner() -> serde_json::Value {
     tools.push(authority_session_challenge_tool_schema());
     tools.push(authority_session_authenticate_tool_schema());
     tools.push(authority_authorize_tool_schema());
+    annotate_floor_gated_descriptions(tools);
     registry
+}
+
+/// Prefix every floor-gated verb's description with the house POLICY-DISABLED
+/// annotation, the sibling of the `ingest` compatibility sweep at scale.
+///
+/// `tools/list` may not advertise as executable a verb the generic MCP/REST gate
+/// refuses: under the M1ND-10 authority floors those calls come back
+/// `generic_action_authority_required`, so an un-annotated description is a lie
+/// the host repeats to every agent. The verdict is DERIVED from the same floor
+/// table [`enforce_generic_action_policy`] enforces, so a future verb cannot be
+/// advertised un-annotated by being forgotten.
+///
+/// Descriptions are the ONLY thing touched. No schema FIELD is added, removed or
+/// renamed: one bad `inputSchema` once emptied the whole tool list in strict
+/// clients, and honesty is not worth re-running that.
+///
+/// A description that already carries a hand-curated `POLICY-DISABLED` sweep
+/// (`ingest`) is left exactly as it is — the curated text says more than the
+/// derived line can.
+fn annotate_floor_gated_descriptions(tools: &mut [serde_json::Value]) {
+    for tool in tools.iter_mut() {
+        let Some(name) = tool.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some(annotation) = floor_gate_annotation(name) else {
+            continue;
+        };
+        let Some(description) = tool.get("description").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if description.contains(FLOOR_GATE_MARKER) {
+            continue;
+        }
+        let annotated = format!("{annotation}{description}");
+        tool["description"] = serde_json::Value::String(annotated);
+    }
+}
+
+/// The house marker for a surface that policy refuses. Introduced by the
+/// `ingest` compatibility sweep; reused verbatim so hosts, tests and agents keep
+/// grepping for exactly one token.
+pub(crate) const FLOOR_GATE_MARKER: &str = "POLICY-DISABLED";
+
+/// The typed G2/G3 consumers — the ones the generic floor gate never judges.
+///
+/// [`enforce_generic_action_policy`] says it in prose ("`mission_service` is not
+/// a generic call: the served transports intercept it before invoking this
+/// gate"); `mcp_http::run_mission_service_wire` implements it for all six, ahead
+/// of the gate call in `route_and_run`. These verbs ARE the exact authority flow
+/// the `ingest` sweep tells agents to use, so calling them policy-disabled would
+/// be the same lie pointed the other way. They are excluded from the derived
+/// annotation and refuse on their own typed terms (an owner-observed session,
+/// selected actor and lease), which their descriptions already state.
+///
+/// Four of the six route only to ORDINARY actions today and would never be
+/// annotated anyway; the exclusion is what keeps that true if a floor rises.
+pub(crate) const TYPED_CONSUMER_TOOLS: &[&str] = &[
+    "mission_service",
+    "external_mutation_service",
+    "graph_ingest_preview",
+    "authority_session_challenge",
+    "authority_session_authenticate",
+    "authority_authorize",
+];
+
+/// Action -> authority floor, read once per process from the canonical M1ND-10
+/// catalog.
+///
+/// `None` when the catalog itself fails to validate; every verb is then
+/// annotated UNRESOLVED, which is what the gate really does in that state
+/// (`generic_action_policy_unresolved`).
+fn catalog_floors_by_action(
+) -> Option<&'static std::collections::BTreeMap<String, m1nd_control::AuthorityFloor>> {
+    static FLOORS: std::sync::OnceLock<
+        Option<std::collections::BTreeMap<String, m1nd_control::AuthorityFloor>>,
+    > = std::sync::OnceLock::new();
+    FLOORS
+        .get_or_init(|| {
+            let catalog = m1nd_control::m1nd10_action_catalog().ok()?;
+            Some(
+                catalog
+                    .entries
+                    .into_iter()
+                    .map(|entry| (entry.action.as_str().to_string(), entry.authority_floor))
+                    .collect(),
+            )
+        })
+        .as_ref()
+}
+
+/// What the generic gate will do with one advertised verb, derived from the
+/// floor table rather than from a hand-kept list.
+enum FloorGate {
+    /// Every branch is ORDINARY: a plain client really can dispatch it.
+    Open,
+    /// The floor could not be resolved — the gate refuses with
+    /// `generic_action_policy_unresolved`.
+    Unresolved,
+    /// At least one branch sits above ORDINARY.
+    Gated {
+        floors: String,
+        gated_actions: Vec<&'static str>,
+        every_branch: bool,
+    },
+}
+
+fn floor_gate_verdict(tool: &str) -> FloorGate {
+    if TYPED_CONSUMER_TOOLS.contains(&tool) {
+        return FloorGate::Open;
+    }
+    let (Some(floors), Some(actions)) = (
+        catalog_floors_by_action(),
+        crate::action_routes::possible_mcp_actions(tool),
+    ) else {
+        return FloorGate::Unresolved;
+    };
+
+    let mut gated_floors = std::collections::BTreeSet::new();
+    let mut gated_actions = Vec::new();
+    let mut open_actions = 0usize;
+    for action in actions {
+        let Some(floor) = floors.get(action) else {
+            return FloorGate::Unresolved;
+        };
+        if generic_dispatch_floor_is_available(*floor) {
+            open_actions += 1;
+        } else {
+            gated_floors.insert(authority_floor_name(*floor));
+            gated_actions.push(action);
+        }
+    }
+    if gated_actions.is_empty() {
+        return FloorGate::Open;
+    }
+    FloorGate::Gated {
+        floors: gated_floors.into_iter().collect::<Vec<_>>().join("|"),
+        gated_actions,
+        every_branch: open_actions == 0,
+    }
+}
+
+/// The derived honesty annotation for one advertised verb, or `None` when every
+/// branch of that verb is ORDINARY and a plain client really can dispatch it.
+fn floor_gate_annotation(tool: &str) -> Option<String> {
+    match floor_gate_verdict(tool) {
+        FloorGate::Open => None,
+        FloorGate::Unresolved => Some(format!(
+            "{FLOOR_GATE_MARKER} (authority floor UNRESOLVED). Do not call it over generic \
+             MCP/REST: dispatch refuses with generic_action_policy_unresolved until the action \
+             catalog resolves this verb's floor. "
+        )),
+        FloorGate::Gated {
+            floors,
+            every_branch: true,
+            ..
+        } => Some(format!(
+            "{FLOOR_GATE_MARKER} (authority floor {floors}). Do not call it over generic \
+             MCP/REST: dispatch refuses with generic_action_authority_required until an exact \
+             typed G2/G3 consumer (authority lease) is installed for this action. "
+        )),
+        FloorGate::Gated {
+            floors,
+            gated_actions,
+            every_branch: false,
+        } => Some(format!(
+            "{FLOOR_GATE_MARKER} (authority floor {floors}) on {}. Do not call those branches \
+             over generic MCP/REST: dispatch refuses with generic_action_authority_required until \
+             an exact typed G2/G3 consumer (authority lease) is installed; the ORDINARY branches \
+             stay callable. ",
+            gated_actions.join(", ")
+        )),
+    }
+}
+
+/// The SHORT form of the same annotation, for a surface that renders its own
+/// one-line summary instead of the schema description.
+///
+/// `help` prefers a curated one-liner from the tool manual over the schema
+/// text, so without this the `help` verb would keep telling agents the lie
+/// `tools/list` just stopped telling — for the 14 gated verbs that have a
+/// manual entry. Same marker, same derived floors, minus the sentence a
+/// one-liner cannot carry.
+pub(crate) fn annotate_floor_gated_summary(tool: &str, summary: &str) -> String {
+    if summary.contains(FLOOR_GATE_MARKER) {
+        return summary.to_string();
+    }
+    let floors = match floor_gate_verdict(tool) {
+        FloorGate::Open => return summary.to_string(),
+        FloorGate::Unresolved => "UNRESOLVED".to_string(),
+        FloorGate::Gated { floors, .. } => floors,
+    };
+    format!(
+        "{FLOOR_GATE_MARKER} (authority floor {floors} — generic dispatch refuses until an exact \
+         typed G2/G3 consumer is installed). {summary}"
+    )
 }
 
 fn authority_session_challenge_tool_schema() -> serde_json::Value {
@@ -10250,6 +10462,144 @@ mod tests {
         assert!(
             instructions.contains("brain_bootstrap_consumer_not_installed"),
             "instructions must name the fail-honest bootstrap state"
+        );
+    }
+
+    /// The `ingest` sweep above, at registry scale. `tools/list` advertises the
+    /// full verb surface, but under the M1ND-10 authority floors a plain MCP
+    /// client is refused (`generic_action_authority_required`) on every verb
+    /// whose action floor sits above ORDINARY. The gated set is DERIVED here
+    /// from the same floor table the gate reads, so a verb cannot be advertised
+    /// un-annotated by being forgotten, and the lie cannot come back silently.
+    ///
+    /// Both directions are asserted: a floor-gated verb must carry the marker
+    /// AND its floor names, and a plainly dispatchable verb must NOT claim to be
+    /// policy-disabled. The typed G2/G3 consumers are excluded (they bypass this
+    /// gate entirely) and are held to the second rule.
+    #[test]
+    fn public_surface_annotates_every_floor_gated_verb() {
+        use m1nd_control::AuthorityFloor;
+
+        let catalog = m1nd_control::m1nd10_action_catalog().expect("canonical action catalog");
+        let floors: std::collections::BTreeMap<&str, AuthorityFloor> = catalog
+            .entries
+            .iter()
+            .map(|entry| (entry.action.as_str(), entry.authority_floor))
+            .collect();
+
+        let registry = all_tool_schemas();
+        let tools = registry["tools"].as_array().expect("tools array");
+        let advertised: std::collections::BTreeSet<&str> = tools
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("tool name"))
+            .collect();
+
+        // The exclusion may not become a hiding place: every typed consumer it
+        // names must really be on the advertised surface.
+        for typed in super::TYPED_CONSUMER_TOOLS {
+            assert!(
+                advertised.contains(typed),
+                "TYPED_CONSUMER_TOOLS names {typed}, which tools/list does not advertise"
+            );
+        }
+
+        let mut gated = 0usize;
+        let mut unannotated: Vec<String> = Vec::new();
+        let mut over_claimed: Vec<String> = Vec::new();
+        for tool in tools {
+            let name = tool["name"].as_str().expect("tool name");
+            let description = tool["description"].as_str().unwrap_or_default();
+            let actions = crate::action_routes::possible_mcp_actions(name)
+                .unwrap_or_else(|| panic!("unrouted advertised tool {name}"));
+
+            let mut gated_floors: std::collections::BTreeSet<&'static str> = Default::default();
+            for action in &actions {
+                let floor = floors
+                    .get(action)
+                    .unwrap_or_else(|| panic!("{name} routes to absent action {action}"));
+                if !super::generic_dispatch_floor_is_available(*floor) {
+                    gated_floors.insert(super::authority_floor_name(*floor));
+                }
+            }
+
+            if gated_floors.is_empty() || super::TYPED_CONSUMER_TOOLS.contains(&name) {
+                if description.contains(super::FLOOR_GATE_MARKER) {
+                    over_claimed.push(name.to_string());
+                }
+                continue;
+            }
+            gated += 1;
+            let floor_list = gated_floors.into_iter().collect::<Vec<_>>().join("|");
+            // The curated `ingest` sweep names its floors in prose, so only the
+            // house marker is required of it; every derived line must also carry
+            // the floor names an agent needs to know what to ask for.
+            let names_its_floors = name == "ingest"
+                || floor_list
+                    .split('|')
+                    .all(|floor| description.contains(floor));
+            if !description.contains(super::FLOOR_GATE_MARKER) || !names_its_floors {
+                unannotated.push(format!("{name} (authority floor {floor_list})"));
+            }
+        }
+
+        assert!(
+            gated >= 30,
+            "derivation found only {gated} floor-gated verbs — the floor table moved or the \
+             derivation broke; a vacuous pass would hide the lie"
+        );
+        assert!(
+            unannotated.is_empty(),
+            "tools/list advertises {} floor-gated verbs a plain MCP client CANNOT dispatch, \
+             with no {} annotation:\n  {}",
+            unannotated.len(),
+            super::FLOOR_GATE_MARKER,
+            unannotated.join("\n  ")
+        );
+        assert!(
+            over_claimed.is_empty(),
+            "plainly dispatchable verbs must NOT claim to be policy-disabled: {}",
+            over_claimed.join(", ")
+        );
+
+        // The `help` verb is the OTHER advertisement surface: it prefers the
+        // tool manual's curated one-liner over the schema description, so the
+        // annotation has to reach it too or the lie just moves house.
+        let gated_names: std::collections::BTreeSet<&str> = tools
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("tool name"))
+            .filter(|name| {
+                !super::TYPED_CONSUMER_TOOLS.contains(name)
+                    && crate::action_routes::possible_mcp_actions(name)
+                        .unwrap_or_default()
+                        .iter()
+                        .any(|action| {
+                            floors.get(action).is_some_and(|floor| {
+                                !super::generic_dispatch_floor_is_available(*floor)
+                            })
+                        })
+            })
+            .collect();
+        let help_catalog = crate::help_guidance::catalog_entries();
+        let help_gated = help_catalog
+            .iter()
+            .filter(|entry| gated_names.contains(entry.name.as_str()))
+            .count();
+        assert!(
+            help_gated > 0,
+            "the help catalog carries no floor-gated verb — this assertion went vacuous"
+        );
+        let unannotated_help: Vec<String> = help_catalog
+            .into_iter()
+            .filter(|entry| {
+                gated_names.contains(entry.name.as_str())
+                    && !entry.one_liner.contains(super::FLOOR_GATE_MARKER)
+            })
+            .map(|entry| entry.name)
+            .collect();
+        assert!(
+            unannotated_help.is_empty(),
+            "the `help` catalog still summarizes floor-gated verbs as callable: {}",
+            unannotated_help.join(", ")
         );
     }
 

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -119,6 +119,27 @@ this loop by default:
 This is the `m1nd-trained` behavior measured in internal bug-hunt rounds: graph
 plus operating doctrine, not graph alone.
 
+## Advertised ≠ callable — the authority floors
+
+`tools/list` advertises the full verb surface, but generic MCP/REST dispatch
+admits only actions whose M1ND-10 authority floor is `ORDINARY`. A verb above it
+(`SCOPED_GRANT_A2` / `POSITIVE_SOVEREIGN` / `SERVICE_IDENTITY`) refuses with
+`generic_action_authority_required`; no payload shape, capability claim, or retry
+lifts it — only an exact typed G2/G3 consumer (an authority lease), and none is
+installed for those actions yet. 40 of the 141 advertised verbs are affected
+today, including `learn`, `debrief`, `promote`, `calibrate_predict` /
+`calibrate_envelope`, `ghost_edges`, `runtime_overlay`, `apply` / `apply_batch` /
+`edit_commit`, `daemon_start` / `_stop` / `_tick`, `auto_ingest_start` / `_stop`
+/ `_tick` (their `_status` reads stay open), the `xray_*` commit branch,
+`boot_memory` set/delete, `mission_close write_light_memory:true`, and every
+system-blocks writer.
+
+The schema is the live source of truth: each affected description is prefixed
+`POLICY-DISABLED (authority floor …)`. Read it before planning a step around a
+verb, and never spend turns retrying a floor refusal. Reads, `memorize`,
+`delegate`, `trail_save`, the perspective family, and plain `mission_start` /
+`_event` / `_verify` / `_handoff` / `_close` stay `ORDINARY` and work.
+
 ## The Write Surface — closed routing, the map, and missions
 
 Retrieval is forgiving; writing is not. Four things to know before any write:

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -100,6 +100,27 @@ Verdict semantics — trust the calibration:
 Internal bug-hunt rounds call this `m1nd-trained`: graph plus operating
 doctrine. A visible MCP surface without this loop is only `m1nd-basic`.
 
+## Advertised ≠ callable — the authority floors
+
+`tools/list` advertises the full verb surface, but generic MCP/REST dispatch
+admits only actions whose M1ND-10 authority floor is `ORDINARY`. A verb above it
+(`SCOPED_GRANT_A2` / `POSITIVE_SOVEREIGN` / `SERVICE_IDENTITY`) refuses with
+`generic_action_authority_required`; no payload shape, capability claim, or retry
+lifts it — only an exact typed G2/G3 consumer (an authority lease), and none is
+installed for those actions yet. 40 of the 141 advertised verbs are affected
+today, including `learn`, `debrief`, `promote`, `calibrate_predict` /
+`calibrate_envelope`, `ghost_edges`, `runtime_overlay`, `apply` / `apply_batch` /
+`edit_commit`, `daemon_start` / `_stop` / `_tick`, `auto_ingest_start` / `_stop`
+/ `_tick` (their `_status` reads stay open), the `xray_*` commit branch,
+`boot_memory` set/delete, `mission_close write_light_memory:true`, and every
+system-blocks writer.
+
+The schema is the live source of truth: each affected description is prefixed
+`POLICY-DISABLED (authority floor …)`. Read it before planning a step around a
+verb, and never spend turns retrying a floor refusal. Reads, `memorize`,
+`delegate`, `trail_save`, the perspective family, and plain `mission_start` /
+`_event` / `_verify` / `_handoff` / `_close` stay `ORDINARY` and work.
+
 ## Write-Mode Laws — reception governs writes, one repo means one brain
 
 The served owner hosts many per-project brains and routes each request to the

--- a/skills/m1nd-operator/references/tool-families.md
+++ b/skills/m1nd-operator/references/tool-families.md
@@ -2,6 +2,27 @@
 
 This is the compact capability inventory for the current `m1nd` shape. Use the live runtime, not this file, when exact counts or schemas matter.
 
+## Advertised ≠ callable — the authority floors
+
+`tools/list` advertises the full verb surface, but generic MCP/REST dispatch
+admits only actions whose M1ND-10 authority floor is `ORDINARY`. A verb above it
+(`SCOPED_GRANT_A2` / `POSITIVE_SOVEREIGN` / `SERVICE_IDENTITY`) refuses with
+`generic_action_authority_required`; no payload shape, capability claim, or retry
+lifts it — only an exact typed G2/G3 consumer (an authority lease), and none is
+installed for those actions yet. 40 of the 141 advertised verbs are affected
+today, including `learn`, `debrief`, `promote`, `calibrate_predict` /
+`calibrate_envelope`, `ghost_edges`, `runtime_overlay`, `apply` / `apply_batch` /
+`edit_commit`, `daemon_start` / `_stop` / `_tick`, `auto_ingest_start` / `_stop`
+/ `_tick` (their `_status` reads stay open), the `xray_*` commit branch,
+`boot_memory` set/delete, `mission_close write_light_memory:true`, and every
+system-blocks writer.
+
+The schema is the live source of truth: each affected description is prefixed
+`POLICY-DISABLED (authority floor …)`. Read it before planning a step around a
+verb, and never spend turns retrying a floor refusal. Reads, `memorize`,
+`delegate`, `trail_save`, the perspective family, and plain `mission_start` /
+`_event` / `_verify` / `_handoff` / `_close` stay `ORDINARY` and work.
+
 ## Foundation And Search
 
 - `ingest`: load or refresh the graph from code, JSON, memory, or universal docs.

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -274,6 +274,27 @@ this loop by default:
 This is the trained-agent behavior to preserve across hosts: m1nd is graph plus
 operating doctrine, not graph alone.
 
+## Advertised ≠ callable — the authority floors
+
+`tools/list` advertises the full verb surface, but generic MCP/REST dispatch
+admits only actions whose M1ND-10 authority floor is `ORDINARY`. A verb above it
+(`SCOPED_GRANT_A2` / `POSITIVE_SOVEREIGN` / `SERVICE_IDENTITY`) refuses with
+`generic_action_authority_required`; no payload shape, capability claim, or retry
+lifts it — only an exact typed G2/G3 consumer (an authority lease), and none is
+installed for those actions yet. 40 of the 141 advertised verbs are affected
+today, including `learn`, `debrief`, `promote`, `calibrate_predict` /
+`calibrate_envelope`, `ghost_edges`, `runtime_overlay`, `apply` / `apply_batch` /
+`edit_commit`, `daemon_start` / `_stop` / `_tick`, `auto_ingest_start` / `_stop`
+/ `_tick` (their `_status` reads stay open), the `xray_*` commit branch,
+`boot_memory` set/delete, `mission_close write_light_memory:true`, and every
+system-blocks writer.
+
+The schema is the live source of truth: each affected description is prefixed
+`POLICY-DISABLED (authority floor …)`. Read it before planning a step around a
+verb, and never spend turns retrying a floor refusal. Reads, `memorize`,
+`delegate`, `trail_save`, the perspective family, and plain `mission_start` /
+`_event` / `_verify` / `_handoff` / `_close` stay `ORDINARY` and work.
+
 ## Write-Mode Laws — reception governs writes
 
 The served owner hosts many per-project brains and routes each request to the


### PR DESCRIPTION
## 40 of 141 advertised verbs were a lie a plain client discovers by being refused

Under the M1ND-10 authority floors, 40 verbs in `tools/list` (33 fully, 7 partially) refuse plain MCP dispatch with `generic_action_authority_required` — measured live during the lifecycle-gate build, filed as honesty/high, and ratified by tonight's askGOD verdict: **annotate, do not filter**. Filtering would hide what the genesis consumers (P2/P3, ratified in #448) will later unlock, change every host's visible surface, and court the cp31 incident class.

## The mechanism — derived, not curated

`annotate_floor_gated_descriptions` runs at the end of `all_tool_schemas_inner()`, deriving each verdict from the SAME floor table `enforce_generic_action_policy` enforces (`possible_mcp_actions` × the M1ND-10 action catalog, cached in a `OnceLock`). Three annotation shapes: fully-gated (names the floors), partially-gated (names the exact gated actions and says the ORDINARY branches stay callable), UNRESOLVED. The curated `ingest` text stays byte-identical. A future verb **cannot ship advertised-but-unannotated**: the guard derives from the floor table, not from a hand list.

**A correction found by reading:** `mission_service` and `external_mutation_service` carry elevated floors but are deliberately EXCLUDED — `run_mission_service_wire` intercepts all six typed consumers *ahead* of the gate, and they are the exact authority flow the `ingest` sweep points agents toward. Marking them policy-disabled would have been the same lie pointed the other way. Documented constant.

The `help` catalog had a second mouth: 4 gated essential-tier verbs (`learn`, `ingest`, `mission_close`, `audit`) have curated manual one-liners that *shadow* the schema description — annotated there too.

## Proof

RED listed all 39 derivation-annotated verbs verbatim (plus the 4 help shadows) before the sweep; GREEN after. `public_surface_annotates_every_floor_gated_verb` asserts BOTH directions — gated verbs carry the marker + floor names, and plainly-dispatchable verbs must NOT claim to be policy-disabled — over both surfaces, with non-vacuity floors. Descriptions only, no schema field touched: `every_tool_input_schema_is_top_level_object` stays green (the cp31 guard).

Full suite `1463 passed; 0 failed` (EXIT=0) · fmt/clippy clean · npm pack/routing checks green · **agent-docs gate armed and satisfied** — the four agent-facing skill surfaces and `M1ND_INSTRUCTIONS` §0 now carry one canonical "advertised ≠ callable" rule pointing at the schema marker as the live source of truth, instead of re-listing verbs that will drift.

## Filed, not silenced

Three letters to the project inbox, the notable one **high**: the REST route runs the floor gate *before* the `mission_spawn`/`candidate_naming` owner-proxy interceptions — both HTTP-only verbs are dead code behind a 403 on their own designed path.
