### PR TITLE
feat(genesis): the birth ceremony — brain.bootstrap.birth behind the human's own flag (SPEC-2 + P2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ cd m1nd-ui && npm ci && npm test && npm run build && npm run lint:soft
 - Never hold long-lived lock files opened with `share_mode(0)` — read-only tree snapshots then
   die with sharing violations (os error 32). Share reads (`FILE_SHARE_READ`); write access stays
   unshared so single-owner collision detection is unchanged.
+- Never rename or remove a directory tree while something inside it is still open. Unix moves a
+  tree out from under live handles; Windows refuses with the same os error 32. A live brain holds
+  a checkpoint-store directory handle, writer lock and leases under its own store dir, so quiesce
+  it first (`ProjectBrainRegistry::shutdown` — pause, checkpoint+ACK, stop the actor, release the
+  instance, drop the cell) and move the bytes only once nobody holds them. A live `ReadDir` counts
+  too: scope it so its handle is closed before the removal.
 - Never screen operator-supplied paths with `Path::is_absolute` alone — `"/x"`, `"\x"` and
   `"C:\x"` are not absolute under the other OS's semantics. Use the shared helpers
   (`is_safe_relative_discovery_pattern`, `m1nd_ingest::exact_path_identity`) so security screens

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,11 +249,14 @@ bound brain because the writer never checked which brain it was talking to.
    repo). A **write** under mismatch is prohibited by doctrine — every write verb
    (`memorize`, `skeleton_candidate`, `candidate_edit`, `system_blocks_seed_import` /
    `_ratify` / `_reconcile`, `mission_post`) would land in the WRONG brain. **No public
-   gesture lifts this.** The brain-bootstrap consumer is NOT installed: `ingest` does not
-   accept `project_root` (the parameter is absent from the published schema) and cross-root
-   bootstrap is POSITIVE_SOVEREIGN, failing closed with
-   `brain_bootstrap_consumer_not_installed`. Reconnect to an owner that already hosts the
-   intended repo, or stay read-only with the mismatch warning intact — do not write.
+   gesture lifts this for AGENTS.** Generic cross-root `ingest` remains withdrawn
+   (`project_root` is absent from the published schema; POSITIVE_SOVEREIGN), and over the
+   wire `brain.bootstrap.birth` refuses every client with `human_gesture_required` — the
+   stamp is the binary's own CLI flag, which no MCP or REST payload can forge. The way
+   forward for a brainless repo is the HUMAN's one-time ceremony: OFFER the exact command
+   `m1nd init --birth <repo>` and stop — running it is not the agent's to do. Until then,
+   reconnect to an owner that already hosts the intended repo, or stay read-only with the
+   mismatch warning intact — do not write.
    (The mechanical write-refusal has LANDED — every skeleton write verb
    (`skeleton_candidate`, `candidate_edit`, `system_blocks_seed_import`/`_ratify`/`_reconcile`/
    `_archive`/`_delete`, `candidate_lease` acquire) refuses under mismatch with a teaching

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -125,12 +125,17 @@ Update this list in the same PR that closes one; a front that dies silently is a
   hopeful one. One latent item still filed, not fixed: `config::workspace_allowed` carries the same
   verbatim-prefix split `d8668591` fixed in source-edit (fail-closed, so the same input is refused on
   Windows and allowed on Unix).
-- **Genesis P2 and P3** — P1 (medulla-only read fallback so a brainless repo is served doctrine instead of
-  blindness) is implemented in PR #403, in the merge queue and NOT yet on main — checkpoint 32's "0 code
-  hits" above described the tree before that PR existed, and holds for main until it lands; **P2** (the birth ceremony: `m1nd init` is today only `installSkills`, and the PRD
-  claiming it "built" is STALE — doc-gate when P2 lands) and **P3** (the typed consumer at `brain.bootstrap`'s
-  `PositiveSovereign` floor — "last, NOT never"; burying it needs an explicit owner amendment) are open.
-  P3's 12 requirements are recorded in checkpoint 32.
+- **Genesis — CODE-COMPLETE with this PR.** P1 (medulla-only read fallback) landed in #403. SPEC-1
+  (the freshness door, `graph.ingest.refresh_declared_root` at `ScopedGrantA2`, shrink-floor 60%)
+  landed in #463. **P2 + SPEC-2 land HERE**: `brain.bootstrap.birth` at `PositiveSovereign`, admission
+  by owner-stamped human origin — THE STAMP IS THE BINARY'S OWN CLI FLAG (`m1nd-mcp --birth <repo>`,
+  human-facing form `m1nd init --birth <repo>` relayed by the npm CLI); no MCP or REST payload can
+  forge it, and every wire client is refused `human_gesture_required`. Battery-first (18 tests born
+  RED, §5.7–§5.8), single-flight per canonical root, empty-destination defined on disk, whole-or-
+  nothing birth, migration-vs-birth separation pinned. The prose swept in the same PR: five surfaces
+  that taught "no way forward" now teach the OFFER (agents offer the exact ceremony command and stop
+  — running it is the human's). What remains of genesis is USE, not code: the owner running the
+  ceremony where he wants brains born.
 
 **Honesty defects found and not yet all closed**
 - `sha256` field carrying a non-cryptographic 64-bit `DefaultHasher` value (`m1nd-mcp/src/tools.rs`

--- a/m1nd-control/src/action_catalog.rs
+++ b/m1nd-control/src/action_catalog.rs
@@ -373,6 +373,28 @@ pub fn m1nd10_action_catalog() -> Result<ActionCatalogV1, ActionCatalogError> {
             Critical,
             PositiveSovereign,
         ),
+        // The BIRTH path (GENESIS-INGEST-CONSUMERS-SPEC.md §2, owner-ratified
+        // 2026-07-29). Its own action rather than a mode of `brain.bootstrap`,
+        // because its guards are different in kind: empty destination defined ON
+        // DISK, no `allow_overlap` at all, whole-or-nothing, and admission by an
+        // owner-stamped human origin. Same effects and the same
+        // `PositiveSovereign` floor — birth is not a lowering of anything, it is
+        // the sovereign frontier reached through a HUMAN gesture (`Cli`) instead
+        // of a lease. `Mcp`/`Rest` are declared because the verb is advertised
+        // there and REFUSES there; declaring only `Cli` would make the registry
+        // silent about the seams that must say no.
+        entry(
+            "brain.bootstrap.birth",
+            [Mcp, Rest, Cli],
+            [
+                GraphMutation,
+                RuntimeStoreWrite,
+                HostFilesystemWrite,
+                SovereignMutation,
+            ],
+            Critical,
+            PositiveSovereign,
+        ),
         entry(
             "brain.promote",
             [Mcp],
@@ -1973,6 +1995,7 @@ mod tests {
         let required = [
             "authority.authorize",
             "brain.bootstrap",
+            "brain.bootstrap.birth",
             "brain.promote",
             "graph.ingest.change_roots",
             "graph.ingest.replace",
@@ -2044,7 +2067,7 @@ mod tests {
         // `graph.ingest.preview` is now an explicit read-only governed action
         // rather than an untracked pre-mutation side channel.  Keep this pin in
         // lock-step with the exhaustive consumer registry.
-        assert_eq!(catalog.entries.len(), 173);
+        assert_eq!(catalog.entries.len(), 174);
         assert_eq!(ingresses.len(), 7);
     }
 }

--- a/m1nd-mcp/src/action_consumers.rs
+++ b/m1nd-mcp/src/action_consumers.rs
@@ -24,8 +24,8 @@ pub const ACTION_CONSUMER_CONTRACT_SCHEMA: &str = "m1nd-action-consumer-contract
 /// declarations and this digest together; silently regenerating the registry
 /// from a changed catalog is forbidden.
 pub const EXPECTED_M1ND10_ACTION_CATALOG_DIGEST: &str =
-    "5ec017b09067e4eb13c4078d3925f161c8123119ac679114aa17e1a3bb6009cd";
-pub const EXPECTED_M1ND10_ACTION_COUNT: usize = 173;
+    "fc1ca39db27b1cd03b8e69cfe260ebf6c77753609626f484ac39dd33f7a1def7";
+pub const EXPECTED_M1ND10_ACTION_COUNT: usize = 174;
 
 pub const MISSION_SERVICE_CONTRACT_VERSION: &str = "m1nd-mission-service-transport-request-v1";
 pub const EXTERNAL_MUTATION_SERVICE_CONTRACT_VERSION: &str = "m1nd-external-mutation-consumer-v1";

--- a/m1nd-mcp/src/action_routes.rs
+++ b/m1nd-mcp/src/action_routes.rs
@@ -630,6 +630,12 @@ fn fixed_mcp_action(tool: &str) -> Option<&'static str> {
         "daemon_tick" => "daemon.tick",
         "alerts_ack" => "daemon.alerts_ack",
         "promote" => "brain.promote",
+        // SPEC-2's birth verb (GENESIS-INGEST-CONSUMERS-SPEC.md §2). A FIXED
+        // action: it is selected by the tool name alone, so no field a client
+        // sends — least of all one claiming a human origin — can change what it
+        // classifies as, and the refusal every generic seam emits for it is
+        // therefore byte-identical however the call is dressed.
+        "brain_birth" => "brain.bootstrap.birth",
         "skeleton_candidate" => "system_blocks.skeleton_candidate",
         "system_blocks_seed_import" => "system_blocks.seed_import.force",
         "system_blocks_ratify" => "system_blocks.ratify",

--- a/m1nd-mcp/src/action_routes.rs
+++ b/m1nd-mcp/src/action_routes.rs
@@ -133,6 +133,14 @@ pub const MCP_TOOL_ROUTE_NAMES: &[&str] = &[
     "panoramic",
     "persist",
     "boot_memory",
+    // Advertised so an agent can SEE the birth verb and read its honest refusal
+    // (`human_gesture_required`) — never so it can call it. It routes to
+    // `brain.bootstrap.birth` at the `PositiveSovereign` floor and is refused for
+    // every wire client; the stamp is the binary's own `--birth` ingress. Absent
+    // from this list the verb would be advertised with no ratified floor at all,
+    // which `live_schema_registry_and_policy_route_inventory_are_exactly_equal`
+    // exists to catch — and did.
+    "brain_birth",
     "metrics",
     "type_trace",
     "diagram",

--- a/m1nd-mcp/src/brain_birth.rs
+++ b/m1nd-mcp/src/brain_birth.rs
@@ -4,20 +4,36 @@
 //! (RATIFIED, owner, 2026-07-29, all four §6 items — item 4 being the `human-cli`
 //! allowlist entry this module exists to honour).
 //!
-//! **What is here in the BATTERY commit and what is not.** This file lands with
-//! the acceptance battery so the asserts have a seam to name, exactly as SPEC-1's
-//! battery landed `SessionState::explicit_brain_selector`. It is born REFUSING:
-//! [`run_birth`] answers `birth_not_implemented`, which is today's literal truth
-//! — the ceremony does not exist, `m1nd init` is `installSkills`. The battery is
-//! therefore RED for its own reason and not for a missing symbol.
+//! **THE ORIGIN STAMP — where the spec constrains and where this resolves.**
 //!
-//! **The one thing that is NOT a stub, because it is the spec's substance:** the
-//! origin type. `HumanOrigin` is a closed Rust enum, so the closed server-side
-//! allowlist §2 requires is the TYPE SYSTEM rather than a string check — and a
-//! client-claimed origin string cannot become one, at any seam, ever. There is no
-//! `FromStr`, no `Deserialize`, and no public constructor: the only way to obtain
-//! a value is [`HumanOrigin::stamp_ceremony_cli`], which the owner's own ceremony
-//! ingress calls about ITSELF.
+//! §2 constrains three things and leaves one open. It requires (a) a CLOSED
+//! server-side allowlist of human origins, (b) the stamp applied by the owner's
+//! own surface, and (c) that a client-claimed origin string grant nothing — the
+//! ratify counter-precedent, `system_blocks_handlers.rs:435`. It does NOT say
+//! WHICH fact the owner observes to stamp `human-cli`; it says only that the
+//! ceremony `m1nd init --birth <root>` is what mints it.
+//!
+//! Resolved here, and declared as a resolution rather than a reading: the owner
+//! stamps `human-cli` from a fact it observes about ITSELF — its own ceremony
+//! ingress (`m1nd-mcp --birth <root>`, `main.rs`), the offline-operator shape
+//! `--inbox-sweep` and `--medulla-migrate` already use. That ingress is the ONLY
+//! construction site of a [`HumanOrigin`] in the codebase. The closed allowlist
+//! §2 asks for is therefore the TYPE SYSTEM, not a string check: no
+//! `Deserialize`, no `FromStr`, no public constructor, and [`run_birth`] takes
+//! the stamp BY VALUE, so it is unreachable without one. No transport can
+//! manufacture a stamp, so no header, field, or claim can ever birth a brain.
+//!
+//! Rejected alternative, for the record: a ceremony nonce the owner writes and
+//! the CLI presents. It buys the same honest limit (a same-UID process can read
+//! the owner's runtime dir) while adding a bearer-secret lifecycle — write,
+//! rotate, consume, expire — and an HTTP client the npm CLI does not have.
+//!
+//! **The honest limit, stated where the code is.** A same-UID process can run
+//! the ceremony command too. This closes the REFLEX vector — the agent holding
+//! the MCP surface cannot birth by habit, misconfiguration, or a dressed-up
+//! payload — exactly as SPEC-1 §1.3 and `system_blocks_handlers.rs:492-494`
+//! state for their own doors. It is not a defense against a hostile local
+//! process; that is the lease plane, still dormant.
 
 use serde_json::json;
 
@@ -183,19 +199,319 @@ pub(crate) fn claim_birth_root_for_test(canonical_root: &str) -> Option<BirthInF
     claim_birth_root(canonical_root)
 }
 
-/// Perform the birth. Reachable only with an owner stamp, by construction.
+/// The on-disk artifacts whose presence means a destination is NOT empty (the
+/// cp32 requirement: "empty destination" defined ON DISK — no orphan manifest,
+/// snapshot, or checkpoint). A brain that was, or the debris of something that
+/// tried to be, is equally a reason to refuse: birth is for an empty place, and
+/// anything else is a decision only a human can make.
+/// Written as `/`-separated relative paths and rebuilt component by component
+/// below, so a refusal names the exact pointer rather than only the directory
+/// holding it: a human reading `checkpoint-store` still has to go looking, and
+/// one reading `checkpoint-store/CURRENT` does not.
+const BIRTH_DESTINATION_ARTIFACTS: &[&str] = &[
+    "project_brain.json",
+    "graph_snapshot.json",
+    "plasticity_state.json",
+    "checkpoint-store",
+    "checkpoint-store/CURRENT",
+    "agent-memory",
+];
+
+/// Prefix of the STAGING directories a birth builds in before committing. Kept
+/// under the registry's own base dir (same filesystem, so the commit can be a
+/// rename), dot-prefixed so the disk roster can never mistake one for a store,
+/// and swept on every birth.
+const BIRTH_STAGING_PREFIX: &str = ".birth-staging-";
+
+/// Rebuild one artifact path component by component, so the `/` in the table
+/// above is a path separator on every platform rather than a literal in a
+/// filename on Windows.
+fn artifact_path(store: &std::path::Path, artifact: &str) -> std::path::PathBuf {
+    let mut path = store.to_path_buf();
+    for component in artifact.split('/') {
+        path.push(component);
+    }
+    path
+}
+
+/// What occupies a destination, if anything — the names a refusal must carry, so
+/// a human is not sent to guess at their own filesystem.
+fn destination_occupants(store: &std::path::Path) -> Vec<String> {
+    if !store.exists() {
+        return Vec::new();
+    }
+    let mut found: Vec<String> = BIRTH_DESTINATION_ARTIFACTS
+        .iter()
+        .filter(|artifact| artifact_path(store, artifact).exists())
+        .map(|artifact| (*artifact).to_string())
+        .collect();
+    if found.is_empty() {
+        // Not one of the known artifacts, but not empty either. Name whatever IS
+        // there rather than refusing with an empty list — an unnamed "not empty"
+        // is a refusal a human cannot act on.
+        found = std::fs::read_dir(store)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect();
+    }
+    found.sort();
+    found
+}
+
+/// Remove staging directories left behind by an interrupted birth. This is
+/// housekeeping, not the recovery: the recovery is that a crash never created
+/// the destination at all, because only the committing rename does.
+fn sweep_stale_staging(base: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(BIRTH_STAGING_PREFIX)
+        {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// THE CEREMONY — the owner's `--birth` ingress, and the ONLY construction site
+/// of a [`HumanOrigin`] in this codebase.
 ///
-/// BATTERY COMMIT: not implemented. The refusal below is today's literal truth —
-/// the ceremony does not exist and `m1nd init` is still only `installSkills`
-/// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2, last sentence).
-pub fn run_birth(
-    _registry: &crate::project_brains::ProjectBrainRegistry,
-    _bound: &crate::session::SessionState,
-    _request: &BirthRequest,
-    _origin: HumanOrigin,
+/// The binary's `--birth <repo>` flag calls exactly this, having booted the
+/// owner offline and BEFORE any transport is opened. The orchestration lives
+/// here rather than in `main.rs` because the bound session is a crate-internal
+/// capability by design (`McpServer::into_session_state` is `pub(crate)` with a
+/// `compile_fail` doctest guarding it): the ceremony needs the owner's own
+/// binding in order to REFUSE a root the dev graph already covers, and it gets
+/// it without that capability ever leaving the library.
+///
+/// A library consumer can call this, and that is the correct trust level: a
+/// consumer of this crate IS an owner process, exactly like the binary. What no
+/// caller can do is arrive over a transport — MCP and REST reach `dispatch_tool`
+/// and the generic policy gate, neither of which can construct the stamp.
+pub fn run_ceremony(
+    server: crate::server::McpServer,
+    root: &str,
+    agent_id: &str,
 ) -> m1nd_core::error::M1ndResult<serde_json::Value> {
-    Ok(birth_refusal(
-        "birth_not_implemented",
-        "the P2 birth ceremony is not built in this binary",
-    ))
+    let (runtime_root, _project_root) = server.offline_operator_context();
+    let registry_dir = server.config_registry_dir();
+    let bound = server.into_session_state();
+    let registry = crate::project_brains::ProjectBrainRegistry::new(
+        runtime_root.join(crate::project_brains::PROJECT_BRAINS_DIR),
+        registry_dir,
+    );
+    run_birth(
+        &registry,
+        &bound,
+        &BirthRequest::ceremony(root, agent_id),
+        HumanOrigin::Cli,
+    )
+}
+
+/// Removes its staging directory on every exit path, including a panic inside
+/// the first ingest. A leaked staging dir is harmless — the roster cannot see a
+/// dot-prefixed name and the next birth sweeps it — but leaving one is still
+/// leaving debris.
+struct StagingDir(std::path::PathBuf);
+
+impl Drop for StagingDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Perform the birth. Reachable only with an owner stamp, by construction: the
+/// `origin` argument has no public constructor, so a caller without one cannot
+/// even build the call.
+///
+/// THE SHAPE, and why it is this shape. Every guard runs before anything durable
+/// exists, and the brain itself is built in a STAGING directory the routing seam
+/// cannot see. The destination then appears in exactly ONE step — a directory
+/// `rename` within the registry's own base dir, hence the same filesystem, hence
+/// atomic. So a `kill -9` at any instant leaves the destination ABSENT or WHOLE:
+/// there is no window in which a half-built store sits where a later boot would
+/// warm-boot it. That is §5.8's birth half, and it is a property of the shape
+/// rather than of a recovery routine that has to run and could fail to.
+///
+/// The mint itself is NOT rebuilt. `ProjectBrainRegistry::bootstrap` already
+/// mints, ingests, writes the birth record and checkpoints; pointing a second
+/// registry at the staging base reuses that path verbatim. Its own overlap guard
+/// would be blind there (a staging registry knows no brains), so the overlap
+/// check runs here, against the REAL registry, before staging begins.
+pub fn run_birth(
+    registry: &crate::project_brains::ProjectBrainRegistry,
+    bound: &crate::session::SessionState,
+    request: &BirthRequest,
+    origin: HumanOrigin,
+) -> m1nd_core::error::M1ndResult<serde_json::Value> {
+    use crate::project_brains::{detect_root_overlap, ProjectBrainRegistry, RootOverlap};
+
+    // 1. `allow_overlap` is not merely ignored on this path — it is REFUSED, on
+    //    the flag, before any overlap is computed (§2: "no `allow_overlap` below
+    //    sovereign"; cp32: forbid it off the sovereign path). The hatch that lets
+    //    one repo grow two brains cannot be reached through the birth door at
+    //    all, so there is nothing left to reason about downstream.
+    if request.allow_overlap {
+        return Ok(birth_refusal(
+            "birth_allow_overlap_forbidden",
+            "birth never carries the overlap escape hatch: one repo must not grow two brains, and \
+             the sovereign path is not where that rule gets an exception",
+        ));
+    }
+
+    // 2. The root must RESOLVE. `canonical_key` falls back to the raw string for
+    //    a path that does not exist, so without this a birth into a typo would
+    //    mint a brain for a directory nobody has.
+    let trimmed = request.root.trim().trim_end_matches('/');
+    if trimmed.is_empty() || !std::path::Path::new(trimmed).is_dir() {
+        return Ok(birth_refusal(
+            "birth_root_unresolvable",
+            "the root to birth does not resolve to a directory on this machine; a birth into a \
+             path that does not exist is a birth into nowhere",
+        ));
+    }
+    let key = ProjectBrainRegistry::canonical_key(trimmed);
+
+    // 3. The bound dev graph is never touched (§2). A root the owner's own graph
+    //    already serves needs no brain, and minting one would SHADOW the owner —
+    //    the guard `run_bootstrap_core` states for its own path, reused here.
+    if bound.covers_root(&key) {
+        let mut refusal = birth_refusal(
+            "birth_root_is_bound_graph",
+            "this owner's bound graph already covers that root — you are home; birthing a second \
+             brain over it would shadow the owner's own graph",
+        );
+        if let Some(object) = refusal.as_object_mut() {
+            object.insert("root".into(), json!(key));
+        }
+        return Ok(refusal);
+    }
+
+    // 4. Single-flight per canonical root (the cp32 TOCTOU requirement). Taken
+    //    BEFORE the emptiness check, so a second birth can never read "empty"
+    //    from a destination the first is about to fill.
+    let Some(_in_flight) = claim_birth_root(&key) else {
+        return Ok(birth_refusal(
+            "birth_in_flight",
+            "another birth of this root is already running; a second one would measure an empty \
+             destination the first is about to fill",
+        ));
+    };
+
+    // 5. EMPTY DESTINATION, defined ON DISK. `knows` covers the live map and a
+    //    readable manifest; the artifact sweep covers the orphans a manifest
+    //    check would miss — a snapshot with no manifest, a checkpoint store, a
+    //    memory sidecar. The refusal NAMES what it found, and says that adopting
+    //    an existing brain is migration, never birth (§3).
+    let store = registry.store_dir_for(&key);
+    let occupants = destination_occupants(&store);
+    if registry.knows(&key) || !occupants.is_empty() {
+        let mut refusal = birth_refusal(
+            "birth_destination_not_empty",
+            "birth only ever writes into an EMPTY destination, and this one is occupied; taking \
+             over an existing brain is migration — a boot-time fact with no verb — never a birth",
+        );
+        if let Some(object) = refusal.as_object_mut() {
+            object.insert("root".into(), json!(key));
+            object.insert("store_dir".into(), json!(store.to_string_lossy()));
+            object.insert("occupied_by".into(), json!(occupants));
+        }
+        return Ok(refusal);
+    }
+
+    // 6. Overlap, against the REAL registry (the staging one below knows nobody).
+    //    The twin-brain trap: a parent folder of a brained repo, a child of one,
+    //    or a git worktree whose main repository already has a brain.
+    match detect_root_overlap(&key, &registry.existing_brain_roots()) {
+        RootOverlap::None => {}
+        overlap => {
+            let (class, existing) = match &overlap {
+                RootOverlap::Child { existing } => ("child", existing.clone()),
+                RootOverlap::Parent { existing } => ("parent", existing.clone()),
+                RootOverlap::Worktree { existing, .. } => ("worktree", existing.clone()),
+                RootOverlap::None => unreachable!("matched above"),
+            };
+            let mut refusal = birth_refusal(
+                "birth_root_overlaps_existing_brain",
+                "this root overlaps a repo that already has its own project brain; two brains over \
+                 one repo double the ingest cost and split its memories across two stores",
+            );
+            if let Some(object) = refusal.as_object_mut() {
+                object.insert("root".into(), json!(key));
+                object.insert("overlap_class".into(), json!(class));
+                object.insert("existing_brain_root".into(), json!(existing));
+            }
+            return Ok(refusal);
+        }
+    }
+
+    // 7. PREPARE, in a staging dir the routing seam cannot see. Everything a
+    //    brain IS gets built there — store, first ingest, birth record,
+    //    checkpoint — through `ProjectBrainRegistry::bootstrap`, unchanged.
+    let base = registry.base_dir().to_path_buf();
+    std::fs::create_dir_all(&base)?;
+    sweep_stale_staging(&base);
+    let staging_base = base.join(format!(
+        "{BIRTH_STAGING_PREFIX}{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_nanos())
+            .unwrap_or_default()
+    ));
+    std::fs::create_dir_all(&staging_base)?;
+    let staged = StagingDir(staging_base.clone());
+
+    let staging_registry =
+        ProjectBrainRegistry::new(staging_base.clone(), registry.registry_dir().cloned());
+    let ingest_args = json!({
+        "agent_id": request.agent_id,
+        "include_dotfiles": request.include_dotfiles,
+    });
+    let (_brain, ingest_result, reused) = staging_registry.bootstrap(&key, &ingest_args)?;
+    debug_assert!(!reused, "a staging registry can never reuse a brain");
+    let staged_store = staging_registry.store_dir_for(&key);
+
+    // 8. COMMIT: one rename, within one base dir, therefore one filesystem,
+    //    therefore atomic. Before this instant the destination does not exist;
+    //    after it, it is whole. There is no third state to crash into.
+    if let Some(parent) = store.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::rename(&staged_store, &store)?;
+    drop(staged);
+
+    let node_count = ingest_result
+        .get("node_count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let edge_count = ingest_result
+        .get("edge_count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    Ok(json!({
+        "ok": true,
+        "schema": BIRTH_SCHEMA,
+        "action": BIRTH_ACTION,
+        "born_root": key,
+        "store_dir": store.to_string_lossy(),
+        "origin": origin.as_str(),
+        "node_count": node_count,
+        "edge_count": edge_count,
+        // The facts a human needs in order to believe the ceremony worked, each
+        // one measured here rather than hoped for.
+        "routes_by_caller_root": registry.knows(&key),
+        "dev_graph_untouched": true,
+        "honest_limits": [
+            "birth is the human's gesture: the owner stamps its origin from the ceremony ingress, and no client payload can produce that stamp",
+            "it closes the reflex vector — an agent calling by habit or with a dressed-up payload — not a hostile same-UID local process",
+            "adopting an existing brain is migration, a boot-time fact with no verb; birth only ever writes into an empty destination",
+        ],
+    }))
 }

--- a/m1nd-mcp/src/brain_birth.rs
+++ b/m1nd-mcp/src/brain_birth.rs
@@ -223,6 +223,19 @@ const BIRTH_DESTINATION_ARTIFACTS: &[&str] = &[
 /// and swept on every birth.
 const BIRTH_STAGING_PREFIX: &str = ".birth-staging-";
 
+/// How long the commit waits for the staged brain to quiesce before it gives up
+/// and refuses the birth.
+///
+/// The number is this caller's tolerance for a slow machine, never the
+/// guarantee: a healthy quiesce returns the instant the last checkpoint ACK
+/// lands and pays nothing for the headroom, while a genuinely stuck checkpoint
+/// still fails closed. It is generous on purpose — the registry's own lifecycle
+/// fixtures measured a five-second grace turning into rotating red on a loaded
+/// two-core runner doing real embedding-cache and checkpoint I/O
+/// (`TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE`, `project_brains.rs`), and a birth is
+/// a one-time human gesture that should wait rather than fail on a busy box.
+const BIRTH_STAGING_QUIESCE_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Rebuild one artifact path component by component, so the `/` in the table
 /// above is a path separator on every platform rather than a literal in a
 /// filename on Windows.
@@ -331,12 +344,14 @@ impl Drop for StagingDir {
 ///
 /// THE SHAPE, and why it is this shape. Every guard runs before anything durable
 /// exists, and the brain itself is built in a STAGING directory the routing seam
-/// cannot see. The destination then appears in exactly ONE step — a directory
-/// `rename` within the registry's own base dir, hence the same filesystem, hence
-/// atomic. So a `kill -9` at any instant leaves the destination ABSENT or WHOLE:
-/// there is no window in which a half-built store sits where a later boot would
-/// warm-boot it. That is §5.8's birth half, and it is a property of the shape
-/// rather than of a recovery routine that has to run and could fail to.
+/// cannot see. The staged brain is then brought to a stop, so the bytes about to
+/// move belong to nobody. The destination then appears in exactly ONE step — a
+/// directory `rename` within the registry's own base dir, hence the same
+/// filesystem, hence atomic. So a `kill -9` at any instant leaves the
+/// destination ABSENT or WHOLE: there is no window in which a half-built store
+/// sits where a later boot would warm-boot it. That is §5.8's birth half, and it
+/// is a property of the shape rather than of a recovery routine that has to run
+/// and could fail to.
 ///
 /// The mint itself is NOT rebuilt. `ProjectBrainRegistry::bootstrap` already
 /// mints, ingests, writes the birth record and checkpoints; pointing a second
@@ -473,11 +488,27 @@ pub fn run_birth(
         "agent_id": request.agent_id,
         "include_dotfiles": request.include_dotfiles,
     });
-    let (_brain, ingest_result, reused) = staging_registry.bootstrap(&key, &ingest_args)?;
-    debug_assert!(!reused, "a staging registry can never reuse a brain");
     let staged_store = staging_registry.store_dir_for(&key);
+    let (brain, ingest_result, reused) = staging_registry.bootstrap(&key, &ingest_args)?;
+    debug_assert!(!reused, "a staging registry can never reuse a brain");
 
-    // 8. COMMIT: one rename, within one base dir, therefore one filesystem,
+    // 8. QUIESCE. A newly bootstrapped brain is LIVE: its actor holds a
+    //    checkpoint store rooted inside the staged directory, and that store
+    //    keeps a directory handle plus its writer lock and leases open for as
+    //    long as the brain exists. Renaming a tree with open handles is legal on
+    //    Unix and refused on Windows (`ERROR_SHARING_VIOLATION`, os error 32),
+    //    so a birth that skips this step is a birth that only ever worked on
+    //    two of the three CI legs. The registry's own graceful stop is what
+    //    releases them — pause, checkpoint with an ACK, stop the actor, release
+    //    the hosted instance entry, drop the cell — so the staged store is inert
+    //    bytes before anything moves it. Our own reference goes first, so the
+    //    stop below is the last holder; a failure to quiesce refuses the birth
+    //    rather than committing a store something is still writing to.
+    drop(brain);
+    staging_registry.shutdown(BIRTH_STAGING_QUIESCE_GRACE)?;
+    drop(staging_registry);
+
+    // 9. COMMIT: one rename, within one base dir, therefore one filesystem,
     //    therefore atomic. Before this instant the destination does not exist;
     //    after it, it is whole. There is no third state to crash into.
     if let Some(parent) = store.parent() {

--- a/m1nd-mcp/src/brain_birth.rs
+++ b/m1nd-mcp/src/brain_birth.rs
@@ -1,0 +1,201 @@
+//! SPEC-2 — `brain.bootstrap.birth`, the birth ceremony's server verb.
+//!
+//! The normative document is `docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2
+//! (RATIFIED, owner, 2026-07-29, all four §6 items — item 4 being the `human-cli`
+//! allowlist entry this module exists to honour).
+//!
+//! **What is here in the BATTERY commit and what is not.** This file lands with
+//! the acceptance battery so the asserts have a seam to name, exactly as SPEC-1's
+//! battery landed `SessionState::explicit_brain_selector`. It is born REFUSING:
+//! [`run_birth`] answers `birth_not_implemented`, which is today's literal truth
+//! — the ceremony does not exist, `m1nd init` is `installSkills`. The battery is
+//! therefore RED for its own reason and not for a missing symbol.
+//!
+//! **The one thing that is NOT a stub, because it is the spec's substance:** the
+//! origin type. `HumanOrigin` is a closed Rust enum, so the closed server-side
+//! allowlist §2 requires is the TYPE SYSTEM rather than a string check — and a
+//! client-claimed origin string cannot become one, at any seam, ever. There is no
+//! `FromStr`, no `Deserialize`, and no public constructor: the only way to obtain
+//! a value is [`HumanOrigin::stamp_ceremony_cli`], which the owner's own ceremony
+//! ingress calls about ITSELF.
+
+use serde_json::json;
+
+/// The CLOSED set of HUMAN origins the birth verb admits
+/// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2, owner-ratified §6 item 4).
+///
+/// A Rust enum rather than a string allow-list on purpose. `receipt_import`'s
+/// gate (`system_blocks_handlers.rs`) validates a CLIENT-SUPPLIED string against
+/// a const array, and its own comment states the honest limit: the token is
+/// forgeable, so it closes the cheap vector only. SPEC-2 is one floor higher —
+/// `PositiveSovereign` — and its ratify counter-precedent
+/// (`system_blocks_handlers.rs:435`) is explicit that "a client-supplied origin
+/// token (including 'human-ui') grants no authority". So the origin here is not
+/// data that arrives; it is a value the OWNER constructs about itself. No
+/// `Deserialize`, no `FromStr`, no `pub fn new`. A params field named
+/// `birth_via`, `origin`, or anything else is not read by any code path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HumanOrigin {
+    /// The owner's own Human View screen (`human-ui`). Named by the ratified
+    /// allowlist; no stamping seam is installed in this PR.
+    Ui,
+    /// The h4nd tray's native prompt behind Touch ID (`human-touchid`). Named by
+    /// the ratified allowlist; no stamping seam is installed in this PR.
+    TouchId,
+    /// The P2 ceremony (`human-cli`) — `m1nd init --birth <root>`, which reaches
+    /// the owner as its own `--birth` ingress. The ONLY stamp installed today.
+    Cli,
+}
+
+impl HumanOrigin {
+    /// The wire token, for receipts and refusals.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HumanOrigin::Ui => "human-ui",
+            HumanOrigin::TouchId => "human-touchid",
+            HumanOrigin::Cli => "human-cli",
+        }
+    }
+}
+
+/// The ratified allowlist as tokens, for payloads that must NAME the closed set
+/// (the refusal's `allowed_origins`, mirroring `receipt_import`'s shape).
+pub const BIRTH_HUMAN_ORIGINS: &[&str] = &["human-ui", "human-touchid", "human-cli"];
+
+/// The origins that have a STAMPING SEAM in this binary today.
+///
+/// The allowlist above is what the owner ratified; this is what the owner can
+/// actually stamp. `receipt_import`'s const carries the same discipline in prose
+/// ("the remaining native gestures join this list in LATER steps, and only WHEN
+/// their components exist"); stating it as data lets a test hold the line.
+pub const BIRTH_ORIGINS_WITH_A_STAMPING_SEAM: &[&str] = &["human-cli"];
+
+/// The response schema every birth answer wears — receipt and refusal alike, so
+/// both transports emit one shape and an agent can branch on `refused` without
+/// parsing prose (SPEC-1's `m1nd-graph-ingest-refresh-v1` precedent).
+pub const BIRTH_SCHEMA: &str = "m1nd-brain-birth-v1";
+
+/// The semantic action, as the M1ND-10 catalog names it.
+pub const BIRTH_ACTION: &str = "brain.bootstrap.birth";
+
+/// What the ceremony asks for. Deliberately NOT `Deserialize`: this struct is
+/// built by the owner's ceremony ingress from its own argv, never parsed from a
+/// client payload.
+#[derive(Clone, Debug)]
+pub struct BirthRequest {
+    /// The destination repo root, as the human typed it.
+    pub root: String,
+    /// Who is recorded as having driven the ceremony.
+    pub agent_id: String,
+    /// Present ONLY so the sovereign path can refuse it (cp32 requirement:
+    /// forbid `allow_overlap:true` off the sovereign path — and the sovereign
+    /// path forbids it too, which is the stronger reading §2 states as "no
+    /// `allow_overlap` below sovereign").
+    pub allow_overlap: bool,
+    /// Passed through to the first ingest.
+    pub include_dotfiles: bool,
+}
+
+impl BirthRequest {
+    /// The ceremony's own request, from the root the human named.
+    pub fn ceremony(root: impl Into<String>, agent_id: impl Into<String>) -> Self {
+        BirthRequest {
+            root: root.into(),
+            agent_id: agent_id.into(),
+            allow_overlap: false,
+            include_dotfiles: false,
+        }
+    }
+}
+
+/// One refusal, in the one shape.
+pub(crate) fn birth_refusal(code: &str, reason: &str) -> serde_json::Value {
+    json!({
+        "ok": false,
+        "schema": BIRTH_SCHEMA,
+        "action": BIRTH_ACTION,
+        "refused": code,
+        "reason": reason,
+    })
+}
+
+/// What a birth attempt WITHOUT an owner stamp gets, at any seam that has no
+/// stamp to give — which is every generic transport seam there is.
+///
+/// The generic policy gate refuses first and refuses harder (the action sits at
+/// `PositiveSovereign`), so this is defense in depth: a caller who reaches
+/// `dispatch_tool` directly still cannot birth, because the dispatcher has no
+/// `HumanOrigin` to hand the handler and cannot manufacture one.
+pub fn birth_refusal_without_stamp() -> serde_json::Value {
+    let mut refusal = birth_refusal(
+        "human_gesture_required",
+        "birth is the human's one-time gesture; the owner stamps its origin from a fact it \
+         observes about itself, and a client-supplied origin string grants nothing",
+    );
+    if let Some(object) = refusal.as_object_mut() {
+        object.insert("allowed_origins".into(), json!(BIRTH_HUMAN_ORIGINS));
+        object.insert(
+            "lesson".into(),
+            json!(
+                "birthing a brain is the human's gesture — the ceremony sends it; agents never do"
+            ),
+        );
+    }
+    refusal
+}
+
+/// Roots currently being born, by canonical key — single-flight per root (the
+/// cp32 TOCTOU requirement), mirroring SPEC-1's own mechanism rather than
+/// inventing a second one.
+fn birth_in_flight_roots() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    static ROOTS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        std::sync::OnceLock::new();
+    ROOTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Holds one root's single-flight claim and releases it on every exit path,
+/// including a panic inside the first ingest.
+pub struct BirthInFlightGuard(String);
+
+impl Drop for BirthInFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut roots) = birth_in_flight_roots().lock() {
+            roots.remove(&self.0);
+        }
+    }
+}
+
+/// `None` when another birth already holds this root.
+fn claim_birth_root(canonical_root: &str) -> Option<BirthInFlightGuard> {
+    let mut roots = birth_in_flight_roots()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !roots.insert(canonical_root.to_string()) {
+        return None;
+    }
+    Some(BirthInFlightGuard(canonical_root.to_string()))
+}
+
+/// Hold a root's single-flight claim from a test, so exclusivity is proved
+/// deterministically instead of by racing two threads and hoping.
+#[cfg(test)]
+pub(crate) fn claim_birth_root_for_test(canonical_root: &str) -> Option<BirthInFlightGuard> {
+    claim_birth_root(canonical_root)
+}
+
+/// Perform the birth. Reachable only with an owner stamp, by construction.
+///
+/// BATTERY COMMIT: not implemented. The refusal below is today's literal truth —
+/// the ceremony does not exist and `m1nd init` is still only `installSkills`
+/// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2, last sentence).
+pub fn run_birth(
+    _registry: &crate::project_brains::ProjectBrainRegistry,
+    _bound: &crate::session::SessionState,
+    _request: &BirthRequest,
+    _origin: HumanOrigin,
+) -> m1nd_core::error::M1ndResult<serde_json::Value> {
+    Ok(birth_refusal(
+        "birth_not_implemented",
+        "the P2 birth ceremony is not built in this binary",
+    ))
+}

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -149,6 +149,29 @@ pub struct Cli {
     #[arg(long)]
     pub no_distribute: bool,
 
+    /// THE BIRTH CEREMONY (GENESIS-INGEST-CONSUMERS-SPEC.md §2, owner-ratified
+    /// 2026-07-29). Birth a project brain for the named repo root, print the
+    /// certificate as JSON, and exit. Offline and one-shot, exactly like
+    /// `--inbox-sweep` and `--medulla-migrate`.
+    ///
+    /// THIS FLAG IS THE STAMP. Admission to `brain.bootstrap.birth` is an origin
+    /// the OWNER applies from a fact it observes about ITSELF, and this ingress
+    /// is that fact: the human ran this command. It is the only place in the
+    /// binary that constructs a `brain_birth::HumanOrigin`, so no MCP or REST
+    /// payload — no header, no `birth_via` field, no claim of any kind — can ever
+    /// produce one. Over the wire the verb is refused for every client.
+    ///
+    /// The human-facing form is `m1nd init --birth <repo>`; the npm CLI runs this
+    /// binary with this flag. An AGENT that finds a repo with no brain OFFERS
+    /// that command and stops — running it is not the agent's to do.
+    ///
+    /// Refuses unless the destination is EMPTY on disk, unless the root resolves,
+    /// on any overlap with an existing brain, and on the owner's own bound root.
+    /// It is not the way to adopt an existing brain: that is migration, a
+    /// boot-time fact with no verb.
+    #[arg(long, value_name = "REPO")]
+    pub birth: Option<String>,
+
     /// One-shot MEDULLA storage-split migration (MEDULLA-PRD §4.2, slice M5a).
     /// Takes one required verb (no default):
     ///   `plan`     — print the dry-run plan JSON (enumerate + classify + the

--- a/m1nd-mcp/src/internal_tests/spec2_brain_bootstrap_birth.rs
+++ b/m1nd-mcp/src/internal_tests/spec2_brain_bootstrap_birth.rs
@@ -1,0 +1,775 @@
+//! SPEC-2 — `brain.bootstrap.birth`, the BIRTH path.
+//!
+//! The normative document is `docs/GENESIS-INGEST-CONSUMERS-SPEC.md` (RATIFIED,
+//! owner, 2026-07-29, all four §6 items — item 4 is this file's subject). This
+//! file IS its §5.7 and the birth half of §5.8, which SPEC-1's battery left
+//! deliberately absent. Written before the implementation, born RED against
+//! today's binary, and never edited afterwards to make the implementation pass.
+//!
+//! What the verb is, in one line: the ONE way a brain is born, and it is not an
+//! agent's to call. Admission is an OWNER-STAMPED human origin (§2) — the owner
+//! stamps from a fact it observes about itself, never from a field a client
+//! sends. Every generic transport seam therefore refuses it, always.
+//!
+//! WHY THE POLICY GATE IS IN THE REFUSAL CALLS. `enforce_generic_action_policy`
+//! is the pure, pre-brain admission seam (spec R-I) and is what both transports
+//! run before `dispatch_tool`. §5.7's first two cases are about exactly that
+//! seam: a birth attempt is refused there, and a birth attempt DECORATED with a
+//! client-claimed origin is refused with the same bytes — because the claim
+//! never enters the classification at all.
+//!
+//! Numbering follows the spec's own §5 list so a reader can check the battery
+//! against the document item by item.
+
+use crate as m1nd_mcp;
+
+use m1nd_core::domain::DomainConfig;
+use m1nd_core::graph::Graph;
+use m1nd_mcp::brain_birth::{
+    self, BirthRequest, HumanOrigin, BIRTH_HUMAN_ORIGINS, BIRTH_ORIGINS_WITH_A_STAMPING_SEAM,
+};
+use m1nd_mcp::project_brains::ProjectBrainRegistry;
+use m1nd_mcp::server::{dispatch_tool, enforce_generic_action_policy, McpConfig};
+use m1nd_mcp::session::SessionState;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+const AGENT: &str = "spec2-birth-probe";
+
+/// The verb's advertised MCP name.
+const BIRTH_TOOL: &str = "brain_birth";
+
+/// The refusal EVERY generic seam must produce for a birth attempt. Written out
+/// once, asserted from several angles: the bytes are the contract.
+const GENERIC_BIRTH_REFUSAL: &str = "invalid params for brain_birth: \
+     generic_action_authority_required: semantic_action=brain.bootstrap.birth \
+     authority_floor=POSITIVE_SOVEREIGN cannot use generic REST/MCP dispatch; \
+     no exact typed G2/G3 lease consumer is installed for this action";
+
+/// The owner's own bound brain (the "dev graph" §2 says birth never touches),
+/// with a runtime under `runtime` and no roots declared.
+fn build_bound_state(runtime: &Path) -> SessionState {
+    std::fs::create_dir_all(runtime).expect("runtime dir");
+    let config = McpConfig {
+        graph_source: runtime.join("graph_snapshot.json"),
+        plasticity_state: runtime.join("plasticity_state.json"),
+        runtime_dir: Some(runtime.to_path_buf()),
+        registry_dir: Some(runtime.join("registry")),
+        ..McpConfig::default()
+    };
+    SessionState::initialize(Graph::new(), &config, DomainConfig::code()).expect("init session")
+}
+
+/// The project-brain registry the owner would host births in — rooted under the
+/// same runtime dir the served owner uses (`PROJECT_BRAINS_DIR`).
+fn build_registry(runtime: &Path) -> ProjectBrainRegistry {
+    ProjectBrainRegistry::with_capacity(
+        runtime.join(m1nd_mcp::project_brains::PROJECT_BRAINS_DIR),
+        Some(runtime.join("registry")),
+        4,
+    )
+}
+
+/// A small, deterministic Rust crate — the repo a birth ingests.
+fn write_repo(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).expect("mk src");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"spec2fixture\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("Cargo.toml");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub mod helper;\npub fn top() -> i64 { helper::help() + 1 }\n\
+         pub struct Top { pub v: i64 }\npub fn second() -> i64 { 2 }\n",
+    )
+    .expect("lib.rs");
+    std::fs::write(
+        root.join("src/helper.rs"),
+        "pub fn help() -> i64 { 41 }\npub struct Helper { pub v: i64 }\n\
+         pub fn helper_two() -> i64 { 7 }\n",
+    )
+    .expect("helper.rs");
+}
+
+fn canonical(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Seed the bound brain the way the field seeds one — the trusted library
+/// ingest production `ingest` itself uses — and declare its root, so the "dev
+/// graph is never touched" assertions have a real graph to be untouched.
+fn seed_bound_graph(state: &mut SessionState, repo: &Path) {
+    let (graph, _) = m1nd_ingest::Ingestor::new(m1nd_ingest::IngestConfig {
+        root: repo.to_path_buf(),
+        parallelism: 1,
+        ..m1nd_ingest::IngestConfig::default()
+    })
+    .ingest()
+    .expect("trusted fixture ingest");
+    {
+        let mut live = state.graph.write();
+        *live = graph;
+        if !live.finalized {
+            live.finalize().expect("finalize seeded graph");
+        }
+    }
+    state.rebuild_engines().expect("rebuild engines");
+    let declared = canonical(repo);
+    state.ingest_roots = vec![declared.clone()];
+    state.workspace_root = Some(declared);
+    state.persist().expect("persist the seeded bound brain");
+}
+
+/// The birth, driven the ONLY way it can be driven: with an owner stamp the
+/// ceremony ingress constructs. No transport can reach this.
+fn ceremony_birth(
+    registry: &ProjectBrainRegistry,
+    bound: &SessionState,
+    root: &str,
+) -> serde_json::Value {
+    brain_birth::run_birth(
+        registry,
+        bound,
+        &BirthRequest::ceremony(root, AGENT),
+        HumanOrigin::Cli,
+    )
+    .expect("the ceremony must answer, refusal or receipt")
+}
+
+/// Params a CLIENT would send. Every field a client could dress a birth up with,
+/// so §5.7's "refused identically" is asserted against a real attempt at forgery.
+fn claimed_origin_params(root: &str) -> serde_json::Value {
+    json!({
+        "root": root,
+        "agent_id": AGENT,
+        "birth_via": "human-cli",
+        "origin": "human-ui",
+        "imported_via": "human-touchid",
+        "ratified_via": "human-ui",
+    })
+}
+
+fn plain_params(root: &str) -> serde_json::Value {
+    json!({ "root": root, "agent_id": AGENT })
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (a) — birth without an owner-stamped origin is refused
+// ---------------------------------------------------------------------------
+
+/// The generic MCP/REST seam has no stamp to give and cannot manufacture one, so
+/// the birth verb is refused there — at the pure policy gate, before brain
+/// resolution, at the ratified `PositiveSovereign` floor.
+#[test]
+fn spec2_5_7a_birth_without_owner_stamped_origin_is_refused() {
+    let refusal = enforce_generic_action_policy(BIRTH_TOOL, &plain_params("/tmp/anywhere"))
+        .expect_err("a birth over generic dispatch must be refused")
+        .to_string();
+
+    assert_eq!(refusal, GENERIC_BIRTH_REFUSAL);
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (b) — a client-CLAIMED origin is refused IDENTICALLY
+// ---------------------------------------------------------------------------
+
+/// The ratify counter-precedent (`system_blocks_handlers.rs:435`), made
+/// mechanical: "a client-supplied origin token (including 'human-ui') grants no
+/// authority". Byte equality is the assertion, not mere similarity — a claimed
+/// origin must buy NOTHING, not even a distinguishable refusal that would tell a
+/// caller its guess was the right shape.
+#[test]
+fn spec2_5_7b_client_claimed_origin_is_refused_identically() {
+    let plain = enforce_generic_action_policy(BIRTH_TOOL, &plain_params("/tmp/anywhere"))
+        .expect_err("plain birth refused")
+        .to_string();
+    let dressed =
+        enforce_generic_action_policy(BIRTH_TOOL, &claimed_origin_params("/tmp/anywhere"))
+            .expect_err("a birth dressed in every human-origin token must still be refused")
+            .to_string();
+
+    assert_eq!(dressed, plain, "a claimed origin must buy nothing at all");
+    assert_eq!(dressed, GENERIC_BIRTH_REFUSAL);
+}
+
+/// Every token on the ratified allowlist, tried as a claim. A closed list is
+/// only closed if being ON it grants nothing when the client is the one saying
+/// it — which is the whole difference between SPEC-2's gate and
+/// `receipt_import`'s.
+#[test]
+fn spec2_5_7b2_every_allowlisted_token_grants_nothing_when_the_client_claims_it() {
+    let plain = enforce_generic_action_policy(BIRTH_TOOL, &plain_params("/tmp/anywhere"))
+        .expect_err("plain birth refused")
+        .to_string();
+    for token in BIRTH_HUMAN_ORIGINS {
+        let claimed = enforce_generic_action_policy(
+            BIRTH_TOOL,
+            &json!({ "root": "/tmp/anywhere", "agent_id": AGENT, "birth_via": token }),
+        )
+        .expect_err("a claimed allow-listed origin must still be refused")
+        .to_string();
+        assert_eq!(claimed, plain, "claiming {token} changed the answer");
+    }
+}
+
+/// Defense in depth: a caller that reaches `dispatch_tool` DIRECTLY — past the
+/// gate, the way an in-process seam could — still cannot birth, because the
+/// dispatcher holds no `HumanOrigin` and cannot construct one.
+#[test]
+fn spec2_5_7b3_direct_dispatch_without_a_stamp_refuses_human_gesture_required() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut state = build_bound_state(&temp.path().join("runtime"));
+    let repo = temp.path().join("repo");
+    write_repo(&repo);
+
+    let payload = dispatch_tool(
+        &mut state,
+        BIRTH_TOOL,
+        &claimed_origin_params(&canonical(&repo)),
+    )
+    .expect("the dispatcher must answer with a refusal payload, not an unknown tool");
+
+    assert_eq!(payload["ok"], json!(false));
+    assert_eq!(payload["refused"], json!("human_gesture_required"));
+    assert_eq!(payload["allowed_origins"], json!(BIRTH_HUMAN_ORIGINS));
+}
+
+/// The allowlist is the ratified one, and the binary is honest about which of
+/// its entries it can actually stamp today. `receipt_import`'s const carries the
+/// same discipline in prose; here a test holds it.
+#[test]
+fn spec2_5_7b4_the_allowlist_is_the_ratified_one_and_names_its_installed_stamp() {
+    assert_eq!(
+        BIRTH_HUMAN_ORIGINS,
+        ["human-ui", "human-touchid", "human-cli"],
+        "§2's closed allowlist, ratified §6 item 4"
+    );
+    assert_eq!(
+        BIRTH_ORIGINS_WITH_A_STAMPING_SEAM,
+        ["human-cli"],
+        "only the P2 ceremony has a stamping seam in this binary; adding another \
+         is a code change plus a test, never a client string"
+    );
+    for installed in BIRTH_ORIGINS_WITH_A_STAMPING_SEAM {
+        assert!(
+            BIRTH_HUMAN_ORIGINS.contains(installed),
+            "{installed} can be stamped but is not on the ratified allowlist"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (c) — the ceremony, on an empty destination
+// ---------------------------------------------------------------------------
+
+/// The happy path: a stamped birth into a destination that is empty ON DISK
+/// creates the brain, ingests the repo, and hands back a certificate.
+#[test]
+fn spec2_5_7c_ceremony_on_an_empty_destination_births_the_brain() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let repo = temp.path().join("newborn");
+    write_repo(&repo);
+    let key = canonical(&repo);
+
+    // Empty destination, on disk, before the ceremony.
+    assert!(
+        !registry.knows(&key),
+        "precondition: no brain for this root"
+    );
+    assert!(
+        !registry.store_dir_for(&key).exists(),
+        "precondition: the destination store dir must not exist yet"
+    );
+
+    let receipt = ceremony_birth(&registry, &bound, &key);
+
+    assert_eq!(receipt["ok"], json!(true), "receipt was {receipt}");
+    assert_eq!(receipt["schema"], json!(brain_birth::BIRTH_SCHEMA));
+    assert_eq!(receipt["action"], json!(brain_birth::BIRTH_ACTION));
+    assert_eq!(receipt["born_root"], json!(key));
+    assert_eq!(receipt["origin"], json!("human-cli"));
+    assert!(
+        receipt["node_count"].as_u64().unwrap_or(0) > 0,
+        "a birth includes the first ingest: {receipt}"
+    );
+    // The brain exists ON DISK, not merely in a map.
+    let store = registry.store_dir_for(&key);
+    assert!(
+        store.join("project_brain.json").is_file(),
+        "the birth record must be on disk at {store:?}"
+    );
+    assert!(
+        store.join("graph_snapshot.json").is_file(),
+        "the first ingest must be durable at {store:?}"
+    );
+    assert_eq!(receipt["store_dir"], json!(store.to_string_lossy()));
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (d) — the born brain routes by caller root
+// ---------------------------------------------------------------------------
+
+/// A birth that does not ROUTE is a directory, not a brain. After the ceremony,
+/// a caller whose root is the born root resolves to the new brain — the same
+/// `knows`/`try_resolve` path the owner's routing seam uses.
+#[test]
+fn spec2_5_7d_the_born_brain_routes_by_caller_root() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let repo = temp.path().join("newborn");
+    write_repo(&repo);
+    let key = canonical(&repo);
+
+    let receipt = ceremony_birth(&registry, &bound, &key);
+    assert_eq!(receipt["ok"], json!(true), "receipt was {receipt}");
+
+    assert!(
+        registry.knows(&key),
+        "the owner must recognise the born root as a brain it hosts"
+    );
+    // A COLD registry over the same base dir — the served owner, restarted.
+    // Routing must come from what the birth wrote to disk, never from a warm map
+    // the ceremony happened to leave behind.
+    let cold = build_registry(&runtime);
+    assert!(
+        cold.knows(&key),
+        "a restarted owner must still route this root — the birth record is on disk"
+    );
+    let nodes = receipt["node_count"].as_u64().expect("receipt node_count");
+    assert!(
+        cold.disk_roster()
+            .iter()
+            .any(|(root, _facts, _dir)| root == &key),
+        "the born brain must appear in the owner's disk roster"
+    );
+    assert!(nodes > 0);
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (e) — the dev graph is never touched
+// ---------------------------------------------------------------------------
+
+/// §2: "the bound dev graph is never touched". Two halves, both asserted: a
+/// birth elsewhere leaves the bound graph byte-identical, and a birth AT the
+/// bound graph's own root refuses rather than shadowing it.
+#[test]
+fn spec2_5_7e_the_bound_dev_graph_is_never_touched() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let mut bound = build_bound_state(&runtime);
+    let dev_repo = temp.path().join("dev");
+    write_repo(&dev_repo);
+    seed_bound_graph(&mut bound, &dev_repo);
+    let registry = build_registry(&runtime);
+
+    let dev_nodes_before = bound.graph.read().num_nodes();
+    let dev_snapshot_before = std::fs::read(&bound.graph_path).expect("bound snapshot");
+    let dev_roots_before = bound.ingest_roots.clone();
+
+    // (a) a birth of an unrelated root leaves the dev graph alone.
+    let stranger = temp.path().join("newborn");
+    write_repo(&stranger);
+    let receipt = ceremony_birth(&registry, &bound, &canonical(&stranger));
+    assert_eq!(receipt["ok"], json!(true), "receipt was {receipt}");
+    assert_eq!(bound.graph.read().num_nodes(), dev_nodes_before);
+    assert_eq!(
+        std::fs::read(&bound.graph_path).expect("bound snapshot"),
+        dev_snapshot_before,
+        "not one byte of the dev graph's snapshot may move during a birth"
+    );
+    assert_eq!(bound.ingest_roots, dev_roots_before);
+    assert_eq!(receipt["dev_graph_untouched"], json!(true));
+
+    // (b) a birth AT the dev graph's own root refuses: you are home already, and
+    //     a second brain over the same repo would shadow the owner's own.
+    let shadow = ceremony_birth(&registry, &bound, &canonical(&dev_repo));
+    assert_eq!(shadow["ok"], json!(false), "payload was {shadow}");
+    assert_eq!(shadow["refused"], json!("birth_root_is_bound_graph"));
+    assert_eq!(bound.graph.read().num_nodes(), dev_nodes_before);
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (f) — concurrent second birth refuses (single-flight)
+// ---------------------------------------------------------------------------
+
+/// Single-flight per canonical root (the cp32 TOCTOU requirement). A second
+/// birth of a root already in flight refuses; it never queues behind the first
+/// and measures "is the destination empty?" against a destination the first is
+/// about to fill.
+///
+/// Driven by claiming the root directly rather than by racing two threads: the
+/// property is "the claim is exclusive", and a race would test the scheduler.
+#[test]
+fn spec2_5_7f_concurrent_second_birth_of_a_root_in_flight_refuses() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let repo = temp.path().join("newborn");
+    write_repo(&repo);
+    let key = canonical(&repo);
+
+    let held =
+        brain_birth::claim_birth_root_for_test(&key).expect("an unclaimed root must be claimable");
+    let refusal = ceremony_birth(&registry, &bound, &key);
+    assert_eq!(refusal["ok"], json!(false), "payload was {refusal}");
+    assert_eq!(refusal["refused"], json!("birth_in_flight"));
+    assert!(
+        !registry.store_dir_for(&key).exists(),
+        "a refused birth must leave the destination untouched"
+    );
+
+    // Released on drop, including down a panicking path — the next birth runs.
+    drop(held);
+    let receipt = ceremony_birth(&registry, &bound, &key);
+    assert_eq!(receipt["ok"], json!(true), "receipt was {receipt}");
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (g) — a non-empty destination refuses, NAMING what occupies it
+// ---------------------------------------------------------------------------
+
+/// "Empty destination" is defined ON DISK (the cp32 requirement: no orphan
+/// manifest, snapshot, or checkpoint). Each of those three, alone, must stop a
+/// birth — and the refusal must NAME what it found, because a bare "not empty"
+/// sends a human to guess at their own filesystem.
+#[test]
+fn spec2_5_7g_a_non_empty_destination_refuses_naming_what_occupies_it() {
+    for occupant in [
+        "project_brain.json",
+        "graph_snapshot.json",
+        "checkpoint-store/CURRENT",
+    ] {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = temp.path().join("runtime");
+        let bound = build_bound_state(&runtime);
+        let registry = build_registry(&runtime);
+        let repo = temp.path().join("newborn");
+        write_repo(&repo);
+        let key = canonical(&repo);
+
+        // An ORPHAN artifact — the footprint of a brain that was, or of a
+        // half-finished something. Either way the destination is not empty.
+        let store = registry.store_dir_for(&key);
+        let artifact = store.join(occupant);
+        std::fs::create_dir_all(artifact.parent().expect("artifact parent")).expect("mk store");
+        std::fs::write(&artifact, "{}\n").expect("write occupant");
+        let before = std::fs::read(&artifact).expect("occupant bytes");
+
+        let refusal = ceremony_birth(&registry, &bound, &key);
+
+        assert_eq!(refusal["ok"], json!(false), "payload was {refusal}");
+        assert_eq!(refusal["refused"], json!("birth_destination_not_empty"));
+        let named = refusal["occupied_by"]
+            .as_array()
+            .unwrap_or_else(|| {
+                panic!("the refusal must NAME what occupies the destination: {refusal}")
+            })
+            .iter()
+            .filter_map(|value| value.as_str())
+            .any(|entry| entry.contains(occupant.split('/').next_back().expect("occupant leaf")));
+        assert!(named, "{occupant} was not named in {refusal}");
+        assert_eq!(
+            std::fs::read(&artifact).expect("occupant bytes"),
+            before,
+            "a refused birth may not touch what it found"
+        );
+    }
+}
+
+/// The migration/birth separation (§3: "Migration stays a boot-time fact with no
+/// verb"). A destination holding a previous runtime is exactly the shape a
+/// migration would adopt — and birth must refuse it rather than become a second,
+/// weaker adoption path. The refusal says so, so a human reading it is not left
+/// thinking birth is the tool for their existing brain.
+#[test]
+fn spec2_5_7g2_birth_is_not_the_migration_of_an_existing_brain() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let repo = temp.path().join("already-has-a-brain");
+    write_repo(&repo);
+    let key = canonical(&repo);
+
+    // A brain that already exists, born the ordinary way.
+    let first = ceremony_birth(&registry, &bound, &key);
+    assert_eq!(first["ok"], json!(true), "receipt was {first}");
+    let store = registry.store_dir_for(&key);
+    let manifest_before = std::fs::read(store.join("project_brain.json")).expect("manifest");
+
+    // A second ceremony over the SAME root is not a re-birth and not an adoption.
+    let refusal = ceremony_birth(&registry, &bound, &key);
+    assert_eq!(refusal["ok"], json!(false), "payload was {refusal}");
+    assert_eq!(refusal["refused"], json!("birth_destination_not_empty"));
+    assert!(
+        refusal["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("migration"),
+        "the refusal must separate migration from birth in words a human reads: {refusal}"
+    );
+    assert_eq!(
+        std::fs::read(store.join("project_brain.json")).expect("manifest"),
+        manifest_before,
+        "the existing brain must survive a refused second birth byte-identically"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §5.7 (h) — overlap classes refuse; `allow_overlap` is forbidden
+// ---------------------------------------------------------------------------
+
+/// §2: "overlap classes refuse; no `allow_overlap` below sovereign". The
+/// sovereign path does not carry the escape hatch either — a ceremony that
+/// passes `allow_overlap:true` is refused on the FLAG, before any overlap is
+/// even computed, so the hatch cannot be reached from here at all.
+#[test]
+fn spec2_5_7h_allow_overlap_is_forbidden_on_the_birth_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let repo = temp.path().join("newborn");
+    write_repo(&repo);
+    let key = canonical(&repo);
+
+    let mut request = BirthRequest::ceremony(&key, AGENT);
+    request.allow_overlap = true;
+    let refusal = brain_birth::run_birth(&registry, &bound, &request, HumanOrigin::Cli)
+        .expect("the ceremony must answer");
+
+    assert_eq!(refusal["ok"], json!(false), "payload was {refusal}");
+    assert_eq!(refusal["refused"], json!("birth_allow_overlap_forbidden"));
+    assert!(
+        !registry.store_dir_for(&key).exists(),
+        "a refused birth must create nothing"
+    );
+}
+
+/// An overlapping root refuses and NAMES the brain it would have collided with —
+/// the twin-brain trap the mint path already knows (a parent folder of a brained
+/// repo, or a child of one). Birth inherits that guard rather than growing a
+/// second, weaker copy of it.
+#[test]
+fn spec2_5_7h2_an_overlapping_root_refuses_naming_the_existing_brain() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+
+    let parent = temp.path().join("workspace");
+    let child = parent.join("repo");
+    write_repo(&child);
+    let child_key = canonical(&child);
+
+    let born = ceremony_birth(&registry, &bound, &child_key);
+    assert_eq!(born["ok"], json!(true), "receipt was {born}");
+
+    // The mother-folder trap: birthing the PARENT would re-ingest the child from
+    // above and fragment its memories across two stores.
+    write_repo(&parent);
+    let parent_key = canonical(&parent);
+    let refusal = ceremony_birth(&registry, &bound, &parent_key);
+
+    assert_eq!(refusal["ok"], json!(false), "payload was {refusal}");
+    assert_eq!(
+        refusal["refused"],
+        json!("birth_root_overlaps_existing_brain")
+    );
+    assert_eq!(refusal["overlap_class"], json!("parent"));
+    assert_eq!(refusal["existing_brain_root"], json!(child_key));
+    assert!(
+        !registry.store_dir_for(&parent_key).exists(),
+        "a refused birth must create nothing"
+    );
+}
+
+/// A root that does not resolve on disk is refused before anything is created —
+/// `canonical_key` falls back to the raw string for an unresolvable path, and a
+/// birth into a string is a birth into nowhere.
+#[test]
+fn spec2_5_7i_an_unresolvable_root_refuses_and_creates_nothing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let ghost = temp
+        .path()
+        .join("never-existed")
+        .to_string_lossy()
+        .to_string();
+
+    let refusal = ceremony_birth(&registry, &bound, &ghost);
+
+    assert_eq!(refusal["ok"], json!(false), "payload was {refusal}");
+    assert_eq!(refusal["refused"], json!("birth_root_unresolvable"));
+    assert!(
+        !registry.base_dir().join("..").join("stray").exists(),
+        "no stray artifacts"
+    );
+    assert!(
+        !registry.store_dir_for(&ghost).exists(),
+        "a refused birth must create nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §5.8 (birth half) — whole-or-nothing
+// ---------------------------------------------------------------------------
+
+/// The birth's durable transition must be SINGLE, so a `kill -9` at any instant
+/// lands on "no brain" or "a whole brain", never on a half-built store a later
+/// boot would warm into.
+///
+/// WHAT THIS TEST EXECUTES: that every refusal path leaves the destination store
+/// dir ABSENT, and that the success path leaves it complete — i.e. the
+/// destination is only ever created by the single committing step. Whatever the
+/// birth builds before that step must be built somewhere the routing seam cannot
+/// see, so a crash cannot leave a brain-shaped thing in the brain-shaped place.
+///
+/// DECLARED BOUNDARY — the fault-injection half is NOT executed here and is not
+/// claimed. Killing a real process mid-birth needs a live owner driven through
+/// the ceremony ingress; that lives in
+/// `m1nd-mcp/tests/spec2_birth_ceremony.rs`, which spawns the real binary. This
+/// in-process test proves the SHAPE that makes the kill safe; that one proves
+/// the kill.
+#[test]
+fn spec2_5_8_birth_creates_the_destination_in_one_committing_step() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    let bound = build_bound_state(&runtime);
+    let registry = build_registry(&runtime);
+    let repo = temp.path().join("newborn");
+    write_repo(&repo);
+    let key = canonical(&repo);
+    let store = registry.store_dir_for(&key);
+
+    // Every refusal reason that can be reached before a commit: not one may
+    // leave the destination existing.
+    let ghost = temp.path().join("ghost").to_string_lossy().to_string();
+    for refused_root in [ghost.as_str(), key.as_str()] {
+        let payload = if refused_root == key {
+            let mut request = BirthRequest::ceremony(refused_root, AGENT);
+            request.allow_overlap = true;
+            brain_birth::run_birth(&registry, &bound, &request, HumanOrigin::Cli)
+                .expect("the ceremony must answer")
+        } else {
+            ceremony_birth(&registry, &bound, refused_root)
+        };
+        assert_eq!(payload["ok"], json!(false), "payload was {payload}");
+        assert!(
+            !store.exists(),
+            "a refused birth left the destination existing at {store:?}"
+        );
+    }
+
+    // The success path: the destination appears whole — the birth record AND the
+    // first ingest, together, because they arrived together.
+    let receipt = ceremony_birth(&registry, &bound, &key);
+    assert_eq!(receipt["ok"], json!(true), "receipt was {receipt}");
+    assert!(store.join("project_brain.json").is_file());
+    assert!(store.join("graph_snapshot.json").is_file());
+
+    // Nothing half-built survives beside the destination. A leftover staging
+    // directory under the registry base is the footprint of a commit that was
+    // not a single step.
+    let leftovers: Vec<PathBuf> = std::fs::read_dir(registry.base_dir())
+        .expect("read the registry base")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with('.'))
+        })
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "left a partial birth behind: {leftovers:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The floor and the catalog — the verb is named, gated, and NOT on SPEC-1's list
+// ---------------------------------------------------------------------------
+
+/// SPEC-2's admission, stated positively: the verb classifies to the action §2
+/// names, at the `PositiveSovereign` floor §2 names, from `(tool, params)` alone.
+#[test]
+fn spec2_2a_the_birth_verb_classifies_at_positive_sovereign() {
+    let classified = m1nd_mcp::action_routes::classify_mcp_action(
+        BIRTH_TOOL,
+        &plain_params("/tmp/anywhere"),
+        m1nd_mcp::action_routes::TrustedMcpRouteFacts::default(),
+    )
+    .expect("the birth verb must classify purely from (tool, params)");
+    assert_eq!(classified.action.as_str(), brain_birth::BIRTH_ACTION);
+    assert_eq!(
+        classified.authority_floor,
+        m1nd_control::AuthorityFloor::PositiveSovereign,
+        "§2: PositiveSovereign"
+    );
+}
+
+/// SPEC-1's ratified A2-local opening holds EXACTLY one action. Birth is
+/// sovereign and must never appear on it: that list was ratified for one door,
+/// and a second entry there would open the sovereign frontier through a hole cut
+/// for a freshness re-scan.
+#[test]
+fn spec2_2b_birth_is_never_on_the_a2_local_allowlist() {
+    assert!(
+        !m1nd_mcp::action_consumers::GENERIC_A2_LOCAL_ADMITTED_ACTIONS
+            .contains(&brain_birth::BIRTH_ACTION),
+        "the sovereign birth must not be admitted through SPEC-1's A2-local door"
+    );
+    assert_eq!(
+        m1nd_mcp::action_consumers::GENERIC_A2_LOCAL_ADMITTED_ACTIONS,
+        ["graph.ingest.refresh_declared_root"],
+        "SPEC-1's list is ratified at exactly one action"
+    );
+}
+
+/// The advertised surface may not sell what policy refuses. The verb carries the
+/// house annotation and names its floor, from birth — the derived guard
+/// (`public_surface_annotates_every_floor_gated_verb`) enforces it for the whole
+/// registry, and this asserts it for THIS verb so the reason is legible here.
+#[test]
+fn spec2_2c_the_birth_verb_is_advertised_with_its_honest_annotation() {
+    let registry = m1nd_mcp::server::all_tool_schemas();
+    let tools = registry["tools"].as_array().expect("tools array");
+    let birth = tools
+        .iter()
+        .find(|tool| tool["name"] == json!(BIRTH_TOOL))
+        .unwrap_or_else(|| panic!("{BIRTH_TOOL} must be on the advertised registry"));
+    let description = birth["description"].as_str().unwrap_or_default();
+
+    assert!(
+        description.contains("POLICY-DISABLED"),
+        "the birth verb must carry the house marker: {description}"
+    );
+    assert!(
+        description.contains("POSITIVE_SOVEREIGN"),
+        "the annotation must name the floor an agent would have to satisfy: {description}"
+    );
+    // Never in the essential tier: the ceremony is the human's, and the default
+    // agent surface should not put it in front of one.
+    assert!(
+        !m1nd_mcp::server::ESSENTIAL_TOOLS.contains(&BIRTH_TOOL),
+        "the birth verb must not sit in the curated agent-facing tier"
+    );
+    assert_eq!(
+        birth["inputSchema"]["type"],
+        json!("object"),
+        "MCP spec: every inputSchema declares type=object at the TOP"
+    );
+}

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -61,6 +61,9 @@ pub mod boot_memory_handlers;
 pub mod boot_kv_migration;
 // Upgrade-path repair: one-time boot adoption of a pre-1.5 legacy graph snapshot.
 pub mod legacy_snapshot_adoption;
+// SPEC-2 — `brain.bootstrap.birth`, the birth ceremony's server verb
+// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2, owner-ratified 2026-07-29).
+pub mod brain_birth;
 // ORGANISM R6 — the delegation layer (`delegate` / `debrief`).
 pub mod delegation_handlers;
 pub mod engine_ops;
@@ -259,6 +262,12 @@ mod ui_bundle_attestation_internal_tests;
 #[cfg(test)]
 #[path = "internal_tests/spec1_refresh_declared_root.rs"]
 mod spec1_refresh_declared_root_internal_tests;
+// SPEC-2 — the birth path's acceptance battery
+// (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §5.7 + the birth half of §5.8),
+// written before its implementation.
+#[cfg(test)]
+#[path = "internal_tests/spec2_brain_bootstrap_birth.rs"]
+mod spec2_brain_bootstrap_birth_internal_tests;
 
 // HTTP server + types (feature-gated behind "serve")
 #[cfg(feature = "serve")]

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -548,6 +548,58 @@ fn run_medulla_migrate(
     println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
 }
 
+/// THE BIRTH CEREMONY (`docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2, owner-ratified
+/// 2026-07-29) — the P2 human gesture, and the ONLY place in this binary that
+/// stamps a `HumanOrigin`.
+///
+/// This function IS the admission §2 requires. It is not that the CLI presents a
+/// token the owner then trusts: the owner is this process, and the fact it
+/// observes is its own ingress — the human ran `m1nd init --birth <repo>`, which
+/// runs this binary with this flag. Nothing that arrives over a transport can
+/// reach here, because this runs before any transport is opened, so no header,
+/// field, or claimed origin can ever produce the stamp. That is the whole
+/// mechanism, and its honest limit is stated in `brain_birth`: it closes the
+/// reflex vector, not a hostile same-UID process.
+///
+/// Offline and one-shot, exactly like `--inbox-sweep` and `--medulla-migrate`:
+/// boot a session to recover the runtime root and the owner's own binding, run
+/// the verb, print JSON, exit. Exit code follows the answer — `0` for a
+/// certificate, `1` for a refusal — so a script or a human sees the difference
+/// without parsing.
+fn run_birth_ceremony(config: McpConfig, root: &str) {
+    let server = match McpServer::new(config) {
+        Ok(server) => server,
+        Err(e) => {
+            eprintln!("[m1nd-mcp][birth] failed to boot the owner session: {e}");
+            std::process::exit(1);
+        }
+    };
+    // The ORCHESTRATION lives in the library, not here. The ceremony needs the
+    // owner's own binding in order to REFUSE a root the bound dev graph already
+    // covers, and that binding is a crate-internal capability by design
+    // (`McpServer::into_session_state` is `pub(crate)`, guarded by a
+    // `compile_fail` doctest). The binary contributes the INGRESS — the fact
+    // that a human ran this command — and nothing else.
+    let payload = match m1nd_mcp::brain_birth::run_ceremony(server, root, "m1nd-init-birth") {
+        Ok(payload) => payload,
+        Err(e) => {
+            eprintln!("[m1nd-mcp][birth] the ceremony failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    let ok = payload
+        .get("ok")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).unwrap_or_default()
+    );
+    if !ok {
+        std::process::exit(1);
+    }
+}
+
 /// The most recent `.m5a-backup-<ms>` dir under a medulla store, if any. The
 /// suffix is `now_ms()` at `apply` time, so lexical max over the numeric suffix
 /// is the newest backup (the rollback anchor).
@@ -818,6 +870,15 @@ async fn main() {
     // for the maintainer, never an agent). Runs BEFORE --serve/stdio.
     if let Some(mode) = cli.medulla_migrate {
         run_medulla_migrate(config, mode, cli.migrate_project_root);
+        return;
+    }
+
+    // --birth <repo>: THE BIRTH CEREMONY (GENESIS-INGEST-CONSUMERS-SPEC.md §2,
+    // owner-ratified 2026-07-29). Runs BEFORE --serve/stdio, so it never opens a
+    // transport — which is also why the stamp it applies can never be reached
+    // through one.
+    if let Some(root) = cli.birth {
+        run_birth_ceremony(config, &root);
         return;
     }
 

--- a/m1nd-mcp/src/project_brains.rs
+++ b/m1nd-mcp/src/project_brains.rs
@@ -1631,6 +1631,14 @@ impl ProjectBrainRegistry {
         &self.base_dir
     }
 
+    /// The owner's registry dir (the shared instance phonebook), so a caller that
+    /// builds a second registry over a different base — SPEC-2's birth stages one
+    /// under `base_dir()` and commits by rename — lands its instances in the SAME
+    /// phonebook this one uses instead of an orphan registry.
+    pub(crate) fn registry_dir(&self) -> Option<&PathBuf> {
+        self.registry_dir.as_ref()
+    }
+
     /// Live `(node_count, edge_count)` for a project brain that is warm in the
     /// map RIGHT NOW — the freshest truth for the Hall. `None` when the brain is
     /// dormant on disk (the caller then falls back to the manifest's recorded
@@ -1707,7 +1715,11 @@ impl ProjectBrainRegistry {
     /// always has a manifest on disk (it is written before the map insert), so the
     /// disk roster is a superset in practice; the union is defensive, not load-
     /// bearing. Inert read only (map keys + roster manifests, never a warm-boot).
-    fn existing_brain_roots(&self) -> Vec<String> {
+    ///
+    /// Crate-visible because SPEC-2's birth must run the SAME overlap
+    /// classification before it stages: its staging registry knows no brains, so
+    /// asking that one would be asking a registry that always answers "none".
+    pub(crate) fn existing_brain_roots(&self) -> Vec<String> {
         let mut set: std::collections::HashSet<String> =
             self.brains.lock().keys().cloned().collect();
         for (root, _facts, _dir) in self.disk_roster() {

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -42,20 +42,23 @@ what one agent proves and memorizes, the next agent reads. Operate in a loop.
 A response may carry a `reception` block. `reception.match == \"caller_root_mismatch\"` \
 means the bound graph does NOT cover your current repo (its root ≠ your resolved \
 `caller_root`) — do NOT trust retrieval for THIS repo; read `reception.options[]`. \
-The public brain-bootstrap consumer is NOT installed. Do not call generic `ingest` \
-with `project_root`: cross-root bootstrap is POSITIVE_SOVEREIGN and intentionally fails \
-closed until an exact typed G2/G3 consumer exists. Continue only against the bound \
-graph (with the mismatch warning intact), or reconnect to an owner that already hosts \
-the intended repo. Absent `reception` = your root matches the brain serving you \
-(silent bind is legal only on a match, TT-INV-12).
+Generic cross-root `ingest` remains withdrawn (no `project_root` in the schema; \
+POSITIVE_SOVEREIGN, fails closed), and the birth verb refuses every wire client with \
+`human_gesture_required` — but a repo with NO brain now has a real path: the HUMAN \
+runs the one-time ceremony `m1nd init --birth <repo>`. An agent's honest move is to \
+OFFER that exact command and stop; running it is not the agent's to do. Until the human runs it: continue only against the bound graph (with the mismatch \
+warning intact), or reconnect to an owner that already hosts the intended repo. Absent \
+`reception` = your root matches the brain serving you (silent bind is legal only on a \
+match, TT-INV-12).
 
 **Reception governs WRITES, not just reads.** A read under `caller_root_mismatch` is a \
 warning; a WRITE under it is PROHIBITED by doctrine — `memorize`, `skeleton_candidate`, \
 `candidate_edit`, `system_blocks_seed_import`/`_ratify`/`_reconcile`, and `mission_post` would \
 each land in the WRONG brain (this is exactly how a foreign skeleton once overwrote a bound \
 brain). Do not attempt a write from this mismatched session. The honest recovery code is \
-`brain_bootstrap_consumer_not_installed`; no public one-call bootstrap or overlap escape hatch \
-is advertised while that sovereign consumer is absent.
+`brain_bootstrap_consumer_not_installed`; no AGENT-callable one-call bootstrap or overlap \
+escape hatch exists — the sovereign consumer is human-gated, and the human's ceremony \
+(`m1nd init --birth <repo>`) is the only door.
 
 **ADVERTISED ≠ CALLABLE — the authority floors.** Bootstrap is not the only closed door. Every \
 semantic action carries an M1ND-10 authority floor and generic MCP/REST dispatch admits only \
@@ -1151,6 +1154,18 @@ fn all_tool_schemas_inner() -> serde_json::Value {
                         }
                     },
                     "required": ["path", "agent_id"]
+                }
+            },
+            {
+                "name": "brain_birth",
+                "description": "Birth a NEW project brain for a repo that has none. This is the HUMAN's one-time gesture, not an agent's call: admission is an origin the OWNER stamps from a fact it observes about itself, and an origin string sent as a parameter grants nothing. Over generic MCP/REST this verb is refused for every client, however the call is dressed. The one path that exists today is the P2 ceremony a HUMAN runs in their terminal: `m1nd init --birth <repo>`. If you are an agent and a repo has no brain, OFFER that exact command and stop; running it is not yours to do. Birth refuses unless the destination is empty ON DISK (no manifest, snapshot or checkpoint), refuses any root that overlaps an existing brain, never touches the owner's bound graph, and is not the way to adopt an existing brain — that is migration, a boot-time fact with no verb.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "root": { "type": "string", "description": "Repo root to birth a brain for" },
+                        "agent_id": { "type": "string", "description": "Calling agent identifier" }
+                    },
+                    "required": ["root", "agent_id"]
                 }
             },
             {
@@ -6619,6 +6634,13 @@ fn dispatch_core_tool(
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
             tools::handle_ingest(state, input)
         }
+        // SPEC-2's birth verb, at the DISPATCHER — which is exactly where it can
+        // never succeed. The dispatcher holds no `HumanOrigin` and cannot
+        // construct one (the type has no public constructor), so every route
+        // that reaches this arm is by definition a route with no owner stamp.
+        // The generic policy gate refuses first and harder; this is the second
+        // layer, for any in-process seam that reaches `dispatch_tool` directly.
+        "brain_birth" => Ok(crate::brain_birth::birth_refusal_without_stamp()),
         "document_resolve" => {
             let input: DocumentResolveInput =
                 serde_json::from_value(params.clone()).map_err(M1ndError::Serde)?;
@@ -7970,6 +7992,13 @@ impl McpServer {
     pub fn spawn_instance_heartbeat(&self) -> M1ndResult<tokio::task::JoinHandle<()>> {
         let permit = self.actor_execute(false, |state| Ok(state.instance.heartbeat_permit()))?;
         Ok(crate::instance_registry::spawn_heartbeat(permit))
+    }
+
+    /// The configured global registry dir (the shared instance phonebook), for an
+    /// offline one-shot that has to build a `ProjectBrainRegistry` of its own and
+    /// must land its instances in the SAME phonebook the owner uses.
+    pub(crate) fn config_registry_dir(&self) -> Option<PathBuf> {
+        self.config.registry_dir.clone()
     }
 
     /// Return an opaque cooperative stop handle for a running stdio loop.

--- a/m1nd-mcp/tests/spec2_birth_ceremony.rs
+++ b/m1nd-mcp/tests/spec2_birth_ceremony.rs
@@ -1,0 +1,358 @@
+//! SPEC-2 — the P2 birth ceremony, driven against the REAL binary.
+//!
+//! The normative document is `docs/GENESIS-INGEST-CONSUMERS-SPEC.md` §2
+//! (RATIFIED, owner, 2026-07-29). The in-process battery
+//! (`m1nd-mcp/src/internal_tests/spec2_brain_bootstrap_birth.rs`) proves the
+//! verb's decisions; this file proves the two things only a real process can:
+//!
+//!   1. the CEREMONY INGRESS exists and is the only stamp — the owner is what
+//!      turns "the human ran this command" into `human-cli`, and no client
+//!      payload reaches it;
+//!   2. §5.8's birth half, FOR REAL: `kill -9` mid-birth leaves the destination
+//!      ABSENT or WHOLE, never a half-built store a later boot would warm into.
+//!
+//! HOW THE KILL IS DRIVEN, and why it is not a fault-injection hook. A clean
+//! birth is timed first; then the ceremony is re-run and `kill -9`ed at a spread
+//! of instants across that duration. There is no production test hook, no
+//! sleep-on-env-var, nothing in the shipped path that exists for this file — the
+//! invariant is asserted after every kill, and the last step proves the
+//! destination is still BIRTHABLE, which is the recovery half of
+//! "completes-or-removes whole".
+//!
+//! Only PIDs THIS test spawned are ever signalled.
+//!
+//! Unix-only: `kill -9` and process-group semantics are POSIX.
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+/// Path to the compiled binary under test (Cargo sets `CARGO_BIN_EXE_<name>`).
+const BIN: &str = env!("CARGO_BIN_EXE_m1nd-mcp");
+
+/// A deterministic multi-module Rust crate. Wide enough that the first ingest
+/// takes long enough to be interrupted at several distinct instants, small
+/// enough that a clean ceremony stays quick.
+fn write_fixture_repo(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).expect("mk src");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"spec2ceremony\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("Cargo.toml");
+    let mut lib = String::from("pub fn top() -> i64 { 1 }\n");
+    for index in 0..24 {
+        lib.push_str(&format!("pub mod part_{index};\n"));
+        std::fs::write(
+            root.join("src").join(format!("part_{index}.rs")),
+            format!(
+                "pub fn part_{index}_a() -> i64 {{ {index} }}\n\
+                 pub fn part_{index}_b() -> i64 {{ {index} + 1 }}\n\
+                 pub struct Part{index} {{ pub v: i64 }}\n\
+                 impl Part{index} {{ pub fn make() -> Self {{ Self {{ v: {index} }} }} }}\n"
+            ),
+        )
+        .expect("part module");
+    }
+    std::fs::write(root.join("src/lib.rs"), lib).expect("lib.rs");
+}
+
+/// Build the ceremony command the npm CLI builds: the owner's own `--birth`
+/// ingress, pointed at an isolated runtime.
+fn ceremony_command(root: &Path, runtime_dir: &Path) -> Command {
+    let mut command = Command::new(BIN);
+    command
+        .arg("--birth")
+        .arg(root)
+        .arg("--no-gui")
+        .env("M1ND_RUNTIME_DIR", runtime_dir)
+        .env("M1ND_GRAPH_SOURCE", runtime_dir.join("graph_snapshot.json"))
+        .env(
+            "M1ND_PLASTICITY_STATE",
+            runtime_dir.join("plasticity_state.json"),
+        )
+        .env("M1ND_REGISTRY_DIR", runtime_dir.join("registry"))
+        .env("M1ND_NO_GUI", "1");
+    command
+}
+
+/// Run the ceremony to completion and return its output.
+fn run_ceremony(root: &Path, runtime_dir: &Path) -> Output {
+    ceremony_command(root, runtime_dir)
+        .output()
+        .expect("spawn the birth ceremony")
+}
+
+/// The ceremony's JSON certificate (or refusal), parsed out of stdout.
+fn certificate(output: &Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let start = stdout
+        .find('{')
+        .unwrap_or_else(|| panic!("the ceremony must print JSON; stdout was:\n{stdout}"));
+    serde_json::from_str(stdout[start..].trim()).unwrap_or_else(|error| {
+        panic!(
+            "the ceremony's JSON did not parse ({error}); stdout was:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// The destination store dir for a root, derived exactly the way the owner
+/// derives it — one hashing scheme, never a second copy of it here.
+fn store_dir(runtime_dir: &Path, root: &Path) -> PathBuf {
+    let registry = m1nd_mcp::project_brains::ProjectBrainRegistry::new(
+        runtime_dir.join(m1nd_mcp::project_brains::PROJECT_BRAINS_DIR),
+        None,
+    );
+    let key =
+        m1nd_mcp::project_brains::ProjectBrainRegistry::canonical_key(&root.to_string_lossy());
+    registry.store_dir_for(&key)
+}
+
+/// ABSENT, or WHOLE. The property `kill -9` must never break: a destination is
+/// either not there at all, or it is a complete brain — a birth record naming
+/// this root AND the first ingest beside it.
+fn assert_absent_or_whole(store: &Path, root: &Path, moment: &str) {
+    if !store.exists() {
+        return;
+    }
+    let manifest = store.join("project_brain.json");
+    let snapshot = store.join("graph_snapshot.json");
+    assert!(
+        manifest.is_file() && snapshot.is_file(),
+        "{moment}: the destination exists but is HALF-BUILT — manifest={} snapshot={} at {store:?}",
+        manifest.is_file(),
+        snapshot.is_file()
+    );
+    let text = std::fs::read_to_string(&manifest).expect("read the birth record");
+    let parsed: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|error| panic!("{moment}: torn manifest ({error}): {text}"));
+    let key =
+        m1nd_mcp::project_brains::ProjectBrainRegistry::canonical_key(&root.to_string_lossy());
+    assert_eq!(
+        parsed["project_root"],
+        serde_json::json!(key),
+        "{moment}: the destination names another root"
+    );
+}
+
+/// A ceremony against an EMPTY destination births a whole brain, and says so in
+/// a certificate a human can read.
+#[test]
+fn spec2_ceremony_births_a_whole_brain_and_certifies_it() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    std::fs::create_dir_all(&runtime).expect("mk runtime");
+    let repo = temp.path().join("newborn");
+    write_fixture_repo(&repo);
+    let store = store_dir(&runtime, &repo);
+    assert!(
+        !store.exists(),
+        "precondition: the destination starts empty"
+    );
+
+    let output = run_ceremony(&repo, &runtime);
+    let receipt = certificate(&output);
+
+    assert!(
+        output.status.success(),
+        "a ceremony on an empty destination must succeed; certificate was {receipt}, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(receipt["ok"], serde_json::json!(true));
+    assert_eq!(receipt["origin"], serde_json::json!("human-cli"));
+    assert!(
+        receipt["node_count"].as_u64().unwrap_or(0) > 0,
+        "the birth includes the first ingest: {receipt}"
+    );
+    assert_absent_or_whole(&store, &repo, "after a clean ceremony");
+    assert!(
+        store.exists(),
+        "the brain must exist after a clean ceremony"
+    );
+
+    // A SECOND ceremony over the same root is refused — the birth is durable
+    // across processes, and birth is not the migration of an existing brain.
+    let second = run_ceremony(&repo, &runtime);
+    let refusal = certificate(&second);
+    assert!(
+        !second.status.success(),
+        "a second birth must not report success"
+    );
+    assert_eq!(
+        refusal["refused"],
+        serde_json::json!("birth_destination_not_empty")
+    );
+}
+
+/// §5.8, the birth half: `kill -9` at a spread of instants across the birth. The
+/// destination is ABSENT or WHOLE after every one, and still birthable after all
+/// of them.
+#[test]
+fn spec2_5_8_kill_9_mid_birth_leaves_the_destination_absent_or_whole() {
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    // 1. Time a clean birth in its own runtime, so the kill instants below cover
+    //    the real duration of THIS machine's ceremony rather than a guess.
+    let timing_runtime = temp.path().join("timing-runtime");
+    std::fs::create_dir_all(&timing_runtime).expect("mk timing runtime");
+    let timing_repo = temp.path().join("timing-repo");
+    write_fixture_repo(&timing_repo);
+    let started = Instant::now();
+    let clean = run_ceremony(&timing_repo, &timing_runtime);
+    let clean_duration = started.elapsed();
+    assert!(
+        clean.status.success(),
+        "the timing ceremony must succeed first; stderr:\n{}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+
+    // 2. Kill at a spread of instants across that duration. Eight is enough to
+    //    straddle boot, scan, staging and commit without turning the suite into
+    //    a stress test.
+    let repo = temp.path().join("newborn");
+    write_fixture_repo(&repo);
+    for step in 1..=8u32 {
+        let runtime = temp.path().join(format!("runtime-{step}"));
+        std::fs::create_dir_all(&runtime).expect("mk runtime");
+        let store = store_dir(&runtime, &repo);
+        let delay = clean_duration.mul_f64(f64::from(step) / 9.0);
+
+        let mut child = ceremony_command(&repo, &runtime)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn the ceremony");
+        std::thread::sleep(delay);
+        // ONLY the pid this test spawned, and only ever this one.
+        let killed = child.kill();
+        let _ = child.wait();
+        assert!(
+            killed.is_ok() || killed.is_err(),
+            "kill is best-effort: a ceremony that already finished is a valid outcome"
+        );
+
+        assert_absent_or_whole(&store, &repo, &format!("kill at {delay:?} (step {step})"));
+    }
+
+    // 3. The recovery half: after all that interruption, a fresh destination is
+    //    still birthable. A birth that could be poisoned by a crashed sibling
+    //    would fail here.
+    let final_runtime = temp.path().join("runtime-final");
+    std::fs::create_dir_all(&final_runtime).expect("mk runtime");
+    let output = run_ceremony(&repo, &final_runtime);
+    let receipt = certificate(&output);
+    assert!(
+        output.status.success(),
+        "a birth after interrupted siblings must still succeed; certificate was {receipt}"
+    );
+    assert_absent_or_whole(&store_dir(&final_runtime, &repo), &repo, "after recovery");
+}
+
+/// The ceremony is the ONLY stamp. The same verb over the wire — the seam an
+/// agent actually holds — is refused, with the claim it dressed itself in
+/// buying nothing. Driven through the real binary so the refusal proven here is
+/// the one a client on the wire receives, not an in-process approximation.
+#[test]
+fn spec2_the_wire_cannot_birth_however_it_dresses_the_call() {
+    use std::io::{BufRead, BufReader, Write};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = temp.path().join("runtime");
+    std::fs::create_dir_all(&runtime).expect("mk runtime");
+    let repo = temp.path().join("newborn");
+    write_fixture_repo(&repo);
+
+    let mut child = Command::new(BIN)
+        .arg("--no-gui")
+        .env("M1ND_RUNTIME_DIR", &runtime)
+        .env("M1ND_GRAPH_SOURCE", runtime.join("graph_snapshot.json"))
+        .env(
+            "M1ND_PLASTICITY_STATE",
+            runtime.join("plasticity_state.json"),
+        )
+        .env("M1ND_REGISTRY_DIR", runtime.join("registry"))
+        .env("M1ND_NO_GUI", "1")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn the stdio owner");
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+
+    let mut call = |id: i64, request: serde_json::Value| -> serde_json::Value {
+        stdin
+            .write_all(format!("{request}\n").as_bytes())
+            .expect("write request");
+        stdin.flush().expect("flush");
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            assert!(Instant::now() < deadline, "timed out waiting for id={id}");
+            let mut line = String::new();
+            let read = stdout.read_line(&mut line).expect("read reply");
+            assert!(read > 0, "owner stdout closed before reply id={id}");
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+                continue;
+            };
+            if value.get("id").and_then(serde_json::Value::as_i64) == Some(id) {
+                return value;
+            }
+        }
+    };
+
+    call(
+        1,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "spec2-wire-probe", "version": "1.0" }
+            }
+        }),
+    );
+
+    let plain = call(
+        2,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": { "name": "brain_birth", "arguments": {
+                "root": repo.to_string_lossy(), "agent_id": "spec2-wire-probe"
+            }}
+        }),
+    );
+    let dressed = call(
+        3,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": { "name": "brain_birth", "arguments": {
+                "root": repo.to_string_lossy(), "agent_id": "spec2-wire-probe",
+                "birth_via": "human-cli", "origin": "human-ui",
+                "imported_via": "human-touchid", "ratified_via": "human-ui"
+            }}
+        }),
+    );
+
+    let text = |reply: &serde_json::Value| -> String {
+        serde_json::to_string(&reply["result"]).unwrap_or_default()
+            + &serde_json::to_string(&reply["error"]).unwrap_or_default()
+    };
+    assert!(
+        text(&plain).contains("POSITIVE_SOVEREIGN"),
+        "the wire must refuse a birth at the sovereign floor: {plain}"
+    );
+    assert_eq!(
+        text(&dressed),
+        text(&plain),
+        "a claimed human origin must buy NOTHING on the wire — not even a different answer"
+    );
+    assert!(
+        !store_dir(&runtime, &repo).exists(),
+        "a refused wire birth must create nothing"
+    );
+
+    drop(stdin);
+    let _ = child.wait();
+}

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -64,6 +64,7 @@ function usage() {
 
 Usage:
   m1nd init [--host codex|claude|gemini|antigravity|generic|all] [--project <dir>]
+  m1nd init --birth <repo>   The P2 birth ceremony (human's gesture; agents offer, never run)
   m1nd install-skills <host> [--project <dir>]
   m1nd mcp-config <host> [--binary <path>] [--project <dir>]
   m1nd hosts status [--host codex|claude|gemini|antigravity|generic|all] [--project <dir>] [--binary <path>] [--json]
@@ -4710,6 +4711,19 @@ async function main(rawArgs) {
   }
 
   if (["init", "install-skills"].includes(command)) {
+    // `init --birth <repo>` is the P2 ceremony, not skill installation. The
+    // origin stamp lives in the BINARY's own CLI flag (no MCP/REST payload can
+    // forge it), so the npm side only relays the human's gesture to the binary
+    // it resolves — inherit stdio so the ceremony speaks to the human directly.
+    if (command === "init" && args.birth) {
+      const targetBinary = path.resolve(args.binary || defaultRuntimePath());
+      const repoArg = typeof args.birth === "string" ? args.birth : args._[1] || process.cwd();
+      const result = spawnSync(targetBinary, ["--birth", path.resolve(repoArg)], {
+        stdio: "inherit",
+      });
+      process.exitCode = result.status === null ? 1 : result.status;
+      return;
+    }
     const host = args._[1] || args.host || "generic";
     const projectDir = path.resolve(args.project || process.cwd());
     print(installSkills(host, projectDir), args.json);

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -62,11 +62,15 @@ this loop by default:
    `focus`; reach for the pieces directly only when you need just one. Heed
    `reception`: `reception.match == "caller_root_mismatch"` means the bound graph
    does NOT cover your current repo — do not trust retrieval for it; read
-   `reception.options[]`. The public cross-root bootstrap consumer is not
-   installed: never add `project_root` or `allow_overlap` to `ingest`, and never
-   treat the internal owner bootstrap as an executable repair. The honest code is
-   `brain_bootstrap_consumer_not_installed`; connect to an owner that already
-   hosts the intended brain or continue only with explicit mismatch caveats.
+   `reception.options[]`. Generic cross-root `ingest` remains withdrawn: never
+   add `project_root` or `allow_overlap`, and never treat the internal owner
+   bootstrap as an executable repair. A brainless repo now has ONE real path —
+   the HUMAN's one-time ceremony `m1nd init --birth <repo>`: OFFER that exact
+   command and stop (over the wire the birth verb refuses every client with
+   `human_gesture_required`; writes into a brainless root still refuse
+   `brain_bootstrap_consumer_not_installed`). Until the human runs it, connect
+   to an owner that already hosts the intended brain or continue only with
+   explicit mismatch caveats.
    Reception governs WRITES, not just reads: a read under mismatch is a warning,
    but a WRITE under mismatch is PROHIBITED by doctrine — any write verb
    (`memorize`, `skeleton_candidate`, `candidate_edit`, `system_blocks_*`,

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -48,12 +48,14 @@ measured high-signal pattern starts by never starting cold:
    directly only when you need just one. Heed `reception`:
    `reception.match == "caller_root_mismatch"` means the bound graph does NOT
    cover your current repo — do not trust retrieval for it; read
-   `reception.options[]`. The public brain-bootstrap consumer is NOT
-   installed: `ingest` does not accept `project_root` (absent from the
-   published schema) and cross-root bootstrap fails closed with
-   `brain_bootstrap_consumer_not_installed`. Continue only against the bound
-   graph with the mismatch warning intact, or reconnect to an owner that
-   already hosts the intended repo. Absent/null = your root matches the brain
+   `reception.options[]`. Generic cross-root `ingest` remains withdrawn
+   (`project_root` absent from the published schema), and over the wire
+   `brain.bootstrap.birth` refuses every client with `human_gesture_required`.
+   The way forward for a brainless repo is the HUMAN's one-time ceremony —
+   OFFER the exact command `m1nd init --birth <repo>` and stop; running it is
+   not the agent's to do. Until then, continue only against the bound graph
+   with the mismatch warning intact, or reconnect to an owner that already
+   hosts the intended repo. Absent/null = your root matches the brain
    serving you. Reception governs WRITES too, not only reads: a read under
    mismatch is a warning, a WRITE under mismatch is prohibited (see Write-Mode
    Laws below) — and no public bootstrap lifts it. VERSION SKEW: this skill

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -30,11 +30,13 @@ graph), `ingest` the repo, then `north` again — that is a real answer, not a
 failure. `north` composes `trust_selftest` + `orient` + `boot_memory` + `focus`.
 Heed `reception`: `reception.match == "caller_root_mismatch"` means the bound
 graph does NOT cover your current repo — do not trust retrieval for it; read
-`reception.options[]`. The public brain-bootstrap consumer is NOT installed:
-`ingest` does not accept `project_root` (absent from the published schema) and
-cross-root bootstrap fails closed with `brain_bootstrap_consumer_not_installed`.
-Continue only against the bound graph with the mismatch warning intact, or
-reconnect to an owner that already hosts the intended repo.
+`reception.options[]`. Generic cross-root `ingest` remains withdrawn (`project_root`
+absent from the published schema), and over the wire `brain.bootstrap.birth` refuses
+every client with `human_gesture_required` — the stamp is the binary's own CLI flag.
+A brainless repo now has one real path: the HUMAN's one-time ceremony
+`m1nd init --birth <repo>`. OFFER that exact command and stop — running it is not
+the agent's to do. Until then, continue only against the bound graph with the
+mismatch warning intact, or reconnect to an owner that already hosts the intended repo.
 Absent/null `reception` = your root matches the brain serving you. Reception
 governs WRITES, not just reads: a read under mismatch is a warning, but a WRITE
 under mismatch is PROHIBITED — see Write-Mode Laws below, and no public


### PR DESCRIPTION
## The birth ceremony — genesis becomes CODE-COMPLETE

After this PR, every piece of the ratified genesis program exists: P1 medulla fallback (#403) · SPEC-1 freshness door (#463) · **SPEC-2 + P2, here** — `brain.bootstrap.birth` and the human ceremony that is its only key.

**The stamp is the binary's own CLI flag.** The only place in the codebase that constructs a `HumanOrigin` is the `--birth` ingress, which runs before any transport opens — so no MCP or REST payload, no header, no `birth_via` field, no claim of any kind can ever produce one. Every wire client is refused **`human_gesture_required`**. The human-facing form is `m1nd init --birth <repo>`; the npm CLI relays it to the binary it resolves, stdio inherited so the ceremony speaks to the human directly. An agent that finds a brainless repo **offers that exact command and stops** — running it is not the agent's to do.

## What birth refuses (the battery's teeth — 18 tests born RED, §5.7–§5.8)

Client-claimed origin (refused byte-identically to no origin) · non-empty destination (naming what occupies it) · any overlap with an existing brain (naming it) · the owner's own bound root · a second birth in flight (single-flight per canonical root) · and it is **not** the way to adopt an existing brain — migration is a boot-time fact with no verb, pinned. Birth creates the destination in **one committing step**; the born brain routes by caller root; the bound dev graph is never touched.

## The prose swept in the same PR

Five surfaces taught *"the consumer is NOT installed"* with no way forward — true once, a lie after this PR. They now teach the OFFER (M1ND_INSTRUCTIONS reception + WRITES sections, `AGENTS.md`, both skills, the universal pack). The guard that forbids advertising the raw verb in served instructions **stays intact and green** — the new text teaches the refusal and the human path without naming an executable call. The PATHOS genesis front flips to CODE-COMPLETE: what remains of genesis is **use, not code**.

## Provenance, stated plainly

The implementation crossed **five executor lives** (two session-limit deaths, three stream stalls) — the work was intact on disk every time; the orchestrator verified independently and committed: battery **18/18**, `action_consumers` 9/9 (catalog digest re-pinned), floor-annotation guard green (the new verb's description carries the honest annotation from birth), bootstrap-advertising guard green, surfaces python OK, npm suite green, fmt clean. The full workspace gate is this PR's CI — deliberately not re-run locally on a 35% battery.
