### PR TITLE
fix(release): sign with the keychain entitlement the custody ceremony requires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,10 +567,31 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
           rm -f "$RUNNER_TEMP/cert.p12"
 
-          # 2) sign with hardened runtime + secure timestamp (notarization requires both)
+          # 2) sign with hardened runtime + secure timestamp (notarization requires
+          #    both) AND the keychain-access-groups entitlement.
+          #
+          #    The entitlement is NOT cosmetic. The G9 custody floor persists the
+          #    owner's authority key in the data-protection keychain — the only
+          #    keychain a Secure Enclave key can be permanent in — and an unentitled
+          #    binary cannot persist or resolve it at all, so `open`/`sign` fail
+          #    closed. Signing without it shipped a binary structurally incapable of
+          #    running the owner's custody ceremony, invisible until the ceremony
+          #    failed at its first step (measured 2026-07-29 while staging G9).
+          #    See build/m1nd-mcp.entitlements.plist and the HARD PREREQUISITE block
+          #    in m1nd-mcp/src/enclave_authority.rs.
           codesign --force --timestamp --options runtime \
+            --entitlements build/m1nd-mcp.entitlements.plist \
             --sign "$APPLE_SIGNING_IDENTITY" "$BIN_PATH"
           codesign --verify --strict --verbose=2 "$BIN_PATH"
+          # Prove the entitlement actually landed on the shipped bytes. This check is
+          # NOT belt-and-braces: `codesign` parses entitlements with AMFIUnserializeXML,
+          # and when that parse fails (an XML comment anywhere in the plist is enough —
+          # `plutil -lint` accepts what AMFI rejects) it prints the error, signs the
+          # binary WITHOUT the entitlement, and still exits 0. Measured 2026-07-29.
+          # Without this grep the ceremony breaks and the release stays green.
+          codesign -d --entitlements - "$BIN_PATH" 2>/dev/null \
+            | grep -q "keychain-access-groups" \
+            || { echo "::error::signed binary carries no keychain-access-groups entitlement — the G9 custody ceremony would fail closed"; exit 1; }
 
           # 3) notarize (a bare executable is submitted zipped; stapling is not
           #    possible for a raw binary, so Gatekeeper resolves the ticket online)

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,41 @@
+# `build/` — signing surface
+
+## `m1nd-mcp.entitlements.plist`
+
+**A HARD PREREQUISITE for the G9 Secure Enclave custody ceremony, not a nicety.**
+
+The custody floor persists the owner's authority key in the **data-protection
+keychain** (`Location::DataProtectionKeychain`) — the only keychain a Secure
+Enclave key can be made permanent in — and scopes both the provisioning write and
+`resolve_persisted_key` to it via `kSecUseDataProtectionKeychain`. See the
+`HARD PREREQUISITE` block above the real Security.framework key store in
+`m1nd-mcp/src/enclave_authority.rs`.
+
+An unsigned or **unentitled** binary cannot persist or resolve that key at all:
+`open`/`sign` fail closed. Before this file existed, `release.yml` signed with
+`--options runtime` and **no `--entitlements`**, so the shipped, notarized binary
+was structurally incapable of running the owner's ceremony — a gap invisible until
+the ceremony would have failed at its first step. Measured 2026-07-29 while staging
+G9; the release step now passes the entitlement **and proves it landed on the
+shipped bytes** (a signature that silently dropped it would leave the ceremony
+broken and the release green).
+
+`4KLJ4N9D5K` is the Developer ID team the release already signs with
+(`Developer ID Application: … (4KLJ4N9D5K)`).
+
+### This file is a custody surface
+
+It is deliberately **minimal** — one entitlement, one group. Every entry widens
+what a signed binary may do, so adding to it is a **security decision**, never a
+build tweak.
+
+### Why the plist carries no comments
+
+`codesign` parses entitlements with `AMFIUnserializeXML`, which **rejects XML
+comments anywhere in the file** — including inside `<dict>`. `plutil -lint`
+accepts them, so a commented plist lints clean and then fails at signing time with
+`Failed to parse entitlements: AMFIUnserializeXML: syntax error`. Worse, that
+failure does **not** set a non-zero exit on `codesign`: the binary signs *without*
+the entitlement and the pipeline looks green. Both facts were proven by signing a
+probe binary rather than assumed — which is why the rationale lives in this README
+and the release step verifies the entitlement is present on the output.

--- a/build/m1nd-mcp.entitlements.plist
+++ b/build/m1nd-mcp.entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>4KLJ4N9D5K.world.m1nd.custody</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## The shipped binary could not have run the G9 ceremony

Staging G9 measured it: `release.yml` signed with `--options runtime` and **no `--entitlements`**, while the custody floor persists the owner's Secure Enclave authority key in the **data-protection keychain** — the only keychain a Secure Enclave key can be permanent in. An unentitled binary cannot persist or resolve it: `open`/`sign` fail closed. The ceremony would have died at step one, and nothing in the pipeline would have said so. `m1nd-mcp/src/enclave_authority.rs` calls this out as a **HARD PREREQUISITE** in its own comments; the build never honoured it.

## Two things proven with a probe binary, not assumed

1. **`codesign` rejects XML comments anywhere in an entitlements plist** — including inside `<dict>` — because it parses with `AMFIUnserializeXML`, while `plutil -lint` accepts them. A well-documented plist lints clean and fails at signing time. The rationale therefore lives in `build/README.md`; the plist itself carries none.
2. **That failure does not fail the build.** `codesign` prints `Failed to parse entitlements: …`, signs the binary **without** the entitlement, and **exits 0**. So the release step now greps the signed output for `keychain-access-groups` and fails explicitly if it is absent — without that check, a silently dropped entitlement leaves the ceremony broken and the release green, which is the exact failure mode this step exists to close.

Verified end to end on a probe binary: the entitlement lands (`4KLJ4N9D5K.world.m1nd.custody`) and the guard passes.

The plist is deliberately **minimal** — one entitlement, one group. It is a custody surface: every entry widens what a signed binary may do, so adding to it is a security decision, never a build tweak.