### PR TITLE
ci: return windows-latest to the required matrix; delete the advisory scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # windows-latest lives in the advisory `rust-gates-windows` job below —
-        # it still runs the full gate and reports its own honest red/green check,
-        # but is deliberately OUT of the `test-status` aggregator so a red Windows
-        # leg (the tracked phase-2 source-edit path-canon debt) does not block
-        # merge. Re-add windows-latest here and delete that job when Windows goes
-        # green. (2026-07-23 — CI throughput was hostage to admin overrides.)
-        os: [ubuntu-latest, macos-latest]
+        # windows-latest is REQUIRED again (2026-07-29). It left on 2026-07-23 as
+        # an advisory job while the phase-2 debt was diagnosed and paid down —
+        # source-edit path-canon (#435), the transplant harness (#436), runnerd
+        # fixtures (#437), cfg(windows)-only clippy (#438, #440), wall-clock
+        # budgets (#444). The flip was made against a fully green advisory run on
+        # main (run 30426528487), not a hopeful one. The scaffold is deleted; if
+        # Windows regresses now, it blocks merge — which is the point.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -67,41 +68,6 @@ jobs:
       # proved nothing tests+clippy don't, at ~half the round's wall-clock, and
       # the signed release pipeline rebuilds --release at tag time anyway. A
       # release-profile-only breakage is now caught on the main push instead.
-      - name: Build the complete release workspace
-        if: github.event_name == 'push'
-        run: cargo build --locked --release --workspace
-
-  # ADVISORY (phase-2, since 2026-07-23): Windows runs the full Rust gate and
-  # reports its own honest check, but is NOT in `test-status.needs`, so its red
-  # (the ~22 source-edit path-canon tests — declared phase-2 debt, diagnosed) no
-  # longer blocks merge. This restores auto-merge; the debt stays visible.
-  rust-gates-windows:
-    name: Rust gates (windows-latest · phase-2 advisory)
-    runs-on: windows-latest
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          components: clippy,rustfmt
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: rust-gates-windows-latest
-      # Mirrors the required gate exactly: no standalone check (clippy subsumes
-      # it), release-profile build on main pushes only.
-      #
-      # `--no-fail-fast` ONLY here, and deliberately. Cargo stops after the first
-      # test binary that fails, so on a leg carrying known debt every fix reveals
-      # the next failure one CI round at a time — the source-edit family masked a
-      # transplant-harness bug, which was in turn masking runnerd's. An advisory
-      # leg exists to MEASURE the debt, so it has to report all of it in one run.
-      # The required gate keeps failing fast.
-      - name: Test every target
-        run: cargo test --locked --workspace --all-targets --no-fail-fast
-      - name: Deny clippy warnings
-        run: cargo clippy --locked --workspace --all-targets -- -D warnings
-      - name: Verify formatting
-        run: cargo fmt --all --check
       - name: Build the complete release workspace
         if: github.event_name == 'push'
         run: cargo build --locked --release --workspace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,14 @@ don't and cost ~half of every 70-minute CI round; the signed release pipeline re
 `--release` at tag time regardless). A release-profile-only breakage is caught on the main
 push — if you suspect one, run `cargo build --release --workspace` locally before merging.
 
-**Windows is ADVISORY (phase-2, since 2026-07-23):** the `rust-gates-windows` job runs the
-identical gate and reports its own honest check, but it is NOT in the required `Test` aggregator
-— a red Windows leg (the ~22 diagnosed source-edit path-canon tests, tracked phase-2 debt) does
-**not** block merge. This restored auto-merge (the whole queue was hostage to admin overrides).
-Still write cross-platform-correct code (the fs/path contract below is real); when Windows goes
-green, re-add `windows-latest` to the matrix and delete the advisory job.
+**Windows is REQUIRED again (since 2026-07-29):** `windows-latest` runs in the same
+`rust-gates` matrix as ubuntu/macos and its red blocks merge. It spent 2026-07-23→29 as an
+advisory job while the phase-2 debt was diagnosed and paid (#435–#440, #444); the flip back was
+made against a fully green advisory run on main, and the scaffold is deleted. The fs/path
+contract below is load-bearing — the whole debt family was path identity and cfg-gated code the
+Unix legs are structurally blind to, so a green local run on macOS proves nothing about your
+`#[cfg(windows)]` branches: mirror-probe them (flip `cfg(unix)`↔`cfg(windows)` locally) when
+you touch one.
 
 UI changes (`m1nd-ui/`) additionally:
 

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -147,11 +147,13 @@ Update this list in the same PR that closes one; a front that dies silently is a
   The lesson worth keeping: **"~22 tests" was a count taken behind fail-fast** — `cargo test` stops at the
   first failing binary, so each fix only revealed the next masked layer. The advisory leg now runs
   `--no-fail-fast`, because a job that exists to MEASURE debt and reports one layer at a time measures
-  nothing. **Remaining flip:** return `windows-latest` to the required matrix and DELETE the
-  `rust-gates-windows` advisory job (added 2026-07-23 as a scaffold) — do it against a green run, not a
-  hopeful one. One latent item still filed, not fixed: `config::workspace_allowed` carries the same
-  verbatim-prefix split `d8668591` fixed in source-edit (fail-closed, so the same input is refused on
-  Windows and allowed on Unix).
+  nothing. **The flip is DONE (2026-07-29):** `windows-latest` is back in the required matrix and the
+  `rust-gates-windows` advisory scaffold is deleted — made against a fully green advisory run on main
+  (run 30426528487, carrying SPEC-1 + the RustCrypto sweep + Cycle B), not a hopeful one. Windows red
+  now blocks merge again, six days after it was demoted for holding the queue hostage — this time with
+  the debt paid instead of overridden. One latent item still filed, not fixed: `config::workspace_allowed`
+  carries the same verbatim-prefix split `d8668591` fixed in source-edit (fail-closed, so the same input
+  is refused on Windows and allowed on Unix).
 - **Genesis P2 and P3** — P1 (medulla-only read fallback so a brainless repo is served doctrine instead of
   blindness) is implemented in PR #403, in the merge queue and NOT yet on main — checkpoint 32's "0 code
   hits" above described the tree before that PR existed, and holds for main until it lands; **P2** (the birth ceremony: `m1nd init` is today only `installSkills`, and the PRD


### PR DESCRIPTION
## The scaffold comes down — against a green run, not a hopeful one

The `rust-gates-windows` advisory job was added 2026-07-23 because a red Windows leg held the merge queue hostage behind per-PR admin overrides. The demotion was honest: the job kept running the identical gate and reporting its own red, and its `--no-fail-fast` measured the debt in one pass instead of a layer per CI round.

Six days later the debt is **paid, not overridden**: source-edit path-canon (#435) · transplant harness (#436) · runnerd fixtures (#437) · cfg(windows)-only clippy (#438, #440) · wall-clock budgets (#444). The latest main advisory run — **30426528487**, carrying SPEC-1, the full RustCrypto sweep and the crash half of the lifecycle gate — is **fully green**.

So: `windows-latest` rejoins the required `rust-gates` matrix (fail-fast like its siblings — `--no-fail-fast` was the advisory leg's measuring instrument, and a required gate is not a measuring instrument), the scaffold is deleted, and a Windows red blocks merge again.

**Swept in the same commit** (the prose IS the interface): `AGENTS.md` — which taught the advisory state and now teaches the mirror-probe discipline for `#[cfg(windows)]` branches — and the PATHOS Windows front, whose "Remaining flip" line becomes "DONE", with the one latent filed item (`config::workspace_allowed`) kept visible.

CI cost note: this adds the Windows leg (~15-17 min, the slowest of the three) back to every PR's required path — the price of it meaning something.