### PR TITLE
bench(g6): stage the formal blind run to one owner command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ m1nd-ui/node_modules/
 !docs/benchmarks/m1nd10-g6-generalization-v2/public/queries.json
 !docs/benchmarks/m1nd10-g6-generalization-v2/manifest/source-manifest.json
 !docs/benchmarks/m1nd10-g6-generalization-v2/manifest/digests.json
+# M1ND-10 G6 formal ceremony output (scripts/benchmark/g6_formal_run.sh). The
+# verdict and its receipt are public formal artifacts and must never be
+# gitignored; the raw measurements beside them stay operator-only through the
+# `docs/benchmarks/**/runner-results/` rule further down.
+!docs/benchmarks/m1nd10-g6-formal-*/report.json
+!docs/benchmarks/m1nd10-g6-formal-*/receipt.json
 !package.json
 !tsconfig.json
 !postcss.config.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,22 @@ owner on port `1338` — all tests use temp dirs.
 - **`docs/ORGANISM-PRD.md`** — the constitution (the spine, the four grammars, the build ladder).
 - **`CLAUDE.md`** — the repo's canonical build/gate/automation notes (also read by Claude Code).
 
+## The G6 blind benchmark is the owner's, not yours
+
+The G6 knowledge-quality ceremony is staged to one command
+(`scripts/benchmark/g6_formal_run.sh`, described in
+`docs/benchmarks/G6-FORMAL-CEREMONY.md`) and **only the owner runs it**. Agents may
+stage it, verify it, and run `--dry-run` or `g6_formal_preflight.sh`, which touch
+nothing but public artifacts. Three hard rules:
+
+- **Never open `docs/benchmarks/**/operator-only/` or `**/runner-results/`.** Those hold
+  the labels and the raw measurements. The blindness is structural — do not be the
+  hole in it. Hashing a sealed file against its pinned digest is fine; parsing it is not.
+- **Never simulate the ceremony.** A run that did not happen is `NOT_RUN`; a verdict
+  that was not measured is fraud. `NOT_PROVEN` is a legitimate, valuable outcome.
+- **Never re-run to chase green.** The metric spec allows one sealed run per revision
+  (`one_sealed_run_only_no_rerun_until_pass`); a `FAIL` stays in the record.
+
 ## Dogfood m1nd — for LOCAL agents only
 
 If you can reach the served m1nd owner (a local process on `127.0.0.1:1338`), orient with

--- a/docs/benchmarks/G6-FORMAL-CEREMONY.md
+++ b/docs/benchmarks/G6-FORMAL-CEREMONY.md
@@ -1,0 +1,197 @@
+# M1ND-10 G6 — the formal blind run, as one owner command
+
+This is the owner-facing description of the G6 Knowledge Quality ceremony: what
+you type, what you will see, how long it takes, what PASS and FAIL mean, what is
+committed afterwards, and what you must not do.
+
+G6 today is `COMPONENT_PASS`. The runner, the scorer and the corpus contract are
+`LOCAL_PROVEN`; the formal blind run itself is `NOT_RUN`. Nothing in this
+document changes that. Running the ceremony is the only thing that can, and only
+the owner can run it.
+
+## 1. The command
+
+```bash
+scripts/benchmark/g6_formal_run.sh \
+  --metric-spec               <ratified metric spec v2> \
+  --sealed-corpus             <operator-only/corpus.json> \
+  --sealed-corpus-self-digest sha256:<the sealed corpus self_digest> \
+  --authority-assembly        <pinned production authority assembly> \
+  --authority-assembly-digest <its 64-hex self digest> \
+  --authority-provider        <authority provider executable> \
+  --binary                    <pinned candidate m1nd-mcp binary> \
+  --baseline-binary           <pinned baseline m1nd-mcp binary> \
+  --baseline                  <previously sealed baseline result> \
+  --baseline-receipt          <outcome-blind baseline-ratification receipt> \
+  --run-ledger                <sealed-run ledger>
+```
+
+Every path is owner-held. The script holds none of them, and it never reads a
+label: the sealed corpus is hashed and handed to the scorer, never parsed here.
+
+To see how far the machinery gets without any of that:
+
+```bash
+scripts/benchmark/g6_formal_run.sh --dry-run
+```
+
+To check readiness without running anything at all:
+
+```bash
+scripts/benchmark/g6_formal_preflight.sh [same owner-held flags]
+```
+
+## 2. What the script does, in order
+
+1. **Preflight** (`g6_formal_preflight.sh`). Verifies every public artifact
+   against the pinned digests in `manifest/digests.json`, recomputes that
+   manifest's own self digest, replays the frozen-contract byte pins, lints the
+   frozen contracts for world state, re-validates the corpus through the
+   runner's own `validate_public_queries`, confirms the corpus commit and all
+   357 manifest files are present in the object store, and reports each
+   owner-held input as present-and-valid or missing. Exit `0` READY, `3`
+   READY_PUBLIC_ONLY, `1` FAIL. A formal run demands `0`.
+2. **Run identity.** Refuses a dirty working tree (a dirty tree already produced
+   one discarded run: `m1nd10-g6-failed-b59-dirty-af02c141.json`). Derives
+   `run_id` and `system_revision` from `HEAD`.
+3. **Isolated source snapshot.** Materialises the exact manifest file set from
+   immutable Git objects at the corpus commit into a fresh `0700` directory
+   outside every Git worktree, then verifies it through the runner's own
+   `verify_public_source_snapshot`: byte, size and line count per file, no
+   symlink, no extra file, no missing file.
+4. **Blind run.** Invokes `m1nd10_g6_blind_runner.py` for the `current` lane:
+   four owners (one per corpus repository), governed graph ingest with every
+   authority receipt verified offline by the pinned candidate binary itself, a
+   post-ingest re-proof that the source did not move, warm-up, then one `north`
+   and one `seek` per task for all 220 tasks.
+5. **Score.** Invokes `m1nd10_g6_retrieval.py` against the sealed corpus, the
+   ratified baseline, the baseline-ratification receipt and the sealed-run
+   ledger, then prints every metric next to its ratified threshold and writes
+   the report and the receipt.
+
+## 3. What you will see
+
+Steps 1-3 print a check table, the run identity, and the snapshot verification
+line (`checked=357 missing=0 mismatched=0 extra=0`). Step 4 prints runner
+progress. Step 5 prints the verdict as measured-versus-ratified pairs:
+
+```
+measured vs ratified
+  top-5 anchor recall      measured=0.905  >= ratified=0.9    PASS
+  abstention recall        measured=0.95   >= ratified=0.95   PASS
+  wrong-ground act rate    measured=0.0    <= ratified=0.01   PASS
+  north p95 (ms)           measured=1085.8 <= ratified=2000   PASS
+  seek p95 (ms)            measured=236.8  <= ratified=500    PASS
+  paired regression        p=1.4e-24  alpha=0.05  improvements=102 regressions=5
+
+VERDICT: PASS (claimable=true)
+```
+
+*(Those numbers are the 2026-07-18 held-out-v1 run, shown only so the shape of
+the output is recognisable. They are not a prediction.)*
+
+## 4. How long it takes
+
+| Phase | Cost | Basis |
+|---|---|---|
+| Preflight | ~2 s | measured: hashes 6 public artifacts and walks one tree |
+| Snapshot materialise + verify | ~11 s | measured: 357 files, 8,186,532 bytes, verified twice |
+| Whole `--dry-run` | 13.7 s | measured end to end on this machine |
+| Owner boot + 4 governed ingests | 10-25 min | **estimate**, not measured: 206,361 source lines across four owners |
+| 220 measured tasks | 5-8 min | derived from the prior run's p95s (north 1086 ms + seek 237 ms per task) |
+| Scoring | seconds | measured: the scorer is pure JSON evaluation |
+
+Budget **20-40 minutes** end to end and do not interrupt it. Only the first two
+rows have been measured; the rest is arithmetic on the previous era's numbers
+and will be replaced by a real figure once the ceremony has run once.
+
+## 5. What PASS and FAIL mean
+
+**PASS** (`status: PASS`, `claimable: true`) means every ratified threshold was
+met on complete evidence: top-5 anchor recall on localizable tasks, abstention
+recall on unlocalizable tasks, the wrong-ground `act` rate, the `north` and
+`seek` p95 SLOs, and no statistically significant paired regression against the
+ratified baseline. That is the evidence G6 has been missing. It does not by
+itself close G6 cumulatively — the receipt still has to be accepted by the
+release authority alongside the other gates.
+
+**FAIL** means a measured threshold was missed. The numbers are real; preserve
+them.
+
+**NOT_PROVEN** means the evidence was incomplete — a missing task, a duplicate
+measurement, an unresolved SLO, an unratified spec, a non-finite latency, an
+absent baseline. It is neither a pass nor a fail, and it is the honest outcome
+whenever the machinery cannot see enough to judge.
+
+## 6. What gets committed afterwards
+
+The script writes to `docs/benchmarks/m1nd10-<run_id>/`:
+
+| Artifact | Visibility | Commit? |
+|---|---|---|
+| `report.json` | public | yes — the scorer's verdict |
+| `receipt.json` | public | yes — digests binding spec, runner, scorer, both binaries, the raw result and the report to the verdict |
+| `runner-results/` | operator-only | never — already gitignored |
+
+`.gitignore` carries explicit allow-lines for `report.json` and `receipt.json`
+under `m1nd10-g6-formal-*/`, so the two public artifacts survive the repository's
+blanket `*.json` rule while the raw measurements stay out. That is the
+boundary-era law: public formal artifacts are never gitignored, operator-only
+always is.
+
+`receipt.json` is **not** a `GateReceiptV1`. That structure
+(`m1nd-control::release`) binds a ratified custody floor and is minted by the
+release authority. This receipt is the evidence the release authority consumes.
+
+Also update `docs/PATHOS.md` in the same session: G6 moves off `NOT_RUN`, and the
+checkpoint records the verdict with its numbers.
+
+## 7. What NOT to do
+
+- **Do not re-run until it goes green.** The metric spec is explicit:
+  `same_revision_rerun_policy: "one_sealed_run_only_no_rerun_until_pass"`, and
+  `new_run_requires: "new system_revision or binary_digest; preserve prior
+  FAIL/NOT_PROVEN evidence"`. One sealed run per revision. A new run needs a new
+  revision or a new binary, and the old FAIL stays in the record — the repository
+  already keeps two of them on purpose (`m1nd10-g6-failed-*.json`).
+- **Do not run from a dirty tree.** The script refuses; do not work around it.
+- **Do not open the labels.** No agent, implementer or reviewer reads
+  `operator-only/`. The runner and the authority provider are sandboxed away
+  from those paths precisely so the blindness is structural, not promised.
+- **Do not weaken a fail-closed check to get a verdict.** `NOT_PROVEN` is a
+  legitimate outcome and is worth more than a manufactured `PASS`.
+- **Do not run against the served owner or port 1338.** The ceremony spawns its
+  own owners on kernel-assigned ports with private registries.
+
+## 8. What is still missing before this can run
+
+The preflight names these every time it runs. As of this writing none of them
+exist in the repository, and none of them can be produced by an agent:
+
+1. **A ratified metric spec v2.** The checked-in
+   `m1nd10-g6-metric-spec-v1.json` is v1. Both the runner
+   (`validate_metric_spec_for_runner`) and the scorer (`_validate_spec`) require
+   schema `m1nd10-g6-metric-spec-v2` with a calibration gate, an outcome-blind
+   ratification, and an authority receipt digest. The v1 thresholds carry over;
+   the artifact has to be re-minted under authority.
+2. **A pinned production authority assembly and its provider executable.** The
+   runner refuses formal mode without one: *"formal run requires a pinned
+   production authority assembly"*. This is the G9 custody floor — Path B,
+   amendment G9-A1, ratified 2026-07-21 in
+   `docs/M1ND-10-G9-CUSTODY-DECISION-20260721.md`, implementation not started.
+3. **One frozen immutable candidate binary**, for the current lane and for the
+   baseline lane.
+4. **The sealed held-out corpus**, matching the pinned digest
+   `sha256:5abe6f7d…` in `m1nd10-g6-held-out-v2/manifest/digests.json`.
+5. **A ratified baseline run, its outcome-blind ratification receipt, and the
+   sealed-run ledger.**
+
+Item 2 is the frontier; it gates G6-formal, G7-complete and G8-signing together.
+Everything else in this ceremony is staged, verified and waiting.
+
+## 9. Related documents
+
+- `docs/benchmarks/M1ND10_G6_RETRIEVAL_PROTOCOL.md` — the gate's measurement contract
+- `docs/proofs/m1nd10-g6-knowledge-quality.md` — the G6 proof receipt
+- `docs/M1ND-10-HANDOFF-20260719.md` §7 — why the run is blocked
+- `docs/M1ND-10-G9-CUSTODY-DECISION-20260721.md` — the custody decision it waits on

--- a/scripts/benchmark/g6_formal_preflight.sh
+++ b/scripts/benchmark/g6_formal_preflight.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# M1ND-10 G6 formal blind run — integrity preflight.
+#
+# Verifies everything that can be verified BEFORE the owner ceremony spends any
+# runtime: the public corpus against its pinned digests, the frozen contracts,
+# the materialisability of the isolated source snapshot, the runner/scorer
+# toolchain, and the presence plus validity of every owner-held input.
+#
+# It never reads, parses, or prints label-bearing content. The sealed corpus is
+# only ever hashed and compared against its pinned digest.
+#
+# Exit codes:
+#   0  READY               — every check passed; the formal run may proceed.
+#   3  READY_PUBLIC_ONLY   — the repository half is sound; owner-held inputs are
+#                            missing. A dry run may proceed; a formal run may not.
+#   1  FAIL                — a repository-side check failed. Fix before anything.
+#   2  usage error.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: g6_formal_preflight.sh [options]
+
+Owner-held inputs (all optional here; all required for a formal run):
+  --metric-spec PATH         ratified metric spec v2 (m1nd10-g6-metric-spec-v2)
+  --sealed-corpus PATH       sealed held-out corpus (hashed only, never parsed)
+  --authority-assembly PATH  pinned production authority assembly manifest
+  --authority-provider PATH  authority provider executable
+  --binary PATH              pinned candidate m1nd-mcp binary (current lane)
+  --baseline-binary PATH     pinned baseline m1nd-mcp binary
+  --baseline PATH            previously sealed baseline result artifact
+  --baseline-receipt PATH    outcome-blind baseline-ratification receipt
+  --run-ledger PATH          sealed-run ledger
+
+Other options:
+  --json PATH                also write the machine-readable preflight report
+  -h, --help                 this text
+USAGE
+}
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+
+METRIC_SPEC=""
+SEALED_CORPUS=""
+AUTHORITY_ASSEMBLY=""
+AUTHORITY_PROVIDER=""
+CANDIDATE_BINARY=""
+BASELINE_BINARY=""
+BASELINE=""
+BASELINE_RECEIPT=""
+RUN_LEDGER=""
+JSON_OUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --metric-spec) METRIC_SPEC="${2:?}"; shift 2 ;;
+    --sealed-corpus) SEALED_CORPUS="${2:?}"; shift 2 ;;
+    --authority-assembly) AUTHORITY_ASSEMBLY="${2:?}"; shift 2 ;;
+    --authority-provider) AUTHORITY_PROVIDER="${2:?}"; shift 2 ;;
+    --binary) CANDIDATE_BINARY="${2:?}"; shift 2 ;;
+    --baseline-binary) BASELINE_BINARY="${2:?}"; shift 2 ;;
+    --baseline) BASELINE="${2:?}"; shift 2 ;;
+    --baseline-receipt) BASELINE_RECEIPT="${2:?}"; shift 2 ;;
+    --run-ledger) RUN_LEDGER="${2:?}"; shift 2 ;;
+    --json) JSON_OUT="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+export G6_REPO_ROOT="$REPO_ROOT"
+export G6_METRIC_SPEC="$METRIC_SPEC"
+export G6_SEALED_CORPUS="$SEALED_CORPUS"
+export G6_AUTHORITY_ASSEMBLY="$AUTHORITY_ASSEMBLY"
+export G6_AUTHORITY_PROVIDER="$AUTHORITY_PROVIDER"
+export G6_CANDIDATE_BINARY="$CANDIDATE_BINARY"
+export G6_BASELINE_BINARY="$BASELINE_BINARY"
+export G6_BASELINE="$BASELINE"
+export G6_BASELINE_RECEIPT="$BASELINE_RECEIPT"
+export G6_RUN_LEDGER="$RUN_LEDGER"
+export G6_JSON_OUT="$JSON_OUT"
+
+exec python3 - <<'PREFLIGHT'
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(os.environ["G6_REPO_ROOT"]).resolve()
+BENCH = ROOT / "docs" / "benchmarks"
+HELD_OUT = BENCH / "m1nd10-g6-held-out-v2"
+GENERALIZATION = BENCH / "m1nd10-g6-generalization-v2"
+METRIC_SPEC_V1 = BENCH / "m1nd10-g6-metric-spec-v1.json"
+RUNNER = ROOT / "scripts" / "benchmark" / "m1nd10_g6_blind_runner.py"
+SCORER = ROOT / "scripts" / "benchmark" / "m1nd10_g6_retrieval.py"
+
+# Frozen-contract pins. PRD/UML repeat .github/workflows/ci.yml `contract-gates`
+# verbatim; the metric-spec pin is this ceremony's own, on the same mechanism.
+FROZEN_PINS = {
+    "docs/M1ND-10-PRD.md": (
+        "2745560daf6e5cf6237b84663f895e81e2c4979de4190dfef649b032b680f87b"
+    ),
+    "docs/M1ND-10-UML.md": (
+        "d5bc29776f516c300cb1a0668f0a53844286f75395fd0ad1e875b52ea3a067a5"
+    ),
+    "docs/benchmarks/m1nd10-g6-metric-spec-v1.json": (
+        "4b22e391154d219de4efbb8787ef8340a61d1b27e093bc9c9bc3e4fdb13ca8f0"
+    ),
+}
+
+PASS, FAIL, MISSING = "PASS", "FAIL", "OWNER_INPUT_MISSING"
+checks: list[dict[str, object]] = []
+
+
+def record(name: str, state: str, detail: str) -> None:
+    checks.append({"check": name, "state": state, "detail": detail})
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def load(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# 1. Runner and scorer must import; the ceremony reuses their law, never a copy.
+sys.path.insert(0, str(RUNNER.parent))
+try:
+    import m1nd10_g6_blind_runner as runner_module
+
+    record(
+        "toolchain.runner_import",
+        PASS,
+        f"python {sys.version_info.major}.{sys.version_info.minor}; "
+        f"m1nd10_g6_blind_runner imported from {RUNNER}",
+    )
+except Exception as error:  # noqa: BLE001 - preflight reports, never raises
+    runner_module = None
+    record("toolchain.runner_import", FAIL, f"{type(error).__name__}: {error}")
+
+try:
+    import m1nd10_g6_retrieval as scorer_module
+
+    record(
+        "toolchain.scorer_import",
+        PASS,
+        f"m1nd10_g6_retrieval imported from {SCORER}",
+    )
+except Exception as error:  # noqa: BLE001
+    scorer_module = None
+    record("toolchain.scorer_import", FAIL, f"{type(error).__name__}: {error}")
+
+for label, path in (("runner", RUNNER), ("scorer", SCORER)):
+    if path.is_file():
+        record(
+            f"toolchain.{label}_digest",
+            PASS,
+            f"sha256:{sha256_file(path)} (bound into every receipt)",
+        )
+    else:
+        record(f"toolchain.{label}_digest", FAIL, f"{path} is absent")
+
+
+# 2. Public artifacts against the pinned digest manifests.
+def verify_digest_manifest(corpus_dir: pathlib.Path, label: str) -> dict | None:
+    digests_path = corpus_dir / "manifest" / "digests.json"
+    if not digests_path.is_file():
+        record(f"{label}.digests_manifest", FAIL, f"{digests_path} is absent")
+        return None
+    document = load(digests_path)
+    if "self_digest" in document:
+        recomputed = "sha256:" + hashlib.sha256(
+            canonical({k: v for k, v in document.items() if k != "self_digest"})
+        ).hexdigest()
+        state = PASS if recomputed == document["self_digest"] else FAIL
+        record(
+            f"{label}.digests_self_digest",
+            state,
+            f"{document['self_digest']} recomputed {'exactly' if state == PASS else 'to ' + recomputed}",
+        )
+    public_ok = True
+    owner_held: list[str] = []
+    for artifact in document.get("artifacts", []):
+        relative = artifact["path"]
+        path = corpus_dir / relative
+        if relative.startswith("operator-only/"):
+            owner_held.append(relative)
+            continue
+        if not path.is_file():
+            record(f"{label}.artifact:{relative}", FAIL, "absent from the checkout")
+            public_ok = False
+            continue
+        observed = "sha256:" + sha256_file(path)
+        size_ok = "bytes" not in artifact or path.stat().st_size == artifact["bytes"]
+        if observed == artifact["sha256"] and size_ok:
+            record(f"{label}.artifact:{relative}", PASS, observed)
+        else:
+            record(
+                f"{label}.artifact:{relative}",
+                FAIL,
+                f"pinned {artifact['sha256']} != observed {observed}",
+            )
+            public_ok = False
+    record(
+        f"{label}.public_artifact_set",
+        PASS if public_ok else FAIL,
+        "every public artifact matches its pinned digest"
+        if public_ok
+        else "at least one public artifact drifted from its pin",
+    )
+    if owner_held:
+        record(
+            f"{label}.operator_only_artifacts",
+            MISSING if not all((corpus_dir / p).is_file() for p in owner_held) else PASS,
+            "owner-held, never read by this preflight: " + ", ".join(sorted(owner_held)),
+        )
+    return document
+
+
+held_out_digests = verify_digest_manifest(HELD_OUT, "held_out_v2")
+verify_digest_manifest(GENERALIZATION, "generalization_v2")
+
+# 3. The corpus must satisfy the runner's own law, not a restatement of it.
+queries_path = HELD_OUT / "public" / "queries.json"
+queries = load(queries_path) if queries_path.is_file() else None
+if runner_module is not None and queries is not None:
+    try:
+        tasks = runner_module.validate_public_queries(queries)
+        record(
+            "held_out_v2.runner_validation",
+            PASS,
+            f"validate_public_queries accepted {len(tasks)} tasks; "
+            f"corpus_id={queries['corpus_id']}",
+        )
+    except Exception as error:  # noqa: BLE001
+        record("held_out_v2.runner_validation", FAIL, str(error))
+else:
+    record("held_out_v2.runner_validation", FAIL, "runner or corpus unavailable")
+
+# 4. Frozen contracts: pinned bytes, and law-not-world content.
+for relative, pin in FROZEN_PINS.items():
+    path = ROOT / relative
+    if not path.is_file():
+        record(f"frozen.{relative}", FAIL, "absent")
+        continue
+    observed = sha256_file(path)
+    record(
+        f"frozen.{relative}",
+        PASS if observed == pin else FAIL,
+        observed if observed == pin else f"pinned {pin} != observed {observed}",
+    )
+
+CLOCK_KEYS = ("generated_at", "measured_at", "observed_at", "run_at", "now_ms", "now")
+WORLD_KEYS = ("instance_id", "fixture_id", "fixture", "task_count", "measurements")
+
+
+def frozen_lint(path: pathlib.Path, label: str) -> None:
+    """A frozen contract declares LAW; world state belongs outside it."""
+    if not path.is_file():
+        record(f"frozen_lint.{label}", MISSING, f"{path} is absent")
+        return
+    document = load(path)
+    findings: list[str] = []
+
+    def walk(node: object, trail: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                where = f"{trail}.{key}" if trail else key
+                if key in CLOCK_KEYS:
+                    findings.append(f"wall clock at {where}")
+                if key in WORLD_KEYS:
+                    findings.append(f"world state at {where}")
+                if key.endswith("_at") and isinstance(value, str) and "T" in value:
+                    findings.append(f"instant (not a date) at {where}")
+                walk(value, where)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{trail}[{index}]")
+        elif isinstance(node, str) and node.startswith("/"):
+            findings.append(f"absolute filesystem path at {trail}")
+
+    walk(document, "")
+    record(
+        f"frozen_lint.{label}",
+        PASS if not findings else FAIL,
+        "declares law only (date-only ratification provenance and repo-relative "
+        "references are the declared carve-outs)"
+        if not findings
+        else "; ".join(sorted(set(findings))),
+    )
+
+
+frozen_lint(METRIC_SPEC_V1, "metric_spec_v1")
+
+# 5. The isolated source snapshot must be materialisable from immutable objects.
+if queries is not None:
+    manifest = queries["source_manifest"]
+    commit = manifest.get("source_commit")
+    if commit is None:
+        record("snapshot.source_commit", FAIL, "public manifest has no source_commit")
+    else:
+        probe = subprocess.run(
+            ["git", "-C", str(ROOT), "cat-file", "-t", commit],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if probe.returncode != 0 or probe.stdout.strip() != "commit":
+            record(
+                "snapshot.source_commit",
+                FAIL,
+                f"corpus commit {commit} is not present in this object store",
+            )
+        else:
+            expected = sum(len(repo["files"]) for repo in manifest["repos"])
+            listing = subprocess.run(
+                ["git", "-C", str(ROOT), "ls-tree", "-r", "--name-only", commit],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            available = set(listing.stdout.splitlines())
+            wanted = {
+                f"{repo['source_root']}/{entry['path']}"
+                for repo in manifest["repos"]
+                for entry in repo["files"]
+            }
+            absent = sorted(wanted - available)
+            record(
+                "snapshot.source_commit",
+                PASS if not absent else FAIL,
+                f"commit {commit} present; {expected} manifest files resolvable"
+                if not absent
+                else f"{len(absent)} manifest files absent at {commit}: "
+                + ", ".join(absent[:5]),
+            )
+
+# 6. Owner-held inputs.
+def owner_input(env_key: str, label: str, executable: bool = False) -> pathlib.Path | None:
+    raw = os.environ.get(env_key, "")
+    if not raw:
+        record(f"owner.{label}", MISSING, "not supplied")
+        return None
+    path = pathlib.Path(raw).expanduser().resolve()
+    if not path.is_file():
+        record(f"owner.{label}", FAIL, f"{path} is not a regular file")
+        return None
+    if executable and not os.access(path, os.X_OK):
+        record(f"owner.{label}", FAIL, f"{path} is not executable")
+        return None
+    record(f"owner.{label}", PASS, f"{path} sha256:{sha256_file(path)}")
+    return path
+
+
+owner_metric_spec = owner_input("G6_METRIC_SPEC", "metric_spec_v2")
+if owner_metric_spec is not None and runner_module is not None:
+    try:
+        calibration = runner_module.validate_metric_spec_for_runner(
+            load(owner_metric_spec)
+        )
+        record(
+            "owner.metric_spec_v2_contract",
+            PASS,
+            "accepted by the runner; calibration gate "
+            + json.dumps(calibration, sort_keys=True),
+        )
+        frozen_lint(owner_metric_spec, "metric_spec_v2")
+    except Exception as error:  # noqa: BLE001
+        record("owner.metric_spec_v2_contract", FAIL, str(error))
+else:
+    record(
+        "owner.metric_spec_v2_contract",
+        MISSING,
+        "the checked-in metric spec is v1; the runner and the scorer both require "
+        "schema m1nd10-g6-metric-spec-v2 with a calibration gate, an outcome-blind "
+        "ratification, and an authority receipt digest",
+    )
+
+sealed = owner_input("G6_SEALED_CORPUS", "sealed_corpus")
+if sealed is not None and held_out_digests is not None:
+    pinned = next(
+        (
+            entry["sha256"]
+            for entry in held_out_digests["artifacts"]
+            if entry["path"] == "operator-only/corpus.json"
+        ),
+        None,
+    )
+    observed = "sha256:" + sha256_file(sealed)
+    record(
+        "owner.sealed_corpus_pin",
+        PASS if observed == pinned else FAIL,
+        "matches the pinned sealed-corpus digest (hashed, never parsed)"
+        if observed == pinned
+        else f"pinned {pinned} != observed {observed}",
+    )
+elif sealed is None:
+    record("owner.sealed_corpus_pin", MISSING, "sealed corpus not supplied")
+
+assembly = owner_input("G6_AUTHORITY_ASSEMBLY", "authority_assembly")
+owner_input("G6_AUTHORITY_PROVIDER", "authority_provider", executable=True)
+candidate = owner_input("G6_CANDIDATE_BINARY", "candidate_binary", executable=True)
+owner_input("G6_BASELINE_BINARY", "baseline_binary", executable=True)
+owner_input("G6_BASELINE", "baseline_result")
+owner_input("G6_BASELINE_RECEIPT", "baseline_ratification_receipt")
+owner_input("G6_RUN_LEDGER", "sealed_run_ledger")
+
+if assembly is not None:
+    document = load(assembly)
+    production = document.get("production_authority_assembly")
+    kind = document.get("provider_kind")
+    record(
+        "owner.production_authority",
+        PASS if production is True and kind == "production" else FAIL,
+        f"provider_kind={kind} production_authority_assembly={production}"
+        + (
+            ""
+            if production is True and kind == "production"
+            else "; the formal run refuses a non-production assembly "
+            "(m1nd10_g6_blind_runner.py: 'formal run requires a pinned production "
+            "authority assembly')"
+        ),
+    )
+else:
+    record(
+        "owner.production_authority",
+        MISSING,
+        "no pinned production authority assembly; it is minted under the G9 custody "
+        "floor (docs/M1ND-10-G9-CUSTODY-DECISION-20260721.md, amendment G9-A1)",
+    )
+
+if candidate is not None:
+    probe = subprocess.run(
+        [str(candidate), "--verify-authorization-receipt"],
+        input="{}",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    record(
+        "owner.candidate_verifier_mode",
+        PASS if probe.returncode in (1, 2) else FAIL,
+        f"--verify-authorization-receipt answered exit {probe.returncode} on an "
+        "invalid request (a refusal proves the exclusive offline mode exists)",
+    )
+else:
+    record(
+        "owner.candidate_verifier_mode",
+        MISSING,
+        "no pinned candidate binary; freeze one immutable candidate first",
+    )
+
+# 7. Verdict.
+failures = [c for c in checks if c["state"] == FAIL]
+absent = [c for c in checks if c["state"] == MISSING]
+if failures:
+    status, exit_code = "FAIL", 1
+elif absent:
+    status, exit_code = "READY_PUBLIC_ONLY", 3
+else:
+    status, exit_code = "READY", 0
+
+width = max(len(str(c["check"])) for c in checks)
+print("M1ND-10 G6 formal blind run — integrity preflight")
+print(f"repository: {ROOT}")
+print("-" * (width + 24))
+for check in checks:
+    print(f"{check['state']:<19} {str(check['check']):<{width}}  {check['detail']}")
+print("-" * (width + 24))
+print(f"STATUS: {status}")
+if failures:
+    print("\nrepository-side failures — fix before any run:")
+    for check in failures:
+        print(f"  - {check['check']}: {check['detail']}")
+if absent:
+    print("\nowner-held inputs still missing — a formal run cannot start:")
+    for check in absent:
+        print(f"  - {check['check']}: {check['detail']}")
+
+report = {
+    "schema": "m1nd10-g6-formal-preflight-v1",
+    "status": status,
+    "repository": str(ROOT),
+    "checks": checks,
+}
+if os.environ.get("G6_JSON_OUT"):
+    out = pathlib.Path(os.environ["G6_JSON_OUT"])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"\npreflight report: {out}")
+
+sys.exit(exit_code)
+PREFLIGHT

--- a/scripts/benchmark/g6_formal_run.sh
+++ b/scripts/benchmark/g6_formal_run.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+# M1ND-10 G6 formal blind run — the owner ceremony, as one command.
+#
+#   scripts/benchmark/g6_formal_run.sh --dry-run
+#       Exercise the whole pipeline that precedes measurement, against the public
+#       corpus half only. Touches no labels, spawns no owner, claims nothing.
+#
+#   scripts/benchmark/g6_formal_run.sh --metric-spec ... --sealed-corpus ... ...
+#       The formal blind run. Requires every owner-held input; refuses otherwise.
+#
+# This script orchestrates the existing runner and scorer. It does not
+# reimplement any part of their law, and it never reads a label.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: g6_formal_run.sh [--dry-run] [options]
+
+Mode:
+  --dry-run                  exercise the public half; never score, never claim
+
+Owner-held inputs (all required for a formal run):
+  --metric-spec PATH         ratified metric spec v2
+  --sealed-corpus PATH       sealed held-out corpus (hashed only, never parsed)
+  --sealed-corpus-self-digest SHA256
+                             the sealed corpus self_digest, supplied by the owner
+  --authority-assembly PATH  pinned production authority assembly manifest
+  --authority-assembly-digest SHA256
+  --authority-provider PATH  authority provider executable
+  --binary PATH              pinned candidate m1nd-mcp binary (current lane)
+  --baseline-binary PATH     pinned baseline m1nd-mcp binary
+  --baseline PATH            previously sealed baseline result artifact
+  --baseline-receipt PATH    outcome-blind baseline-ratification receipt
+  --run-ledger PATH          sealed-run ledger
+
+Placement:
+  --out DIR                  artifact directory (default: docs/benchmarks/<run-id>)
+  --snapshot-root DIR        isolated source snapshot root
+  --run-id ID                sealed run id (default: derived, unique per run)
+  --keep-snapshot            do not delete the materialised snapshot afterwards
+  -h, --help                 this text
+USAGE
+}
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+PREFLIGHT="$REPO_ROOT/scripts/benchmark/g6_formal_preflight.sh"
+RUNNER="$REPO_ROOT/scripts/benchmark/m1nd10_g6_blind_runner.py"
+SCORER="$REPO_ROOT/scripts/benchmark/m1nd10_g6_retrieval.py"
+GENERALIZATION_SCORER="$REPO_ROOT/scripts/benchmark/m1nd10_g6_generalization_score.py"
+HELD_OUT="$REPO_ROOT/docs/benchmarks/m1nd10-g6-held-out-v2"
+GENERALIZATION="$REPO_ROOT/docs/benchmarks/m1nd10-g6-generalization-v2"
+
+DRY_RUN=0
+METRIC_SPEC=""
+SEALED_CORPUS=""
+SEALED_CORPUS_SELF_DIGEST=""
+AUTHORITY_ASSEMBLY=""
+AUTHORITY_ASSEMBLY_DIGEST=""
+AUTHORITY_PROVIDER=""
+CANDIDATE_BINARY=""
+BASELINE_BINARY=""
+BASELINE=""
+BASELINE_RECEIPT=""
+RUN_LEDGER=""
+OUT_DIR=""
+SNAPSHOT_ROOT=""
+RUN_ID=""
+KEEP_SNAPSHOT=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --metric-spec) METRIC_SPEC="${2:?}"; shift 2 ;;
+    --sealed-corpus) SEALED_CORPUS="${2:?}"; shift 2 ;;
+    --sealed-corpus-self-digest) SEALED_CORPUS_SELF_DIGEST="${2:?}"; shift 2 ;;
+    --authority-assembly) AUTHORITY_ASSEMBLY="${2:?}"; shift 2 ;;
+    --authority-assembly-digest) AUTHORITY_ASSEMBLY_DIGEST="${2:?}"; shift 2 ;;
+    --authority-provider) AUTHORITY_PROVIDER="${2:?}"; shift 2 ;;
+    --binary) CANDIDATE_BINARY="${2:?}"; shift 2 ;;
+    --baseline-binary) BASELINE_BINARY="${2:?}"; shift 2 ;;
+    --baseline) BASELINE="${2:?}"; shift 2 ;;
+    --baseline-receipt) BASELINE_RECEIPT="${2:?}"; shift 2 ;;
+    --run-ledger) RUN_LEDGER="${2:?}"; shift 2 ;;
+    --out) OUT_DIR="${2:?}"; shift 2 ;;
+    --snapshot-root) SNAPSHOT_ROOT="${2:?}"; shift 2 ;;
+    --run-id) RUN_ID="${2:?}"; shift 2 ;;
+    --keep-snapshot) KEEP_SNAPSHOT=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+say() { printf '%s\n' "$*"; }
+rule() { printf '%s\n' "--------------------------------------------------------------"; }
+
+# ---------------------------------------------------------------- step 1: preflight
+say "M1ND-10 G6 formal blind run"
+say "mode: $([ "$DRY_RUN" -eq 1 ] && echo 'DRY RUN (public half only)' || echo 'FORMAL')"
+rule
+say "step 1/5  integrity preflight"
+
+PREFLIGHT_ARGS=()
+[ -n "$METRIC_SPEC" ] && PREFLIGHT_ARGS+=(--metric-spec "$METRIC_SPEC")
+[ -n "$SEALED_CORPUS" ] && PREFLIGHT_ARGS+=(--sealed-corpus "$SEALED_CORPUS")
+[ -n "$AUTHORITY_ASSEMBLY" ] && PREFLIGHT_ARGS+=(--authority-assembly "$AUTHORITY_ASSEMBLY")
+[ -n "$AUTHORITY_PROVIDER" ] && PREFLIGHT_ARGS+=(--authority-provider "$AUTHORITY_PROVIDER")
+[ -n "$CANDIDATE_BINARY" ] && PREFLIGHT_ARGS+=(--binary "$CANDIDATE_BINARY")
+[ -n "$BASELINE_BINARY" ] && PREFLIGHT_ARGS+=(--baseline-binary "$BASELINE_BINARY")
+[ -n "$BASELINE" ] && PREFLIGHT_ARGS+=(--baseline "$BASELINE")
+[ -n "$BASELINE_RECEIPT" ] && PREFLIGHT_ARGS+=(--baseline-receipt "$BASELINE_RECEIPT")
+[ -n "$RUN_LEDGER" ] && PREFLIGHT_ARGS+=(--run-ledger "$RUN_LEDGER")
+
+set +e
+bash "$PREFLIGHT" ${PREFLIGHT_ARGS[@]+"${PREFLIGHT_ARGS[@]}"}
+PREFLIGHT_STATUS=$?
+set -e
+
+if [ "$PREFLIGHT_STATUS" -eq 1 ]; then
+  rule
+  say "ABORTED: the repository half of the preflight failed. Nothing ran."
+  exit 1
+fi
+if [ "$DRY_RUN" -eq 0 ] && [ "$PREFLIGHT_STATUS" -ne 0 ]; then
+  rule
+  say "ABORTED: the formal run needs every owner-held input listed above."
+  say "Re-run with --dry-run to exercise the public half in the meantime."
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  # Two owner-held values are digests, not files, so the preflight cannot see them.
+  MISSING_VALUES=()
+  [ -z "$SEALED_CORPUS_SELF_DIGEST" ] && MISSING_VALUES+=(--sealed-corpus-self-digest)
+  [ -z "$AUTHORITY_ASSEMBLY_DIGEST" ] && MISSING_VALUES+=(--authority-assembly-digest)
+  if [ ${#MISSING_VALUES[@]} -gt 0 ]; then
+    rule
+    say "ABORTED: missing required value(s): ${MISSING_VALUES[*]}"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------- step 2: identity
+rule
+say "step 2/5  run identity"
+
+CORPUS_ID="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["corpus_id"])' \
+  "$HELD_OUT/public/queries.json")"
+HEAD_COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+if [ "$DRY_RUN" -eq 0 ] && [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+  say "ABORTED: the working tree is dirty. A formal run must bind one immutable"
+  say "candidate revision; a dirty tree already produced a discarded run"
+  say "(docs/benchmarks/m1nd10-g6-failed-b59-dirty-af02c141.json)."
+  exit 1
+fi
+SYSTEM_REVISION="git:$HEAD_COMMIT"
+if [ -z "$RUN_ID" ]; then
+  RUN_ID="g6-$([ "$DRY_RUN" -eq 1 ] && echo dry || echo formal)-$(date -u +%Y%m%dT%H%M%SZ)-${HEAD_COMMIT:0:12}"
+fi
+if [ -z "$OUT_DIR" ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    # A dry run proves nothing claimable, so it never lands in the repository.
+    OUT_DIR="${TMPDIR:-/tmp}/m1nd10-$RUN_ID"
+  else
+    OUT_DIR="$REPO_ROOT/docs/benchmarks/m1nd10-$RUN_ID"
+  fi
+fi
+[ -z "$SNAPSHOT_ROOT" ] && SNAPSHOT_ROOT="${TMPDIR:-/tmp}/m1nd-g6-snapshot-$RUN_ID"
+
+# The runner refuses any path with a symlink component, and a macOS $TMPDIR is
+# reached through one. Resolve the parents; keep the leaves fresh and absent.
+resolve_leaf() {
+  mkdir -p "$(dirname "$1")"
+  python3 -c 'import pathlib,sys
+leaf = pathlib.Path(sys.argv[1])
+print(leaf.parent.resolve() / leaf.name)' "$1"
+}
+OUT_DIR="$(resolve_leaf "$OUT_DIR")"
+SNAPSHOT_ROOT="$(resolve_leaf "$SNAPSHOT_ROOT")"
+
+say "corpus_id        $CORPUS_ID"
+say "run_id           $RUN_ID"
+say "system_revision  $SYSTEM_REVISION"
+say "artifacts        $OUT_DIR"
+say "snapshot root    $SNAPSHOT_ROOT"
+
+mkdir -p "$OUT_DIR"
+[ "$DRY_RUN" -eq 0 ] && mkdir -p "$OUT_DIR/runner-results"
+
+# --------------------------------------------------- step 3: isolated source snapshot
+rule
+say "step 3/5  materialise and verify the isolated source snapshot"
+
+if [ -e "$SNAPSHOT_ROOT" ]; then
+  say "ABORTED: $SNAPSHOT_ROOT already exists; the snapshot root must be fresh."
+  exit 1
+fi
+
+cleanup() {
+  if [ "$KEEP_SNAPSHOT" -eq 0 ] && [ -d "$SNAPSHOT_ROOT" ]; then
+    rm -rf "$SNAPSHOT_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+G6_REPO_ROOT="$REPO_ROOT" \
+G6_QUERIES="$HELD_OUT/public/queries.json" \
+G6_SNAPSHOT_ROOT="$SNAPSHOT_ROOT" \
+python3 - <<'MATERIALISE'
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(os.environ["G6_REPO_ROOT"])
+queries = json.loads(pathlib.Path(os.environ["G6_QUERIES"]).read_text(encoding="utf-8"))
+snapshot = pathlib.Path(os.environ["G6_SNAPSHOT_ROOT"])
+manifest = queries["source_manifest"]
+commit = manifest["source_commit"]
+
+# The snapshot must be an isolated live tree outside every Git worktree, holding
+# exactly the manifest file set — the runner rejects a missing or an extra file.
+for candidate in (snapshot, *snapshot.parents):
+    if os.path.lexists(candidate / ".git"):
+        print(f"ABORTED: {candidate} is inside a Git worktree", file=sys.stderr)
+        sys.exit(1)
+
+snapshot.mkdir(parents=True, mode=0o700)
+written = 0
+for repo in manifest["repos"]:
+    for entry in repo["files"]:
+        destination = snapshot / repo["source_root"] / entry["path"]
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        blob = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "cat-file",
+                "blob",
+                f"{commit}:{repo['source_root']}/{entry['path']}",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if blob.returncode != 0:
+            print(
+                f"ABORTED: {repo['repo_id']}/{entry['path']} is absent at {commit}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        destination.write_bytes(blob.stdout)
+        written += 1
+print(f"materialised {written} files from immutable Git objects at {commit}")
+MATERIALISE
+
+G6_REPO_ROOT="$REPO_ROOT" \
+G6_HELD_OUT="$HELD_OUT" \
+G6_GENERALIZATION="$GENERALIZATION" \
+G6_SNAPSHOT_ROOT="$SNAPSHOT_ROOT" \
+python3 - <<'VERIFY'
+import json
+import os
+import pathlib
+import sys
+
+root = pathlib.Path(os.environ["G6_REPO_ROOT"])
+sys.path.insert(0, str(root / "scripts" / "benchmark"))
+import m1nd10_g6_blind_runner as runner  # noqa: E402
+
+snapshot = pathlib.Path(os.environ["G6_SNAPSHOT_ROOT"])
+for label, corpus in (
+    ("held-out-v2", pathlib.Path(os.environ["G6_HELD_OUT"])),
+    ("generalization-v2", pathlib.Path(os.environ["G6_GENERALIZATION"])),
+):
+    queries = json.loads((corpus / "public" / "queries.json").read_text(encoding="utf-8"))
+    report = runner.verify_public_source_snapshot(queries, snapshot)
+    print(
+        f"{label:<18} checked={report['checked_files']} "
+        f"missing={report['missing_files']} mismatched={report['digest_mismatches']} "
+        f"extra={report['extra_files']} bytes={report['checked_bytes']} "
+        f"lines={report['checked_lines']}"
+    )
+VERIFY
+
+# ----------------------------------------------------------- step 4: run and score
+rule
+if [ "$DRY_RUN" -eq 1 ]; then
+  say "step 4/5  exercise the pre-measurement pipeline (public half, zero labels)"
+
+  G6_REPO_ROOT="$REPO_ROOT" \
+  G6_HELD_OUT="$HELD_OUT" \
+  G6_SNAPSHOT_ROOT="$SNAPSHOT_ROOT" \
+  G6_OUT_DIR="$OUT_DIR" \
+  python3 - <<'PIPELINE'
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+root = pathlib.Path(os.environ["G6_REPO_ROOT"])
+sys.path.insert(0, str(root / "scripts" / "benchmark"))
+import m1nd10_g6_blind_runner as runner  # noqa: E402
+
+held_out = pathlib.Path(os.environ["G6_HELD_OUT"])
+snapshot = pathlib.Path(os.environ["G6_SNAPSHOT_ROOT"])
+out_dir = pathlib.Path(os.environ["G6_OUT_DIR"])
+queries = json.loads((held_out / "public" / "queries.json").read_text(encoding="utf-8"))
+
+stages: list[dict[str, object]] = []
+
+
+def stage(name: str, thunk) -> None:
+    try:
+        stages.append({"stage": name, "state": "PASS", "detail": thunk()})
+    except Exception as error:  # noqa: BLE001 - a dry run reports, never raises
+        stages.append({"stage": name, "state": "FAIL", "detail": str(error)})
+
+
+stage(
+    "validate_public_queries",
+    lambda: f"{len(runner.validate_public_queries(queries))} tasks accepted; "
+    f"self, corpus, manifest and file-set digests recomputed",
+)
+stage(
+    "public_source_revision",
+    lambda: runner.public_source_revision(queries),
+)
+
+plan_root = out_dir / "dry-run-plan"
+plan_root.mkdir(parents=True, exist_ok=True)
+namespace = argparse.Namespace(
+    queries=held_out / "public" / "queries.json",
+    metric_spec=root / "docs" / "benchmarks" / "m1nd10-g6-metric-spec-v1.json",
+    binary=pathlib.Path("/bin/sh"),
+    authority_provider=None,
+    authority_assembly=None,
+    source_root=snapshot,
+    runtime_dir=plan_root / "runtime",
+    registry_dir=plan_root / "registry",
+    output=plan_root / "result.json",
+    checkpoint=None,
+)
+stage(
+    "validate_runner_paths",
+    lambda: json.dumps(runner.validate_runner_paths(namespace)["paths"], sort_keys=True),
+)
+
+
+def owner_plan() -> str:
+    specs = runner.build_owner_specs(
+        queries, snapshot, namespace.runtime_dir, namespace.registry_dir, 0
+    )
+    return "; ".join(f"{spec.repo_id} -> {spec.root.name}" for spec in specs)
+
+
+stage("build_owner_specs", owner_plan)
+
+width = max(len(str(entry["stage"])) for entry in stages)
+for entry in stages:
+    print(f"{entry['state']:<6} {str(entry['stage']):<{width}}  {entry['detail']}")
+
+(out_dir / "dry-run-pipeline.json").write_text(
+    json.dumps(
+        {"schema": "m1nd10-g6-dry-run-pipeline-v1", "stages": stages},
+        indent=2,
+        sort_keys=True,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+if any(entry["state"] == "FAIL" for entry in stages):
+    sys.exit(1)
+PIPELINE
+
+  rule
+  say "step 5/5  prove the ceremony stops at the owner's boundary"
+  say ""
+  say "The runner and the scorer are invoked for real. Every one must refuse: the"
+  say "custody-bound inputs do not exist yet, and a dry run must never fake past"
+  say "them. Their verbatim refusals are the proof. Each names the first blocker"
+  say "it reaches; the preflight above is what enumerates them all."
+  say ""
+
+  DRY_PROBE="$OUT_DIR/dry-run-plan"
+  set +e
+  say "\$ m1nd10_g6_blind_runner.py --lane current ...   (custody-bound inputs absent)"
+  python3 "$RUNNER" \
+    --queries "$HELD_OUT/public/queries.json" \
+    --metric-spec "$REPO_ROOT/docs/benchmarks/m1nd10-g6-metric-spec-v1.json" \
+    --sealed-corpus-self-digest "sha256:$(printf '0%.0s' $(seq 64))" \
+    --binary /bin/sh \
+    --source-root "$SNAPSHOT_ROOT" \
+    --runtime-dir "$DRY_PROBE/runtime" \
+    --registry-dir "$DRY_PROBE/registry" \
+    --expected-authority-assembly-digest "$(printf '0%.0s' $(seq 64))" \
+    --lane current \
+    --run-id "$RUN_ID-probe" \
+    --system-revision "$SYSTEM_REVISION" \
+    --output "$DRY_PROBE/result.json"
+  RUNNER_EXIT=$?
+  say "runner exit: $RUNNER_EXIT (non-zero is the expected, honest refusal)"
+  say ""
+
+  say "\$ m1nd10_g6_retrieval.py ...   (no sealed corpus, baseline, receipt, ledger)"
+  python3 "$SCORER" \
+    --spec "$REPO_ROOT/docs/benchmarks/m1nd10-g6-metric-spec-v1.json" \
+    --public "$HELD_OUT/public/queries.json" \
+    --cases "$HELD_OUT/operator-only/corpus.json" \
+    --results "$DRY_PROBE/result.json" \
+    --baseline "$DRY_PROBE/baseline.json" \
+    --baseline-receipt "$DRY_PROBE/baseline-receipt.json" \
+    --run-ledger "$DRY_PROBE/ledger.json" \
+    --runner "$RUNNER" \
+    --current-binary /bin/sh \
+    --baseline-binary /bin/sh \
+    --output "$DRY_PROBE/report.json"
+  SCORER_EXIT=$?
+  say "scorer exit: $SCORER_EXIT (non-zero is the expected, honest refusal)"
+  say ""
+
+  say "\$ m1nd10_g6_generalization_score.py ...   (supplemental guard, no labels)"
+  python3 "$GENERALIZATION_SCORER" \
+    --spec "$REPO_ROOT/docs/benchmarks/m1nd10-g6-metric-spec-v1.json" \
+    --cases "$GENERALIZATION/operator-only/corpus.json" \
+    --results "$DRY_PROBE/result.json" \
+    --output "$DRY_PROBE/generalization-report.json"
+  GENERALIZATION_EXIT=$?
+  say "generalization scorer exit: $GENERALIZATION_EXIT"
+  set -e
+
+  rule
+  say "DRY RUN COMPLETE"
+  say ""
+  say "Proved: the public corpus is intact, the isolated snapshot materialises"
+  say "byte-exactly from immutable Git objects, the runner's own validators accept"
+  say "the corpus and plan all four owners, and every scoring path fails closed"
+  say "without the owner's custody-bound inputs."
+  say ""
+  say "NOT proved, and not claimable: no owner was spawned, no query was measured,"
+  say "no label was read, no threshold was evaluated. G6 stays COMPONENT_PASS."
+  say "artifacts: $OUT_DIR"
+  exit 0
+fi
+
+say "step 4/5  formal blind run — 220 tasks over four owners"
+
+python3 "$RUNNER" \
+  --queries "$HELD_OUT/public/queries.json" \
+  --metric-spec "$METRIC_SPEC" \
+  --sealed-corpus-self-digest "$SEALED_CORPUS_SELF_DIGEST" \
+  --binary "$CANDIDATE_BINARY" \
+  --source-root "$SNAPSHOT_ROOT" \
+  --runtime-dir "$OUT_DIR/runner-results/runtime" \
+  --registry-dir "$OUT_DIR/runner-results/registry" \
+  --authority-provider "$AUTHORITY_PROVIDER" \
+  --authority-assembly "$AUTHORITY_ASSEMBLY" \
+  --expected-authority-assembly-digest "$AUTHORITY_ASSEMBLY_DIGEST" \
+  --lane current \
+  --run-id "$RUN_ID" \
+  --system-revision "$SYSTEM_REVISION" \
+  --checkpoint "$OUT_DIR/runner-results/checkpoint.json" \
+  --output "$OUT_DIR/runner-results/current.json"
+
+rule
+say "step 5/5  score against the ratified thresholds"
+
+set +e
+python3 "$SCORER" \
+  --spec "$METRIC_SPEC" \
+  --public "$HELD_OUT/public/queries.json" \
+  --cases "$SEALED_CORPUS" \
+  --results "$OUT_DIR/runner-results/current.json" \
+  --baseline "$BASELINE" \
+  --baseline-receipt "$BASELINE_RECEIPT" \
+  --run-ledger "$RUN_LEDGER" \
+  --runner "$RUNNER" \
+  --current-binary "$CANDIDATE_BINARY" \
+  --baseline-binary "$BASELINE_BINARY" \
+  --output "$OUT_DIR/report.json" >/dev/null
+SCORE_EXIT=$?
+set -e
+
+G6_REPORT="$OUT_DIR/report.json" \
+G6_SPEC="$METRIC_SPEC" \
+G6_OUT_DIR="$OUT_DIR" \
+G6_RUN_ID="$RUN_ID" \
+G6_SYSTEM_REVISION="$SYSTEM_REVISION" \
+G6_RUNNER="$RUNNER" \
+G6_SCORER="$SCORER" \
+G6_CANDIDATE_BINARY="$CANDIDATE_BINARY" \
+G6_BASELINE_BINARY="$BASELINE_BINARY" \
+G6_RESULT="$OUT_DIR/runner-results/current.json" \
+python3 - <<'VERDICT'
+import hashlib
+import json
+import os
+import pathlib
+
+report = json.loads(pathlib.Path(os.environ["G6_REPORT"]).read_text(encoding="utf-8"))
+spec = json.loads(pathlib.Path(os.environ["G6_SPEC"]).read_text(encoding="utf-8"))
+out_dir = pathlib.Path(os.environ["G6_OUT_DIR"])
+thresholds = spec.get("thresholds", {})
+latency = spec.get("latency_slo_ms", {})
+metrics = report.get("metrics", {})
+
+
+def sha256_file(key: str) -> str | None:
+    raw = os.environ.get(key, "")
+    path = pathlib.Path(raw) if raw else None
+    if path is None or not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+COMPARISONS = (
+    ("top-5 anchor recall", "top5_anchor_recall", "top5_anchor_recall_min", ">=", thresholds),
+    ("abstention recall", "abstention_recall", "abstention_recall_min", ">=", thresholds),
+    (
+        "wrong-ground act rate",
+        "wrong_ground_action_rate",
+        "wrong_ground_action_rate_max",
+        "<=",
+        thresholds,
+    ),
+    ("north p95 (ms)", "north_p95_ms", "north_p95", "<=", latency),
+    ("seek p95 (ms)", "seek_p95_ms", "seek_p95", "<=", latency),
+)
+
+print("measured vs ratified")
+for label, metric_key, spec_key, sense, source in COMPARISONS:
+    measured = metrics.get(metric_key)
+    ratified = source.get(spec_key)
+    if measured is None or ratified is None:
+        print(f"  {label:<24} measured=<absent>  ratified={ratified}")
+        continue
+    ok = measured >= ratified if sense == ">=" else measured <= ratified
+    print(
+        f"  {label:<24} measured={measured}  {sense} ratified={ratified}  "
+        f"{'PASS' if ok else 'FAIL'}"
+    )
+
+p_value = metrics.get("regression_sign_test_p")
+alpha = thresholds.get("regression_significance_alpha")
+if p_value is not None:
+    print(
+        f"  {'paired regression':<24} p={p_value}  alpha={alpha}  "
+        f"improvements={metrics.get('paired_improvements')} "
+        f"regressions={metrics.get('paired_regressions')}"
+    )
+
+receipt = {
+    "schema": "m1nd10-g6-formal-ceremony-receipt-v1",
+    "run_id": os.environ["G6_RUN_ID"],
+    "system_revision": os.environ["G6_SYSTEM_REVISION"],
+    "status": report.get("status"),
+    "claimable": report.get("claimable"),
+    "corpus_id": report.get("corpus_id"),
+    "blockers": report.get("blockers", []),
+    "metrics": metrics,
+    "checks": report.get("checks", {}),
+    "bindings": {
+        "metric_spec_digest": sha256_file("G6_SPEC"),
+        "runner_digest": sha256_file("G6_RUNNER"),
+        "scorer_digest": sha256_file("G6_SCORER"),
+        "current_binary_digest": sha256_file("G6_CANDIDATE_BINARY"),
+        "baseline_binary_digest": sha256_file("G6_BASELINE_BINARY"),
+        "result_digest": sha256_file("G6_RESULT"),
+        "report_digest": sha256_file("G6_REPORT"),
+    },
+    "gate_receipt_v1_minted": False,
+    "gate_receipt_v1_note": (
+        "A GateReceiptV1 (m1nd-control::release) binds a ratified custody floor and "
+        "is minted by the release authority, not by this ceremony. This artifact is "
+        "the evidence receipt the release authority consumes."
+    ),
+}
+(out_dir / "receipt.json").write_text(
+    json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+)
+
+print()
+print(f"VERDICT: {report.get('status')} (claimable={report.get('claimable')})")
+for blocker in report.get("blockers", []):
+    print(f"  blocker: {blocker}")
+print(f"report:  {out_dir / 'report.json'}")
+print(f"receipt: {out_dir / 'receipt.json'}")
+VERDICT
+
+rule
+if [ "$SCORE_EXIT" -eq 0 ]; then
+  say "G6 formal blind run: PASS. Commit the report and the receipt; the raw"
+  say "result under runner-results/ stays operator-only (already gitignored)."
+else
+  say "G6 formal blind run: not PASS. Preserve this evidence exactly as it is."
+  say "The metric spec forbids re-running until pass on the same revision:"
+  say "  same_revision_rerun_policy = one_sealed_run_only_no_rerun_until_pass"
+fi
+exit "$SCORE_EXIT"


### PR DESCRIPTION
## G6's formal blind run, staged to one owner command — and two blockers nobody knew about

**Every repository-side check is green: 22 PASS, 0 FAIL.** The preflight (`scripts/benchmark/g6_formal_preflight.sh`, independently re-run by the orchestrator: `STATUS: READY_PUBLIC_ONLY`, exit 3) replays CI's own byte pins on the frozen contracts, recomputes every public artifact digest of both corpora, validates 220 held-out tasks through **the runner's own validator**, and materialises the 357-file source snapshot from immutable Git objects — `missing=0 mismatched=0 extra=0`.

The dry-run (exit 0, **13.7 s measured**) exercises the whole pre-measurement pipeline on the public half with **zero labels touched**, then proves the ceremony stops exactly at the owner's boundary: the runner and both scorers refuse with named blockers rather than producing a number.

Both scripts orchestrate the existing runner/scorer and **import the runner's own validators** — no law reimplemented. Neither ever parses a label; the sealed corpus is only ever hashed against its pin. `operator-only/` and `runner-results/` were never read.

## The two hard blockers found by staging

1. **The ratified metric spec v2 does not exist.** Only v1 is checked in, while the runner and both scorers require `m1nd10-g6-metric-spec-v2` with a calibration gate, an outcome-blind ratification and an authority receipt digest — the runner refuses on this *before* it reaches authority. Minting it is custody-bound and the owner's; fabricating it would be precisely the fraud this staging exists to prevent.
2. **No pinned production authority assembly or provider** — that is the G9 custody floor, which the parallel G9 staging just measured as implemented-but-entirely-unwired.

Plus the expected owner inputs: sealed corpus, frozen candidate and baseline binaries, ratified baseline run and receipt, sealed-run ledger. **15 items wait on the owner; 0 fail.**

**G6 stays `COMPONENT_PASS`. The formal blind run remains `NOT_RUN`.** Nothing simulated.

## Honest numbers in the expectations doc

Duration is split by evidence: preflight ~2 s and snapshot ~11 s are **measured**; owner boot + 4 governed ingests (206,361 lines) is a 10–25 min **estimate**; 220 measured tasks is 5–8 min **derived** from the prior run's p95s. The doc labels each as such rather than presenting one confident range.

`AGENTS.md` gains the rule this exists to protect: the ceremony is the owner's, and an agent may stage it, never run it. The gitignore keeps the verdict and receipt public while raw measurements stay operator-only.

## Filed, not fixed

Three letters — the documented scorer command no longer runs (6 required flags missing, reproduced); `m1nd10-g6-current-report.json` is a held-out-v1-era `+dirty` PASS still named "current" while the runner rejects held-out-v1 as formal evidence; and the metric-spec-v2 gap (high).

85/85 existing G6 runner+scorer tests green; shellcheck clean on both scripts. No Rust or Python source touched.
