### PR TITLE
test(lifecycle): prove state crossing a kill -9, the crash half of the gate

### DIFF
--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -95,7 +95,7 @@ Everything promised or planned and not yet done, named here rather than left in 
 Update this list in the same PR that closes one; a front that dies silently is a lie.
 
 **Blocking the product**
-- **LIFECYCLE PROOF — first slice LANDED 2026-07-29; the crash half stays declared open.** m1nd is a
+- **LIFECYCLE PROOF — BOTH CYCLES LANDED 2026-07-29 (clean shutdown AND crash).** m1nd is a
   CONTINUITY system, and until this slice the property *boot → serve → mutate → clean shutdown → boot
   again → still serves* had no proof anywhere — which is how three bricking boot defects (#441, #442)
   lived undetected under 1458 green unit tests until the OWNER asked whether m1nd was working. The gate
@@ -106,8 +106,35 @@ Update this list in the same PR that closes one; a front that dies silently is a
   nobody unless the shutdown checkpoint carries it), asserting zero sidecar refusals on captured stderr,
   designed by an askGOD verdict (CHANGE, applied), condition-based from birth, and **proven to bite**:
   temporarily reverting either boot fix turns it red with a message naming the regression. Cost measured:
-  ≈ +2.6s. **What remains NOT_RUN, said loudly: Cycle B — crash/kill-9 without a checkpoint — is wave 2,
-  and G4's "fault injection" claim stays open until it lands.** Two finds the build itself surfaced, both
+  ≈ +2.6s. **Cycle B — crash/`kill -9` with no checkpoint — landed the same day**, as
+  `brain_survives_a_kill_nine_between_boots` in the same file, reusing the same harness (one new spawn
+  method, no second harness): three boots on one runtime root with the clean shutdown replaced by an
+  uncatchable SIGKILL of a fully-serving owner — asserted through the exit status, not assumed, and
+  delivered to the child pid the harness itself spawned and reaped, never to a name. It pins the two
+  durability classes on opposite sides of ONE crash. The CLASSIFIED write survives, including the
+  `memorize` committed seconds before the kill with no clean shutdown behind it; the DEBOUNCED
+  `alerts_ack` does NOT, and that is the point — measured `acked: false` on the recovered boot, cleanly
+  on the OLD state, which is the declared loss window demonstrated rather than described (Cycle A asserts
+  the same ack SURVIVES a clean shutdown, so the pair brackets the window from both sides). It is held to
+  COHERENCE and not to survival on purpose: pinning the loss would turn the gate red the day someone
+  narrows the window. Also asserted: the recovery boot comes up AT ALL (the #442 class), never serves an
+  empty graph (the #441 class), sweeps its own unpublished checkpoint temporaries, and prints none of the
+  blind-boot signatures. **Proven to bite**: deferring the actor's publish decision to the debounce turns
+  it red at `strict recovery refused non-current or lossy plasticity_state checkpoint payload` — and it
+  takes Cycle A red with it, which is itself the finding: there is no weakening of publish-on-turn that
+  leaves the clean cycle green, so the two cycles really are one property seen from two premises. Cost
+  measured: the test itself runs ≈10.1s, but the binary's wall-clock goes 8.94s → 10.21s, so **≈ +1.3s**
+  — it runs in parallel with the two tests already there and is simply the new longest pole. Two probes
+  that did NOT bite are worth as much as the one that did, both recorded in
+  the test: reverting #442's co-change `?` does not reach this path (the crash cycle never produces that
+  drift), and dropping `memorize` from `READ_ONLY_DENIED_TOOLS` leaves the gate GREEN because the actor's
+  graph-generation witness catches it anyway — the classification is NOT the load-bearing half for a verb
+  that ingests, only for one that dirties a sidecar alone. **What remains NOT_RUN, said precisely: a kill
+  DURING boot and a kill DURING the checkpoint write itself** — the latter belongs at the store's own
+  `CheckpointFaultPoint` seam (`RenameCurrent`, `FsyncCurrentParent`), in-process and deterministic, not
+  behind a sleep in an integration test; both were declared out rather than shipped as timing races.
+  **G4's "fault injection" claim is now true for the crash class and still open for disk-full and
+  corruption**, which are its own separate items. Two finds the build itself surfaced, both
   filed: under the M1ND-10 authority floors **~29 mutating verbs that `tools/list` still advertises are
   unreachable from a plain MCP client** (`generic_action_authority_required` — measured live, converges
   with the bootstrap-instruction front and genesis P2/P3); and the light-ingest merge behind `memorize`

--- a/m1nd-mcp/tests/persist_runtime_root.rs
+++ b/m1nd-mcp/tests/persist_runtime_root.rs
@@ -42,13 +42,19 @@
 //! (`anchor_persist_target`) is covered by cross-platform unit tests in
 //! `m1nd-mcp/src/main.rs`.
 //!
-//! THE SECOND TEST IN THIS FILE generalizes that subprocess seam into the
-//! LIFECYCLE GATE — `boot → serve → mutate → clean shutdown → boot again →
-//! still serves` — because the boot-path defects of 2026-07-27 all needed a
-//! second boot over prior state to exist at all. It lives here rather than in a
-//! file of its own so it reuses this harness instead of growing a second one.
-//! Its own long comment block, below, carries the reasoning and the declared
-//! wave-2 boundary.
+//! THE SECOND AND THIRD TESTS IN THIS FILE generalize that subprocess seam into
+//! the LIFECYCLE GATE, because the boot-path defects of 2026-07-27 all needed a
+//! second boot over prior state to exist at all. They are the two halves of one
+//! property, and each carries its own long comment block below:
+//!
+//!   * Cycle A — `boot → serve → mutate → CLEAN SHUTDOWN → boot again → still
+//!     serves`, across four generations of one runtime root;
+//!   * Cycle B — the same walk with the shutdown replaced by a `kill -9`:
+//!     `boot → serve → mutate → CRASH → boot again → comes up, serves, and is
+//!     consistent`.
+//!
+//! Both live here rather than in files of their own so they reuse this harness
+//! instead of growing a second and a third one.
 #![cfg(unix)]
 
 use std::io::{BufRead, BufReader, Write};
@@ -266,6 +272,64 @@ impl Owner {
             .unwrap_or_else(|| panic!("no node_count in health body: {health}"))
     }
 
+    /// How many `search` results mention `label`. Looks inside `results` and
+    /// nowhere else: `search` echoes the query back in its own `query` field, so
+    /// matching the whole payload would report a hit on zero results.
+    fn memory_hits(&mut self, label: &str) -> (usize, serde_json::Value) {
+        let found = self.call(
+            "search",
+            serde_json::json!({
+                "agent_id": LIFECYCLE_AGENT,
+                "query": label,
+                "mode": "literal",
+                "top_k": 20
+            }),
+        );
+        let hits = found
+            .get("results")
+            .and_then(|results| results.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|entry| entry.to_string().contains(label))
+                    .count()
+            })
+            .unwrap_or(0);
+        (hits, found)
+    }
+
+    /// Commit one CLASSIFIED durable write and prove it reached the graph.
+    ///
+    /// `memorize` both sits in `READ_ONLY_DENIED_TOOLS` and moves the graph
+    /// generation, so the actor publishes CURRENT on the turn it acks: when this
+    /// returns, the write is durable to DISK and not merely to memory. That is
+    /// what makes it the right probe for a crash — the assertion after the kill
+    /// is about a write that was already committed, never about one in flight.
+    fn memorize_marker(&mut self, label: &str) -> u64 {
+        let before = self.node_count();
+        let memorized = self.call(
+            "memorize",
+            serde_json::json!({
+                "agent_id": LIFECYCLE_AGENT,
+                "node_label": label,
+                "claims": [ { "label": label, "text": "knowledge that must cross a crash" } ]
+            }),
+        );
+        assert_eq!(
+            memorized.get("ingested").and_then(|value| value.as_bool()),
+            Some(true),
+            "memorize must write its light file AND ingest it — an un-ingested \
+             memory never reaches the graph this gate follows: {memorized}"
+        );
+        let after = self.node_count();
+        assert!(
+            after > before,
+            "memorize({label}) must actually grow the graph it will be asked to \
+             remember across the crash: {before} -> {after}"
+        );
+        after
+    }
+
     /// This owner's captured stderr, or an honest note when it was not captured.
     fn owner_stderr(&self) -> String {
         match self.stderr_log.as_deref() {
@@ -285,6 +349,46 @@ impl Owner {
             status.success(),
             "owner shutdown failed with {status}. Its stderr said:\n{stderr}"
         );
+    }
+
+    /// The CRASH seam: SIGKILL this owner where `shutdown` would have let it
+    /// checkpoint, then reap it. Returns its captured stderr.
+    ///
+    /// The signal goes to the CHILD HANDLE THIS HARNESS SPAWNED AND HOLDS —
+    /// `Child::kill` addresses that one pid and nothing else. Nothing here ever
+    /// matches a process by name, which would hit a sibling worktree's owner.
+    ///
+    /// Reaping is not bookkeeping. `InstanceRegistry` decides a lease is
+    /// recoverable by asking whether its recorded pid is live, and an unreaped
+    /// child stays a zombie whose pid still answers `kill(pid, 0)`. Leaving it
+    /// would make the next boot refuse a lease no real crash would hold — the
+    /// parent (launchd, in the field) always reaps.
+    ///
+    /// `Child::wait` closes stdin before waiting, which is the cooperative
+    /// shutdown seam — harmless only because SIGKILL cannot be caught: the
+    /// process is already un-runnable in userspace when `kill` returns, so it
+    /// can never observe that EOF and run the persist-before-release path.
+    fn kill_nine(mut self) -> String {
+        use std::os::unix::process::ExitStatusExt;
+
+        let stderr = self.owner_stderr();
+        self.child.kill().expect("SIGKILL the owner we spawned");
+        let status = self.child.wait().expect("reap the SIGKILLed owner");
+        assert_eq!(
+            status.signal(),
+            Some(9),
+            "the crash cycle needs a real uncatchable kill: the owner exited \
+             {status} instead of dying to SIGKILL. Any other status means it \
+             ran a shutdown path, and the un-checkpointed state this gate is \
+             about was flushed after all. Its stderr said:\n{stderr}"
+        );
+        assert_eq!(
+            status.code(),
+            None,
+            "a SIGKILLed owner has no exit code; got {status}, so it terminated \
+             through some other path. Its stderr said:\n{stderr}"
+        );
+        stderr
     }
 }
 
@@ -410,9 +514,20 @@ fn persist_lands_under_runtime_root_and_second_process_warm_boots() {
 // whose own alert has to be SEEDED, because every producer of a real alert
 // (`daemon_tick`, `apply`) is above the floor too.
 //
-// Cycle B — crash / `kill -9` with no checkpoint — is deliberately NOT here.
-// It is wave 2, and until it lands the fault-injection half of this property
-// stays NOT_RUN rather than silently claimed.
+// Cycle B — crash / `kill -9` with no checkpoint — is NOT here, but it is no
+// longer missing: it is the third test in this file,
+// `brain_survives_a_kill_nine_between_boots`, which walks the same property with
+// the clean shutdown replaced by an uncatchable signal. Split rather than merged
+// because a shutdown and a crash are opposite premises about the same boot: this
+// cycle can demand that EVERY sidecar round-trips exactly, and that one cannot.
+//
+// What that closes, precisely, and what it does not. The crash class G4 asks for
+// is now covered at ONE fault point: a SIGKILL of a fully-serving owner, mid-
+// life, with both a checkpointed and a staged write outstanding. Still NOT_RUN
+// and not claimed by either cycle: a kill DURING boot, a kill DURING the
+// checkpoint write itself (which belongs at the store's own
+// `CheckpointFaultPoint` seam, in-process and deterministic), and the disk-full
+// and corruption classes, which are separate G4 items with separate proofs.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// The agent identity every call in the lifecycle cycle carries.
@@ -759,5 +874,336 @@ fn brain_serves_its_own_state_across_clean_shutdowns_and_second_boots() {
                  adopt every sidecar exactly. stderr was:\n{log}"
             );
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE LIFECYCLE GATE — Cycle B
+//
+// Cycle A above proves the CLEAN half: every boot ends in the cooperative
+// persist-before-release checkpoint. That is the half the field never gets. An
+// owner is SIGKILLed by a laptop that sleeps too hard, an OOM killer, a
+// `launchctl kickstart -k`, or a developer who closes the terminal — and the
+// durability guard in `session.rs` names the consequence outright: a write that
+// is neither classified a mutation nor routed through a persist choke point is
+// "durable to nobody: the ack returns, the debounce counter never advances, and
+// `kill -9` loses it". That sentence was, until this test, unproven either way.
+//
+// This is the crash half of the same property:
+//
+//   boot → serve → durable write → CRASH with no checkpoint → boot again →
+//   comes up, serves, and is CONSISTENT
+//
+// The three failure modes it forbids are the three the boot path already
+// produced once (#441/#442): a next boot that BRICKS, a next boot that serves an
+// EMPTY graph, and a next boot that loses state a completed ack promised.
+//
+// WHAT MAKES THE CRASH REAL, and not a slower shutdown:
+//   * the signal is SIGKILL, uncatchable, so no persist path can run — asserted
+//     through the exit status, not assumed;
+//   * it lands AFTER both writes are acknowledged on the wire, so the window
+//     under test is exactly "acked but not yet checkpointed";
+//   * the two writes are deliberately on OPPOSITE sides of the durability
+//     classification, so one crash exercises both consequences at once.
+//
+// THE TWO SIDES, and why each assertion is the shape it is:
+//   * `memorize` is durable ON THE TURN IT ACKS, so the recovered boot MUST
+//     still have it — including the marker committed seconds before the crash,
+//     with no clean shutdown behind it. Asserted hard, on boot #1's marker and
+//     boot #2's. It earns that durability TWICE over, which is measured and not
+//     assumed: the actor publishes when `mutating || witness_moved || …`, and
+//     `memorize` is both in `READ_ONLY_DENIED_TOOLS` (so `mutating`) and a verb
+//     that ingests (so the graph generation moves and `witness_moved` fires).
+//     Dropping it from `READ_ONLY_DENIED_TOOLS` alone leaves this gate GREEN —
+//     probed, 2026-07-29 — because the witness still catches the graph. A verb
+//     that dirtied only a SIDECAR would have neither, which is precisely the
+//     hole `antibody_create` fell through.
+//   * `alerts_ack` is DEBOUNCED (`StagedPersistDebounce`, default 50 deferring
+//     turns), so its write is durable to nobody until a flush or a clean
+//     shutdown — neither of which happens here. Losing it is the DECLARED loss
+//     window, and it IS lost: probed at the same time, the recovered boot reads
+//     the alert back `acked: false`, cleanly on the OLD state. So this test
+//     holds it to COHERENCE, not survival — present and well-formed, acked or
+//     open, never half-written and never gone. That is the "old-or-new, never
+//     mixed" contract the content-addressed checkpoint store is built on, and it
+//     is the exact complement of Cycle A, which asserts the SAME ack survives a
+//     CLEAN shutdown. Pinning the loss as `acked: false` would be the third
+//     mistake available here: it would turn this gate red the day someone
+//     narrows the window, which is an improvement.
+// Asserting the debounced write survives would ship a lie; asserting its loss
+// would freeze a defect as a requirement; asserting nothing would let a
+// corrupted alerts sidecar pass. Coherence is the one true claim of the three.
+//
+// UNIX-ONLY, and inherited rather than chosen: the whole file is `#![cfg(unix)]`
+// already, because the FIRST test pins cwd to `/` for the sealed-launchd-volume
+// reproduction. That gate is right for this test too and would have been added
+// for it anyway. `Child::kill` does map to `TerminateProcess` on Windows and
+// would compile, but it is not the same fault: SIGKILL is a POSIX signal the
+// process cannot handle, whereas the durability window under test is defined by
+// what the runtime does with an flock the KERNEL releases on death, a pid the
+// registry probes for liveness, and a zombie the parent must reap — three
+// POSIX-shaped mechanics. Running this on Windows would assert the same
+// sentences about a different mechanism, which is the kind of green worth less
+// than red. The portable half — that a checkpoint published on its turn is on
+// disk — is covered cross-platform by the checkpoint store's own unit tests.
+//
+// FAULT POINTS EXERCISED: crash BETWEEN boots — a SIGKILL of a fully-serving
+// owner, mid-life, with staged state outstanding.
+// FAULT POINTS DECLARED OUT: a kill DURING boot (mid-adoption / mid-restore),
+// and a kill DURING the checkpoint write itself. Neither is dropped for being
+// unimportant. Both need the signal delivered inside a window this harness
+// cannot observe the edges of — the stdio seam only becomes observable once the
+// owner answers `initialize`, which is already past boot — so both would be
+// timing races dressed as gates. The checkpoint store has a real seam for that
+// class (`CheckpointFaultInjector` / `CheckpointFaultPoint`, which name
+// `RenameCurrent` and `FsyncCurrentParent` explicitly) and interrupting a
+// checkpoint belongs there, in-process and deterministic, not behind a sleep
+// here. The disk-full and corruption classes of G4 remain their own items.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The CLASSIFIED write boot #1 commits and every later boot must still find,
+/// including the one that comes up after the crash.
+const CRASH_BASELINE_MEMORY_LABEL: &str = "CrashCycleBaselineMarkerQ3";
+
+/// The CLASSIFIED write boot #2 commits moments before it is SIGKILLed. It is
+/// published on the turn it acks, so the crash must not be able to take it.
+const CRASH_PRE_KILL_MEMORY_LABEL: &str = "CrashCyclePreKillMarkerQ4";
+
+/// Lines the boot recovering from a CRASH must never print.
+///
+/// A strict subset of `SIDECAR_REFUSAL_SIGNATURES`, and the difference is the
+/// point. Cycle A forbids every sidecar degrade because a clean shutdown
+/// promises an exact round trip: anything it wrote, the next boot must adopt. A
+/// crash promises no such thing — sidecars the checkpoint never reached MAY be
+/// stale against the recovered graph, and dropping one ("continuing without it")
+/// is the designed, honest response rather than a defect. Listing those here
+/// would make this gate red for behaving correctly.
+///
+/// What survives into this list is the class that is never acceptable: a boot
+/// that came up BLIND (no graph, zero nodes), one that failed to write at all,
+/// and one that fell back to the one-time legacy rescue over a runtime that is
+/// already populated — each of which means the crash cost state that a completed
+/// checkpoint had already made durable.
+const CRASH_RECOVERY_FORBIDDEN_SIGNATURES: &[&str] = &[
+    "persist failed",
+    "No graph snapshot found",
+    "Server ready. 0 nodes",
+    "adopted legacy graph snapshot",
+];
+
+/// Every unpublished checkpoint temporary left anywhere under `root`: the
+/// `.CURRENT.tmp-<pid>-<nonce>` pointer-swap file and the `.staging-<pid>-…`
+/// directory a checkpoint is assembled in before its atomic rename.
+///
+/// A crash can strand either one, and `CheckpointStore::open` sweeps both on the
+/// next boot (`cleanup_unpublished_temporaries`). Scanning AFTER the recovery
+/// boot therefore checks recovery, not the crash: litter still here means the
+/// sweep did not run, and the runtime root grows an orphan per crash forever.
+fn unpublished_checkpoint_temporaries(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with(".CURRENT.tmp-") || name.starts_with(".staging-") {
+                found.push(path.clone());
+            }
+            if entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false) {
+                pending.push(path);
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+#[test]
+fn brain_survives_a_kill_nine_between_boots() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("mk runtime dir");
+    let repo = tmp.path().join("repo");
+    write_fixture_repo(&repo);
+    seed_unacked_alert(&runtime_dir);
+
+    // The owner's working directory across every boot — the one a restart keeps.
+    let cwd = tmp.path().join("cwd");
+    std::fs::create_dir_all(&cwd).expect("mk owner cwd");
+
+    let boot1_stderr = tmp.path().join("crash-boot1.stderr");
+    let boot2_stderr = tmp.path().join("crash-boot2.stderr");
+    let boot3_stderr = tmp.path().join("crash-boot3.stderr");
+
+    // The same adversarial graph shape Cycle A runs on: a parallel edge, so
+    // every checkpoint this cycle writes carries two plasticity rows under one
+    // full synaptic key. The crash must not turn that into a brick either.
+    let seed_graph = seed_graph_with_a_parallel_edge(&repo);
+    let seeded_nodes = u64::from(seed_graph.num_nodes());
+    assert!(
+        seeded_nodes >= 3,
+        "fixture ingest should create several nodes, got {seeded_nodes}"
+    );
+    m1nd_core::snapshot::save_graph(&seed_graph, &runtime_dir.join("graph_snapshot.json"))
+        .expect("seed the runtime graph snapshot");
+
+    // ── Boot #1: the baseline generation a crash must never cost ─────────────
+    let mut owner1 = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot1_stderr);
+    let served = owner1.node_count();
+    assert!(
+        served >= seeded_nodes,
+        "the first boot must SERVE the graph it loaded: expected at least \
+         {seeded_nodes} nodes, got {served}"
+    );
+    let baseline_nodes = owner1.memorize_marker(CRASH_BASELINE_MEMORY_LABEL);
+    owner1.shutdown();
+
+    // ── Boot #2: serve the baseline, write both classes, then CRASH ──────────
+    let mut owner2 = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot2_stderr);
+    let rebooted = owner2.node_count();
+    assert!(
+        rebooted >= baseline_nodes,
+        "the second boot must serve what the first one checkpointed: booted \
+         with {rebooted} nodes, the clean shutdown had {baseline_nodes}"
+    );
+    let (baseline_hits_before_crash, baseline_payload) =
+        owner2.memory_hits(CRASH_BASELINE_MEMORY_LABEL);
+    assert!(
+        baseline_hits_before_crash > 0,
+        "the baseline write must be present BEFORE the crash, or the recovery \
+         assertion below proves nothing about the crash. Read back: \
+         {baseline_payload}"
+    );
+
+    // The CLASSIFIED write: published with this turn's checkpoint, so it is
+    // already on disk when the signal lands.
+    let pre_kill_nodes = owner2.memorize_marker(CRASH_PRE_KILL_MEMORY_LABEL);
+
+    // The DEBOUNCED write: acked here, durable to nobody. The default interval
+    // is 50 deferring turns, so the flush cannot happen inside this cycle and
+    // the clean shutdown that would have carried it never runs.
+    let acked = owner2.call(
+        "alerts_ack",
+        serde_json::json!({ "agent_id": LIFECYCLE_AGENT, "alert_ids": [LIFECYCLE_ALERT_ID] }),
+    );
+    assert_eq!(
+        acked.get("acked").and_then(|value| value.as_u64()),
+        Some(1),
+        "the seeded alert must be acknowledged in memory before the crash: {acked}"
+    );
+
+    // THE CRASH. Both writes are acknowledged on the wire; neither the shutdown
+    // checkpoint nor the debounce flush will ever run.
+    let boot2_log = owner2.kill_nine();
+    assert!(
+        boot2_log.contains("Server ready."),
+        "the crashed boot must have actually come up before it was killed, \
+         otherwise the recovery below is recovering from nothing. stderr \
+         was:\n{boot2_log}"
+    );
+
+    // ── Boot #3: recovery ────────────────────────────────────────────────────
+    // COMING UP AT ALL is the first assertion, and it is not a formality: every
+    // defect in the #442 class turned a readable-but-unexpected sidecar into a
+    // dead process, and a crash leaves strictly more unexpected state behind
+    // than a clean shutdown does. `spawn_logging_stderr` panics with this
+    // owner's stderr if it dies before answering.
+    let mut owner3 = Owner::spawn_logging_stderr(&cwd, &runtime_dir, &boot3_stderr);
+    let recovered_nodes = owner3.node_count();
+    assert!(
+        recovered_nodes >= pre_kill_nodes,
+        "the boot after the crash must serve the last CHECKPOINTED generation: \
+         booted with {recovered_nodes} nodes but the classified write published \
+         {pre_kill_nodes} before the kill. A lower count is state that a \
+         completed ack had already made durable being lost to the crash — or, \
+         at zero, the field's exact #441 signature."
+    );
+
+    // Boot #1's write: committed a whole clean cycle before the crash. If the
+    // crash can take THIS, nothing in the brain is durable.
+    let (baseline_hits, baseline_recovery_payload) =
+        owner3.memory_hits(CRASH_BASELINE_MEMORY_LABEL);
+    assert!(
+        baseline_hits > 0,
+        "the baseline CLASSIFIED write must survive the crash: \
+         {CRASH_BASELINE_MEMORY_LABEL} was memorized on boot #1 and carried \
+         through a CLEAN shutdown, and the recovered brain cannot find it. Read \
+         back: {baseline_recovery_payload}"
+    );
+
+    // Boot #2's write: committed seconds before the kill, with no clean shutdown
+    // behind it. It is durable because the turn that acked it PUBLISHED it —
+    // that is the whole difference between the two durability classes, and it is
+    // exactly what a crash is supposed to test.
+    let (pre_kill_hits, pre_kill_payload) = owner3.memory_hits(CRASH_PRE_KILL_MEMORY_LABEL);
+    assert!(
+        pre_kill_hits > 0,
+        "the pre-crash CLASSIFIED write must survive the crash: \
+         {CRASH_PRE_KILL_MEMORY_LABEL} was acked on the turn that published \
+         CURRENT, so it was on disk when SIGKILL landed. Losing it means the \
+         classified-mutation checkpoint is not durable at the moment it acks — \
+         the ack is a lie. Read back: {pre_kill_payload}"
+    );
+
+    // The DEBOUNCED write: no survival claim, a COHERENCE claim. The alert row
+    // must be readable and well-formed whichever side of the loss window it
+    // landed on — the alternative is a sidecar the crash left half-written.
+    let alerts = owner3.call(
+        "alerts_list",
+        serde_json::json!({ "agent_id": LIFECYCLE_AGENT, "include_acked": true, "limit": 50 }),
+    );
+    let alert_state = alerts
+        .get("alerts")
+        .and_then(|list| list.as_array())
+        .and_then(|list| {
+            list.iter()
+                .find(|entry| {
+                    entry.get("alert_id").and_then(|id| id.as_str()) == Some(LIFECYCLE_ALERT_ID)
+                })
+                .and_then(|entry| entry.get("acked"))
+                .and_then(|acked| acked.as_bool())
+        });
+    assert!(
+        alert_state.is_some(),
+        "the alerts sidecar must survive the crash COHERENTLY: \
+         {LIFECYCLE_ALERT_ID} must be readable with a well-formed `acked` flag \
+         — acknowledged if the debounce happened to flush, still open if it did \
+         not. Missing or malformed is neither the old state nor the new one, \
+         which is the mixed-state failure the checkpoint store exists to \
+         prevent. Read back: {alerts}"
+    );
+
+    owner3.shutdown();
+
+    // ── The recovery left no litter ──────────────────────────────────────────
+    // Checked after the recovery boot, so it measures the crash SWEEP rather
+    // than the crash: `CheckpointStore::open` clears unpublished temporaries,
+    // and anything surviving that is an orphan the runtime root keeps forever.
+    let litter = unpublished_checkpoint_temporaries(&runtime_dir);
+    assert!(
+        litter.is_empty(),
+        "the boot after the crash must sweep unpublished checkpoint \
+         temporaries; these survived it: {litter:?}"
+    );
+
+    // ── The recovery boot came up clean, by its own stderr ───────────────────
+    let boot3_log = read_stderr(&boot3_stderr);
+    // An absence check over an empty file proves nothing. Pin that this log is
+    // the real one, from a boot that actually came up, first.
+    assert!(
+        boot3_log.contains("Server ready."),
+        "the recovery boot's captured stderr must carry its ready banner, \
+         otherwise the scan below is checking an empty file. Log was:\n{boot3_log}"
+    );
+    for signature in CRASH_RECOVERY_FORBIDDEN_SIGNATURES {
+        assert!(
+            !boot3_log.contains(signature),
+            "the boot after the crash came up blind or refused its own state \
+             ({signature:?}). A crash may cost the debounce window; it may never \
+             cost a checkpointed generation. stderr was:\n{boot3_log}"
+        );
     }
 }


### PR DESCRIPTION
## The crash half of the lifecycle gate — G4's fault-injection claim starts becoming true

The lifecycle gate (#447) proved the CLEAN cycle and declared its boundary out loud: *"Cycle B — crash/kill-9 — is wave 2; until it lands, G4's fault-injection claim remains NOT_RUN."* This PR is wave 2.

`brain_survives_a_kill_nine_between_boots`: a real subprocess owner is killed mid-life by **its own recorded PID** (`Child::kill` + reap — the reap is load-bearing: `InstanceRegistry` probes pid liveness for lease recovery, and an unreaped zombie still answers) with a checkpointed write AND a staged write outstanding. The next boot must come up (the #442 brick class), must serve the graph (the #441 empty class), must keep the checkpointed write — and the staged debounce write **may be lost**, which the test pins as *coherence, not survival*: the recovery lands cleanly on the OLD state. Asserting survival would ship a lie; pinning the loss turns the gate red the day someone narrows the window.

## Proven to bite — and the probes that did NOT, recorded

RED came from a real weakening (deferring the actor's publish decision): both cycles fail with the field's exact brick signature — which is itself a finding: **the two cycles are one property from two premises**; no weakening of publish-on-turn leaves the clean cycle green.

Two probes did NOT bite and are written into the test as the gate's declared blind spots rather than silently dropped: reverting #442's fatal sidecar `?` stays green (this crash never produces that drift), and un-classifying `memorize` stays green (an ingesting verb moves the graph generation regardless — classification is load-bearing only for a verb that dirties a sidecar *alone*, exactly the hole `antibody_create` fell through). The first draft's comment claimed otherwise; corrected to the measured truth.

## Declared out, with reasons in the file

Kill DURING boot (unobservable before `initialize` answers — a timing race dressed as a gate) · kill during the checkpoint write (belongs at the store's own `CheckpointFaultInjector` seam, deterministic and in-process) · Windows (`#![cfg(unix)]` was already the file's posture; the window under test is POSIX-shaped — flock released on death, pid probe, zombie reap) · G4's disk-full/corruption items remain their own line.

Docs in the same commit: the file header now describes both cycles as two halves of one property, and the PATHOS lifecycle front is retitled **BOTH CYCLES LANDED** with the precise remainder named.

## Gates

fmt clean · clippy `-D warnings` clean · `persist_runtime_root` **3/3** (independently re-run) · lib **1466 passed; 0 failed**. Added wall-clock ≈ **+1.3s** (the new test runs in parallel and is simply the new longest pole).
