### PR TITLE
feat(ingest): open the freshness door — graph.ingest.refresh_declared_root (SPEC-1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,23 @@ bound brain because the writer never checked which brain it was talking to.
    (`healed workspace_root: <from> -> <to>`). If you ever see a bare-REST
    `caller_root_mismatch` naming an `agent-memory` dir as the bound workspace, that is this
    disease on a pre-fix binary — rebuild/restart heals it; never hand-edit the manifest.
+4. **The one ingest you CAN run is `ingest {mode:"refresh"}` — from exactly your own root.**
+   `replace` and `merge` stay policy-disabled for every client; `refresh` re-scans a root the
+   brain has ALREADY declared and is admitted at `SCOPED_GRANT_A2`, A2-locally, with no lease
+   (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §1, owner-ratified 2026-07-29). It is admitted by
+   ACTION, never by floor: the two siblings at that same floor — `source.edit.commit` and
+   `graph.ingest.merge_existing` — stay refused, and a test pins their refusal bytes.
+   What it refuses, always with nothing mutated: a caller root that is not EXACTLY a declared
+   root (`refresh_root_not_exact` — a subdirectory is not the root, and neither is an explicit
+   REST `?brain=` selector); a path that does not resolve (`refresh_root_unresolvable`); a
+   second refresh of the same root (`refresh_in_flight`); a root set that would move
+   (`refresh_would_change_roots`); and — the armor that matters — a candidate holding under
+   **60%** of the live graph's nodes (`refresh_would_shrink_graph`, naming both counts). That
+   last one exists because the persist layer's own shrink guard is fail-open by written
+   design: it backs up and writes anyway. Do NOT reach for `refresh` to repair a reception
+   mismatch — it cannot create or rebind anything, and law 1 still governs. It closes the
+   reflex vector, an agent acting from habit or misconfiguration; it is not a defense against
+   a hostile same-UID process (that is the lease plane, still dormant).
 
 **When you withdraw a capability, sweep the prose in the same PR.** The cross-root bootstrap
 was withdrawn in the runtime (the published `ingest` schema lost `project_root` and

--- a/m1nd-control/src/action_catalog.rs
+++ b/m1nd-control/src/action_catalog.rs
@@ -393,6 +393,18 @@ pub fn m1nd10_action_catalog() -> Result<ActionCatalogV1, ActionCatalogError> {
             High,
             ScopedGrantA2,
         ),
+        // The freshness door (GENESIS-INGEST-CONSUMERS-SPEC.md §1, owner-ratified
+        // 2026-07-29). It re-scans a root the bound brain has ALREADY declared:
+        // same effects as `merge_existing`, and deliberately NO `SovereignMutation`,
+        // because it structurally cannot change the root set or cross to another
+        // brain's territory. Its floor is the ratified `ScopedGrantA2`.
+        entry(
+            "graph.ingest.refresh_declared_root",
+            [Mcp],
+            [GraphMutation, RuntimeStoreWrite],
+            High,
+            ScopedGrantA2,
+        ),
         entry(
             "graph.ingest.change_roots",
             [Mcp],
@@ -2032,7 +2044,7 @@ mod tests {
         // `graph.ingest.preview` is now an explicit read-only governed action
         // rather than an untracked pre-mutation side channel.  Keep this pin in
         // lock-step with the exhaustive consumer registry.
-        assert_eq!(catalog.entries.len(), 172);
+        assert_eq!(catalog.entries.len(), 173);
         assert_eq!(ingresses.len(), 7);
     }
 }

--- a/m1nd-mcp/src/action_consumers.rs
+++ b/m1nd-mcp/src/action_consumers.rs
@@ -24,8 +24,8 @@ pub const ACTION_CONSUMER_CONTRACT_SCHEMA: &str = "m1nd-action-consumer-contract
 /// declarations and this digest together; silently regenerating the registry
 /// from a changed catalog is forbidden.
 pub const EXPECTED_M1ND10_ACTION_CATALOG_DIGEST: &str =
-    "9d738cfad09d8ac4de7fcc4b848cda703cb0b46c874a658cc4d2243b774ff493";
-pub const EXPECTED_M1ND10_ACTION_COUNT: usize = 172;
+    "5ec017b09067e4eb13c4078d3925f161c8123119ac679114aa17e1a3bb6009cd";
+pub const EXPECTED_M1ND10_ACTION_COUNT: usize = 173;
 
 pub const MISSION_SERVICE_CONTRACT_VERSION: &str = "m1nd-mission-service-transport-request-v1";
 pub const EXTERNAL_MUTATION_SERVICE_CONTRACT_VERSION: &str = "m1nd-external-mutation-consumer-v1";
@@ -106,6 +106,14 @@ pub enum ConsumerPolicyDisabledReasonV1 {
 #[serde(tag = "disposition", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ActionConsumerDispositionV1 {
     EnabledGenericOrdinary,
+    /// Admitted on the generic ingress ABOVE the ordinary floor, with no lease
+    /// plane, because the action is named one by one in
+    /// [`GENERIC_A2_LOCAL_ADMITTED_ACTIONS`]. This exists so the registry keeps
+    /// telling the truth: an action reachable through the generic door must not
+    /// be recorded here as `PolicyDisabled`, or the one artifact whose whole job
+    /// is "absence is recorded as policy, never inferred" would lie about
+    /// presence instead.
+    EnabledGenericScopedA2Local,
     EnabledTypedConsumer {
         consumer_id: TypedConsumerIdV1,
         contract_version: String,
@@ -115,6 +123,26 @@ pub enum ActionConsumerDispositionV1 {
         reason: ConsumerPolicyDisabledReasonV1,
     },
 }
+
+/// The action-keyed generic-dispatch allowlist — the ONE opening in the
+/// authority wall (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §1.1, owner-ratified
+/// 2026-07-29).
+///
+/// Keyed BY ACTION, never by floor. That is the whole point of the shape: the
+/// two `SCOPED_GRANT_A2` siblings that already exist — `source.edit.commit` and
+/// `graph.ingest.merge_existing` — sit at exactly this floor and must stay
+/// refused, so a floor-keyed exception would have opened all three at once
+/// (verdict RC-4). `internal_tests/spec1_refresh_declared_root.rs` §5.9 pins
+/// their refusal bytes verbatim against that mistake.
+///
+/// Admission here only admits the CATEGORY. Every authority-relevant fact —
+/// which root, whether the caller exactly inhabits it, whether the candidate
+/// would shrink the graph — is enforced inside the typed handler, after brain
+/// resolution, fail-closed.
+///
+/// ONE source of truth: `server::enforce_generic_action_policy` reads this list
+/// to admit, and `expected_disposition` reads it to describe. They cannot drift.
+pub const GENERIC_A2_LOCAL_ADMITTED_ACTIONS: &[&str] = &["graph.ingest.refresh_declared_root"];
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -562,11 +590,13 @@ fn expected_disposition(
         };
     }
     if entry.authority_floor == AuthorityFloor::Ordinary {
-        ActionConsumerDispositionV1::EnabledGenericOrdinary
-    } else {
-        ActionConsumerDispositionV1::PolicyDisabled {
-            reason: ConsumerPolicyDisabledReasonV1::NoExactConsumer,
-        }
+        return ActionConsumerDispositionV1::EnabledGenericOrdinary;
+    }
+    if GENERIC_A2_LOCAL_ADMITTED_ACTIONS.contains(&entry.action.as_str()) {
+        return ActionConsumerDispositionV1::EnabledGenericScopedA2Local;
+    }
+    ActionConsumerDispositionV1::PolicyDisabled {
+        reason: ConsumerPolicyDisabledReasonV1::NoExactConsumer,
     }
 }
 
@@ -858,6 +888,15 @@ pub fn external_consumer_contract(
                 Some(&registry),
             ))
         }
+        ActionConsumerDispositionV1::EnabledGenericScopedA2Local => {
+            return Err(disabled(
+                action,
+                ingress,
+                ConsumerPolicyDisabledReasonV1::NoExactConsumer,
+                "cell is admitted A2-LOCAL through the action-keyed generic allowlist; it has no typed lease consumer and none may be inferred",
+                Some(&registry),
+            ))
+        }
     };
 
     Ok(ActionConsumerContractV1 {
@@ -910,6 +949,39 @@ mod tests {
         );
     }
 
+    /// The generic door opens for EXACTLY the ratified action and nothing else,
+    /// and it opens at exactly the ratified floor
+    /// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §6 items 1–2, owner 2026-07-29).
+    /// A second entry appearing here without a second ratification is the failure
+    /// this test exists to make loud.
+    #[test]
+    fn the_a2_local_allowlist_holds_exactly_the_ratified_action() {
+        assert_eq!(
+            GENERIC_A2_LOCAL_ADMITTED_ACTIONS,
+            ["graph.ingest.refresh_declared_root"]
+        );
+        let catalog = m1nd10_action_catalog().unwrap();
+        for action in GENERIC_A2_LOCAL_ADMITTED_ACTIONS {
+            let entry = catalog
+                .entries
+                .iter()
+                .find(|entry| entry.action.as_str() == *action)
+                .unwrap_or_else(|| panic!("{action} is allowlisted but absent from the catalog"));
+            assert_eq!(entry.authority_floor, AuthorityFloor::ScopedGrantA2);
+            assert!(entry.ingresses.contains(&Ingress::Mcp));
+            // Never sovereign: a door that could change roots or cross brains
+            // does not belong on a list that skips the lease plane.
+            assert!(!entry.complete_effects.contains(&Effect::SovereignMutation));
+        }
+        // The two siblings at the SAME floor must NOT be on it (verdict RC-4).
+        for sibling in ["source.edit.commit", "graph.ingest.merge_existing"] {
+            assert!(
+                !GENERIC_A2_LOCAL_ADMITTED_ACTIONS.contains(&sibling),
+                "{sibling} shares the floor but was never ratified through the generic door"
+            );
+        }
+    }
+
     #[test]
     fn declared_and_undeclared_ingresses_have_closed_exact_dispositions() {
         let catalog = m1nd10_action_catalog().unwrap();
@@ -931,6 +1003,22 @@ mod tests {
                     ActionConsumerDispositionV1::EnabledGenericOrdinary
                 ) {
                     assert_eq!(entry.authority_floor, AuthorityFloor::Ordinary);
+                    assert!(entry.ingresses.contains(&ingress));
+                }
+                // The A2-local opening is CLOSED and named. Any cell carrying it
+                // must be one of the explicitly listed actions, must be at the
+                // ratified `ScopedGrantA2` floor, and must be on a declared
+                // ingress — an unnamed action can never acquire it by drift.
+                if matches!(
+                    cell.disposition,
+                    ActionConsumerDispositionV1::EnabledGenericScopedA2Local
+                ) {
+                    assert!(
+                        GENERIC_A2_LOCAL_ADMITTED_ACTIONS.contains(&entry.action.as_str()),
+                        "{} is A2-local without being on the allowlist",
+                        entry.action.as_str()
+                    );
+                    assert_eq!(entry.authority_floor, AuthorityFloor::ScopedGrantA2);
                     assert!(entry.ingresses.contains(&ingress));
                 }
             }

--- a/m1nd-mcp/src/action_routes.rs
+++ b/m1nd-mcp/src/action_routes.rs
@@ -253,6 +253,7 @@ pub fn possible_mcp_actions(tool: &str) -> Option<Vec<&'static str>> {
             "brain.bootstrap",
             "graph.ingest.change_roots",
             "graph.ingest.merge_existing",
+            "graph.ingest.refresh_declared_root",
             "graph.ingest.replace",
         ],
         "auto_ingest_start" => vec![
@@ -473,6 +474,13 @@ fn classify_ingest(
     }
     match string_field(arguments, "mode").unwrap_or("replace") {
         "replace" => Ok("graph.ingest.replace"),
+        // The freshness door (GENESIS-INGEST-CONSUMERS-SPEC.md §1.1). It is its
+        // OWN action, selected from `(tool, params)` ALONE — no trusted route
+        // fact, so the gate's pure/pre-brain invariant (spec R-I) is untouched.
+        // The spec is explicit that no future need may reuse that plumbing until
+        // someone proves by test that `TrustedMcpRouteFacts::default()` is no
+        // longer what production passes.
+        "refresh" => Ok("graph.ingest.refresh_declared_root"),
         "merge" => match trusted.ingest_changes_roots {
             Some(true) => Ok("graph.ingest.change_roots"),
             Some(false) => Ok("graph.ingest.merge_existing"),

--- a/m1nd-mcp/src/http_server.rs
+++ b/m1nd-mcp/src/http_server.rs
@@ -4068,6 +4068,7 @@ async fn handle_tool_call(
         .map(str::to_string);
     let dispatch_is_bound = Arc::ptr_eq(&target_session, &state.session);
     let explicit_brain_selector = brain.brain.is_some();
+    let caller_root_header = mission_header(&headers, CALLER_ROOT_HEADER);
     let dispatch_mutates = crate::server::read_only_denied(&tool, &body);
 
     // A running spawn_blocking task cannot be cancelled safely. Cross the
@@ -4085,6 +4086,27 @@ async fn handle_tool_call(
                 dispatch_mutates,
                 move |session| {
                     let caller_root = session.caller_root.clone();
+                    // SPEC-1g: an explicit `?brain=` selector says WHICH brain to
+                    // talk to; it never says the caller legitimately inhabits that
+                    // brain's root. Carried into the session so the exact-root
+                    // predicate can refuse it, request-scoped and restored below
+                    // exactly like `caller_root`.
+                    session.explicit_brain_selector = explicit_brain_selector;
+                    // SPEC-1b: the REST tools seam is one of the places a value
+                    // becomes `session.caller_root`, so it canonicalizes at
+                    // ingress. Scoped to the freshness door on purpose — this
+                    // route has never stamped a caller root, and widening that to
+                    // every verb would change reception/routing behaviour far
+                    // outside SPEC-1. Reuses the external-mutation seam's own
+                    // canonicalization precedent.
+                    let stamped_caller_root = crate::server::refresh_caller_root_from_header(
+                        &tool,
+                        &body,
+                        &caller_root_header,
+                    );
+                    if let Some(root) = stamped_caller_root {
+                        session.caller_root = Some(root);
+                    }
                     if explicit_brain_selector
                         && crate::server::skeleton_write_needs_root_gate(&tool, &body)
                     {
@@ -4115,6 +4137,7 @@ async fn handle_tool_call(
                         dispatch_generic_tool(session, &tool, &body)
                     }));
                     session.caller_root = caller_root;
+                    session.explicit_brain_selector = false;
                     session.apply_batch_progress_sink = None;
                     session.scan_progress_sink = None;
                     match result {

--- a/m1nd-mcp/src/internal_tests/spec1_refresh_declared_root.rs
+++ b/m1nd-mcp/src/internal_tests/spec1_refresh_declared_root.rs
@@ -677,3 +677,135 @@ fn spec1_1a_refresh_is_admitted_by_action_at_the_ratified_floor() {
         "the action-keyed allowlist must admit the refresh at the dispatch seam"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Written AFTER the implementation, and labelled as such.
+//
+// The two tests below could not be born RED: both name machinery that did not
+// exist before the door did — the single-flight claim (SPEC-1c) and the REST
+// seam's caller-root stamping (SPEC-1b). Everything above this line was written
+// first and never edited to fit. Saying which is which is cheaper than letting a
+// reader assume the wrong one.
+// ---------------------------------------------------------------------------
+
+/// SPEC-1c — single-flight per canonical root. A second refresh of a root
+/// already in flight refuses; it never queues behind the first and measures its
+/// candidate against a graph the first is about to replace (the cp32 TOCTOU).
+///
+/// Driven by claiming the root directly rather than by racing two threads: the
+/// property is "the claim is exclusive", and a race would test the scheduler.
+#[test]
+fn spec1_1c_second_refresh_of_a_root_in_flight_refuses() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let root = canonical(&repo);
+
+    let held = m1nd_mcp::tools::claim_refresh_root_for_test(&root)
+        .expect("an unclaimed root must be claimable");
+    state.caller_root = Some(root.clone());
+    let payload =
+        admit_then_dispatch(&mut state, "ingest", &refresh_params(&root)).expect("refusal payload");
+    assert_eq!(payload["refused"], json!("refresh_in_flight"));
+
+    // Released on drop, including down a panicking path — the next refresh runs.
+    drop(held);
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&root))
+        .expect("the released root must refresh");
+    assert_eq!(payload["ok"], json!(true), "payload was {payload}");
+}
+
+/// The REST seam really reaches the door: `POST /api/tools/ingest` with
+/// `mode:"refresh"` and an `M1nd-Caller-Root` header canonicalizes that header
+/// at ingress (SPEC-1b) and lands on the exact-root predicate — rather than
+/// arriving with no caller root at all, which every refresh would refuse for the
+/// wrong reason and which would make the §5.6 parity claim vacuous.
+#[cfg(feature = "serve")]
+#[tokio::test]
+async fn spec1_5_6c_rest_seam_stamps_a_canonical_caller_root_and_reaches_the_predicate() {
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    std::fs::create_dir_all(&runtime).expect("runtime dir");
+    let config = McpConfig {
+        graph_source: runtime.join("graph_snapshot.json"),
+        plasticity_state: runtime.join("plasticity_state.json"),
+        runtime_dir: Some(runtime.clone()),
+        registry_dir: Some(runtime.join("registry")),
+        ..McpConfig::default()
+    };
+    let server = m1nd_mcp::server::McpServer::new(config).expect("boot owner");
+    let session = Arc::new(m1nd_mcp::brain_runtime::BrainSessionCell::new(
+        server.into_session_state(),
+    ));
+    let (event_tx, _rx) = tokio::sync::broadcast::channel::<m1nd_mcp::http_server::SseEvent>(64);
+    let app = Arc::new(m1nd_mcp::http_server::AppState {
+        session,
+        tool_schemas_cache: m1nd_mcp::server::tool_schemas()
+            .get("tools")
+            .cloned()
+            .unwrap_or(serde_json::Value::Array(vec![])),
+        event_tx,
+        event_log_path: None,
+        registry_dir: Some(runtime.join("registry")),
+        mcp_sessions: m1nd_mcp::mcp_http::new_mcp_session_registry(),
+        project_brains: Arc::new(
+            m1nd_mcp::project_brains::ProjectBrainRegistry::with_capacity(
+                runtime.join("project-brains"),
+                Some(runtime.join("registry")),
+                4,
+            ),
+        ),
+        runnerd: Arc::new(m1nd_mcp::runnerd_owner::RunnerdRegistry::default()),
+        ui_authority: Arc::new(m1nd_mcp::ui_attestation::UiBundleAttestor::default()),
+        mission_service: None,
+        external_mutation_service: None,
+        authority_service: None,
+        autonomy_owner: None,
+    });
+
+    // A real directory that this fresh brain has NOT declared. The door must
+    // refuse it on the PREDICATE (`refresh_root_not_exact`), which is only
+    // reachable if the header was read and canonicalized first — with no caller
+    // root the answer would be `refresh_caller_root_unknown` instead.
+    let stranger = temp.path().join("stranger");
+    std::fs::create_dir_all(&stranger).expect("stranger dir");
+    let response = m1nd_mcp::http_server::build_router(app.clone(), false)
+        .oneshot(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/api/tools/ingest")
+                .header("content-type", "application/json")
+                .header("m1nd-caller-root", stranger.to_string_lossy().to_string())
+                .body(axum::body::Body::from(
+                    serde_json::to_vec(&refresh_params(&stranger.to_string_lossy())).unwrap(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("router answered");
+
+    assert_eq!(
+        response.status(),
+        200,
+        "the refresh action must be ADMITTED"
+    );
+    let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .expect("read body");
+    let payload: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    let refused = payload
+        .pointer("/refused")
+        .or_else(|| payload.pointer("/result/refused"))
+        .cloned()
+        .unwrap_or(payload.clone());
+    assert_eq!(
+        refused,
+        json!("refresh_root_not_exact"),
+        "the REST seam must reach the exact-root predicate, not stop short of it; body was {payload}"
+    );
+}

--- a/m1nd-mcp/src/internal_tests/spec1_refresh_declared_root.rs
+++ b/m1nd-mcp/src/internal_tests/spec1_refresh_declared_root.rs
@@ -1,0 +1,679 @@
+//! SPEC-1 — `graph.ingest.refresh_declared_root`, the freshness door.
+//!
+//! The normative document is `docs/GENESIS-INGEST-CONSUMERS-SPEC.md` (RATIFIED,
+//! owner, 2026-07-29, all four §6 items). This file IS its §5 acceptance list —
+//! written before the implementation, born RED against today's binary, and
+//! never edited afterwards to make the implementation pass.
+//!
+//! What the door is, in one line: the ONE opening in the authority wall. It
+//! re-ingests a root the bound brain has ALREADY declared. It never creates a
+//! brain, never adds a root, never crosses to another brain's territory.
+//!
+//! Numbering below follows the spec's own §5 list so a reader can check the
+//! battery against the document item by item. §5.7 (birth) and the birth half of
+//! §5.8 belong to SPEC-2 and are deliberately absent — SPEC-2 is not this PR.
+//!
+//! WHY THE POLICY GATE IS IN EVERY CALL. `enforce_generic_action_policy` is the
+//! pure, pre-brain admission seam (spec R-I) — the door's lock. Driving
+//! `dispatch_tool` without it would test the handler while leaving the lock
+//! untested, and on today's binary it would run a DESTRUCTIVE replace, because
+//! `normalized_ingest_mode` maps an unknown mode to `"replace"`. So every call
+//! here goes through `admit_then_dispatch`, exactly as both transports do.
+
+use crate as m1nd_mcp;
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::server::{dispatch_tool, enforce_generic_action_policy, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+const AGENT: &str = "spec1-refresh-probe";
+
+/// A brain whose runtime lives under `runtime`, with no roots declared yet.
+fn build_state(runtime: &Path) -> SessionState {
+    std::fs::create_dir_all(runtime).expect("runtime dir");
+    let config = McpConfig {
+        graph_source: runtime.join("graph_snapshot.json"),
+        plasticity_state: runtime.join("plasticity_state.json"),
+        runtime_dir: Some(runtime.to_path_buf()),
+        registry_dir: Some(runtime.join("registry")),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+/// A small, deterministic Rust crate. `extra` adds one more module so a later
+/// call can absorb a "new commit" and the node count moves for a reason.
+fn write_repo(root: &Path, extra: Option<(&str, &str)>) {
+    std::fs::create_dir_all(root.join("src")).expect("mk src");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"spec1fixture\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("Cargo.toml");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub mod helper;\npub fn top() -> i64 { helper::help() + 1 }\n\
+         pub struct Top { pub v: i64 }\npub fn second() -> i64 { 2 }\n",
+    )
+    .expect("lib.rs");
+    std::fs::write(
+        root.join("src/helper.rs"),
+        "pub fn help() -> i64 { 41 }\npub struct Helper { pub v: i64 }\n\
+         pub fn helper_two() -> i64 { 7 }\npub fn helper_three() -> i64 { 8 }\n",
+    )
+    .expect("helper.rs");
+    if let Some((name, body)) = extra {
+        std::fs::write(root.join("src").join(name), body).expect("extra module");
+    }
+}
+
+/// Seed the brain the way the field seeds one: the trusted library ingest that
+/// production `ingest` itself uses, then declare the root. The public generic
+/// route cannot do this — that is the wall SPEC-1 opens exactly one door in.
+fn seed_declared_root(state: &mut SessionState, repo: &Path) {
+    let (graph, _) = m1nd_ingest::Ingestor::new(m1nd_ingest::IngestConfig {
+        root: repo.to_path_buf(),
+        parallelism: 1,
+        ..m1nd_ingest::IngestConfig::default()
+    })
+    .ingest()
+    .expect("trusted fixture ingest");
+    {
+        let mut live = state.graph.write();
+        *live = graph;
+        if !live.finalized {
+            live.finalize().expect("finalize seeded graph");
+        }
+    }
+    state.rebuild_engines().expect("rebuild engines");
+    let declared = canonical(repo);
+    state.ingest_roots = vec![declared.clone()];
+    state.workspace_root = Some(declared);
+    state.persist().expect("persist the seeded brain");
+}
+
+fn canonical(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+fn node_count(state: &SessionState) -> u32 {
+    state.graph.read().num_nodes()
+}
+
+/// The exact sequence both transports run: the pure policy gate first, then
+/// dispatch. Returns the gate's refusal as `Err`, the handler's payload as `Ok`.
+fn admit_then_dispatch(
+    state: &mut SessionState,
+    tool: &str,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    enforce_generic_action_policy(tool, params).map_err(|error| error.to_string())?;
+    dispatch_tool(state, tool, params).map_err(|error| error.to_string())
+}
+
+fn refresh_params(path: &str) -> serde_json::Value {
+    json!({ "path": path, "agent_id": AGENT, "mode": "refresh" })
+}
+
+// ---------------------------------------------------------------------------
+// §5.1 — the hijack stays dead
+// ---------------------------------------------------------------------------
+
+/// Opening ONE door must not widen the wall. A foreign-root `replace` — the R-D
+/// hijack class, two bound-brain replacements in 24h on the deployed 1.4.x owner
+/// — keeps today's refusal, verbatim, including the floor it names.
+#[test]
+fn spec1_5_1_foreign_root_replace_keeps_todays_refusal_bytes() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let foreign = temp.path().join("foreign");
+    std::fs::create_dir_all(&foreign).expect("foreign root");
+
+    let refusal = admit_then_dispatch(
+        &mut state,
+        "ingest",
+        &json!({ "path": canonical(&foreign), "agent_id": AGENT, "mode": "replace" }),
+    )
+    .expect_err("a foreign-root replace must stay refused");
+
+    assert_eq!(
+        refusal,
+        "invalid params for ingest: generic_action_authority_required: \
+         semantic_action=graph.ingest.replace authority_floor=POSITIVE_SOVEREIGN \
+         cannot use generic REST/MCP dispatch; no exact typed G2/G3 lease \
+         consumer is installed for this action"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §5.2 — the verdict's kill-shot, the first RED case
+// ---------------------------------------------------------------------------
+
+/// `covers_root` is PREFIX (spec R-F), so a caller at `<root>/m1nd-ui` is
+/// "covered" by the brain at `<root>`. The refresh must NOT reuse it: SPEC-1.2
+/// admits only EQUALITY of canonical keys. A descendant refuses.
+#[test]
+fn spec1_5_2_descendant_root_refresh_refuses_root_not_exact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let descendant = repo.join("m1nd-ui");
+    std::fs::create_dir_all(&descendant).expect("descendant dir");
+    let before = node_count(&state);
+
+    state.caller_root = Some(canonical(&descendant));
+    let payload = admit_then_dispatch(
+        &mut state,
+        "ingest",
+        &refresh_params(&canonical(&descendant)),
+    )
+    .expect("the refresh action must be admitted and answer with a refusal payload");
+
+    assert_eq!(payload["ok"], json!(false));
+    assert_eq!(payload["refused"], json!("refresh_root_not_exact"));
+    // The prefix predicate would have said yes. Pin that it was not consulted.
+    assert!(
+        state.covers_root(&canonical(&descendant)),
+        "precondition: the descendant IS covered by the prefix predicate — that is \
+         exactly why the exact predicate has to be a different function"
+    );
+    assert_eq!(node_count(&state), before, "a refusal mutates nothing");
+}
+
+// ---------------------------------------------------------------------------
+// §5.3 — ingress canonicalization (SPEC-1b), never string matching
+// ---------------------------------------------------------------------------
+
+/// `<root>/../out` is textually "inside" nothing and resolves OUTSIDE the root.
+/// `canonical_key` resolves it; the predicate then refuses on equality.
+#[test]
+fn spec1_5_3a_parent_traversal_caller_refuses() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let out = temp.path().join("out");
+    std::fs::create_dir_all(&out).expect("out dir");
+    let traversal = repo.join("..").join("out").to_string_lossy().to_string();
+
+    state.caller_root = Some(traversal.clone());
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&traversal))
+        .expect("admitted, then refused in the handler");
+
+    assert_eq!(payload["refused"], json!("refresh_root_not_exact"));
+}
+
+/// A symlink INSIDE the root pointing OUT of it. The textual layer sees a child
+/// of the declared root; `canonical_key` resolves the link and sees a stranger.
+#[cfg(unix)]
+#[test]
+fn spec1_5_3b_symlink_out_of_root_refuses() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&outside).expect("outside dir");
+    let link = repo.join("escape");
+    std::os::unix::fs::symlink(&outside, &link).expect("symlink out of the root");
+    let via_link = link.to_string_lossy().to_string();
+
+    state.caller_root = Some(via_link.clone());
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&via_link))
+        .expect("admitted, then refused in the handler");
+
+    assert_eq!(payload["refused"], json!("refresh_root_not_exact"));
+}
+
+/// The `/tmp` → `/private/tmp` alias (spec R-J). Two spellings of ONE directory
+/// must reach the SAME decision — a brain that declares one spelling must accept
+/// the other, because they are the same root.
+#[cfg(target_os = "macos")]
+#[test]
+fn spec1_5_3c_tmp_alias_reaches_the_same_decision() {
+    let temp = tempfile::TempDir::with_prefix_in("spec1-alias-", "/tmp").expect("tempdir in /tmp");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+
+    let unresolved = repo.to_string_lossy().to_string();
+    let resolved = canonical(&repo);
+    assert_ne!(
+        unresolved, resolved,
+        "precondition: this fixture must actually exercise the /tmp alias"
+    );
+
+    state.caller_root = Some(unresolved.clone());
+    let via_alias = admit_then_dispatch(&mut state, "ingest", &refresh_params(&unresolved))
+        .expect("the aliased spelling must be admitted");
+    state.caller_root = Some(resolved.clone());
+    let via_resolved = admit_then_dispatch(&mut state, "ingest", &refresh_params(&resolved))
+        .expect("the resolved spelling must be admitted");
+
+    assert_eq!(
+        via_alias["ok"], via_resolved["ok"],
+        "/tmp and /private/tmp must reach the same decision, not two"
+    );
+    assert_eq!(via_alias["ok"], json!(true));
+}
+
+/// Two textually equal NONEXISTENT paths must never match each other.
+/// `canonical_key` falls back to the raw string when a path does not resolve
+/// (spec §1.2 SPEC-1b), so the door has to refuse unresolvable paths ITSELF.
+#[test]
+fn spec1_5_3d_nonexistent_path_refuses_rather_than_string_matching() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+
+    // A path that does not exist, declared verbatim as a root. Under a pure
+    // string comparison this is an exact match and the refresh would be admitted.
+    let ghost = temp
+        .path()
+        .join("ghost-root-that-never-existed")
+        .to_string_lossy()
+        .to_string();
+    state.ingest_roots.push(ghost.clone());
+
+    state.caller_root = Some(ghost.clone());
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&ghost))
+        .expect("admitted, then refused in the handler");
+
+    assert_eq!(payload["refused"], json!("refresh_root_unresolvable"));
+}
+
+/// The door authenticates a ROOT RELATIONSHIP (spec §1.3). With no caller root
+/// there is no relationship to authenticate, so it is fail-closed, not open.
+#[test]
+fn spec1_1b_unknown_caller_root_refuses_fail_closed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    assert!(
+        state.caller_root.is_none(),
+        "precondition: stdio sends no root"
+    );
+
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&canonical(&repo)))
+        .expect("admitted, then refused in the handler");
+
+    assert_eq!(payload["refused"], json!("refresh_caller_root_unknown"));
+}
+
+// ---------------------------------------------------------------------------
+// §5.4 — the happy path
+// ---------------------------------------------------------------------------
+
+/// Exact-root refresh succeeds, absorbs a new commit, leaves the root set
+/// unchanged (SPEC-1d) and leaves a journaled receipt (SPEC-1f).
+#[test]
+fn spec1_5_4_exact_root_refresh_absorbs_a_new_commit_and_keeps_the_root_set() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let before = node_count(&state);
+    let roots_before = state.ingest_roots.clone();
+    let workspace_before = state.workspace_root.clone();
+
+    // The "new commit": one more module the brain has never seen.
+    write_repo(
+        &repo,
+        Some((
+            "arrived.rs",
+            "pub fn arrived() -> i64 { 99 }\npub struct Arrived { pub v: i64 }\n\
+             pub fn arrived_two() -> i64 { 100 }\n",
+        )),
+    );
+
+    state.caller_root = Some(canonical(&repo));
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&canonical(&repo)))
+        .expect("an exact-root refresh must succeed");
+
+    assert_eq!(payload["ok"], json!(true), "payload was {payload}");
+    assert_eq!(payload["mode"], json!("refresh"));
+    assert!(
+        node_count(&state) > before,
+        "the refresh must absorb the new commit: {before} → {}",
+        node_count(&state)
+    );
+    assert_eq!(
+        state.ingest_roots, roots_before,
+        "SPEC-1d: root set unchanged"
+    );
+    assert_eq!(
+        state.workspace_root, workspace_before,
+        "SPEC-1d: binding unchanged"
+    );
+    // SPEC-1f: a receipt, naming both node counts and the root it refreshed.
+    assert_eq!(payload["refreshed_root"], json!(canonical(&repo)));
+    assert_eq!(payload["node_count_before"], json!(before));
+    assert_eq!(payload["node_count"], json!(node_count(&state)));
+}
+
+// ---------------------------------------------------------------------------
+// §5.5 — the shrink floor, ratified at 60%
+// ---------------------------------------------------------------------------
+
+/// The R-D damage signature is a NARROW scan replacing a WIDE graph. The persist
+/// layer's own guard is fail-open by written design (spec R-G: it backs up and
+/// writes anyway), so this armor is the refresh's own: candidate first, and a
+/// candidate under 60% of the live node count REFUSES, names BOTH counts, and
+/// mutates nothing.
+#[test]
+fn spec1_5_5_narrow_scan_refuses_would_shrink_graph_with_the_graph_untouched() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    // Widen the repo well past the floor so deleting most of it is a real shrink.
+    for index in 0..12 {
+        std::fs::write(
+            repo.join("src").join(format!("wide_{index}.rs")),
+            format!(
+                "pub fn wide_{index}() -> i64 {{ {index} }}\n\
+                 pub struct Wide{index} {{ pub v: i64 }}\n\
+                 pub fn wide_{index}_b() -> i64 {{ {index} }}\n"
+            ),
+        )
+        .expect("wide module");
+    }
+    seed_declared_root(&mut state, &repo);
+    let before = node_count(&state);
+    let snapshot_before = std::fs::read(&state.graph_path).expect("snapshot exists after seeding");
+
+    // The narrow scan: the repo loses almost everything between two calls.
+    for index in 0..12 {
+        std::fs::remove_file(repo.join("src").join(format!("wide_{index}.rs"))).expect("rm wide");
+    }
+    std::fs::remove_file(repo.join("src/helper.rs")).expect("rm helper");
+    std::fs::write(repo.join("src/lib.rs"), "pub fn top() -> i64 { 1 }\n").expect("shrink lib.rs");
+
+    state.caller_root = Some(canonical(&repo));
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&canonical(&repo)))
+        .expect("admitted, then refused in the handler");
+
+    assert_eq!(payload["refused"], json!("refresh_would_shrink_graph"));
+    // "names BOTH counts" — the spec's words, so both are asserted present.
+    assert_eq!(payload["live_node_count"], json!(before));
+    let candidate = payload["candidate_node_count"]
+        .as_u64()
+        .expect("the refusal must name the candidate's node count");
+    assert!(
+        candidate * 100 < u64::from(before) * 60,
+        "precondition: the fixture must actually fall below the ratified 60% floor \
+         ({candidate} vs {before})"
+    );
+    assert_eq!(payload["floor_percent"], json!(60));
+
+    assert_eq!(node_count(&state), before, "the live graph is untouched");
+    assert_eq!(
+        std::fs::read(&state.graph_path).expect("snapshot still there"),
+        snapshot_before,
+        "not one byte of the durable snapshot may move on a refusal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §5.6 — one admission seam, both transports (SPEC-1g)
+// ---------------------------------------------------------------------------
+
+/// An explicit `?brain=` selector NEVER satisfies the exact-root predicate, and
+/// therefore buys NOTHING: a refresh under a selector refuses byte-identically
+/// to the plain MCP non-exact case. Byte equality is the assertion because the
+/// spec's guarantee is that the two transports share ONE seam — not two seams
+/// that happen to agree today.
+///
+/// The REST selector precedent this closes is R-K: `caller_root` is already
+/// overwritten under `?brain=` for the skeleton-write family. §5.6's sibling
+/// assertion — that `ingest` never joins that family — is pinned below.
+#[test]
+fn spec1_5_6_rest_brain_selector_refuses_byte_identically_to_mcp() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let stranger = temp.path().join("stranger");
+    std::fs::create_dir_all(&stranger).expect("stranger dir");
+
+    // (a) plain MCP, caller root that is not a declared root.
+    state.caller_root = Some(canonical(&stranger));
+    state.explicit_brain_selector = false;
+    let mcp = admit_then_dispatch(&mut state, "ingest", &refresh_params(&canonical(&stranger)))
+        .expect("admitted, then refused");
+
+    // (b) REST under an explicit `?brain=` selector, caller root EXACTLY the
+    //     declared root — the case a selector would otherwise "unlock".
+    state.caller_root = Some(canonical(&repo));
+    state.explicit_brain_selector = true;
+    let rest = admit_then_dispatch(&mut state, "ingest", &refresh_params(&canonical(&repo)))
+        .expect("admitted, then refused");
+    state.explicit_brain_selector = false;
+
+    assert_eq!(rest["refused"], json!("refresh_root_not_exact"));
+    assert_eq!(
+        serde_json::to_string(&mcp).unwrap(),
+        serde_json::to_string(&rest).unwrap(),
+        "a selector must refuse byte-identically, not merely similarly"
+    );
+}
+
+/// `ingest`/refresh must never join the `skeleton_write_needs_root_gate`
+/// caller-root overwrite list (spec R-K, verdict RC-7). If it did, the REST
+/// selector would REWRITE `caller_root` to the selected brain's own workspace
+/// root — and the exact-root predicate would then authenticate the door against
+/// a value the door itself just invented.
+#[test]
+fn spec1_5_6b_refresh_never_joins_the_caller_root_overwrite_list() {
+    for mode in ["refresh", "replace", "merge"] {
+        assert!(
+            !m1nd_mcp::server::skeleton_write_needs_root_gate(
+                "ingest",
+                &json!({ "path": "/x", "agent_id": AGENT, "mode": mode }),
+            ),
+            "ingest mode={mode} must never overwrite caller_root under ?brain="
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §5.8 (refresh half) — old-or-new, never mixed
+// ---------------------------------------------------------------------------
+
+/// The refresh's durable transition must be SINGLE and ATOMIC, so a crash lands
+/// on the old graph or the new one and never on a blend.
+///
+/// WHAT THIS TEST EXECUTES: that every refusal path leaves the durable snapshot
+/// byte-identical (nothing is written before the decision), and that the success
+/// path leaves the durable snapshot holding exactly the NEW graph — i.e. there
+/// is exactly ONE durable transition, and it is `snapshot::save_graph`'s
+/// temp-file + `rename` (FM-PL-008). A `rename` on one filesystem is atomic, so
+/// a `kill -9` at any instant lands on one side of it.
+///
+/// DECLARED BOUNDARY — the fault-injection half is NOT executed here, and is not
+/// claimed. Killing a real process mid-refresh needs a live owner driven over a
+/// transport that carries `M1nd-Caller-Root`; the existing subprocess harness
+/// (`tests/persist_runtime_root.rs`) speaks stdio, which carries no caller root,
+/// so SPEC-1 correctly refuses there and the verb cannot be driven to the point
+/// of the kill. This is the SAME declared boundary that harness already carries
+/// for its own crash cycle ("Cycle B — crash / `kill -9` with no checkpoint — is
+/// deliberately NOT here. It is wave 2, and until it lands the fault-injection
+/// half of this property stays NOT_RUN rather than silently claimed"). SPEC-1's
+/// refresh joins that wave rather than growing a second, weaker harness.
+#[test]
+fn spec1_5_8_refresh_durable_transition_is_single_and_atomic() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo, None);
+    seed_declared_root(&mut state, &repo);
+    let snapshot_path = state.graph_path.clone();
+    let before_bytes = std::fs::read(&snapshot_path).expect("seeded snapshot");
+    let before_nodes = node_count(&state);
+
+    // Every refusal reason, one after another: not one may move a durable byte.
+    let stranger = temp.path().join("stranger");
+    std::fs::create_dir_all(&stranger).expect("stranger dir");
+    let refusals: Vec<(Option<String>, String)> = vec![
+        (None, canonical(&repo)),
+        (Some(canonical(&stranger)), canonical(&stranger)),
+        (
+            Some(temp.path().join("ghost").to_string_lossy().to_string()),
+            temp.path().join("ghost").to_string_lossy().to_string(),
+        ),
+    ];
+    for (caller, path) in refusals {
+        state.caller_root = caller;
+        let payload =
+            admit_then_dispatch(&mut state, "ingest", &refresh_params(&path)).expect("refusal");
+        assert_eq!(payload["ok"], json!(false));
+        assert_eq!(
+            std::fs::read(&snapshot_path).expect("snapshot"),
+            before_bytes,
+            "a refused refresh wrote to the durable snapshot"
+        );
+    }
+
+    // The success path: the durable snapshot ends holding the NEW graph — not
+    // the old one, and not something between the two.
+    write_repo(
+        &repo,
+        Some((
+            "arrived.rs",
+            "pub fn arrived() -> i64 { 99 }\npub struct A { pub v: i64 }\n",
+        )),
+    );
+    state.caller_root = Some(canonical(&repo));
+    let payload = admit_then_dispatch(&mut state, "ingest", &refresh_params(&canonical(&repo)))
+        .expect("the exact-root refresh must succeed");
+    assert_eq!(payload["ok"], json!(true));
+
+    let after_nodes = node_count(&state);
+    assert!(after_nodes > before_nodes);
+    let durable = std::fs::read_to_string(&snapshot_path).expect("snapshot after refresh");
+    let durable: serde_json::Value = serde_json::from_str(&durable).expect("snapshot parses");
+    assert_eq!(
+        durable["nodes"].as_array().map(Vec::len),
+        Some(after_nodes as usize),
+        "the durable snapshot must hold exactly the NEW graph"
+    );
+    // No temp file survives the transition — a leftover `.tmp` is the footprint
+    // of a write that was not a single rename.
+    let leftovers: Vec<PathBuf> = std::fs::read_dir(snapshot_path.parent().unwrap())
+        .expect("read runtime dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension().and_then(|ext| ext.to_str()) == Some("tmp")
+                && path.file_stem().and_then(|stem| stem.to_str()) == Some("graph_snapshot")
+        })
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "left a partial write behind: {leftovers:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §5.9 — the regression pin (verdict RC-4)
+// ---------------------------------------------------------------------------
+
+/// The admission MUST be keyed BY ACTION, never by floor. `source.edit.commit`
+/// and `graph.ingest.merge_existing` both sit at `SCOPED_GRANT_A2` — the exact
+/// floor SPEC-1 is admitted at. If the allowlist were keyed by floor, opening
+/// the refresh would open these two as well. Their refusal bytes are pinned
+/// here, verbatim, so that mistake cannot be made silently.
+#[test]
+fn spec1_5_9_scoped_grant_a2_siblings_keep_todays_refusal_bytes() {
+    let edit_commit = enforce_generic_action_policy(
+        "edit_commit",
+        &json!({ "agent_id": AGENT, "edit_id": "e-1" }),
+    )
+    .expect_err("source.edit.commit must stay refused")
+    .to_string();
+    assert_eq!(
+        edit_commit,
+        "invalid params for edit_commit: generic_action_authority_required: \
+         semantic_action=source.edit.commit authority_floor=SCOPED_GRANT_A2 \
+         cannot use generic REST/MCP dispatch; no exact typed G2/G3 lease \
+         consumer is installed for this action"
+    );
+
+    let merge_existing = enforce_generic_action_policy(
+        "external_mutation_service",
+        &json!({ "agent_id": AGENT, "action": "graph_ingest_merge_existing" }),
+    )
+    .expect_err("graph.ingest.merge_existing must stay refused")
+    .to_string();
+    assert_eq!(
+        merge_existing,
+        "invalid params for external_mutation_service: generic_action_authority_required: \
+         semantic_action=graph.ingest.merge_existing authority_floor=SCOPED_GRANT_A2 \
+         cannot use generic REST/MCP dispatch; no exact typed G2/G3 lease \
+         consumer is installed for this action"
+    );
+
+    // And the same floor reached through the `ingest` tool's own merge selector,
+    // which additionally depends on a trusted fact that production never proves
+    // (spec R-I). It must stay unresolved, not become admitted.
+    let ingest_merge = enforce_generic_action_policy(
+        "ingest",
+        &json!({ "path": "/x", "agent_id": AGENT, "mode": "merge" }),
+    )
+    .expect_err("ingest mode=merge must stay refused")
+    .to_string();
+    assert!(
+        ingest_merge.contains("generic_action_authority_required"),
+        "got: {ingest_merge}"
+    );
+}
+
+/// SPEC-1's own admission, stated positively: the refresh is admitted because
+/// its ACTION is named, and the action it is named under is exactly the one the
+/// owner ratified at `ScopedGrantA2`, A2-local.
+#[test]
+fn spec1_1a_refresh_is_admitted_by_action_at_the_ratified_floor() {
+    let classified = m1nd_mcp::action_routes::classify_mcp_action(
+        "ingest",
+        &json!({ "path": "/x", "agent_id": AGENT, "mode": "refresh" }),
+        m1nd_mcp::action_routes::TrustedMcpRouteFacts::default(),
+    )
+    .expect("mode=refresh must classify purely from (tool, params)");
+    assert_eq!(
+        classified.action.as_str(),
+        "graph.ingest.refresh_declared_root"
+    );
+    assert_eq!(
+        classified.authority_floor,
+        m1nd_control::AuthorityFloor::ScopedGrantA2,
+        "§6 item 2, ratified: ScopedGrantA2, A2-local"
+    );
+    assert!(
+        enforce_generic_action_policy(
+            "ingest",
+            &json!({ "path": "/x", "agent_id": AGENT, "mode": "refresh" })
+        )
+        .is_ok(),
+        "the action-keyed allowlist must admit the refresh at the dispatch seam"
+    );
+}

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -254,6 +254,11 @@ mod two_tier_project_brains_internal_tests;
 #[cfg(all(test, feature = "serve"))]
 #[path = "internal_tests/ui_bundle_attestation.rs"]
 mod ui_bundle_attestation_internal_tests;
+// SPEC-1 — the freshness door's acceptance battery
+// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §5), written before its implementation.
+#[cfg(test)]
+#[path = "internal_tests/spec1_refresh_declared_root.rs"]
+mod spec1_refresh_declared_root_internal_tests;
 
 // HTTP server + types (feature-gated behind "serve")
 #[cfg(feature = "serve")]

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -66,10 +66,13 @@ age + author — absent, never faked, when unknown), a sufficiency signal, one \
 `next_move`, `honest_gaps` (what m1nd does NOT yet know), and — when missions \
 await the human landing — the `landing_bell` (a `merge_wait` count + one honest \
 line, absent when none do). If it returns `needs_ingest`, do not call generic \
-`ingest`: every generic graph mutation is policy-disabled. For an existing brain, \
+`ingest` to REPLACE or MERGE — those stay policy-disabled. For an existing brain, \
 use the exact authority flow plus `external_mutation_service`; under \
 `caller_root_mismatch`, creating or rebinding a brain remains unavailable until the \
-typed bootstrap consumer is installed. `north` \
+typed bootstrap consumer is installed. The ONE ingest you CAN run is \
+`ingest` with mode=refresh — it re-scans a root this brain already declared, and only \
+when your caller root is exactly that root; it refuses rather than shrink the graph. \
+`north` \
 composes trust_selftest + orient + boot_memory + focus — reach for the pieces directly \
 only when you need just one.
 
@@ -286,7 +289,7 @@ savings (G1).
 - `am_i_stale(claim)` — check BEFORE editing on the strength of remembered/cached knowledge.
 - `soul_check` / `soul_read` — verify (freshness receipt) / pull the project's PATHOS handoff soul.
 - `coverage_session` — surface the blind spots in what you have and haven't looked at this session.
-- `ingest` — compatibility name only; generic graph mutation is policy-disabled and must not be called.
+- `ingest` — `replace`/`merge` are policy-disabled and must not be called. `ingest` with mode=refresh is the one exception: re-scan a root this brain already declared, from exactly that root.
 - `external_mutation_service` — governed elevated graph ingest for an existing brain after the exact authority flow; it does not create project brains.
 ";
 
@@ -1096,7 +1099,7 @@ fn all_tool_schemas_inner() -> serde_json::Value {
             },
             {
                 "name": "ingest",
-                "description": "POLICY-DISABLED generic graph mutation compatibility surface. Do not call it: use the exact authority flow plus external_mutation_service for an existing brain. Cross-root project-brain bootstrap is unavailable until an exact typed G2/G3 consumer is installed.",
+                "description": "POLICY-DISABLED generic graph mutation compatibility surface, with ONE exception. mode='replace' and mode='merge' are refused for every client: use the exact authority flow plus external_mutation_service for an existing brain, and cross-root project-brain bootstrap is unavailable until an exact typed G2/G3 consumer is installed. mode='refresh' IS callable at the SCOPED_GRANT_A2 floor, admitted A2-locally with no lease: it re-scans a root this brain has already declared, and only when your caller root is EXACTLY that root. It never creates a brain, never adds a root, never crosses to another brain, and refuses (refresh_would_shrink_graph) rather than replace a wide graph with a narrow scan.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -1112,8 +1115,8 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         "mode": {
                             "type": "string",
                             "default": "replace",
-                            "enum": ["replace", "merge"],
-                            "description": "Replace the bound graph or merge the ingest into it"
+                            "enum": ["replace", "merge", "refresh"],
+                            "description": "Replace the bound graph, merge the ingest into it, or 'refresh' — re-scan a root this brain already declared (the only mode a plain client can execute; requires your caller root to be exactly that root)"
                         },
                         "namespace": {
                             "type": "string",
@@ -5849,6 +5852,22 @@ pub(crate) fn enforce_generic_action_policy(
         }
     };
 
+    // The ONE opening in the wall, keyed BY ACTION and never by floor
+    // (GENESIS-INGEST-CONSUMERS-SPEC.md §1.1, owner-ratified 2026-07-29).
+    //
+    // It is deliberately reachable ONLY from the exactly-classified branch. The
+    // `MissingTrustedFact` arm above resolves a UNION of floors with no exact
+    // action, so it can never land here — an unresolved classification stays
+    // fail-closed, as it must.
+    //
+    // Admission here admits the CATEGORY only. Every authority-relevant fact
+    // about the refresh is enforced inside the handler, after brain resolution.
+    if action.as_deref().is_some_and(|exact| {
+        crate::action_consumers::GENERIC_A2_LOCAL_ADMITTED_ACTIONS.contains(&exact)
+    }) {
+        return Ok(());
+    }
+
     let unavailable: Vec<&'static str> = floors
         .iter()
         .copied()
@@ -6165,6 +6184,39 @@ pub(crate) fn skeleton_write_needs_root_gate(tool_name: &str, params: &serde_jso
         "candidate_lease" => params.get("action").and_then(|v| v.as_str()) == Some("acquire"),
         _ => false,
     }
+}
+
+/// SPEC-1b's ingress canonicalization for the REST tools seam.
+///
+/// Returns the canonicalized `M1nd-Caller-Root` to stamp on the session for THIS
+/// dispatch, or `None` to leave the session's own value alone.
+///
+/// Deliberately narrow. `/api/tools/*` has never stamped a caller root, and
+/// making it do so for every verb would newly switch on reception verdicts and
+/// brainless-root routing for every REST caller that happens to send the header
+/// — a behaviour change far outside this door. So it stamps for exactly the
+/// action that needs a caller root to decide anything: the refresh. Both
+/// transports then reach ONE predicate with a canonical value, which is what
+/// makes their refusals byte-identical (SPEC-1g) rather than merely similar.
+pub(crate) fn refresh_caller_root_from_header(
+    tool_name: &str,
+    params: &serde_json::Value,
+    header: &Option<String>,
+) -> Option<String> {
+    let bare = tool_name
+        .strip_prefix("m1nd.")
+        .or_else(|| tool_name.strip_prefix("m1nd_"))
+        .unwrap_or(tool_name);
+    if bare != "ingest" || params.get("mode").and_then(|v| v.as_str()) != Some("refresh") {
+        return None;
+    }
+    let raw = header.as_deref()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    Some(crate::project_brains::ProjectBrainRegistry::canonical_key(
+        raw,
+    ))
 }
 
 /// Dispatch core + superpowers tools (35 tools).

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -1308,6 +1308,76 @@ impl SessionState {
             .any(|known| Self::path_starts_with_loosely(candidate, known))
     }
 
+    /// The exact-root predicate — `covers_root`'s AUTHORITY-EXCLUSIVE sibling
+    /// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §1.2, verdict RC-1).
+    ///
+    /// `covers_root` above is a PREFIX test by design, and it stays one: it
+    /// answers "may this brain legitimately serve that caller's questions?", and
+    /// a caller deep inside a repo is legitimately served by that repo's brain.
+    /// It is the wrong question for a WRITE. `<root>/m1nd-ui` is covered by the
+    /// brain at `<root>`, so reusing the prefix test here would let any
+    /// subdirectory rewrite the whole repo's graph — the verdict's kill-shot.
+    ///
+    /// So this one asks a different question, and answers it with EQUALITY of
+    /// `canonical_key`s, never a prefix and never a textual comparison:
+    ///
+    /// - `canonical_key` resolves symlinks and the `/tmp` → `/private/tmp` alias
+    ///   (spec R-J), so two spellings of one directory reach ONE decision;
+    /// - it FALLS BACK to the raw string when a path does not resolve
+    ///   (`project_brains.rs`), which alone would let two textually-equal
+    ///   NONEXISTENT paths "match" — so unresolvable paths are refused here
+    ///   explicitly, before any comparison (SPEC-1b);
+    /// - an explicit brain selector is refused outright: `?brain=` says WHICH
+    ///   brain to talk to, never that the caller inhabits that brain's root
+    ///   (SPEC-1g). It is folded into `refresh_root_not_exact` on purpose, so a
+    ///   selector cannot even be DISTINGUISHED from the plain miss — it must buy
+    ///   nothing at all, not even information.
+    ///
+    /// `Ok(canonical_root)` is the canonical key of the declared root the caller
+    /// exactly inhabits. `Err(code)` is a stable refusal code.
+    pub fn exact_declared_root(&self, caller_root: &str) -> Result<String, &'static str> {
+        use crate::project_brains::ProjectBrainRegistry;
+
+        if self.explicit_brain_selector {
+            return Err("refresh_root_not_exact");
+        }
+        let trimmed = caller_root.trim().trim_end_matches('/');
+        if trimmed.is_empty() || !std::path::Path::new(trimmed).exists() {
+            return Err("refresh_root_unresolvable");
+        }
+        let caller_key = ProjectBrainRegistry::canonical_key(trimmed);
+
+        let declared = self
+            .workspace_root
+            .iter()
+            .chain(self.ingest_roots.iter())
+            .filter(|root| std::path::Path::new(root.trim().trim_end_matches('/')).exists())
+            .map(|root| ProjectBrainRegistry::canonical_key(root))
+            .any(|declared| declared == caller_key);
+
+        if declared {
+            Ok(caller_key)
+        } else {
+            Err("refresh_root_not_exact")
+        }
+    }
+
+    /// Every declared root this brain holds, canonicalized — the list the
+    /// exact-root predicate compares against, surfaced so a refusal can name it.
+    pub fn declared_roots_canonical(&self) -> Vec<String> {
+        use crate::project_brains::ProjectBrainRegistry;
+
+        let mut roots: Vec<String> = self
+            .workspace_root
+            .iter()
+            .chain(self.ingest_roots.iter())
+            .map(|root| ProjectBrainRegistry::canonical_key(root))
+            .collect();
+        roots.sort();
+        roots.dedup();
+        roots
+    }
+
     /// The brain's real PROJECT root — the repo it maps, NOT its runtime sidecar.
     ///
     /// The Hall (HUMAN-LAYER-PRD §4A.3) must name brains by their project, never
@@ -4559,6 +4629,16 @@ mod tests {
         ),
         (
             "finalize_ingest_with_inventory",
+            "ingest",
+            DurabilityRoute::ClassifiedMutation,
+        ),
+        // SPEC-1's freshness door. It writes `ingest_roots` for exactly one
+        // reason: to RESTORE the value it captured before committing, so
+        // SPEC-1d's root-set invariance holds mechanically even if the finalize
+        // path below it ever grows a new root writer. That restore runs inside
+        // the same classified `ingest` turn, which is what makes it durable.
+        (
+            "handle_ingest_refresh",
             "ingest",
             DurabilityRoute::ClassifiedMutation,
         ),

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -528,6 +528,16 @@ pub struct SessionState {
     /// header does not inherit a stale value. Feeds First-Contact Reception's
     /// mismatch verdict (`reception_verdict`). See TWO-TIER-BRAIN-PRD §9.5.4.
     pub caller_root: Option<String>,
+    /// True while this dispatch was routed by an EXPLICIT brain selector
+    /// (REST `?brain=`, or the wire's own selected-brain route) rather than by
+    /// the caller's own root. Request-scoped exactly like `caller_root`: the
+    /// transport sets it before dispatch and restores it after.
+    ///
+    /// It exists for the authority-exclusive predicates that must never be
+    /// satisfied by a selector (`GENESIS-INGEST-CONSUMERS-SPEC.md` §1.2
+    /// SPEC-1g): a selector says WHICH brain to talk to, never that the caller
+    /// legitimately inhabits that brain's root. `false` on every other path.
+    pub explicit_brain_selector: bool,
     /// Dedicated runtime root for persisted sidecar state.
     pub runtime_root: PathBuf,
     /// F11-b: the owner-process naming facts (the runnerd announce registry + the
@@ -2122,6 +2132,7 @@ impl SessionState {
             workspace_root: Some(workspace_root.to_string_lossy().to_string()),
             workspace_root_source: Some(workspace_root_source),
             caller_root: None,
+            explicit_brain_selector: false,
             runtime_root: runtime_root.clone(),
             // Threaded in by the HTTP owner at boot; None on stdio (no announce).
             runnerd_naming: None,

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -44,9 +44,275 @@ pub const HOST_BINDING_REQUIRED_TOOLS: [&str; 8] = [
 fn normalized_ingest_mode(mode: &str) -> &str {
     if mode.eq_ignore_ascii_case("merge") {
         "merge"
+    } else if mode.eq_ignore_ascii_case("refresh") {
+        "refresh"
     } else {
         "replace"
     }
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-1 — `graph.ingest.refresh_declared_root`, the freshness door.
+// `docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §1, owner-ratified 2026-07-29.
+// ---------------------------------------------------------------------------
+
+/// The shrink floor, ratified by the owner at 60% (spec §6 item 3).
+///
+/// A candidate holding fewer than this share of the live graph's nodes REFUSES.
+/// This is armor the persist layer deliberately does not provide: its own guard
+/// is fail-open by written design (spec R-G — it backs up and writes anyway), so
+/// "root set unchanged" never implied "graph intact". The R-D damage signature —
+/// a narrow scan replacing a wide graph, measured twice in 24h on the deployed
+/// 1.4.x owner — dies here even for a caller who is entirely legitimate.
+pub const REFRESH_SHRINK_FLOOR_PERCENT: u64 = 60;
+
+/// The refusal envelope. ONE shape for every refusal reason so both transports
+/// emit the same bytes for the same decision (SPEC-1g), and so an agent can
+/// branch on `refused` without parsing prose.
+fn refresh_refusal(code: &str, reason: &str) -> serde_json::Value {
+    serde_json::json!({
+        "ok": false,
+        "schema": "m1nd-graph-ingest-refresh-v1",
+        "action": "graph.ingest.refresh_declared_root",
+        "refused": code,
+        "reason": reason,
+    })
+}
+
+/// Roots currently being refreshed, by canonical key — single-flight per root
+/// (SPEC-1c, a cp32 requirement, closing the TOCTOU between "candidate measured"
+/// and "candidate committed").
+fn refresh_in_flight_roots() -> &'static std::sync::Mutex<HashSet<String>> {
+    static ROOTS: std::sync::OnceLock<std::sync::Mutex<HashSet<String>>> =
+        std::sync::OnceLock::new();
+    ROOTS.get_or_init(|| std::sync::Mutex::new(HashSet::new()))
+}
+
+/// Holds one root's single-flight claim and releases it on every exit path,
+/// including a panic inside the ingest.
+struct RefreshInFlightGuard(String);
+
+impl Drop for RefreshInFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut roots) = refresh_in_flight_roots().lock() {
+            roots.remove(&self.0);
+        }
+    }
+}
+
+/// Hold a root's single-flight claim from a test, so SPEC-1c's exclusivity is
+/// proved deterministically instead of by racing two threads and hoping.
+#[cfg(test)]
+pub(crate) fn claim_refresh_root_for_test(canonical_root: &str) -> Option<impl Drop> {
+    claim_refresh_root(canonical_root)
+}
+
+/// `None` when another refresh already holds this root.
+fn claim_refresh_root(canonical_root: &str) -> Option<RefreshInFlightGuard> {
+    let mut roots = refresh_in_flight_roots()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !roots.insert(canonical_root.to_string()) {
+        return None;
+    }
+    Some(RefreshInFlightGuard(canonical_root.to_string()))
+}
+
+/// Re-ingest a root this brain has ALREADY declared.
+///
+/// The door never creates a brain, never adds a root, and never crosses to
+/// another brain's territory. Admission at the dispatch seam admitted only the
+/// CATEGORY (`action_consumers::GENERIC_A2_LOCAL_ADMITTED_ACTIONS`); everything
+/// that actually carries authority is decided HERE, after brain resolution, and
+/// every branch is fail-closed.
+///
+/// WHAT THIS DOES NOT CLOSE, stated where the code is (spec §1.3, following
+/// `system_blocks_handlers.rs`'s own honest-phrasing precedent): `caller_root` is
+/// resolved by the CLIENT and travels as a header (spec R-H). Canonicalizing it
+/// kills the textual tricks, but a same-UID local process that sets
+/// `PROJECT_ROOT` to a root it does not legitimately inhabit can still present as
+/// that root. SPEC-1 closes the REFLEX vector — an agent acting from habit or
+/// misconfiguration. It is not a defense against a hostile local process; that
+/// is the lease plane, and it is not this door.
+fn handle_ingest_refresh(
+    state: &mut SessionState,
+    input: &IngestInput,
+) -> M1ndResult<serde_json::Value> {
+    // 1. The door authenticates a ROOT RELATIONSHIP. With no caller root there
+    //    is nothing to authenticate — fail closed, never open.
+    let Some(caller_root) = state.caller_root.clone() else {
+        return Ok(refresh_refusal(
+            "refresh_caller_root_unknown",
+            "a refresh is authorized by the caller's own root; this session carries none, and an unknown root is never treated as a match",
+        ));
+    };
+
+    // 2. The exact-root predicate (SPEC-1.2): EQUALITY of canonical keys against
+    //    the declared roots — never `covers_root`'s prefix, never a raw string.
+    let canonical_root = match state.exact_declared_root(&caller_root) {
+        Ok(root) => root,
+        Err(code) => {
+            let mut refusal = refresh_refusal(
+                code,
+                match code {
+                    "refresh_root_unresolvable" => {
+                        "the caller's root does not resolve on disk; an unresolvable path is refused rather than compared as text"
+                    }
+                    _ => {
+                        "a refresh re-scans a root this brain has ALREADY declared, and only from that exact root — a subdirectory, a neighbour, or an explicit brain selector is not it"
+                    }
+                },
+            );
+            if let Some(object) = refusal.as_object_mut() {
+                object.insert(
+                    "declared_roots".to_string(),
+                    serde_json::json!(state.declared_roots_canonical()),
+                );
+            }
+            return Ok(refusal);
+        }
+    };
+
+    // 3. The path argument must name that SAME root. `path` is what gets scanned;
+    //    letting it differ from the authenticated root would authorize one root
+    //    and then re-ingest another.
+    let target = input.path.trim().trim_end_matches('/');
+    if target.is_empty() || !std::path::Path::new(target).exists() {
+        return Ok(refresh_refusal(
+            "refresh_root_unresolvable",
+            "the path to refresh does not resolve on disk",
+        ));
+    }
+    if crate::project_brains::ProjectBrainRegistry::canonical_key(target) != canonical_root {
+        return Ok(refresh_refusal(
+            "refresh_root_not_exact",
+            "the path to refresh is not the root this caller is authorized for",
+        ));
+    }
+
+    // 4. Single-flight per canonical root (SPEC-1c).
+    let Some(_in_flight) = claim_refresh_root(&canonical_root) else {
+        return Ok(refresh_refusal(
+            "refresh_in_flight",
+            "another refresh of this root is already running; its candidate would be measured against a graph this one is about to replace",
+        ));
+    };
+
+    // 5. Root-set invariance (SPEC-1d), decided BEFORE anything is mutated. The
+    //    one way a refresh could move the root set without touching it: the
+    //    post-replace agent-memory restore mints the sidecar dir as a new root on
+    //    a brain that has never declared one.
+    let declared_before = state.declared_roots_canonical();
+    if let Some(sidecar) = pending_memory_sidecar_root(state) {
+        if !declared_before.contains(&sidecar) {
+            return Ok(serde_json::json!({
+                "ok": false,
+                "schema": "m1nd-graph-ingest-refresh-v1",
+                "action": "graph.ingest.refresh_declared_root",
+                "refused": "refresh_would_change_roots",
+                "reason": "restoring this brain's agent memory would declare a root it does not hold; a refresh never changes the root set",
+                "declared_roots": declared_before,
+                "would_add_root": sidecar,
+            }));
+        }
+    }
+
+    // 6. The CANDIDATE, computed first and committed only if it survives. The
+    //    ingest itself is the existing one — this door builds no second scanner.
+    let (candidate, stats) = m1nd_ingest::Ingestor::new(m1nd_ingest::IngestConfig {
+        root: std::path::PathBuf::from(target),
+        include_dotfiles: input.include_dotfiles,
+        dotfile_patterns: input.dotfile_patterns.clone(),
+        ..m1nd_ingest::IngestConfig::default()
+    })
+    .ingest()?;
+
+    let live_nodes = u64::from(state.graph.read().num_nodes());
+    let candidate_nodes = u64::from(candidate.num_nodes());
+
+    // 7. The shrink floor (SPEC-1e), HARD and fail-closed.
+    if live_nodes > 0 && candidate_nodes * 100 < live_nodes * REFRESH_SHRINK_FLOOR_PERCENT {
+        return Ok(serde_json::json!({
+            "ok": false,
+            "schema": "m1nd-graph-ingest-refresh-v1",
+            "action": "graph.ingest.refresh_declared_root",
+            "refused": "refresh_would_shrink_graph",
+            "reason": "the candidate holds too little of the live graph to be a refresh of it; nothing was mutated",
+            "refreshed_root": canonical_root,
+            "live_node_count": live_nodes,
+            "candidate_node_count": candidate_nodes,
+            "floor_percent": REFRESH_SHRINK_FLOOR_PERCENT,
+        }));
+    }
+
+    // 8. Commit. `finalize_ingest` is the SAME durable path every ingest takes —
+    //    graph swap, engine rebuild, inventory, `state.persist()`. Refresh mode
+    //    differs from `replace` in exactly one way: it never writes the root set
+    //    or the workspace binding. Captured and restored around the call anyway,
+    //    so the invariant holds even if that path grows a new root writer.
+    let roots_before = state.ingest_roots.clone();
+    let workspace_before = state.workspace_root.clone();
+    let mut output = finalize_ingest(state, input, "code", candidate, stats)?;
+    state.ingest_roots = roots_before;
+    state.workspace_root = workspace_before;
+
+    let node_count = u64::from(state.graph.read().num_nodes());
+    if let Some(object) = output.as_object_mut() {
+        object.insert("ok".to_string(), serde_json::json!(true));
+        object.insert(
+            "schema".to_string(),
+            serde_json::json!("m1nd-graph-ingest-refresh-v1"),
+        );
+        object.insert(
+            "action".to_string(),
+            serde_json::json!("graph.ingest.refresh_declared_root"),
+        );
+        object.insert(
+            "refreshed_root".to_string(),
+            serde_json::json!(canonical_root),
+        );
+        object.insert(
+            "node_count_before".to_string(),
+            serde_json::json!(live_nodes),
+        );
+        object.insert("node_count".to_string(), serde_json::json!(node_count));
+        object.insert(
+            "root_set_unchanged".to_string(),
+            serde_json::json!(state.declared_roots_canonical() == declared_before),
+        );
+        object.insert(
+            "shrink_floor_percent".to_string(),
+            serde_json::json!(REFRESH_SHRINK_FLOOR_PERCENT),
+        );
+    }
+    Ok(output)
+}
+
+/// The agent-memory sidecar root a post-replace restore would ingest, canonical,
+/// or `None` when this refresh will not restore anything. Mirrors
+/// `reload_agent_memory`'s own preconditions rather than guessing at them.
+fn pending_memory_sidecar_root(state: &SessionState) -> Option<String> {
+    let enabled = std::env::var("M1ND_AUTO_LOAD_AGENT_MEMORY")
+        .map(|value| value != "0" && value != "false")
+        .unwrap_or(true);
+    if !enabled {
+        return None;
+    }
+    let dir = state.runtime_root.join("agent-memory");
+    if !dir.is_dir() {
+        return None;
+    }
+    let has_light = std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .any(|entry| entry.path().to_string_lossy().ends_with(".light.md"));
+    if !has_light {
+        return None;
+    }
+    Some(crate::project_brains::ProjectBrainRegistry::canonical_key(
+        &dir.to_string_lossy(),
+    ))
 }
 
 fn playbook_step(
@@ -822,7 +1088,10 @@ fn finalize_ingest_with_inventory(
         serde_json::Value::Null
     };
 
-    if mode == "replace" {
+    // `refresh` shares `replace`'s whole-graph semantics (it IS a fresh scan of
+    // the root), so it resets the inventory too — a file deleted upstream must
+    // stop being claimed as known.
+    if mode != "merge" {
         state.reset_file_inventory();
     }
     state.record_file_inventory(inventory_entries);
@@ -834,7 +1103,14 @@ fn finalize_ingest_with_inventory(
 
     // Track ingest roots for L3 git discovery and scope normalization.
     // Replace mode resets the active roots to the new source of truth.
-    if mode == "replace" {
+    //
+    // `refresh` writes NEITHER branch: SPEC-1d says a refresh never changes the
+    // root set, and the cheapest way to guarantee that is to have no code that
+    // could. It re-scans a root the brain already declared, so there is nothing
+    // to declare and nothing to reset.
+    if mode == "refresh" {
+        // deliberately nothing
+    } else if mode == "replace" {
         state.ingest_roots.clear();
         state.ingest_roots.push(input.path.clone());
     } else {
@@ -916,7 +1192,12 @@ fn finalize_ingest_with_inventory(
     // bind (`runnerd_naming` None) is untouched, and a per-project
     // `ingest {project_root}` routes to a hosted brain before this seam runs.
     let served_owner_pinned = state.runnerd_naming.is_some() && holds_code_root;
-    if !(demotes_to_store && (holds_code_root || manifest_bound)) && !served_owner_pinned {
+    // `refresh` never rebinds: the root it scanned is already this brain's, so
+    // there is no binding to move (SPEC-1d).
+    if mode != "refresh"
+        && !(demotes_to_store && (holds_code_root || manifest_bound))
+        && !served_owner_pinned
+    {
         state.workspace_root = Some(candidate_workspace_root);
     }
 
@@ -929,7 +1210,10 @@ fn finalize_ingest_with_inventory(
     // which also re-anchors evidence to the freshly-ingested code. (Skip for the
     // light adapter: the caller is explicitly managing light content, and the
     // re-merge runs as adapter=light/mode=merge so it never recurses here.)
-    let agent_memory_restored = if mode == "replace" && adapter != "light" {
+    // (`refresh` wipes it the same way and restores it the same way; SPEC-1d's
+    // root-set invariance is preserved because the door refuses up front when
+    // that restore would have to declare a root the brain does not hold.)
+    let agent_memory_restored = if mode != "merge" && adapter != "light" {
         reload_agent_memory(state)
     } else {
         None
@@ -3075,6 +3359,14 @@ pub fn handle_ingest(
     input: IngestInput,
 ) -> M1ndResult<serde_json::Value> {
     use m1nd_ingest::IngestAdapter;
+
+    // SPEC-1: the freshness door is its own action and its own handler. It is
+    // intercepted BEFORE the adapter match because it is not an adapter choice —
+    // it re-scans one already-declared repo root, always through the code
+    // ingestor, and it answers with a refusal-or-receipt envelope of its own.
+    if normalized_ingest_mode(&input.mode) == "refresh" {
+        return handle_ingest_refresh(state, &input);
+    }
 
     let path = std::path::PathBuf::from(&input.path);
     if input.incremental && input.adapter != "code" {

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -66,8 +66,13 @@ measured high-signal pattern starts by never starting cold:
    wrong in EVERY era: on a legacy owner it wholesale-REPLACES the bound brain
    (2026-07-24 incident — a 29k-node brain swapped for a foreign graph,
    restored the same day).
-2. If `north` returns `needs_ingest` (empty/unbound graph), `ingest` the repo,
-   then `north` again. `needs_ingest` is a REAL answer, not a failure.
+2. If `north` returns `needs_ingest` (empty/unbound graph), re-scan and call
+   `north` again. `needs_ingest` is a REAL answer, not a failure. On a brain that
+   already DECLARES your root, the repair is yours to run and needs no human:
+   `ingest {mode:"refresh", path: <your root>}` from exactly that root (Law 3
+   below). On a root no brain declares, it is not a refresh — bootstrap is still
+   the absent consumer, and the honest move is to reconnect to an owner that
+   hosts the repo. A plain `ingest {path}` (mode `replace`) remains refused.
 3. Act on verdicts, do not override them (see below).
 4. Prove final truth with direct source reads, tests, compiler/runtime output,
    and focused probes.
@@ -107,7 +112,7 @@ brain that covers the caller's repo (`M1nd-Caller-Root` ↔ `covers_root`).
 Retrieval under a wrong binding is a recoverable annoyance; a WRITE under a wrong
 binding is corruption of shared state. A real incident set this law: a foreign
 repo's skeleton was written into a bound brain because the writer never checked
-which brain answered it. Two laws:
+which brain answered it. Three laws:
 
 - **Law 1 — no write under a reception mismatch.** When a response carries
   `reception.match == "caller_root_mismatch"`, the brain serving you does NOT
@@ -144,6 +149,27 @@ which brain answered it. Two laws:
   REST caller gets the same refusal as an HTTP 400. A burst worktree does NOT earn
   its own brain — bind to the main repo's. (Separately, bootstrap never SHADOWS
   the bound dev graph: a `project_root` the bound graph already covers is refused.)
+
+- **Law 3 — the freshness door is the ONE ingest a plain client can run, and only
+  from its own root.** `ingest {mode:"refresh"}` re-scans a root the brain has
+  ALREADY declared. It is admitted at `SCOPED_GRANT_A2`, A2-locally, with no
+  lease, and admitted BY ACTION rather than by floor — the two siblings sitting at
+  that same floor (`source.edit.commit`, `graph.ingest.merge_existing`) stay
+  refused, and their refusal bytes are pinned by test. `replace` and `merge` are
+  unchanged: refused. Every refusal mutates nothing and names itself:
+  `refresh_root_not_exact` (your caller root is not EXACTLY a declared root — a
+  subdirectory is not the root, and an explicit REST `?brain=` selector never
+  satisfies the predicate), `refresh_root_unresolvable` (the path does not resolve
+  on disk — an unresolvable path is refused, never string-matched),
+  `refresh_in_flight`, `refresh_would_change_roots`, and
+  `refresh_would_shrink_graph` — which refuses when the fresh scan holds under
+  **60%** of the live graph's nodes, and names both counts. That floor is armor
+  the persist layer does not give you: its own shrink guard is fail-open by
+  written design (it backs up and writes anyway), so "root set unchanged" never
+  meant "graph intact". Reach for `refresh` when a declared root's graph is stale;
+  never as a repair for a reception mismatch, which Law 1 still governs. Honest
+  limit, from the spec itself: it closes the reflex vector, not a malicious
+  same-UID local process. (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §1.)
 
 Not yet built (do not rely on it): `skeleton_coherence`, a vital sign that makes
 a brain flag loudly when it is wearing a skeleton from a foreign repo. Until it

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -148,7 +148,7 @@ merit; facts, never estimated savings (G1).
 | fresh / stale | freshness is priced per boundary (the block's scope), never vibes |
 | `full_trust` | the binding verdict (the graph covers and answers) — not a code-quality grade |
 | the bell | a call to the human (missions await landing) — never an error |
-| `needs_ingest` | "I don't know this repo yet" + the honest repair — never a crash. Follow the packet's `recovery_playbook`: where generic `ingest` is policy-allowed it names it; under the sovereign mutation policy it returns `blocked` (`brain_bootstrap_consumer_not_installed`) with the real paths (legacy snapshot adoption at owner restart, or the served owner's authenticated ingress) — never retry a verb the playbook did not name |
+| `needs_ingest` | "I don't know this repo yet" + the honest repair — never a crash. Follow the packet's `recovery_playbook`: where generic `ingest` is policy-allowed it names it; under the sovereign mutation policy it returns `blocked` (`brain_bootstrap_consumer_not_installed`) with the real paths (legacy snapshot adoption at owner restart, or the served owner's authenticated ingress) — never retry a verb the playbook did not name. ONE repair is yours to run without asking: if the brain already DECLARES your root and its graph is stale or empty, `ingest {mode:"refresh", path: <your root>}` re-scans it — from exactly that root, and refusing rather than replacing the graph with a scan holding under 60% of its nodes. It never creates or rebinds a brain, so it is not a fix for `caller_root_mismatch` |
 | the tray | the human's door to land receipts — agents never land |
 
 **The verb families (translate by family, not tool-by-tool):**


### PR DESCRIPTION
## The freshness door — SPEC-1, ratified then built battery-first

After the hijack incidents, every ingest path went behind the sovereign wall — and the wall had no door: a brain could be born but never refreshed. *"The graph is frozen because the lease plane is dormant."* This PR opens the ONE ratified opening: `graph.ingest.refresh_declared_root` — re-ingest a root the bound brain has ALREADY declared. Never creates a brain, never adds roots, never crosses territory.

**The normative document is `docs/GENESIS-INGEST-CONSUMERS-SPEC.md`, status RATIFIED** (owner, 2026-07-29, all four §6 items answered individually): floor `ScopedGrantA2` A2-local via the action-keyed allowlist · shrink-floor **60%** · classification purity preserved.

## Battery-first, git-provable

Commit 1 is the acceptance battery alone — **11 of 14 tests born RED**, every failure for the same honest reason (`unsupported selector mode=refresh`); the 3 passing are the must-not-change pins (the §5.1 hijack refusal bytes, the §5.9 A2-sibling refusals, the R-K overwrite-list). Commit 2 opens the door; the battery file's diff across the two commits **removes zero lines** — asserts untouched, only appended. 16 spec1 tests green in the final tree.

## What the door refuses (the battery's teeth)

Undeclared root · descendant root (`root/sub` ≠ root) · parent-traversal caller · symlink escaping the root · `/tmp` alias games · nonexistent path (canonical decision, never string-matching) · REST `?brain=` selector — refused **byte-identically** to MCP · and the ratified armor: a candidate scan below **60%** of the live graph refuses `refresh_would_shrink_graph`, names BOTH counts, mutates nothing.

## Reuse over invention

The candidate IS `m1nd_ingest::Ingestor`'s return; the durable transition IS the existing atomic temp+rename; the actor turn seals it as a classified mutation. Refresh differs from replace in exactly one way — it never writes the root set or workspace binding — and the house's own `no_undeclared_durable_sidecar_writer_exists` guard **caught the restore and forced the durability decision to be declared**. New machinery: the exact-root predicate, the shrink comparison, a ~25-line single-flight guard, the refusal envelope. Catalog 172→173, digest re-pinned.

## Spec ambiguities resolved (named, with the spec line)

The caller-root vs path-argument predicate became one equality chain (both spec sentences hold) · the REST selector folds into `refresh_root_not_exact` so a selector buys nothing, not even a distinguishable refusal · `refresh_would_change_roots`' real trigger found (agent-memory restore minting an undeclared sidecar root — checked preflight) · `caller_root` stamped on the REST tools seam **scoped to this action only**, keeping reception routing untouched.

## Declared boundaries

kill-9 mid-refresh is NOT executed (same wave-2 boundary the lifecycle gate already declares; what IS proven: refusals leave the snapshot byte-identical, success is one atomic transition, no `.tmp` survives) · §5.7 and the birth half are SPEC-2, absent by design · the 60% floor taken literally means a mostly-non-code brain will refuse — both counts named so it is diagnosable.

## Gates

fmt clean · `clippy --workspace --all-targets -D warnings` exit 0 · lib `1481 passed; 0 failed` · lifecycle gate 2/2 · m1nd-control full · action_consumers 9/9 · agent-surface honesty python OK. Battery + catalog + surfaces independently re-run by the orchestrator. Prose swept in the same PR (M1ND_INSTRUCTIONS, ingest description keeps `POLICY-DISABLED` and names the one exception mode, AGENTS.md, both skills).
