### PR TITLE
build(deps): move the whole RustCrypto family one major, together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,23 +35,6 @@ updates:
       # than letting a grouped bump decide.
       - dependency-name: bincode
         versions: ["3.x"]
-      # sha2 0.11 cannot arrive alone. It moves to `digest` 0.11, which swaps
-      # `generic-array` for `hybrid-array` — and `hybrid-array::Array` drops the
-      # `LowerHex` impl the whole repo hashes through (~26 `format!("{:x}", ..)`
-      # sites over letter ids, content digests and WAL record hashes). Worse, it
-      # buys nothing on its own: `ed25519-dalek` 2.2.0 and `p256` 0.13.2 both
-      # require `sha2 = "0.10"`, so 0.10 stays in the graph either way and the
-      # workspace merely straddles both majors (measured: with m1nd-core on
-      # 0.11, `cargo tree -i sha2@0.10.9` still resolves via m1nd-control).
-      # The coherent move is the whole RustCrypto sweep — ed25519-dalek 3.0,
-      # p256 0.14, ecdsa 0.17, elliptic-curve 0.14, curve25519-dalek 5.0,
-      # signature 3.0, all of which DO want sha2 0.11 — as one deliberate,
-      # security-reviewed PR against the authority/enclave signing paths.
-      # Drop this entry as part of that sweep, never as a lone sha2 bump.
-      # (The hash OUTPUT is stable across the majors: sha2 0.11 reproduces the
-      # pinned NIST vectors for sha256("") and sha256("abc") byte for byte.)
-      - dependency-name: sha2
-        versions: ["0.11.x"]
 
   - package-ecosystem: npm
     directory: /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -259,15 +259,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -391,7 +382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -472,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,12 +531,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -571,13 +562,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -665,24 +653,18 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
 ]
 
 [[package]]
@@ -691,19 +673,31 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -767,11 +761,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "zeroize",
 ]
 
@@ -808,25 +802,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
- "const-oid 0.10.2",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
@@ -869,23 +852,24 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -893,14 +877,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2 0.10.9",
+ "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -913,18 +898,19 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "crypto-common",
+ "digest",
  "ff",
- "generic-array",
  "group",
+ "hybrid-array",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -989,19 +975,19 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1144,17 +1130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,12 +1191,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1297,11 +1272,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1361,7 +1336,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1795,7 +1772,7 @@ dependencies = [
  "p256",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tempfile",
  "thiserror 2.0.19",
 ]
@@ -1813,7 +1790,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "static_assertions",
  "tempfile",
@@ -1833,7 +1810,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
@@ -1891,7 +1868,7 @@ dependencies = [
  "security-framework-sys",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "socket2",
  "sysinfo",
  "tempfile",
@@ -1928,7 +1905,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -2200,14 +2177,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -2269,9 +2247,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -2340,12 +2318,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -2498,15 +2494,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2673,12 +2660,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -2726,7 +2713,7 @@ version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.11.0",
+ "sha2",
  "walkdir",
 ]
 
@@ -2895,14 +2882,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3017,14 +3004,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
+name = "serdect"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -3034,8 +3020,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3056,12 +3042,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3108,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
@@ -4604,6 +4590,17 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/docs/MEDULLA-PRD.md
+++ b/docs/MEDULLA-PRD.md
@@ -477,9 +477,12 @@ Each event that survives triage adds its case to the battery of the brain it bit
 > (`mailbox.rs`, mirroring `medulla_migration.rs`) — no live `SessionState`, so
 > distribution/sweep/read are scratch-testable and structurally incapable of
 > touching a running owner's graph. **Letter id = `sha256(raw line bytes)[0..12]`**
-> via a direct `sha2 0.10` dep (already in Cargo.lock transitively — SipHash's
+> via a direct `sha2` dep (already in Cargo.lock transitively — SipHash's
 > `DefaultHasher` is NOT cross-version/platform stable, which would break the
-> git-travel dedup contract, so the spec's sha256 is load-bearing). The
+> git-travel dedup contract, so the spec's sha256 is load-bearing). The id is
+> pinned to independently computed known answers by
+> `letter_id_matches_pinned_known_answers`, so the dedup contract is proven
+> across a hashing-crate major rather than assumed. The
 > **distribution rule** normalizes `repo`/`brain` (expand `~`, strip parenthetical
 > annotations, `<base>-*` worktree names collapse to `<base>` — kept NEUTRAL: the
 > rule is "a `<base>-<suffix>` sibling collapses to `<base>`", the project basename

--- a/m1nd-control/Cargo.toml
+++ b/m1nd-control/Cargo.toml
@@ -7,11 +7,11 @@ license = "MIT"
 repository = "https://github.com/maxkle1nz/m1nd"
 
 [dependencies]
-ed25519-dalek = { version = "2.1", default-features = false, features = ["std"] }
-p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "std"] }
+ed25519-dalek = { version = "3", default-features = false, features = ["alloc"] }
+p256 = { version = "0.14", default-features = false, features = ["ecdsa", "std"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10"
+sha2 = "0.11"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/m1nd-control/src/crypto_authority.rs
+++ b/m1nd-control/src/crypto_authority.rs
@@ -1210,7 +1210,7 @@ impl DecodedPublicKey {
     fn canonical_bytes(&self) -> Vec<u8> {
         match self {
             Self::Ed25519(key) => key.as_bytes().to_vec(),
-            Self::P256(key) => key.to_encoded_point(false).as_bytes().to_vec(),
+            Self::P256(key) => key.to_sec1_point(false).as_bytes().to_vec(),
         }
     }
 }
@@ -1234,7 +1234,7 @@ fn decode_public_key(
             }
             let key = P256VerifyingKey::from_sec1_bytes(&bytes)
                 .map_err(|_| AuthorityCryptoError::PublicKeyEncoding)?;
-            if key.to_encoded_point(false).as_bytes() != bytes {
+            if key.to_sec1_point(false).as_bytes() != bytes {
                 return Err(AuthorityCryptoError::PublicKeyEncoding);
             }
             Ok(DecodedPublicKey::P256(key))
@@ -1274,7 +1274,11 @@ fn canonicalize_and_verify_signature(
         DecodedPublicKey::P256(key) => {
             let parsed = P256Signature::from_der(signature)
                 .map_err(|_| AuthorityCryptoError::SignatureEncoding)?;
-            let normalized = parsed.normalize_s().unwrap_or(parsed);
+            // `ecdsa` 0.17 made `normalize_s` infallible: it used to return
+            // `None` when `s` was already low and `Some(flipped)` otherwise,
+            // so the old spelling was `.normalize_s().unwrap_or(parsed)`. The
+            // value produced is identical — always the low-S representative.
+            let normalized = parsed.normalize_s();
             key.verify(message, &normalized)
                 .map_err(|_| AuthorityCryptoError::SignatureInvalid)?;
             Ok(normalized.to_der().as_bytes().to_vec())

--- a/m1nd-control/tests/crypto_continuity.rs
+++ b/m1nd-control/tests/crypto_continuity.rs
@@ -1,0 +1,434 @@
+//! Cross-version crypto continuity: the vectors that must survive a RustCrypto
+//! major bump.
+//!
+//! Two invariants live here, both of them about *already persisted* bytes:
+//!
+//! 1. **Hash stability.** `digest_domain_bytes` is the domain-separated SHA-256
+//!    that stamps every authority receipt, WAL record and signed-body digest in
+//!    the workspace. Its output is pinned to answers computed by an INDEPENDENT
+//!    oracle (Python `hashlib`), never re-derived from the code under test, so a
+//!    silent change in the hashing stack fails here instead of orphaning stored
+//!    digests.
+//!
+//! 2. **Signature continuity.** Authority-WAL records, authorization receipts
+//!    and enclave-provisioned capabilities carry Ed25519 and P-256 signatures
+//!    minted by whatever crate version was current when they were written. The
+//!    verifier must keep verifying those exact bytes forever.
+//!
+//! ## Fixture provenance
+//!
+//! Every signature below was produced on `origin/main` @ 47dbb532 by the
+//! PRE-SWEEP stack — `ed25519-dalek 2.2.0`, `p256 0.13.2`, `ecdsa 0.16.9`,
+//! `sha2 0.10.9` — via a throwaway generator driving this crate's own public
+//! signing API. The inputs are fully deterministic and therefore reproducible:
+//! Ed25519 seed `[7u8; 32]`, P-256 secret scalar `[11u8; 32]`, Ed25519 signing
+//! is deterministic by construction and RustCrypto ECDSA signs via RFC6979.
+//! Nothing here is a live key: both secrets are constant test material.
+
+use std::collections::BTreeMap;
+
+use m1nd_control::{
+    digest_canonical, digest_domain_bytes, verify_authority_message_signature, verify_capability,
+    ActionId, ActiveMode, AuthorityCapabilityV1, AuthorityCryptoError, AuthorityVariant,
+    CapabilityVerificationContext, CryptographicIntegrity, IdentityStatus, OpaqueSignature,
+    VerificationKeyRegistryV1, VerificationKeyV1, AUTHORITY_CAPABILITY_SCHEMA,
+    ECDSA_P256_SHA256_X962_ALGORITHM, ED25519_ALGORITHM, VERIFICATION_KEY_REGISTRY_SCHEMA,
+};
+
+const NOW: u64 = 2_000;
+const SKEW: u64 = 100;
+
+/// The exact authority message the fixtures were signed over: the crate's
+/// length-delimited envelope around a capability-signature domain and a small
+/// JSON payload.
+const MESSAGE_HEX: &str = "6d316e642d617574686f726974792d7369676e61747572652d6d6573736167652d76310000000000000000266d316e642d617574686f726974792d6361706162696c6974792d7369676e61747572652d763100000000000000407b22617574686f72697a65645f6174223a313730303030303030303030302c2272656365697074223a22636f6e74696e756974792d766563746f722d7631227d";
+
+const ED25519_PUBLIC_KEY: &str = "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c";
+const ED25519_SIGNATURE: &str = "307733f4cefba48e1b74fb5c0e1c737dfb0d75b1aa435fec12fb5b7961407813de04019323bc3213c1019ab947957bc8be57d3dfa6d1f7a0fcb11a6d83b39d0b";
+
+const P256_PUBLIC_KEY: &str = "04209c317b637935dd3da1c54f63495dfb31f97d293df085710320595c9aacb83fdde4c69fc17a0c74c20cc692662f049892ba37a4ba47d2c70cd8a99986391f9b";
+/// Canonical low-S ASN.1 DER — the only shape the verifier accepts at rest.
+const P256_SIGNATURE_LOW_S: &str = "30440220152508d38b7a86dc661f0ea8bd66aa247ec9f0badac335b61e657f73b135bbd10220323f3c8525bc64d54d12215e8966aa1345311000ddfe0c689e30eceeb8c8e944";
+/// The same signature in its high-S representation. Cryptographically valid,
+/// but non-canonical at rest, so the verifier must refuse it.
+const P256_SIGNATURE_HIGH_S: &str = "30450220152508d38b7a86dc661f0ea8bd66aa247ec9f0badac335b61e657f73b135bbd1022100cdc0c379da439b2bb2eddea1769955ec77b5eaacc919921c5588ddd4439a3c0d";
+
+/// Signatures over the full canonical-JSON body of the capability built by
+/// [`continuity_capability`], produced through `sign_capability`.
+const ED25519_CAPABILITY_SIGNATURE: &str = "97fa653137699b347e9d07b63ec1fa3635d9afb1f9a43d8b540a97a397629061a2b6a173724dc207df6190338e01a274c619b9e0d81420aa4cfb6f7b903be008";
+const P256_CAPABILITY_SIGNATURE: &str = "304402201f3c10eae3a2873c172cff1b2f92d3940d102f0f7e46acf2add8489e09fc130d02203cc0ff7c10e497716f9d8c60bf36a87e0e1aa5fcf10f9968e4a2ff21fffa3e3d";
+
+fn decode_hex(value: &str) -> Vec<u8> {
+    assert!(value.len().is_multiple_of(2), "hex fixture must be even");
+    (0..value.len() / 2)
+        .map(|index| {
+            u8::from_str_radix(&value[index * 2..index * 2 + 2], 16).expect("hex fixture digit")
+        })
+        .collect()
+}
+
+fn key_record(key_id: &str, algorithm: &str, public_key: &str) -> VerificationKeyV1 {
+    VerificationKeyV1 {
+        key_id: key_id.to_owned(),
+        subject_id: "owner-1".to_owned(),
+        algorithm: algorithm.to_owned(),
+        public_key: public_key.to_owned(),
+        created_at: 1_000,
+        activated_at: 1_000,
+        expires_at: None,
+        revoked_at: None,
+        rotated_at: None,
+        replacement_key_id: None,
+        status: IdentityStatus::Active,
+    }
+}
+
+fn registry() -> VerificationKeyRegistryV1 {
+    VerificationKeyRegistryV1 {
+        schema: VERIFICATION_KEY_REGISTRY_SCHEMA.to_owned(),
+        registry_epoch: 1,
+        keys: BTreeMap::from([
+            (
+                "owner-ed25519-1".to_owned(),
+                key_record("owner-ed25519-1", ED25519_ALGORITHM, ED25519_PUBLIC_KEY),
+            ),
+            (
+                "owner-p256-1".to_owned(),
+                key_record(
+                    "owner-p256-1",
+                    ECDSA_P256_SHA256_X962_ALGORITHM,
+                    P256_PUBLIC_KEY,
+                ),
+            ),
+        ]),
+    }
+}
+
+/// The exact record the persisted capability signatures cover. Any field change
+/// here invalidates the fixtures, which is the point: the canonical-JSON body is
+/// part of the signed message.
+fn continuity_capability(
+    algorithm: &str,
+    issuer_key_id: &str,
+    signature: &str,
+) -> AuthorityCapabilityV1 {
+    AuthorityCapabilityV1 {
+        schema: AUTHORITY_CAPABILITY_SCHEMA.to_owned(),
+        capability_id: "cap-continuity-1".to_owned(),
+        issuer_subject_id: "owner-1".to_owned(),
+        issuer_key_id: issuer_key_id.to_owned(),
+        algorithm: algorithm.to_owned(),
+        subject_id: "agent-1".to_owned(),
+        audience: "m1nd-control".to_owned(),
+        organism_id: "organism-1".to_owned(),
+        brain_id: "brain-1".to_owned(),
+        mission_id: None,
+        mission_head_id: None,
+        action: ActionId::new("memorize").expect("action id"),
+        authority_variant: AuthorityVariant::Human,
+        active_mode: ActiveMode::HumanGated,
+        payload_digest: "sha256:continuity".to_owned(),
+        policy_registry_digest: "sha256:policy".to_owned(),
+        constitution_digest: "sha256:constitution".to_owned(),
+        key_registry_epoch: 1,
+        issued_at: 1_500,
+        expires_at: 900_000,
+        nonce: "nonce-continuity-1".to_owned(),
+        signature: OpaqueSignature::new(signature),
+    }
+}
+
+fn capability_context() -> CapabilityVerificationContext<'static> {
+    CapabilityVerificationContext {
+        now_ms: NOW,
+        max_future_clock_skew_ms: SKEW,
+        expected_schema: AUTHORITY_CAPABILITY_SCHEMA,
+        expected_audience: "m1nd-control",
+        expected_subject_id: "agent-1",
+        expected_payload_digest: "sha256:continuity",
+        expected_organism_id: "organism-1",
+        expected_brain_id: "brain-1",
+        expected_mission_id: None,
+        expected_mission_head_id: None,
+        expected_action: "memorize",
+        expected_authority_variant: AuthorityVariant::Human,
+        expected_active_mode: ActiveMode::HumanGated,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Hash stability
+// ---------------------------------------------------------------------------
+
+/// Known-answer vectors for the domain-separated digest, computed independently
+/// of this codebase. If the hashing stack ever changes shape, every persisted
+/// `signed_body_digest`, receipt digest and WAL head would silently stop
+/// matching; this fails first instead.
+#[test]
+fn domain_separated_digest_matches_pinned_known_answers() {
+    for (domain, payload, expected) in [
+        (
+            "",
+            "".as_bytes(),
+            "21050b19bf447cbf61bb3931d2e87a7c433e9f171843b4ee6bef973f19291bb4",
+        ),
+        (
+            "abc",
+            "abc".as_bytes(),
+            "696c178e8f074bb75140921a383962ad6ce86e6722e84e4d48379fe57bdff8aa",
+        ),
+        (
+            "m1nd-authority-signed-body-v1",
+            "{}".as_bytes(),
+            "385a588a312963c2cc67c54ee7b118584622b56c21cf5bd2929c72bb551c52ce",
+        ),
+    ] {
+        let observed = digest_domain_bytes(domain, payload);
+        assert_eq!(
+            observed, expected,
+            "domain-separated digest for domain '{domain}' changed; persisted digests would be orphaned"
+        );
+        assert_eq!(observed.len(), 64, "a SHA-256 hex digest is 64 chars");
+        assert!(
+            observed
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "digest must be lowercase hex"
+        );
+    }
+}
+
+/// The domain separator must actually separate: same payload, different domain,
+/// different digest. Guards against a hashing change that drops the prefix.
+#[test]
+fn domain_separation_is_load_bearing() {
+    assert_ne!(
+        digest_domain_bytes("a", b"bc"),
+        digest_domain_bytes("ab", b"c"),
+        "length-delimited framing must make these distinguishable"
+    );
+    assert_ne!(
+        digest_domain_bytes("abc", b"abc"),
+        "696c178e8f074bb75140921a383962ad6ce86e6722e84e4d48379fe57bdff8ab",
+        "a near-miss vector must not compare equal"
+    );
+}
+
+/// `digest_canonical` is `digest_domain_bytes` over canonical JSON; pinning it
+/// keeps the serializer and the hasher moving together.
+#[test]
+fn canonical_digest_is_stable_over_the_empty_object() {
+    let observed = digest_canonical("m1nd-authority-signed-body-v1", &serde_json::json!({}))
+        .expect("canonical digest");
+    assert_eq!(
+        observed, "385a588a312963c2cc67c54ee7b118584622b56c21cf5bd2929c72bb551c52ce",
+        "canonical JSON of {{}} is `{{}}`, so this must equal the pinned domain digest"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Signature continuity
+// ---------------------------------------------------------------------------
+
+/// An Ed25519 signature minted by the pre-sweep stack still verifies through
+/// the raw-message seam used by the offline receipt verifier, the enclave
+/// authority runtime and the mission-service transport.
+#[test]
+fn pre_sweep_ed25519_signature_still_verifies() {
+    let message = decode_hex(MESSAGE_HEX);
+    let key = key_record("owner-ed25519-1", ED25519_ALGORITHM, ED25519_PUBLIC_KEY);
+    let integrity = verify_authority_message_signature(
+        &message,
+        &OpaqueSignature::new(ED25519_SIGNATURE),
+        &key,
+    )
+    .expect("a signature persisted by ed25519-dalek 2.2.0 must still verify");
+    assert_eq!(integrity, CryptographicIntegrity::VerifiedEd25519);
+}
+
+/// The same, for P-256 ECDSA in canonical low-S DER.
+#[test]
+fn pre_sweep_p256_signature_still_verifies() {
+    let message = decode_hex(MESSAGE_HEX);
+    let key = key_record(
+        "owner-p256-1",
+        ECDSA_P256_SHA256_X962_ALGORITHM,
+        P256_PUBLIC_KEY,
+    );
+    let integrity = verify_authority_message_signature(
+        &message,
+        &OpaqueSignature::new(P256_SIGNATURE_LOW_S),
+        &key,
+    )
+    .expect("a signature persisted by p256 0.13.2 must still verify");
+    assert_eq!(
+        integrity,
+        CryptographicIntegrity::VerifiedEcdsaP256Sha256X962
+    );
+}
+
+/// Low-S canonicalization is a *storage* rule, not just a verification detail:
+/// a high-S DER encoding of an otherwise valid signature must be refused, so
+/// signature bytes at rest have exactly one accepted representation and cannot
+/// be malleated into a second valid record.
+///
+/// This is the vector that pins `ecdsa`'s low-S normalization semantics across
+/// the major bump. It fails loudly if normalization ever stops being applied.
+#[test]
+fn high_s_signature_at_rest_is_refused() {
+    let message = decode_hex(MESSAGE_HEX);
+    let key = key_record(
+        "owner-p256-1",
+        ECDSA_P256_SHA256_X962_ALGORITHM,
+        P256_PUBLIC_KEY,
+    );
+    let error = verify_authority_message_signature(
+        &message,
+        &OpaqueSignature::new(P256_SIGNATURE_HIGH_S),
+        &key,
+    )
+    .expect_err("a high-S DER signature must never be accepted at rest");
+    assert!(
+        matches!(error, AuthorityCryptoError::SignatureEncoding),
+        "high-S must be refused as a non-canonical encoding, got {error:?}"
+    );
+}
+
+/// A full authority capability signed by the pre-sweep Ed25519 stack still
+/// verifies through the record seam — canonical JSON, domain envelope and
+/// signature check together.
+#[test]
+fn pre_sweep_ed25519_capability_still_verifies() {
+    let capability = continuity_capability(
+        ED25519_ALGORITHM,
+        "owner-ed25519-1",
+        ED25519_CAPABILITY_SIGNATURE,
+    );
+    let verified = verify_capability(&capability, &registry(), capability_context())
+        .expect("a capability signed before the sweep must still verify");
+    assert_eq!(verified.integrity, CryptographicIntegrity::VerifiedEd25519);
+    assert_eq!(verified.key_id, "owner-ed25519-1");
+}
+
+/// The same, for a capability signed with P-256.
+#[test]
+fn pre_sweep_p256_capability_still_verifies() {
+    let capability = continuity_capability(
+        ECDSA_P256_SHA256_X962_ALGORITHM,
+        "owner-p256-1",
+        P256_CAPABILITY_SIGNATURE,
+    );
+    let verified = verify_capability(&capability, &registry(), capability_context())
+        .expect("a capability signed before the sweep must still verify");
+    assert_eq!(
+        verified.integrity,
+        CryptographicIntegrity::VerifiedEcdsaP256Sha256X962
+    );
+    assert_eq!(verified.key_id, "owner-p256-1");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Negative controls — the fixtures above only mean something if these fail
+// ---------------------------------------------------------------------------
+
+/// Corrupting a single byte of each persisted signature must break
+/// verification. Without this, the vectors above could pass against a verifier
+/// that accepted anything.
+#[test]
+fn corrupting_a_fixture_signature_breaks_verification() {
+    let message = decode_hex(MESSAGE_HEX);
+    for (algorithm, public_key, key_id, signature) in [
+        (
+            ED25519_ALGORITHM,
+            ED25519_PUBLIC_KEY,
+            "owner-ed25519-1",
+            ED25519_SIGNATURE,
+        ),
+        (
+            ECDSA_P256_SHA256_X962_ALGORITHM,
+            P256_PUBLIC_KEY,
+            "owner-p256-1",
+            P256_SIGNATURE_LOW_S,
+        ),
+    ] {
+        let mut bytes = decode_hex(signature);
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0x01;
+        let corrupted: String = bytes.iter().map(|byte| format!("{byte:02x}")).collect();
+        let key = key_record(key_id, algorithm, public_key);
+        verify_authority_message_signature(&message, &OpaqueSignature::new(&corrupted), &key)
+            .expect_err("a one-bit signature corruption must be rejected");
+    }
+}
+
+/// Corrupting the signed message must break verification too — proving the
+/// fixtures bind to these exact bytes and not to some looser property.
+#[test]
+fn corrupting_the_signed_message_breaks_verification() {
+    let mut message = decode_hex(MESSAGE_HEX);
+    let last = message.len() - 1;
+    message[last] ^= 0x01;
+    for (algorithm, public_key, key_id, signature) in [
+        (
+            ED25519_ALGORITHM,
+            ED25519_PUBLIC_KEY,
+            "owner-ed25519-1",
+            ED25519_SIGNATURE,
+        ),
+        (
+            ECDSA_P256_SHA256_X962_ALGORITHM,
+            P256_PUBLIC_KEY,
+            "owner-p256-1",
+            P256_SIGNATURE_LOW_S,
+        ),
+    ] {
+        let key = key_record(key_id, algorithm, public_key);
+        verify_authority_message_signature(&message, &OpaqueSignature::new(signature), &key)
+            .expect_err("a one-bit message corruption must be rejected");
+    }
+}
+
+/// A capability body edited after signing must fail, even though the signature
+/// bytes themselves are untouched.
+#[test]
+fn editing_a_signed_capability_body_breaks_verification() {
+    let mut capability = continuity_capability(
+        ED25519_ALGORITHM,
+        "owner-ed25519-1",
+        ED25519_CAPABILITY_SIGNATURE,
+    );
+    capability.payload_digest = "sha256:tampered".to_owned();
+    let mut context = capability_context();
+    context.expected_payload_digest = "sha256:tampered";
+    let error = verify_capability(&capability, &registry(), context)
+        .expect_err("a tampered signed body must be rejected");
+    assert!(
+        matches!(error, AuthorityCryptoError::SignatureInvalid),
+        "tampering must fail the signature check, got {error:?}"
+    );
+}
+
+/// Cross-key verification must fail: the Ed25519 fixture must not verify under
+/// the P-256 key record and vice versa.
+#[test]
+fn fixtures_do_not_verify_under_the_wrong_key() {
+    let message = decode_hex(MESSAGE_HEX);
+    let ed_key = key_record("owner-ed25519-1", ED25519_ALGORITHM, ED25519_PUBLIC_KEY);
+    let p256_key = key_record(
+        "owner-p256-1",
+        ECDSA_P256_SHA256_X962_ALGORITHM,
+        P256_PUBLIC_KEY,
+    );
+    verify_authority_message_signature(
+        &message,
+        &OpaqueSignature::new(P256_SIGNATURE_LOW_S),
+        &ed_key,
+    )
+    .expect_err("a P-256 signature must not verify as Ed25519");
+    verify_authority_message_signature(
+        &message,
+        &OpaqueSignature::new(ED25519_SIGNATURE),
+        &p256_key,
+    )
+    .expect_err("an Ed25519 signature must not verify as P-256");
+}

--- a/m1nd-control/tests/crypto_p256.rs
+++ b/m1nd-control/tests/crypto_p256.rs
@@ -36,7 +36,7 @@ impl TestP256Signer {
 
     fn public_key_bytes(&self) -> Vec<u8> {
         VerifyingKey::from(&self.signing_key)
-            .to_encoded_point(false)
+            .to_sec1_point(false)
             .as_bytes()
             .to_vec()
     }
@@ -324,7 +324,7 @@ fn p256_rejects_compressed_keys_and_non_der_signer_output() {
         .unwrap();
     key.public_key = hex_lower(
         VerifyingKey::from(&fixtures.owner_signer.signing_key)
-            .to_encoded_point(true)
+            .to_sec1_point(true)
             .as_bytes(),
     );
     assert!(matches!(

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -17,7 +17,7 @@ parking_lot = { workspace = true }
 rayon = { workspace = true }
 static_assertions = { workspace = true }
 bincode = "1.3"
-sha2 = "0.10"
+sha2 = "0.11"
 
 # OPTIONAL: pure-Rust static embeddings (model2vec). OFF by default.
 # `fancy-regex` avoids the oniguruma C dependency; `hf-hub` lets from_pretrained

--- a/m1nd-core/src/temporal.rs
+++ b/m1nd-core/src/temporal.rs
@@ -564,7 +564,7 @@ fn co_change_state_digest(state: &CoChangeMatrixStateV1) -> M1ndResult<String> {
     let mut hasher = Sha256::new();
     hasher.update(b"m1nd/co-change-state/v1\0");
     hasher.update(bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex_lower(&hasher.finalize()))
 }
 
 fn graph_external_ids(graph: &Graph) -> M1ndResult<Vec<String>> {
@@ -1333,3 +1333,20 @@ pub struct TemporalReport {
 
 // Ensure Send + Sync.
 static_assertions::assert_impl_all!(TemporalEngine: Send, Sync);
+
+/// Lowercase hex of a byte slice.
+///
+/// `digest` 0.11 returns `hybrid_array::Array`, which — unlike the old
+/// `generic_array::GenericArray` — does not implement `LowerHex`, so the
+/// former `format!("{:x}", ..)` spelling no longer compiles. This is the
+/// workspace's existing hex idiom, kept local so the digest call sites stay
+/// dependency-free.
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { workspace = true }
 cargo_metadata = { workspace = true }
 libc = "0.2"
 url = "2.5"
-sha2 = "0.10"
+sha2 = "0.11"
 
 # Tree-sitter core (0.25 — all grammar crates must use new-API via tree-sitter-language)
 tree-sitter = { version = "0.26", optional = true }

--- a/m1nd-ingest/src/ownership.rs
+++ b/m1nd-ingest/src/ownership.rs
@@ -934,8 +934,25 @@ impl OwnershipCollectorV1 {
     }
 }
 
+/// Lowercase hex of a byte slice.
+///
+/// `digest` 0.11 returns `hybrid_array::Array`, which — unlike the old
+/// `generic_array::GenericArray` — does not implement `LowerHex`, so the
+/// former `format!("{:x}", ..)` spelling no longer compiles. This is the
+/// workspace's existing hex idiom, kept local so the digest call sites stay
+/// dependency-free.
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
 pub fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    hex_lower(&Sha256::digest(bytes))
 }
 
 /// Identity of the exact executable image acting as the ingest producer. The
@@ -1047,7 +1064,7 @@ pub fn compiled_producer_build_identity() -> String {
         hasher.update((bytes.len() as u64).to_le_bytes());
         hasher.update(bytes);
     }
-    format!("{:x}", hasher.finalize())
+    hex_lower(&hasher.finalize())
 }
 
 #[derive(Serialize)]

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -42,9 +42,9 @@ sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 # Letter ids are `sha256(raw line bytes)[0..12]` (MEDULLA-PRD §9.2): stable and
 # machine-independent by construction, so git-traveled boxes dedup across
 # machines. DefaultHasher (SipHash) is NOT cross-version/platform stable, which
-# would break that contract. sha2 0.10 is already in Cargo.lock transitively —
+# would break that contract. sha2 is already in Cargo.lock transitively —
 # declaring it direct adds NO new crate to the build graph.
-sha2 = "0.10"
+sha2 = "0.11"
 
 # Tree-sitter, declared direct ONLY so the `transplant` verb can recover an item's
 # TRUE extent (closing-brace line) by PARSING instead of counting braces (which a
@@ -114,19 +114,19 @@ security-framework-sys = "=2.17.0"
 core-foundation = "=0.10.1"
 
 [build-dependencies]
-sha2 = "0.10"
+sha2 = "0.11"
 
 [[bin]]
 name = "m1nd-mcp"
 path = "src/main.rs"
 
 [dev-dependencies]
-ed25519-dalek = { version = "2.1", default-features = false, features = ["std"] }
+ed25519-dalek = { version = "3", default-features = false, features = ["alloc"] }
 # TEST-ONLY P-256 signing for custody-floor fixtures (offline receipt verifier,
 # enclave-crypto mock). Production m1nd-mcp gains NO p256 dependency: every P-256
 # signature is verified through m1nd-control's verifier. Already in Cargo.lock via
 # m1nd-control, so this adds NO new crate to the build graph.
-p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "std"] }
+p256 = { version = "0.14", default-features = false, features = ["ecdsa", "std"] }
 # `socket2` lets tests bind an ephemeral loopback port WITHOUT listening on it, so
 # the owner-alive guard's port can be reserved-closed without a live listener that a
 # parallel test could collide with (see the `closed_port` helpers).

--- a/m1nd-mcp/src/authority_wal.rs
+++ b/m1nd-mcp/src/authority_wal.rs
@@ -135,7 +135,7 @@ impl SoftwareTestAuthorityWalRecordCrypto {
         hasher.update(&self.secret);
         hasher.update((message.len() as u64).to_be_bytes());
         hasher.update(message);
-        format!("{:x}", hasher.finalize())
+        crate::util::hex_lower(&hasher.finalize())
     }
 }
 

--- a/m1nd-mcp/src/authorization_receipt_verifier.rs
+++ b/m1nd-mcp/src/authorization_receipt_verifier.rs
@@ -405,7 +405,7 @@ mod tests {
     fn p256_low_s_der_lower_hex(signing_key: &p256::ecdsa::SigningKey, message: &[u8]) -> String {
         use p256::ecdsa::signature::Signer as _;
         let signature: p256::ecdsa::Signature = signing_key.sign(message);
-        let normalized = signature.normalize_s().unwrap_or(signature);
+        let normalized = signature.normalize_s();
         hex_lower(normalized.to_der().as_bytes())
     }
 
@@ -418,12 +418,7 @@ mod tests {
             key_id: "owner-p256-key-1".to_owned(),
             subject_id: "owner-1".to_owned(),
             algorithm: ECDSA_P256_SHA256_X962_ALGORITHM.to_owned(),
-            public_key: hex_lower(
-                signing_key
-                    .verifying_key()
-                    .to_encoded_point(false)
-                    .as_bytes(),
-            ),
+            public_key: hex_lower(signing_key.verifying_key().to_sec1_point(false).as_bytes()),
             created_at: NOW - 10_000,
             activated_at: NOW - 9_000,
             expires_at: None,

--- a/m1nd-mcp/src/boot_kv_migration.rs
+++ b/m1nd-mcp/src/boot_kv_migration.rs
@@ -139,7 +139,7 @@ struct JournalDigestView<'a> {
 fn sha256(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::util::hex_lower(&hasher.finalize())
 }
 
 fn domain_digest<T: Serialize>(domain: &[u8], value: &T) -> M1ndResult<String> {
@@ -147,7 +147,7 @@ fn domain_digest<T: Serialize>(domain: &[u8], value: &T) -> M1ndResult<String> {
     let mut hasher = Sha256::new();
     hasher.update(domain);
     hasher.update(bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(crate::util::hex_lower(&hasher.finalize()))
 }
 
 fn marker_digest(marker: &BootKvMigrationMarkerV1) -> M1ndResult<String> {

--- a/m1nd-mcp/src/curation_runner.rs
+++ b/m1nd-mcp/src/curation_runner.rs
@@ -417,7 +417,7 @@ fn now_iso() -> String {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::util::hex_lower(&Sha256::digest(bytes))
 }
 
 /// Build one curation mission letter (§3/§4). Every curation letter is seat `oracle`

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -1554,7 +1554,7 @@ mod tests {
             let public_key_sec1 = key
                 .signing_key
                 .verifying_key()
-                .to_encoded_point(false)
+                .to_sec1_point(false)
                 .as_bytes()
                 .to_vec();
             EnclaveOpenedKeyV1 {
@@ -1969,7 +1969,7 @@ mod tests {
 
     fn seat_pubkey(seed: &str) -> String {
         let signing = SigningKey::from_slice(&scalar_for(seed)).unwrap();
-        hex_lower(signing.verifying_key().to_encoded_point(false).as_bytes())
+        hex_lower(signing.verifying_key().to_sec1_point(false).as_bytes())
     }
 
     fn ceremony_seat(id: &str, domain: &str) -> CeremonyVerifierSeatV1 {

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -6126,7 +6126,7 @@ fn require_file_digest(path: &Path, expected: Option<&str>) -> Result<(), Extern
 }
 
 fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    hex_lower_bytes(&Sha256::digest(bytes))
 }
 
 fn sync_parent(path: &Path) -> std::io::Result<()> {

--- a/m1nd-mcp/src/external_mutation_service/graph_ingest_a2.rs
+++ b/m1nd-mcp/src/external_mutation_service/graph_ingest_a2.rs
@@ -1219,7 +1219,7 @@ fn open_candidate_artifact_handle(
 }
 
 fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    super::hex_lower_bytes(&Sha256::digest(bytes))
 }
 
 pub(super) fn capture_inspection_snapshot(

--- a/m1nd-mcp/src/legacy_snapshot_adoption.rs
+++ b/m1nd-mcp/src/legacy_snapshot_adoption.rs
@@ -73,7 +73,7 @@ pub enum LegacyAdoptionOutcome {
 fn sha256(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::util::hex_lower(&hasher.finalize())
 }
 
 fn now_ms() -> u64 {

--- a/m1nd-mcp/src/mailbox.rs
+++ b/m1nd-mcp/src/mailbox.rs
@@ -356,7 +356,7 @@ pub fn resolve_box(
 pub fn letter_id(raw_line: &str) -> String {
     let bytes = raw_line.trim_end_matches(['\n', '\r']).as_bytes();
     let digest = Sha256::digest(bytes);
-    let hex = format!("{digest:x}");
+    let hex = crate::util::hex_lower(&digest);
     hex[..12].to_string()
 }
 
@@ -1050,7 +1050,7 @@ pub fn project_roots_for_runtime(
             let digest = Sha256::digest(root.as_bytes());
             let scoped = owner_runtime_root
                 .join("project-boxes")
-                .join(&format!("{digest:x}")[..12])
+                .join(&crate::util::hex_lower(&digest)[..12])
                 .join(project_basename(root));
             std::fs::create_dir_all(&scoped)?;
             Ok(scoped.to_string_lossy().to_string())
@@ -1162,6 +1162,42 @@ pub fn doctor_mailbox(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `letter_id` is a cross-machine dedup contract — `sha256(raw line
+    /// bytes)[0..12]` — so a git-traveled box must derive the same id for the
+    /// same letter on every machine and every build. Pinned to answers from an
+    /// independent oracle rather than re-derived here, so a change in the
+    /// hashing stack (or in the hex spelling) fails instead of silently
+    /// re-identifying every letter already on disk.
+    #[test]
+    fn letter_id_matches_pinned_known_answers() {
+        for (line, expected) in [(r#"{"a":1}"#, "015abd7f5cc5"), ("", "e3b0c44298fc")] {
+            assert_eq!(
+                letter_id(line),
+                expected,
+                "letter_id({line:?}) must stay the first 12 hex chars of sha256(line)"
+            );
+        }
+    }
+
+    /// The trailing-newline trim is part of that contract: the same letter with
+    /// or without its line terminator is the same letter.
+    #[test]
+    fn letter_id_ignores_only_the_trailing_line_terminator() {
+        let base = r#"{"a":1}"#;
+        for suffix in ["", "\n", "\r\n"] {
+            assert_eq!(
+                letter_id(&format!("{base}{suffix}")),
+                "015abd7f5cc5",
+                "a trailing {suffix:?} must not change the id"
+            );
+        }
+        assert_ne!(
+            letter_id(&format!(" {base}")),
+            "015abd7f5cc5",
+            "leading whitespace is part of the hashed bytes"
+        );
+    }
 
     /// A scratch dir cleaned on drop (mirrors medulla_migration's Scratch).
     struct Scratch {

--- a/m1nd-mcp/src/organism_manifest.rs
+++ b/m1nd-mcp/src/organism_manifest.rs
@@ -642,7 +642,7 @@ fn sha256_file(path: &Path) -> std::io::Result<String> {
     let bytes = std::fs::read(path)?;
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    Ok(sha256_label(&format!("{:x}", hasher.finalize())))
+    Ok(sha256_label(&crate::util::hex_lower(&hasher.finalize())))
 }
 
 fn binary_sha256() -> String {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -8566,7 +8566,7 @@ mod tests {
     fn digest_bytes(bytes: &[u8]) -> String {
         use sha2::{Digest, Sha256};
 
-        format!("sha256:{:x}", Sha256::digest(bytes))
+        format!("sha256:{}", crate::util::hex_lower(&Sha256::digest(bytes)))
     }
 
     fn directory_digest(root: &std::path::Path) -> String {
@@ -8621,7 +8621,7 @@ mod tests {
             hasher.update((bytes.len() as u64).to_le_bytes());
             hasher.update(bytes);
         }
-        format!("sha256:{:x}", hasher.finalize())
+        format!("sha256:{}", crate::util::hex_lower(&hasher.finalize()))
     }
 
     fn graph_digest(state: &SessionState) -> String {

--- a/m1nd-mcp/src/session.rs
+++ b/m1nd-mcp/src/session.rs
@@ -3946,7 +3946,10 @@ impl SessionState {
     fn proof_target_digest(target_identity: &str) -> Result<String, String> {
         let path = Path::new(target_identity);
         match std::fs::read(path) {
-            Ok(bytes) => Ok(format!("sha256:{:x}", Sha256::digest(bytes))),
+            Ok(bytes) => Ok(format!(
+                "sha256:{}",
+                crate::util::hex_lower(&Sha256::digest(bytes))
+            )),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 // Missing is a first-class disk state, not an empty-file hash.
                 Ok("missing".to_string())
@@ -4023,7 +4026,10 @@ impl SessionState {
             agent_id,
             raw_target,
             evidence,
-            Some(format!("sha256:{:x}", Sha256::digest(inspected_content))),
+            Some(format!(
+                "sha256:{}",
+                crate::util::hex_lower(&Sha256::digest(inspected_content))
+            )),
         )
     }
 
@@ -4310,7 +4316,7 @@ fn checkpoint_candidate_digest(files: &[SessionCheckpointCandidateFile]) -> Stri
             CheckpointCandidatePresence::Absent => hasher.update([0]),
         }
     }
-    format!("{:x}", hasher.finalize())
+    crate::util::hex_lower(&hasher.finalize())
 }
 
 fn canonical_json_bytes<T: Serialize>(value: &T) -> M1ndResult<Vec<u8>> {

--- a/m1nd-mcp/src/skeleton_scan.rs
+++ b/m1nd-mcp/src/skeleton_scan.rs
@@ -1628,7 +1628,7 @@ fn short_hash(value: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(value.as_bytes());
-    format!("{:x}", hasher.finalize())[..8].to_string()
+    crate::util::hex_lower(&hasher.finalize())[..8].to_string()
 }
 
 #[cfg(test)]

--- a/m1nd-mcp/src/surgical_handlers.rs
+++ b/m1nd-mcp/src/surgical_handlers.rs
@@ -1146,7 +1146,7 @@ pub(crate) fn content_hash(content: &str) -> String {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::util::hex_lower(&Sha256::digest(bytes))
 }
 
 fn invalid_params(tool: &str, detail: impl Into<String>) -> M1ndError {

--- a/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
+++ b/m1nd-mcp/src/surgical_handlers/source_edit_transaction.rs
@@ -1575,7 +1575,7 @@ fn now_ms() -> Result<u64, SourceEditTransactionError> {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::util::hex_lower(&Sha256::digest(bytes))
 }
 
 fn is_digest(value: &str) -> bool {

--- a/m1nd-mcp/src/system_blocks.rs
+++ b/m1nd-mcp/src/system_blocks.rs
@@ -1674,7 +1674,7 @@ fn membership_fingerprint(sorted_members: &[String]) -> String {
         hasher.update(m.as_bytes());
         hasher.update(b"\n");
     }
-    format!("sha256:{:x}", hasher.finalize())
+    format!("sha256:{}", crate::util::hex_lower(&hasher.finalize()))
 }
 
 /// Resolve a block's EFFECTIVE membership against a real file list. Exact-path

--- a/m1nd-mcp/src/temporal_state.rs
+++ b/m1nd-mcp/src/temporal_state.rs
@@ -47,7 +47,7 @@ fn digest(state: &TemporalRuntimeStateV1) -> M1ndResult<String> {
     let mut hasher = Sha256::new();
     hasher.update(b"m1nd/temporal-runtime-state/v1\0");
     hasher.update(bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(crate::util::hex_lower(&hasher.finalize()))
 }
 
 fn durable_atomic_write(path: &Path, bytes: &[u8], fail_before_rename: bool) -> M1ndResult<()> {

--- a/m1nd-mcp/src/universal_docs.rs
+++ b/m1nd-mcp/src/universal_docs.rs
@@ -1069,7 +1069,7 @@ fn canonical_json_bytes<T: Serialize>(value: &T) -> M1ndResult<Vec<u8>> {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::util::hex_lower(&Sha256::digest(bytes))
 }
 
 #[cfg(test)]

--- a/m1nd-mcp/src/util.rs
+++ b/m1nd-mcp/src/util.rs
@@ -8,6 +8,22 @@ pub(crate) fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Lowercase hex of a byte slice.
+///
+/// `digest` 0.11 returns `hybrid_array::Array`, which — unlike the old
+/// `generic_array::GenericArray` — does not implement `LowerHex`, so the
+/// former `format!("{:x}", ..)` spelling no longer compiles. This is the
+/// workspace's existing hex idiom, the single shared copy for this crate.
+pub(crate) fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
 #[cfg(test)]
 mod tests {
     use super::now_ms;

--- a/m1nd-mcp/src/xray_handlers.rs
+++ b/m1nd-mcp/src/xray_handlers.rs
@@ -746,7 +746,7 @@ pub struct XrayApplyOutput {
 
 /// Cryptographic content digest for both within-call and cross-call OCC.
 fn content_hash(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    crate::util::hex_lower(&Sha256::digest(bytes))
 }
 
 /// Cross-call OCC fingerprint over the PLANNED files' current on-disk content.
@@ -767,7 +767,7 @@ fn plan_version(entries: &[(PathBuf, String)]) -> String {
         hasher.update((guard.len() as u64).to_be_bytes());
         hasher.update(guard.as_bytes());
     }
-    format!("{:x}", hasher.finalize())
+    crate::util::hex_lower(&hasher.finalize())
 }
 
 /// Pure FILE transform: returns `Some(new_content)` if it changes the file,

--- a/m1nd-mcp/ui_bundle_support.rs
+++ b/m1nd-mcp/ui_bundle_support.rs
@@ -94,7 +94,7 @@ pub fn ui_tree_identity_from_entries(mut entries: Vec<(String, Vec<u8>)>) -> UiT
         hasher.update(bytes);
     }
     UiTreeIdentity {
-        sha256: format!("{:x}", hasher.finalize()),
+        sha256: hex_lower(&hasher.finalize()),
         placeholder,
     }
 }
@@ -130,4 +130,21 @@ pub fn stable_ui_tree_identity_with_hook(
         });
     }
     Ok(after)
+}
+
+/// Lowercase hex of a byte slice.
+///
+/// `digest` 0.11 returns `hybrid_array::Array`, which — unlike the old
+/// `generic_array::GenericArray` — does not implement `LowerHex`, so the
+/// former `format!("{:x}", ..)` spelling no longer compiles. This is the
+/// workspace's existing hex idiom, kept local so the digest call sites stay
+/// dependency-free.
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }

--- a/m1nd-runnerd/Cargo.toml
+++ b/m1nd-runnerd/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "4", features = ["derive"] }
 # runners.toml — the pinned-capability config (§5a).
 toml = "1.1"
 # The gate log hash (§5c) — the SAME sha256 the mailbox/receipt taxonomy uses.
-sha2 = "0.10"
+sha2 = "0.11"
 # The per-boot shared secret bytes (§5a). Already in the lockfile transitively.
 rand = "0.9"
 

--- a/m1nd-runnerd/src/mission.rs
+++ b/m1nd-runnerd/src/mission.rs
@@ -129,9 +129,25 @@ pub fn mint_mission_id() -> String {
 
 /// `sha256(bytes)` as lowercase hex — the SAME digest the mailbox/receipt taxonomy
 /// uses, so a candidate is a direct hand-off at import time (§5c).
+/// Lowercase hex of a byte slice.
+///
+/// `digest` 0.11 returns `hybrid_array::Array`, which — unlike the old
+/// `generic_array::GenericArray` — does not implement `LowerHex`, so the
+/// former `format!("{d:x}")` spelling no longer compiles. This is the
+/// workspace's existing hex idiom, kept local so the digest call sites stay
+/// dependency-free.
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
-    let d = Sha256::digest(bytes);
-    format!("{d:x}")
+    hex_lower(&Sha256::digest(bytes))
 }
 
 /// The current instant as `YYYY-MM-DDTHH:MM:SSZ` (UTC) — the repo's dependency-free


### PR DESCRIPTION
## The whole RustCrypto family, one major, together — because alone was impossible

#450 proved a lone sha2 bump straddles two majors (`ed25519-dalek`/`p256` pin `^0.10`) and pinned it with a curated dependabot ignore. This PR is the coherent move that ignore pointed at, superseding dependabot's lone-p256 #459 (which could not have built: p256 0.14 needs sha2 ^0.11 while dalek 2.2 needs ^0.10):

sha2 0.11 · ed25519-dalek 3.0 · ed25519 3.0 · p256 0.14 · ecdsa 0.17 · elliptic-curve 0.14.1 · curve25519-dalek 5.0 · signature 3.0 · digest 0.11 (+ der/spki/rfc6979/primeorder in tow; `generic-array` → `hybrid-array`). **Every old major verified GONE from `Cargo.lock`** — no straddle; lock resolved from manifest requirements only, never a blanket update. The sha2 dependabot ignore is removed in the same commit that makes it unnecessary.

## The security bar — signatures at rest must keep verifying

**Fixtures were minted BEFORE the bump**, on the pre-sweep tree with the OLD crates, through this crate's own public signing API (deterministic: RFC6979 for ECDSA, Ed25519 by construction), committed first, proven green under the old crates — then re-run byte-unchanged under the new: **12/12 green**, covering both algorithms at both seams (`verify_authority_message_signature` — the choke point for the offline receipt verifier, the enclave authority runtime and the mission transport — and full-record `verify_capability`). Falsifiability demonstrated: corrupting three fixtures and one hash vector turns **6 of 12 red**. Hash vectors pinned against an independent oracle (Python `hashlib`), not re-derived from the code under test. The signature-continuity subset was independently re-run by the orchestrator post-rebase.

**The scary changelog entry, investigated and cleared:** ecdsa 0.17 "moved low-S normalization into `verify_prehashed`" — gated on `C::NORMALIZE_S`, and `p256` sets it `false`; our path normalizes explicitly before verifying regardless, and `high_s_signature_at_rest_is_refused` pins it empirically.

## API deltas absorbed

`normalize_s` now infallible (2 sites) · `to_encoded_point` → `to_sec1_point`, identical SEC1 semantics (7 sites) · **29 digest-hex sites** migrated off the dropped `LowerHex` (4 more than estimated — inline-captured `format!("{digest:x}")` args hid from the first grep, **including `letter_id`**, the cross-machine dedup contract — which now has its own pinned vectors, because its spelling changed and nothing guarded it) · dalek 3.0 `std`→`alloc`. Hex strategy: the workspace's existing `hex_lower` idiom, zero new deps (`hex` is not in the lock; checked first).

## Deliberately untouched

The enclave custody pins (`security-framework =3.7.0`, `-sys =2.17.0`, `core-foundation =0.10.1`) — exact-version custody surface outside this family; verified absent from the diff. `bincode` (#431) remains out: serialization-format major, separate compatibility analysis.

## Gates

fmt clean · `clippy --workspace --all-targets -D warnings` clean · m1nd-control **164** · m1nd-core **218** · m1nd-mcp lib **1466** · m1nd-ingest **302** · m1nd-runnerd **34** — all 0 failed. `docs/MEDULLA-PRD.md` §M7b corrected in the same PR (it taught the 0.10 pin). One dedup debt filed, not buried: `hex_lower` now exists 16× workspace-wide — that refactor would have obscured this security diff.
