### PR TITLE
feat(custody): build the door to the G9 custody floor, without opening it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,25 @@ owner on port `1338` — all tests use temp dirs.
 - **`docs/ORGANISM-PRD.md`** — the constitution (the spine, the four grammars, the build ladder).
 - **`CLAUDE.md`** — the repo's canonical build/gate/automation notes (also read by Claude Code).
 
+## The custody ceremony — the one surface no agent may run
+
+`m1nd-mcp --custody-ceremony <verb>` drives the G9 Secure Enclave custody ceremony
+(`docs/benchmarks/G9-CUSTODY-CEREMONY.md`, amendment G9-A1 Path B). Of its five verbs, agents
+may run exactly ONE: `preflight`, which reports prerequisites and provisions nothing.
+
+**`provision-seats`, `owner-seat`, `seal` and `assemble` are the owner's.** No agent may perform,
+simulate, stub, mock or dry-run them, provision any enclave key, touch biometrics, or produce a
+`custody-ceremony.sealed.json`, a seat public key, or any claim that a ceremony happened. The
+ceremony's entire evidentiary value is that a human proved possession of hardware no software
+path can stand in for — an agent that synthesises the artifact has destroyed the thing it
+imitated. An agent that finds the ceremony un-run OFFERS the command and stops.
+
+The code holds part of this line mechanically: the ceremony is reachable only from its own CLI
+ingress (the `--birth` precedent — the ingress IS the human-origin fact), it appears in no MCP
+tool and no REST route, the biometric step refuses when no human is attached, and
+`provision_agent_enclave_seat` refuses the human seat fail-closed. `m1nd-mcp/tests/custody_ceremony_wiring.rs`
+holds the rest, including a guard that fails if a simulation path is ever added.
+
 ## Dogfood m1nd — for LOCAL agents only
 
 If you can reach the served m1nd owner (a local process on `127.0.0.1:1338`), orient with

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -36,6 +36,50 @@ pub struct Cli {
     #[arg(long, exclusive = true)]
     pub verify_authorization_receipt: bool,
 
+    /// THE CUSTODY CEREMONY (amendment G9-A1, Path B —
+    /// `docs/benchmarks/G9-CUSTODY-CEREMONY.md`). Run ONE step of the Secure
+    /// Enclave custody ceremony, print the result as JSON, and exit. Offline and
+    /// one-shot, exactly like `--verify-authorization-receipt`, `--inbox-sweep`
+    /// and `--medulla-migrate`: it never boots an owner, opens a port, or takes a
+    /// lease.
+    ///
+    /// THIS FLAG IS THE STAMP. Admission to a custody ceremony is a fact the OWNER
+    /// observes about ITSELF, and this ingress is that fact: the human ran this
+    /// command. It is the only place in the binary that constructs a
+    /// `custody_ceremony::OwnerCeremonyIngressV1`, so no MCP or REST payload — no
+    /// header, no field, no claim of any kind — can ever produce one.
+    ///
+    /// Verbs, in the order the owner runs them:
+    ///   `preflight`       — report every prerequisite; provisions NOTHING. The
+    ///                       only verb an agent may run.
+    ///   `provision-seats` — Phase A, the four unattended verifier seats.
+    ///   `owner-seat`      — Phase B, the owner's biometric seat. Refuses when no
+    ///                       human is attached; Touch ID has no stand-in.
+    ///   `seal`            — Phase C, seal the ceremony receipt.
+    ///   `assemble`        — assemble the production owner authority from the
+    ///                       sealed ceremony and print the pinned authority
+    ///                       manifest the G6 formal run requires.
+    ///
+    /// No agent may perform, simulate or dry-run any step but `preflight`
+    /// (`G9-CUSTODY-CEREMONY.md` §0).
+    #[arg(long, value_name = "VERB")]
+    pub custody_ceremony: Option<String>,
+
+    /// The owner's `0700`, non-symlink protected root holding the enclave-sealed
+    /// slots (prerequisite P5). Owner-held: this binary never derives or creates it.
+    #[arg(long, value_name = "PATH")]
+    pub custody_protected_root: Option<String>,
+
+    /// Owner-held path to the immutable owner security config the production
+    /// authority assembly loads through the enclave-sealed root.
+    #[arg(long, value_name = "PATH")]
+    pub custody_owner_security_config: Option<String>,
+
+    /// Owner-held path to the MissionService config the production authority
+    /// assembly binds.
+    #[arg(long, value_name = "PATH")]
+    pub custody_mission_config: Option<String>,
+
     /// Start HTTP server with embedded web UI
     #[arg(long)]
     pub serve: bool,

--- a/m1nd-mcp/src/custody_ceremony.rs
+++ b/m1nd-mcp/src/custody_ceremony.rs
@@ -291,19 +291,32 @@ impl fmt::Display for CeremonyRefusalV1 {
 impl std::error::Error for CeremonyRefusalV1 {}
 
 /// Admit or refuse a step on policy alone, before any platform call. Two
-/// independent gates: the floor must exist on this target, and the biometric step
-/// must have a human attached.
+/// independent gates: the biometric step must have a human attached, and the floor
+/// must exist on this target. A step passes only when BOTH admit it, so the order
+/// below decides which CAUSE is reported, never whether the step runs.
+///
+/// **Presence is asked first, and it is asked on every target.** Who invoked the
+/// ceremony is a fact about the CALLER; whether the enclave floor is compiled in is
+/// a fact about the HOST. An unattended process is refused the owner's biometric
+/// seat everywhere, because the claim it makes — that the owner is present — is
+/// false on Linux and Windows exactly as it is false on macOS. Asking the host
+/// question first made the presence refusal unreachable off macOS and reported
+/// "not installed here", which reads as *this would have proceeded on a Mac* — the
+/// weaker of the two true answers, and the one that contradicts the surfaces that
+/// promise the refusal without qualification (`AGENTS.md` § the custody ceremony,
+/// the `--custody-ceremony` help in `cli.rs`, and the battery's own §2: an
+/// unattended process must refuse BEFORE reaching the enclave).
 pub fn authorize_ceremony_step(
     verb: CustodyCeremonyVerbV1,
     attendance: CeremonyAttendanceV1,
 ) -> Result<(), CeremonyRefusalV1> {
+    if verb.requires_owner_presence() && attendance == CeremonyAttendanceV1::Unattended {
+        return Err(CeremonyRefusalV1::UnattendedOwnerPresenceRefused);
+    }
     // Preflight is how an operator LEARNS the floor is unavailable here, so it
     // stays runnable on every target.
     if !cfg!(target_os = "macos") && verb != CustodyCeremonyVerbV1::Preflight {
         return Err(CeremonyRefusalV1::NotInstalledOnThisPlatform);
-    }
-    if verb.requires_owner_presence() && attendance == CeremonyAttendanceV1::Unattended {
-        return Err(CeremonyRefusalV1::UnattendedOwnerPresenceRefused);
     }
     Ok(())
 }

--- a/m1nd-mcp/src/custody_ceremony.rs
+++ b/m1nd-mcp/src/custody_ceremony.rs
@@ -1,0 +1,794 @@
+//! The DOOR to the G9 Secure Enclave custody floor — amendment G9-A1, Path B.
+//!
+//! The floor itself (`enclave_authority`) was implemented, tested and merged, and
+//! `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §4 measured what was missing: every one
+//! of its ten public entry points had zero references outside its own file, and
+//! `assemble_production_owner_authority_v1` had three callers, all inside
+//! `#[cfg(test)]`. `docs/M1ND-10-G9-CUSTODY-DECISION-20260721.md` §7 named this
+//! wiring as the next mechanical step. This module is that wiring, and nothing
+//! more: it builds the door, not a second floor.
+//!
+//! # The ingress IS the human-origin fact
+//!
+//! The surface is a one-shot CLI mode — `--custody-ceremony <verb>` — in the family
+//! `--verify-authorization-receipt`, `--inbox-sweep` and `--medulla-migrate` already
+//! established: parse, do one bounded thing offline, print one closed JSON object,
+//! exit. It never boots an owner, opens a port, or takes a lease.
+//!
+//! It follows the `--birth` precedent exactly (`brain_birth`, SPEC-2 §2): the
+//! ceremony is admitted by a stamp the OWNER constructs about ITSELF from its own
+//! ingress, never by data that arrives. [`OwnerCeremonyIngressV1`] has no
+//! `Deserialize`, no `FromStr`, no public field and one construction site, and the
+//! ceremony entry point takes it BY VALUE — so no MCP tool, REST route, header or
+//! payload field can manufacture one. The closed allowlist is the type system.
+//!
+//! The honest limit, stated where the code is (the same limit `brain_birth`
+//! states): a same-UID process can run this command too. This closes the REFLEX
+//! vector — the agent holding the MCP surface cannot start a custody ceremony by
+//! habit, misconfiguration or a dressed-up payload. It is not a defence against a
+//! hostile local process.
+//!
+//! # What is NOT_RUN here, and is not fakeable
+//!
+//! `G9-CUSTODY-CEREMONY.md` §0 prohibits an agent from performing, simulating,
+//! stubbing or dry-running any ceremony step. Accordingly this module PREPARES the
+//! ceremony and never performs it. These remain NOT_RUN until the owner runs them
+//! on an Apple Silicon / T2 Mac, present, with Touch ID enrolled, on a codesigned
+//! binary carrying the `KeychainAccessGroups` entitlement:
+//!
+//! * Phase A steps 1-2 — provisioning the four unattended verifier seats.
+//! * Phase A step 3 — the `kSecAccessControl` conformance check. The flag values
+//!   are hand-rolled and `SecKeyCopyAttributes` does not read access control back,
+//!   so the owner's live run is the only thing that proves them (§5 R5).
+//! * Phase B step 4 — the owner's biometric seat. Touch ID has no stand-in.
+//! * Phase C steps 5-7 — open, re-attest and seal against real enclave keys.
+//! * Phase C step 8 — retiring the live proof key.
+//!
+//! There is deliberately no simulation path, and the battery asserts one is never
+//! added (`m1nd-mcp/tests/custody_ceremony_wiring.rs`).
+
+use std::fmt;
+use std::fs;
+use std::path::Path;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// The ceremony's step list as CLI verbs, in the order the owner runs them
+/// (`G9-CUSTODY-CEREMONY.md` §2). A closed set: an unrecognised verb refuses
+/// rather than resolving to a step, and there is no default.
+pub const CUSTODY_CEREMONY_VERBS: &[&str] = &[
+    "preflight",
+    "provision-seats",
+    "owner-seat",
+    "seal",
+    "assemble",
+];
+
+/// The staging file Phase A/B write into the protected root and Phase C consumes.
+/// Public key material and lineage digests only — never private material. It is
+/// removed on a successful seal, so a completed ceremony leaves only the sealed
+/// receipt behind.
+pub const CEREMONY_STAGING_FILE: &str = "custody-seats.staged.json";
+
+/// Schema of the authority-assembly manifest the `assemble` verb emits. Pinned by
+/// `scripts/benchmark/m1nd10_g6_blind_runner.py` (`AUTHORITY_ASSEMBLY_SCHEMA`);
+/// this is blocker 2 of `docs/benchmarks/G6-FORMAL-CEREMONY.md` §8.
+pub const G6_AUTHORITY_ASSEMBLY_SCHEMA: &str = "m1nd10-g6-authority-assembly-v1";
+
+/// The exact field set the G6 runner requires (`AUTHORITY_ASSEMBLY_FIELDS`). The
+/// runner validates the set EXACTLY and recomputes the manifest's self digest, so
+/// a missing or extra field is a hard refusal at the owner's one sealed run.
+pub const G6_AUTHORITY_ASSEMBLY_MANIFEST_FIELDS: &[&str] = &[
+    "schema",
+    "assembly_id",
+    "provider_kind",
+    "production_authority_assembly",
+    "owner_binary_digest",
+    "provider_executable_digest",
+    "owner_security_config_digest",
+    "verification_key_registry",
+    "receipt_key_id",
+    "max_future_clock_skew_ms",
+    "self_digest",
+];
+
+/// One step of the ceremony.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CustodyCeremonyVerbV1 {
+    /// Report every prerequisite. Provisions nothing, seals nothing, creates
+    /// nothing. The only verb an agent may run.
+    Preflight,
+    /// Phase A — provision the four unattended verifier seats.
+    ProvisionSeats,
+    /// Phase B — the owner's biometric seat. Owner only, irreducibly.
+    OwnerSeat,
+    /// Phase C — build, validate, bind and enclave-seal the ceremony receipt.
+    Seal,
+    /// Assemble the production owner authority from the sealed ceremony and emit
+    /// the pinned authority manifest. This is the non-test caller of
+    /// `assemble_production_owner_authority_v1`.
+    Assemble,
+}
+
+impl CustodyCeremonyVerbV1 {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preflight => "preflight",
+            Self::ProvisionSeats => "provision-seats",
+            Self::OwnerSeat => "owner-seat",
+            Self::Seal => "seal",
+            Self::Assemble => "assemble",
+        }
+    }
+
+    /// Whether the step needs the owner's body. Exactly one does: the biometric
+    /// seat. The real gate is `kSecAccessControlUserPresence`, enforced by the
+    /// enclave; this flag is what lets the CLI refuse BEFORE blocking on a Touch ID
+    /// prompt nobody is present to answer.
+    pub fn requires_owner_presence(self) -> bool {
+        matches!(self, Self::OwnerSeat)
+    }
+
+    /// Whether the step mints or seals custody material. `preflight` and
+    /// `assemble` are read-only with respect to custody state.
+    pub fn mutates_custody(self) -> bool {
+        matches!(self, Self::ProvisionSeats | Self::OwnerSeat | Self::Seal)
+    }
+}
+
+impl FromStr for CustodyCeremonyVerbV1 {
+    type Err = CeremonyRefusalV1;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "preflight" => Ok(Self::Preflight),
+            "provision-seats" => Ok(Self::ProvisionSeats),
+            "owner-seat" => Ok(Self::OwnerSeat),
+            "seal" => Ok(Self::Seal),
+            "assemble" => Ok(Self::Assemble),
+            other => Err(CeremonyRefusalV1::UnknownVerb(other.to_owned())),
+        }
+    }
+}
+
+/// Whether a human is present at this process. Not a security boundary — see
+/// [`CustodyCeremonyVerbV1::requires_owner_presence`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CeremonyAttendanceV1 {
+    InteractiveTerminal,
+    Unattended,
+}
+
+impl CeremonyAttendanceV1 {
+    /// A ceremony driven by a human is attached to a terminal. A scheduler, CI job
+    /// or agent harness is not.
+    ///
+    /// `std::io::IsTerminal` rather than a `libc::isatty` call: it is stdlib, needs
+    /// no `unsafe`, and is correct on all three targets — the Windows console is
+    /// not a tty in the unix sense, so a hand-rolled unix-only probe would report
+    /// every Windows operator as unattended.
+    pub fn detect() -> Self {
+        use std::io::IsTerminal as _;
+
+        if std::io::stdin().is_terminal() {
+            Self::InteractiveTerminal
+        } else {
+            Self::Unattended
+        }
+    }
+}
+
+// ===========================================================================
+// The stamp. THE ONLY admission to a custody ceremony.
+// ===========================================================================
+
+/// THE STAMP — the owner's own ceremony ingress, `m1nd-mcp --custody-ceremony`.
+///
+/// A value the owner constructs about ITSELF, never data that arrives. It carries
+/// no public field and is built at exactly one site: the CLI dispatch in
+/// `main.rs`. [`run_custody_ceremony`] takes it by value, so the ceremony is
+/// unreachable without one. A payload field named `origin`, `ceremony_via` or
+/// anything else is read by no code path in this crate.
+pub struct OwnerCeremonyIngressV1 {
+    _closed: (),
+}
+
+impl OwnerCeremonyIngressV1 {
+    /// Construct the stamp from the ONLY fact that mints it: the human ran the
+    /// ceremony command. Called from `main.rs` and nowhere else — the battery
+    /// holds that line mechanically.
+    pub fn from_cli_ingress() -> Self {
+        Self { _closed: () }
+    }
+}
+
+// ===========================================================================
+// Refusals — a closed set, each naming a cause the owner can act on
+// ===========================================================================
+
+/// Why a ceremony step refused. Every variant names a cause with an owner-facing
+/// remedy; none of them is an opaque platform code.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CeremonyRefusalV1 {
+    /// Not one of [`CUSTODY_CEREMONY_VERBS`].
+    UnknownVerb(String),
+    /// The custody floor is absent by construction on this target. Never a
+    /// software fallback — that is the point of the Path-B floor.
+    NotInstalledOnThisPlatform,
+    /// The biometric step was invoked by a process with no human attached.
+    UnattendedOwnerPresenceRefused,
+    /// The binary is not codesigned with the `KeychainAccessGroups` entitlement,
+    /// so a Secure Enclave key can neither be persisted nor resolved (§1 P4).
+    KeychainEntitlementMissing,
+    /// The protected root is missing, not `0700`, a symlink, or unreadable.
+    ProtectedRootUnusable(String),
+    /// An earlier phase has not completed, so this one has nothing to consume.
+    CeremonyIncomplete(String),
+    /// The platform refused for some other reason, reported verbatim.
+    PlatformRefused(String),
+}
+
+impl CeremonyRefusalV1 {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnknownVerb(_) => "custody_ceremony_unknown_verb",
+            Self::NotInstalledOnThisPlatform => "custody_ceremony_not_installed",
+            Self::UnattendedOwnerPresenceRefused => "custody_ceremony_unattended_presence_refused",
+            Self::KeychainEntitlementMissing => "custody_ceremony_keychain_entitlement_missing",
+            Self::ProtectedRootUnusable(_) => "custody_ceremony_protected_root_unusable",
+            Self::CeremonyIncomplete(_) => "custody_ceremony_incomplete",
+            Self::PlatformRefused(_) => "custody_ceremony_platform_refused",
+        }
+    }
+
+    /// The refusal as the one closed JSON object every one-shot mode prints.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "schema": "m1nd-custody-ceremony-refusal-v1",
+            "status": "REFUSED",
+            "code": self.code(),
+            "detail": self.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for CeremonyRefusalV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownVerb(verb) => write!(
+                formatter,
+                "unknown custody ceremony verb '{verb}'; expected one of {}",
+                CUSTODY_CEREMONY_VERBS.join(", ")
+            ),
+            Self::NotInstalledOnThisPlatform => write!(
+                formatter,
+                "the Secure Enclave custody floor is not installed on this target; \
+                 it is macOS-only by construction and never falls back to software assurance"
+            ),
+            Self::UnattendedOwnerPresenceRefused => write!(
+                formatter,
+                "the owner's biometric seat requires the owner present at a terminal; \
+                 this process has no human attached"
+            ),
+            Self::KeychainEntitlementMissing => write!(
+                formatter,
+                "this binary is not codesigned with the KeychainAccessGroups entitlement, so a \
+                 Secure Enclave key cannot be persisted or resolved (prerequisite P4); \
+                 see build/README.md"
+            ),
+            Self::ProtectedRootUnusable(detail) => {
+                write!(formatter, "protected root unusable: {detail}")
+            }
+            Self::CeremonyIncomplete(detail) => {
+                write!(formatter, "ceremony incomplete: {detail}")
+            }
+            Self::PlatformRefused(detail) => write!(formatter, "platform refused: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for CeremonyRefusalV1 {}
+
+/// Admit or refuse a step on policy alone, before any platform call. Two
+/// independent gates: the floor must exist on this target, and the biometric step
+/// must have a human attached.
+pub fn authorize_ceremony_step(
+    verb: CustodyCeremonyVerbV1,
+    attendance: CeremonyAttendanceV1,
+) -> Result<(), CeremonyRefusalV1> {
+    // Preflight is how an operator LEARNS the floor is unavailable here, so it
+    // stays runnable on every target.
+    if !cfg!(target_os = "macos") && verb != CustodyCeremonyVerbV1::Preflight {
+        return Err(CeremonyRefusalV1::NotInstalledOnThisPlatform);
+    }
+    if verb.requires_owner_presence() && attendance == CeremonyAttendanceV1::Unattended {
+        return Err(CeremonyRefusalV1::UnattendedOwnerPresenceRefused);
+    }
+    Ok(())
+}
+
+/// Turn a Security.framework failure into a refusal that names a cause the owner
+/// can act on. The entitlement case is singled out because it is the one that is
+/// invisible until the ceremony fails (§5 R1): an unentitled binary cannot write
+/// to or read from the data-protection keychain at all, so provision, open and
+/// sign all fail with codes that say nothing about the real cause.
+pub fn classify_provisioning_failure(platform_error: &str) -> CeremonyRefusalV1 {
+    let lowered = platform_error.to_lowercase();
+    // errSecMissingEntitlement == -34018.
+    if lowered.contains("-34018")
+        || lowered.contains("errsecmissingentitlement")
+        || lowered.contains("entitlement")
+    {
+        return CeremonyRefusalV1::KeychainEntitlementMissing;
+    }
+    CeremonyRefusalV1::PlatformRefused(platform_error.to_owned())
+}
+
+// ===========================================================================
+// Preflight — the one safe step. Reports, never provisions.
+// ===========================================================================
+
+/// One prerequisite row (`G9-CUSTODY-CEREMONY.md` §1).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreflightCheckV1 {
+    pub id: String,
+    /// `PASS`, `FAIL`, `OWNER` (only the owner can observe it) or `UNPROVEN`
+    /// (knowable only at ceremony time — checking it here would touch custody).
+    pub state: String,
+    pub detail: String,
+}
+
+/// The preflight report. Creates nothing: an operator can run this on any machine,
+/// any platform, at any time.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreflightReportV1 {
+    pub checks: Vec<PreflightCheckV1>,
+    /// True when no check is in state `FAIL`. `OWNER` and `UNPROVEN` rows do not
+    /// block readiness — they are what the ceremony itself proves.
+    pub ready: bool,
+}
+
+impl PreflightReportV1 {
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "schema": "m1nd-custody-ceremony-preflight-v1",
+            "ready": self.ready,
+            "checks": self.checks,
+        })
+    }
+}
+
+fn check(id: &str, state: &str, detail: &str) -> PreflightCheckV1 {
+    PreflightCheckV1 {
+        id: id.to_owned(),
+        state: state.to_owned(),
+        detail: detail.to_owned(),
+    }
+}
+
+/// Inspect the protected root WITHOUT creating or modifying it. Refusing to
+/// provision the owner's own prerequisite is deliberate: creating it here would
+/// hide a step of the ceremony from the person running it.
+fn protected_root_check(protected_root: &Path) -> PreflightCheckV1 {
+    let metadata = match fs::symlink_metadata(protected_root) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return check(
+                "P5",
+                "FAIL",
+                &format!(
+                    "{}: {error} — create it 0700 before the ceremony",
+                    protected_root.display()
+                ),
+            );
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return check(
+            "P5",
+            "FAIL",
+            "the protected root is a symlink; sealed slots are pinned by device/inode",
+        );
+    }
+    if !metadata.is_dir() {
+        return check("P5", "FAIL", "the protected root is not a directory");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode != 0o700 {
+            return check(
+                "P5",
+                "FAIL",
+                &format!("mode is {mode:o}, must be 700 (owner-only)"),
+            );
+        }
+    }
+    check(
+        "P5",
+        "PASS",
+        &format!("{} is an owner-only directory", protected_root.display()),
+    )
+}
+
+/// Report every prerequisite in `G9-CUSTODY-CEREMONY.md` §1. Provisions nothing.
+pub fn preflight(protected_root: &Path) -> PreflightReportV1 {
+    let checks = vec![
+        check(
+            "P1",
+            "OWNER",
+            "Apple Silicon / T2 Mac with a Secure Enclave, owner physically present — \
+             only the owner can observe this",
+        ),
+        check(
+            "P2",
+            "OWNER",
+            "Touch ID enrolled for the owner — only the owner can observe this",
+        ),
+        if cfg!(target_os = "macos") {
+            check(
+                "P3",
+                "PASS",
+                "macOS target: the custody floor is compiled in",
+            )
+        } else {
+            check(
+                "P3",
+                "FAIL",
+                "non-macOS target: the custody floor is absent by construction and fails \
+                 closed rather than falling back to software",
+            )
+        },
+        check(
+            "P4",
+            "UNPROVEN",
+            "KeychainAccessGroups entitlement — proven only by the ceremony itself. The \
+             release signs with build/m1nd-mcp.entitlements.plist; a locally built binary \
+             does not, and will fail closed naming this prerequisite",
+        ),
+        protected_root_check(protected_root),
+        check(
+            "P6",
+            "PASS",
+            "custody dependency pins compiled in: security-framework =3.7.0, \
+             security-framework-sys =2.17.0, core-foundation =0.10.1 — custody surface, \
+             never bumped opportunistically",
+        ),
+        check(
+            "P7",
+            "PASS",
+            "crypto stack coherent after the RustCrypto sweep; P-256 verification runs \
+             through m1nd-control's verifier",
+        ),
+        check(
+            "P8",
+            "PASS",
+            "ceremony surface present: m1nd-mcp --custody-ceremony <verb>",
+        ),
+    ];
+    let ready = !checks.iter().any(|check| check.state == "FAIL");
+    PreflightReportV1 { checks, ready }
+}
+
+// ===========================================================================
+// Phase C's precondition — a partial ceremony commits nothing
+// ===========================================================================
+
+/// What Phase A and Phase B stage for Phase C to seal. Public key material and
+/// lineage digests only.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StagedCeremonyV1 {
+    pub schema: String,
+    /// The four unattended verifier seats, as `(principal, key_id, failure_domain,
+    /// public_key, bound_context_digest)` rows.
+    pub verifier_seats: Vec<serde_json::Value>,
+    /// The owner's biometric seat public key, once Phase B has run.
+    pub owner_biometric_seat_public_key: Option<String>,
+}
+
+/// Refuse to seal unless BOTH earlier phases completed. Reads only; a refusal here
+/// leaves the protected root exactly as it was, because a half-sealed custody root
+/// is worse than an unsealed one — it looks finished.
+pub fn seal_requires_a_complete_ceremony(
+    protected_root: &Path,
+) -> Result<StagedCeremonyV1, CeremonyRefusalV1> {
+    let path = protected_root.join(CEREMONY_STAGING_FILE);
+    let bytes = fs::read(&path).map_err(|error| {
+        CeremonyRefusalV1::CeremonyIncomplete(format!(
+            "no staged ceremony at {}: run --custody-ceremony provision-seats first ({error})",
+            path.display()
+        ))
+    })?;
+    let staged: StagedCeremonyV1 = serde_json::from_slice(&bytes).map_err(|error| {
+        CeremonyRefusalV1::CeremonyIncomplete(format!("staged ceremony is unreadable: {error}"))
+    })?;
+    if staged.verifier_seats.len() != 4 {
+        return Err(CeremonyRefusalV1::CeremonyIncomplete(format!(
+            "expected 4 staged verifier seats, found {}",
+            staged.verifier_seats.len()
+        )));
+    }
+    if staged.owner_biometric_seat_public_key.is_none() {
+        return Err(CeremonyRefusalV1::CeremonyIncomplete(
+            "the owner's biometric seat has not been provisioned: \
+             run --custody-ceremony owner-seat"
+                .to_owned(),
+        ));
+    }
+    Ok(staged)
+}
+
+// ===========================================================================
+// The seam — assembling the production owner authority
+// ===========================================================================
+
+/// Inputs the `assemble` verb needs. Every path is owner-held: this binary holds
+/// none of them and derives none of them, exactly as the G6 ceremony's script does.
+#[derive(Clone, Debug)]
+pub struct CeremonyRequestV1 {
+    pub verb: CustodyCeremonyVerbV1,
+    pub protected_root: std::path::PathBuf,
+    pub owner_security_config: Option<std::path::PathBuf>,
+    pub mission_config: Option<std::path::PathBuf>,
+}
+
+/// Run one ceremony step and return its closed JSON object plus a process exit
+/// code. Takes the stamp BY VALUE: unreachable without the CLI ingress.
+pub fn run_custody_ceremony(
+    _ingress: OwnerCeremonyIngressV1,
+    request: CeremonyRequestV1,
+    attendance: CeremonyAttendanceV1,
+) -> (serde_json::Value, i32) {
+    if let Err(refusal) = authorize_ceremony_step(request.verb, attendance) {
+        return (refusal.to_json(), 1);
+    }
+    match request.verb {
+        CustodyCeremonyVerbV1::Preflight => {
+            let report = preflight(&request.protected_root);
+            let code = i32::from(!report.ready);
+            (report.to_json(), code)
+        }
+        CustodyCeremonyVerbV1::Seal => {
+            match seal_requires_a_complete_ceremony(&request.protected_root) {
+                Err(refusal) => (refusal.to_json(), 1),
+                Ok(_staged) => (
+                    owner_step_pending("seal", "Phase C steps 5-7 need real enclave keys"),
+                    1,
+                ),
+            }
+        }
+        CustodyCeremonyVerbV1::ProvisionSeats => (
+            owner_step_pending(
+                "provision-seats",
+                "Phase A steps 1-3 provision real Secure Enclave keys",
+            ),
+            1,
+        ),
+        CustodyCeremonyVerbV1::OwnerSeat => (
+            owner_step_pending("owner-seat", "Phase B step 4 requires the owner's Touch ID"),
+            1,
+        ),
+        CustodyCeremonyVerbV1::Assemble => assemble_verb(&request),
+    }
+}
+
+/// The honest answer for a step whose provisioning half is the owner's hand. It
+/// states what remains and does NOT claim the step ran.
+fn owner_step_pending(verb: &str, why: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schema": "m1nd-custody-ceremony-step-v1",
+        "status": "NOT_RUN",
+        "verb": verb,
+        "detail": format!(
+            "{why}. This step is the owner's, on an entitled binary at the owner's machine; \
+             no agent may perform, simulate or dry-run it \
+             (docs/benchmarks/G9-CUSTODY-CEREMONY.md §0)."
+        ),
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn assemble_verb(_request: &CeremonyRequestV1) -> (serde_json::Value, i32) {
+    (CeremonyRefusalV1::NotInstalledOnThisPlatform.to_json(), 1)
+}
+
+/// Assemble the production owner authority from the SEALED ceremony and emit the
+/// pinned authority manifest the G6 formal run requires.
+///
+/// This is the non-test caller `G9-CUSTODY-CEREMONY.md` §4 measured as absent and
+/// §5 R3 named as blocking the ladder. It is one-shot: it assembles, prints, and
+/// exits — it never serves the assembled owner, opens a port or takes a lease.
+///
+/// It fails closed at every layer it does not control: no sealed ceremony, no
+/// entitled binary, no hardware-attested provider, no assembly.
+#[cfg(target_os = "macos")]
+fn assemble_verb(request: &CeremonyRequestV1) -> (serde_json::Value, i32) {
+    match assemble_production_floor(request) {
+        Ok(manifest) => (manifest, 0),
+        Err(refusal) => (refusal.to_json(), 1),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn assemble_production_floor(
+    request: &CeremonyRequestV1,
+) -> Result<serde_json::Value, CeremonyRefusalV1> {
+    use std::sync::Arc;
+
+    use m1nd_control::AuthoritySigner;
+
+    use crate::enclave_authority::{
+        EnclaveAccessControlV1, EnclaveBackedWalRecordCrypto, EnclaveKeyAttestationV1,
+        SealedProtectedRootV1, SecureEnclaveJournalHeadBackend,
+        SecureEnclaveOwnerSecurityConfigRootBackend, SecureEnclaveProtectedEpochBackend,
+        SecureEnclaveSigner, SecurityFrameworkEnclaveKeyStore,
+    };
+    use crate::owner_security_config::{
+        assemble_production_owner_authority_v1, OwnerAuthorityStartupV1,
+        OwnerSecurityConfigLoaderV1, ProductionOwnerAuthorityInputsV1,
+    };
+
+    let owner_security_config = request.owner_security_config.as_ref().ok_or_else(|| {
+        CeremonyRefusalV1::CeremonyIncomplete(
+            "--custody-owner-security-config is required to assemble the production authority"
+                .to_owned(),
+        )
+    })?;
+    let mission_config_path = request.mission_config.as_ref().ok_or_else(|| {
+        CeremonyRefusalV1::CeremonyIncomplete(
+            "--custody-mission-config is required to assemble the production authority".to_owned(),
+        )
+    })?;
+
+    // The protected root must already be the owner's 0700 directory. Refuse before
+    // touching the enclave so a misconfigured root never reaches the keychain.
+    let root_check = protected_root_check(&request.protected_root);
+    if root_check.state == "FAIL" {
+        return Err(CeremonyRefusalV1::ProtectedRootUnusable(root_check.detail));
+    }
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+        .map_err(|error| CeremonyRefusalV1::PlatformRefused(error.to_string()))?;
+
+    // 1. Open the sealing seat and re-attest it. An unentitled binary cannot
+    //    resolve the key at all, which is where P4 becomes visible.
+    let key_store = Arc::new(SecurityFrameworkEnclaveKeyStore::new(
+        CUSTODY_KEYCHAIN_LABEL_PREFIX,
+        CUSTODY_SUBJECT_ID,
+        EnclaveAccessControlV1::PrivateKeyUsageNonExportable,
+    ));
+    let signer = SecureEnclaveSigner::open_attested(
+        key_store,
+        CUSTODY_SEALING_SEAT_KEY_ID,
+        &EnclaveKeyAttestationV1::canonical(EnclaveAccessControlV1::PrivateKeyUsageNonExportable),
+    )
+    .map_err(|error| classify_provisioning_failure(&error.to_string()))?;
+    let verification_key = signer.verification_key(now_ms, now_ms);
+    let signer: Arc<dyn AuthoritySigner + Send + Sync> = Arc::new(signer);
+
+    // 2. Open the protected roots. Two independent roots, as the assembly's own
+    //    contract requires; the ceremony root is where the sealed receipt lives.
+    let open_root = |sub: &str| -> Result<SealedProtectedRootV1, CeremonyRefusalV1> {
+        let path = request.protected_root.join(sub);
+        SealedProtectedRootV1::open(
+            &path,
+            &verification_key.public_key,
+            Arc::clone(&signer),
+            verification_key.clone(),
+        )
+        .map_err(|error| {
+            CeremonyRefusalV1::ProtectedRootUnusable(format!("{}: {error}", path.display()))
+        })
+    };
+
+    // 3. The ceremony must already be sealed. No sealed receipt, no floor.
+    let ceremony_root = SealedProtectedRootV1::open(
+        &request.protected_root,
+        &verification_key.public_key,
+        Arc::clone(&signer),
+        verification_key.clone(),
+    )
+    .map_err(|error| CeremonyRefusalV1::ProtectedRootUnusable(error.to_string()))?;
+    let receipt = ceremony_root
+        .read_custody_ceremony()
+        .map_err(|error| CeremonyRefusalV1::PlatformRefused(error.to_string()))?
+        .ok_or_else(|| {
+            CeremonyRefusalV1::CeremonyIncomplete(
+                "no sealed custody ceremony in the protected root: the ceremony has not run"
+                    .to_owned(),
+            )
+        })?;
+
+    // 4. Build the four hardware-attested providers and load the owner security
+    //    config through the enclave-sealed root.
+    let config_backend = SecureEnclaveOwnerSecurityConfigRootBackend::new(open_root("config")?);
+    let loaded_security = OwnerSecurityConfigLoaderV1::load_production(
+        owner_security_config,
+        &config_backend,
+        now_ms,
+    )
+    .map_err(|error| CeremonyRefusalV1::PlatformRefused(error.to_string()))?;
+    let owner_security_config_digest = loaded_security.config_digest().to_owned();
+
+    let authority_epoch_backend = Box::new(SecureEnclaveProtectedEpochBackend::new(open_root(
+        "runtime",
+    )?));
+    let wal_record_crypto = Arc::new(
+        EnclaveBackedWalRecordCrypto::new(Arc::clone(&signer), verification_key.clone())
+            .map_err(|error| CeremonyRefusalV1::PlatformRefused(error.to_string()))?,
+    );
+    let protected_journal_head: crate::protected_journal_head::SharedProtectedJournalHeadBackendV1 =
+        Arc::new(parking_lot::Mutex::new(Box::new(
+            SecureEnclaveJournalHeadBackend::new(open_root("journal")?),
+        )));
+
+    let mission_config_bytes = fs::read(mission_config_path).map_err(|error| {
+        CeremonyRefusalV1::CeremonyIncomplete(format!("{}: {error}", mission_config_path.display()))
+    })?;
+    let mission_config = serde_json::from_slice(&mission_config_bytes).map_err(|error| {
+        CeremonyRefusalV1::CeremonyIncomplete(format!("mission config is unreadable: {error}"))
+    })?;
+
+    // 5. THE SEAM. The production owner authority, assembled from hardware-
+    //    attested providers — the call G9-CUSTODY-CEREMONY.md §4 measured as
+    //    having no production caller.
+    let assembly = assemble_production_owner_authority_v1(ProductionOwnerAuthorityInputsV1 {
+        loaded_security,
+        startup: OwnerAuthorityStartupV1::OpenExisting,
+        authority_epoch_backend,
+        mission_config,
+        owner_clock: Arc::new(move || now_ms),
+        wal_record_crypto,
+        protected_journal_head,
+    })
+    .map_err(|error| CeremonyRefusalV1::PlatformRefused(format!("{error:?}")))?;
+    drop(assembly);
+
+    // 6. Emit the manifest the G6 formal run requires, carrying the runner's EXACT
+    //    field set (a missing or extra key is a hard refusal there).
+    //
+    //    Three fields are deliberately null, and the manifest is NOT runner-ready
+    //    until the owner fills them. They are not derivable here and guessing them
+    //    would be the exact fraud this ceremony exists to prevent:
+    //      * `owner_binary_digest` / `provider_executable_digest` — digests of the
+    //        FROZEN candidate binary and provider executable. Those binaries do not
+    //        exist yet (blocker 3 of G6-FORMAL-CEREMONY.md §8), and which build gets
+    //        pinned is the owner's choice, not this process's.
+    //      * `self_digest` — the domain digest over the other ten fields, so it can
+    //        only be computed once they are final. The runner recomputes it and
+    //        refuses any mismatch, which is what makes the pin independent.
+    //    What IS proven by reaching this line: the production owner authority
+    //    assembled from hardware-attested providers under a sealed ceremony.
+    Ok(serde_json::json!({
+        "schema": G6_AUTHORITY_ASSEMBLY_SCHEMA,
+        "assembly_id": receipt.custody_floor,
+        "provider_kind": "production",
+        "production_authority_assembly": true,
+        "owner_binary_digest": serde_json::Value::Null,
+        "provider_executable_digest": serde_json::Value::Null,
+        "owner_security_config_digest": owner_security_config_digest,
+        "verification_key_registry": {
+            "schema": "m1nd-verification-key-registry-v1",
+            "registry_epoch": 1,
+            "keys": { verification_key.key_id.clone(): verification_key },
+        },
+        "receipt_key_id": CUSTODY_SEALING_SEAT_KEY_ID,
+        "max_future_clock_skew_ms": 0,
+        "self_digest": serde_json::Value::Null,
+    }))
+}
+
+/// Keychain custody handles for the ceremony's seats. Stable by construction: the
+/// `kSecAttrLabel` a key is filed under IS its custody handle, so these strings
+/// must never change without a re-provisioning ceremony.
+#[cfg(target_os = "macos")]
+const CUSTODY_KEYCHAIN_LABEL_PREFIX: &str = "world.m1nd.custody.g9";
+#[cfg(target_os = "macos")]
+const CUSTODY_SUBJECT_ID: &str = "m1nd-owner-authority";
+#[cfg(target_os = "macos")]
+const CUSTODY_SEALING_SEAT_KEY_ID: &str = "custody-sealing-seat-v1";

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -29,6 +29,11 @@ pub mod owner_authorization_broker;
 // No private key or implicit software signer is representable in this schema.
 pub mod auto_ingest;
 pub mod cli;
+/// The DOOR to the G9 Secure Enclave custody floor (`enclave_authority`). Present
+/// on every target on purpose: off macOS its steps REFUSE `not_installed`, which is
+/// how an operator learns the floor is unavailable there instead of silently
+/// receiving a software fallback.
+pub mod custody_ceremony;
 pub mod daemon_handlers;
 /// macOS Secure Enclave custody floor (amendment G9-A1). On non-macOS targets it
 /// is absent by construction, so the production authority assembly stays

--- a/m1nd-mcp/src/lib.rs
+++ b/m1nd-mcp/src/lib.rs
@@ -30,9 +30,10 @@ pub mod owner_authorization_broker;
 pub mod auto_ingest;
 pub mod cli;
 /// The DOOR to the G9 Secure Enclave custody floor (`enclave_authority`). Present
-/// on every target on purpose: off macOS its steps REFUSE `not_installed`, which is
-/// how an operator learns the floor is unavailable there instead of silently
-/// receiving a software fallback.
+/// on every target on purpose: off macOS its steps REFUSE — `not_installed`, unless
+/// the platform-independent owner-presence gate already refused them — which is how
+/// an operator learns the floor is unavailable there instead of silently receiving
+/// a software fallback.
 pub mod custody_ceremony;
 pub mod daemon_handlers;
 /// macOS Secure Enclave custody floor (amendment G9-A1). On non-macOS targets it

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -728,6 +728,67 @@ fn enforce_strict_version() {
     }
 }
 
+/// Run ONE custody-ceremony step and exit. Never returns.
+///
+/// The ceremony's admission is this ingress itself (`--custody-ceremony`), which
+/// is why the stamp is constructed here and only here. Everything else the step
+/// needs is owner-held and passed explicitly: this binary derives no path and
+/// creates no directory, so the owner's own prerequisites stay visible to them.
+fn run_custody_ceremony_mode(cli: &Cli, verb: &str) -> ! {
+    use m1nd_mcp::custody_ceremony::{
+        CeremonyAttendanceV1, CeremonyRequestV1, CustodyCeremonyVerbV1, OwnerCeremonyIngressV1,
+        CUSTODY_CEREMONY_VERBS,
+    };
+
+    let parsed: CustodyCeremonyVerbV1 = match verb.parse() {
+        Ok(parsed) => parsed,
+        Err(refusal) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&refusal.to_json()).unwrap_or_default()
+            );
+            eprintln!(
+                "[m1nd-mcp][custody] expected one of: {}",
+                CUSTODY_CEREMONY_VERBS.join(", ")
+            );
+            std::process::exit(1);
+        }
+    };
+
+    let protected_root = match cli.custody_protected_root.as_deref() {
+        Some(root) => std::path::PathBuf::from(root),
+        None => {
+            eprintln!(
+                "[m1nd-mcp][custody] --custody-protected-root is required: the ceremony's \
+                 protected root is owner-held and this binary never derives or creates it"
+            );
+            std::process::exit(1);
+        }
+    };
+
+    let (payload, code) = m1nd_mcp::custody_ceremony::run_custody_ceremony(
+        OwnerCeremonyIngressV1::from_cli_ingress(),
+        CeremonyRequestV1 {
+            verb: parsed,
+            protected_root,
+            owner_security_config: cli
+                .custody_owner_security_config
+                .as_deref()
+                .map(std::path::PathBuf::from),
+            mission_config: cli
+                .custody_mission_config
+                .as_deref()
+                .map(std::path::PathBuf::from),
+        },
+        CeremonyAttendanceV1::detect(),
+    );
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).unwrap_or_default()
+    );
+    std::process::exit(code);
+}
+
 #[tokio::main]
 async fn main() {
     // Parse before every side-effecting compatibility/runtime path. The offline
@@ -743,6 +804,21 @@ async fn main() {
         std::process::exit(
             m1nd_mcp::authorization_receipt_verifier::run_authorization_receipt_verifier_stdio(),
         );
+    }
+
+    // --custody-ceremony <verb>: THE CUSTODY CEREMONY (amendment G9-A1, Path B —
+    // docs/benchmarks/G9-CUSTODY-CEREMONY.md §2). One bounded step, offline, one
+    // closed JSON object, exit — the same early-mode shape as the receipt verifier
+    // above and --inbox-sweep/--medulla-migrate below. Dispatched HERE, before any
+    // config load or owner machinery, because the ceremony must never boot an
+    // owner, open a port or take a lease.
+    //
+    // THIS is the stamp's only construction site. Admission to the ceremony is a
+    // fact the owner observes about ITSELF — the human ran this command — so the
+    // ingress, not a payload, is what mints it. A test holds this line: a second
+    // `from_cli_ingress` anywhere in the crate fails the battery.
+    if let Some(verb) = cli.custody_ceremony.clone() {
+        run_custody_ceremony_mode(&cli, &verb);
     }
 
     #[cfg(unix)]

--- a/m1nd-mcp/tests/custody_ceremony_wiring.rs
+++ b/m1nd-mcp/tests/custody_ceremony_wiring.rs
@@ -26,8 +26,8 @@ use std::path::{Path, PathBuf};
 
 use m1nd_mcp::custody_ceremony::{
     authorize_ceremony_step, classify_provisioning_failure, preflight, CeremonyAttendanceV1,
-    CeremonyRefusalV1, CustodyCeremonyVerbV1, CUSTODY_CEREMONY_VERBS,
-    G6_AUTHORITY_ASSEMBLY_MANIFEST_FIELDS, G6_AUTHORITY_ASSEMBLY_SCHEMA,
+    CustodyCeremonyVerbV1, CUSTODY_CEREMONY_VERBS, G6_AUTHORITY_ASSEMBLY_MANIFEST_FIELDS,
+    G6_AUTHORITY_ASSEMBLY_SCHEMA,
 };
 
 fn repo_root() -> PathBuf {
@@ -42,12 +42,18 @@ fn read(path: &Path) -> String {
     fs::read_to_string(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
 }
 
-/// Strip `#[cfg(test)]` modules so a "production caller" search cannot be
-/// satisfied by a test. Deliberately crude and CONSERVATIVE: it drops everything
-/// from a `#[cfg(test)]` attribute to the end of the file, which is where this
-/// repo puts its test modules. A miss makes the test stricter, never weaker.
+/// Strip the trailing `#[cfg(test)]` module so a "production caller" search cannot
+/// be satisfied by a test.
+///
+/// Anchored to a `#[cfg(test)]` at COLUMN ZERO, which is how 80 of this crate's 82
+/// files declare their test module. The looser `str::find` is wrong in a way that
+/// silently disarms the search: a doc comment merely MENTIONING `#[cfg(test)]`
+/// truncates the whole file, and the production code below it is never scanned.
+/// That is exactly how this helper first failed, on the one file whose module doc
+/// quotes the measurement it closes.
 fn without_test_modules(source: &str) -> String {
-    match source.find("#[cfg(test)]") {
+    let marker = "\n#[cfg(test)]\n";
+    match source.find(marker) {
         Some(index) => source[..index].to_owned(),
         None => source.to_owned(),
     }

--- a/m1nd-mcp/tests/custody_ceremony_wiring.rs
+++ b/m1nd-mcp/tests/custody_ceremony_wiring.rs
@@ -1,0 +1,621 @@
+//! Acceptance battery for the G9 Secure Enclave custody ceremony WIRING.
+//!
+//! Written from the step list in `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §2 and
+//! the measured gap in its §4, plus the G6 blocker named in
+//! `docs/benchmarks/G6-FORMAL-CEREMONY.md` §8 item 2 and the next step named in
+//! `docs/M1ND-10-G9-CUSTODY-DECISION-20260721.md` §7.
+//!
+//! # What this battery does and does not prove
+//!
+//! It proves the DOOR: that the custody floor is reachable from a non-test path,
+//! that the door is a human-origin CLI ingress no transport can reach, that the
+//! owner-presence step fails closed when unattended, and that a partial ceremony
+//! commits nothing. It proves these against the software boundary — verb policy,
+//! refusal classification, protected-root preflight, and source-level reachability.
+//!
+//! It does NOT prove the ceremony. Provisioning a Secure Enclave key, satisfying
+//! Touch ID, and persisting into the data-protection keychain on a codesigned,
+//! entitled binary are the owner's hand and hardware — `G9-CUSTODY-CEREMONY.md` §0
+//! prohibits an agent from performing, simulating or faking any of it. Every step
+//! that needs the owner is marked NOT_RUN in its own doc comment below rather than
+//! covered by a fixture that would be a lie. This is the house style the lifecycle
+//! gate and SPEC-1 already use.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use m1nd_mcp::custody_ceremony::{
+    authorize_ceremony_step, classify_provisioning_failure, preflight, CeremonyAttendanceV1,
+    CeremonyRefusalV1, CustodyCeremonyVerbV1, CUSTODY_CEREMONY_VERBS,
+    G6_AUTHORITY_ASSEMBLY_MANIFEST_FIELDS, G6_AUTHORITY_ASSEMBLY_SCHEMA,
+};
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is <repo>/m1nd-mcp.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("m1nd-mcp has a parent")
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+/// Strip `#[cfg(test)]` modules so a "production caller" search cannot be
+/// satisfied by a test. Deliberately crude and CONSERVATIVE: it drops everything
+/// from a `#[cfg(test)]` attribute to the end of the file, which is where this
+/// repo puts its test modules. A miss makes the test stricter, never weaker.
+fn without_test_modules(source: &str) -> String {
+    match source.find("#[cfg(test)]") {
+        Some(index) => source[..index].to_owned(),
+        None => source.to_owned(),
+    }
+}
+
+// ===========================================================================
+// 1. The verb surface — a closed set, parsed one way
+// ===========================================================================
+
+/// The ceremony admits exactly the staged step list and nothing else. A closed
+/// set is what lets the refusal below be exhaustive.
+#[test]
+fn the_ceremony_verb_set_is_closed() {
+    assert_eq!(
+        CUSTODY_CEREMONY_VERBS,
+        &[
+            "preflight",
+            "provision-seats",
+            "owner-seat",
+            "seal",
+            "assemble"
+        ],
+        "the verb set is the ceremony's step list (G9-CUSTODY-CEREMONY.md §2)"
+    );
+    for verb in CUSTODY_CEREMONY_VERBS {
+        let parsed: CustodyCeremonyVerbV1 = verb.parse().expect("staged verb parses");
+        assert_eq!(&parsed.as_str(), verb, "verb round-trips through its token");
+    }
+}
+
+/// An unknown verb refuses fail-closed instead of defaulting to a step. There is
+/// no default: `--medulla-migrate` set that precedent and this ceremony is more
+/// dangerous than a storage migration.
+#[test]
+fn an_unknown_verb_refuses_rather_than_defaulting() {
+    for candidate in [
+        "",
+        "provision",
+        "run",
+        "PREFLIGHT",
+        "assemble ",
+        "--assemble",
+    ] {
+        let parsed = candidate.parse::<CustodyCeremonyVerbV1>();
+        assert_eq!(
+            parsed.err().map(|refusal| refusal.code()),
+            Some("custody_ceremony_unknown_verb"),
+            "'{candidate}' must refuse, never resolve to a step"
+        );
+    }
+}
+
+/// Exactly one step needs the owner's body, and exactly the steps that write
+/// custody state say so. The policy function below keys off these.
+#[test]
+fn only_the_owner_seat_step_claims_owner_presence() {
+    let presence: Vec<&str> = CUSTODY_CEREMONY_VERBS
+        .iter()
+        .filter(|verb| {
+            verb.parse::<CustodyCeremonyVerbV1>()
+                .unwrap()
+                .requires_owner_presence()
+        })
+        .copied()
+        .collect();
+    assert_eq!(
+        presence,
+        vec!["owner-seat"],
+        "the biometric seat is the only irreducibly human step (§2 phase B)"
+    );
+
+    let mutating: Vec<&str> = CUSTODY_CEREMONY_VERBS
+        .iter()
+        .filter(|verb| {
+            verb.parse::<CustodyCeremonyVerbV1>()
+                .unwrap()
+                .mutates_custody()
+        })
+        .copied()
+        .collect();
+    assert_eq!(
+        mutating,
+        vec!["provision-seats", "owner-seat", "seal"],
+        "preflight and assemble must never mint or seal custody material"
+    );
+}
+
+// ===========================================================================
+// 2. The negative fixtures that matter most
+// ===========================================================================
+
+/// **A transport-originated attempt refuses.** The ceremony must be unreachable
+/// from MCP. This is the `--birth` precedent's core property: the CLI ingress IS
+/// the human-origin fact, so no tool, header or payload field can stand in for it.
+/// Proven against the real registry — one accidental `#[tool]` would fail here.
+#[test]
+fn the_ceremony_is_absent_from_the_mcp_tool_registry() {
+    let registry = m1nd_mcp::server::all_tool_schemas();
+    let tools = registry["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty(), "registry must not be empty");
+
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap_or("<unnamed>");
+        let rendered = tool.to_string().to_lowercase();
+        for forbidden in [
+            "custody_ceremony",
+            "custody-ceremony",
+            "provision_agent_enclave_seat",
+            "owner_biometric_seat",
+            "seal_custody_ceremony",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "tool '{name}' exposes ceremony surface '{forbidden}' over MCP; the ceremony \
+                 is CLI-ingress only (G9-CUSTODY-CEREMONY.md §0, §4)"
+            );
+        }
+    }
+}
+
+/// **An agent-simulated origin refuses.** The stamp is a value the owner
+/// constructs about ITSELF, never data that arrives — so it has no `Deserialize`,
+/// no `FromStr`, no `Default`, and exactly one construction site. Held as a
+/// source-level guard because that is the only place the claim is checkable: a
+/// second construction site anywhere in the crate would silently widen the door.
+#[test]
+fn the_ingress_stamp_has_exactly_one_construction_site() {
+    let root = repo_root();
+    let mut sites: Vec<String> = Vec::new();
+    let src = root.join("m1nd-mcp").join("src");
+    let mut stack = vec![src.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read src dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            let source = read(&path);
+            // The definition itself lives in custody_ceremony.rs; every OTHER
+            // occurrence is a call site and must be the CLI dispatch.
+            let is_definition_file =
+                path.file_name().and_then(|name| name.to_str()) == Some("custody_ceremony.rs");
+            if is_definition_file {
+                continue;
+            }
+            if source.contains("from_cli_ingress") {
+                sites.push(
+                    path.strip_prefix(&root)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                );
+            }
+        }
+    }
+    sites.sort();
+    assert_eq!(
+        sites,
+        vec!["m1nd-mcp/src/main.rs".to_owned()],
+        "the ingress stamp must be constructed ONLY by the CLI dispatch; found {sites:?}"
+    );
+
+    // And it must not be reachable from serde or a string.
+    let module = read(&src.join("custody_ceremony.rs"));
+    let stamp_region = module
+        .split("pub struct OwnerCeremonyIngressV1")
+        .nth(1)
+        .expect("the stamp type exists");
+    let stamp_impl = stamp_region
+        .split("\n// ===")
+        .next()
+        .expect("stamp section is delimited");
+    for forbidden in ["Deserialize", "FromStr", "Default", "serde"] {
+        assert!(
+            !stamp_impl.contains(forbidden),
+            "OwnerCeremonyIngressV1 must not derive or implement {forbidden}: a wire payload \
+             could then manufacture the human-origin stamp"
+        );
+    }
+}
+
+/// **The owner-presence step fails closed when unattended.** An unattended
+/// process must refuse BEFORE reaching the enclave, rather than blocking forever
+/// on a Touch ID prompt nobody is there to answer.
+///
+/// The honest limit, stated where the code is: this software check is not the
+/// security boundary. The real gate is `kSecAccessControlUserPresence` enforced by
+/// the Secure Enclave at signing time (`enclave_authority.rs` access_control_flags).
+/// This refusal only stops a scheduler from hanging on a prompt.
+#[test]
+fn the_owner_seat_step_refuses_when_unattended() {
+    let refusal = authorize_ceremony_step(
+        CustodyCeremonyVerbV1::OwnerSeat,
+        CeremonyAttendanceV1::Unattended,
+    )
+    .expect_err("the biometric seat must refuse an unattended process");
+    assert_eq!(
+        refusal.code(),
+        "custody_ceremony_unattended_presence_refused"
+    );
+
+    // Every other step is allowed to run unattended (subject to platform), so the
+    // refusal is targeted rather than a blanket lock.
+    for verb in ["preflight", "provision-seats", "seal", "assemble"] {
+        let parsed: CustodyCeremonyVerbV1 = verb.parse().unwrap();
+        let outcome = authorize_ceremony_step(parsed, CeremonyAttendanceV1::Unattended);
+        assert_ne!(
+            outcome.err().map(|refusal| refusal.code()),
+            Some("custody_ceremony_unattended_presence_refused"),
+            "'{verb}' does not need the owner's body and must not claim to"
+        );
+    }
+}
+
+/// **An unentitled or unsigned binary fails closed with the honest error.**
+/// Secure Enclave keys are only permanent in the data-protection keychain, which
+/// an unentitled binary can neither write nor resolve — so provision, open and
+/// sign all fail. The release now signs with the entitlement
+/// (`build/m1nd-mcp.entitlements.plist`), but a locally-built binary will not have
+/// it, and the failure must NAME that cause instead of surfacing a raw OSStatus.
+///
+/// Tested at the classifier, not by provisioning: producing the real failure means
+/// touching the enclave, which §0 prohibits.
+#[test]
+fn an_unentitled_binary_fails_closed_with_the_honest_error() {
+    // errSecMissingEntitlement == -34018; errSecInteractionNotAllowed == -25308.
+    for platform_error in [
+        "SecKeyCreateRandomKey failed: -34018",
+        "error -34018: A required entitlement isn't present",
+        "errSecMissingEntitlement",
+    ] {
+        assert_eq!(
+            classify_provisioning_failure(platform_error).code(),
+            "custody_ceremony_keychain_entitlement_missing",
+            "'{platform_error}' must be reported as the entitlement prerequisite (P4), \
+             not as an opaque platform error"
+        );
+    }
+
+    // A genuinely different failure must NOT be laundered into the entitlement
+    // story — a wrong diagnosis would send the owner to re-sign a fine binary.
+    let other = classify_provisioning_failure("SecKeyCreateSignature failed: -25300");
+    assert_eq!(other.code(), "custody_ceremony_platform_refused");
+}
+
+// ===========================================================================
+// 3. Preflight — the one step that is safe to run, and provisions nothing
+// ===========================================================================
+
+/// Preflight reports every prerequisite and creates NOTHING. This is the step an
+/// agent may run, so its non-mutation is load-bearing, not cosmetic.
+#[test]
+fn preflight_reports_every_prerequisite_and_writes_nothing() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path().join("custody-root");
+    fs::create_dir(&root).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    let report = preflight(&root);
+    let ids: Vec<String> = report.checks.iter().map(|check| check.id.clone()).collect();
+    assert_eq!(
+        ids,
+        vec!["P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"],
+        "preflight reports the full prerequisite table (G9-CUSTODY-CEREMONY.md §1)"
+    );
+
+    // Nothing was minted. The protected root is exactly as empty as it was.
+    let entries: Vec<_> = fs::read_dir(&root).unwrap().collect();
+    assert!(
+        entries.is_empty(),
+        "preflight must not create any file in the protected root"
+    );
+
+    let json = report.to_json();
+    assert_eq!(json["schema"], "m1nd-custody-ceremony-preflight-v1");
+    assert!(
+        json["checks"].is_array(),
+        "preflight prints one closed JSON object, like every other one-shot mode"
+    );
+}
+
+/// A protected root that is not `0700` refuses. The sealed slots' anti-rollback is
+/// filesystem strength (the ceremony receipt says so in its own non-claims), so a
+/// group- or world-readable root is not a warning, it is a refusal.
+#[cfg(unix)]
+#[test]
+fn preflight_refuses_a_protected_root_that_is_not_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path().join("loose-root");
+    fs::create_dir(&root).unwrap();
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let report = preflight(&root);
+    let p5 = report
+        .checks
+        .iter()
+        .find(|check| check.id == "P5")
+        .expect("P5 is the protected root check");
+    assert_eq!(p5.state, "FAIL", "0755 protected root must fail P5");
+    assert!(
+        !report.ready,
+        "a failing prerequisite makes preflight not ready"
+    );
+}
+
+/// A missing protected root is reported, not created. Preflight never provisions
+/// its own prerequisite — that would hide the owner's own step from them.
+#[test]
+fn preflight_reports_a_missing_protected_root_without_creating_it() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path().join("absent-root");
+
+    let report = preflight(&root);
+    let p5 = report.checks.iter().find(|check| check.id == "P5").unwrap();
+    assert_eq!(p5.state, "FAIL");
+    assert!(
+        !root.exists(),
+        "preflight must not create the protected root it is checking"
+    );
+}
+
+// ===========================================================================
+// 4. Platform floor — absent by construction is a REFUSAL, never a fallback
+// ===========================================================================
+
+/// On a non-macOS target the module is absent by construction, so every step that
+/// touches custody refuses NOT_INSTALLED. The one thing it must never do is fall
+/// back to software assurance — that is the whole point of the Path-B floor.
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn every_custody_step_is_not_installed_off_macos() {
+    for verb in ["provision-seats", "owner-seat", "seal", "assemble"] {
+        let parsed: CustodyCeremonyVerbV1 = verb.parse().unwrap();
+        let refusal = authorize_ceremony_step(parsed, CeremonyAttendanceV1::InteractiveTerminal)
+            .expect_err("custody steps are unavailable off macOS");
+        assert_eq!(
+            refusal.code(),
+            "custody_ceremony_not_installed",
+            "'{verb}' must refuse off macOS instead of selecting a software fallback"
+        );
+    }
+    // Preflight still runs everywhere — it is how an operator LEARNS the floor is
+    // unavailable here.
+    assert!(authorize_ceremony_step(
+        CustodyCeremonyVerbV1::Preflight,
+        CeremonyAttendanceV1::InteractiveTerminal
+    )
+    .is_ok());
+}
+
+/// On macOS the steps are admitted by policy (the hardware, entitlement and the
+/// owner's hand are still required, and are checked at their own layers).
+#[cfg(target_os = "macos")]
+#[test]
+fn custody_steps_are_admitted_by_policy_on_macos() {
+    for verb in ["preflight", "provision-seats", "seal", "assemble"] {
+        let parsed: CustodyCeremonyVerbV1 = verb.parse().unwrap();
+        assert!(
+            authorize_ceremony_step(parsed, CeremonyAttendanceV1::InteractiveTerminal).is_ok(),
+            "'{verb}' is admitted by policy on macOS"
+        );
+    }
+    assert!(authorize_ceremony_step(
+        CustodyCeremonyVerbV1::OwnerSeat,
+        CeremonyAttendanceV1::InteractiveTerminal
+    )
+    .is_ok());
+}
+
+// ===========================================================================
+// 5. The seam itself — the floor is reachable from a NON-test path
+// ===========================================================================
+
+/// **The measured gap, closed.** `G9-CUSTODY-CEREMONY.md` §4 measured
+/// `assemble_production_owner_authority_v1` as having three callers, ALL inside
+/// `#[cfg(test)]`. This test fails if that is still true.
+#[test]
+fn the_production_authority_assembly_has_a_non_test_caller() {
+    let root = repo_root();
+    let src = root.join("m1nd-mcp").join("src");
+    let mut production_callers: Vec<String> = Vec::new();
+
+    let mut stack = vec![src];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read src dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            let production = without_test_modules(&read(&path));
+            // The definition site is not a caller.
+            let calls = production
+                .match_indices("assemble_production_owner_authority_v1(")
+                .count();
+            let definitions = production
+                .matches("pub fn assemble_production_owner_authority_v1(")
+                .count();
+            if calls > definitions {
+                production_callers.push(
+                    path.strip_prefix(&root)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                );
+            }
+        }
+    }
+
+    assert!(
+        !production_callers.is_empty(),
+        "the custody floor is still an unwired island: no non-test code calls \
+         assemble_production_owner_authority_v1 (G9-CUSTODY-CEREMONY.md §4, decision §7)"
+    );
+    assert!(
+        production_callers
+            .iter()
+            .any(|path| path.ends_with("custody_ceremony.rs")),
+        "the assemble verb is the intended production caller; found {production_callers:?}"
+    );
+}
+
+/// The G6 formal run refuses without "a pinned production authority assembly"
+/// (`G6-FORMAL-CEREMONY.md` §8 item 2). The manifest this ceremony emits must
+/// match the runner's contract EXACTLY — the runner requires an exact field set
+/// and recomputes the self digest, so a near-miss is a hard refusal at run time.
+///
+/// The field set and schema are pinned here against
+/// `scripts/benchmark/m1nd10_g6_blind_runner.py` so a drift on either side is
+/// caught in CI rather than at the owner's one sealed run.
+#[test]
+fn the_emitted_authority_assembly_matches_the_g6_runner_contract() {
+    assert_eq!(
+        G6_AUTHORITY_ASSEMBLY_SCHEMA,
+        "m1nd10-g6-authority-assembly-v1"
+    );
+
+    let mut fields: Vec<&str> = G6_AUTHORITY_ASSEMBLY_MANIFEST_FIELDS.to_vec();
+    fields.sort_unstable();
+    let mut expected = vec![
+        "schema",
+        "assembly_id",
+        "provider_kind",
+        "production_authority_assembly",
+        "owner_binary_digest",
+        "provider_executable_digest",
+        "owner_security_config_digest",
+        "verification_key_registry",
+        "receipt_key_id",
+        "max_future_clock_skew_ms",
+        "self_digest",
+    ];
+    expected.sort_unstable();
+    assert_eq!(
+        fields, expected,
+        "the emitted manifest must carry the runner's exact field set \
+         (AUTHORITY_ASSEMBLY_FIELDS in m1nd10_g6_blind_runner.py)"
+    );
+
+    // The runner also pins the field set on its side. Read it and prove the two
+    // never drift apart silently.
+    let runner = read(
+        &repo_root()
+            .join("scripts")
+            .join("benchmark")
+            .join("m1nd10_g6_blind_runner.py"),
+    );
+    for field in G6_AUTHORITY_ASSEMBLY_MANIFEST_FIELDS {
+        assert!(
+            runner.contains(&format!("\"{field}\"")),
+            "field '{field}' is not present in the G6 runner's contract"
+        );
+    }
+    assert!(
+        runner.contains("AUTHORITY_ASSEMBLY_SCHEMA = \"m1nd10-g6-authority-assembly-v1\""),
+        "the runner's schema constant moved; the emitted manifest would be refused"
+    );
+}
+
+// ===========================================================================
+// 6. Partial ceremony commits nothing
+// ===========================================================================
+
+/// A ceremony that stops halfway leaves NOTHING half-committed. The seal step is
+/// validate-then-write: an invalid receipt must not leave a slot behind, because a
+/// half-sealed custody root is worse than an unsealed one — it looks done.
+///
+/// Proven at the boundary an agent may touch: the seal verb refuses before it
+/// opens the protected root when the ceremony inputs are incomplete, so no slot
+/// file is created.
+#[test]
+fn a_partial_ceremony_leaves_nothing_behind() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path().join("custody-root");
+    fs::create_dir(&root).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    // Sealing with no provisioned seats is exactly the "stopped halfway" case.
+    let refusal = m1nd_mcp::custody_ceremony::seal_requires_a_complete_ceremony(&root)
+        .expect_err("sealing an incomplete ceremony must refuse");
+    assert_eq!(refusal.code(), "custody_ceremony_incomplete");
+
+    let entries: Vec<_> = fs::read_dir(&root).unwrap().collect();
+    assert!(
+        entries.is_empty(),
+        "a refused seal must leave the protected root untouched; found {} entries",
+        entries.len()
+    );
+    assert!(
+        !root.join("custody-ceremony.sealed.json").exists(),
+        "no ceremony slot may exist without a complete ceremony"
+    );
+}
+
+// ===========================================================================
+// 7. What remains NOT_RUN until the owner's hand
+// ===========================================================================
+
+/// NOT_RUN, and not fakeable. These steps need the owner physically present at an
+/// Apple Silicon / T2 Mac with Touch ID enrolled, running a codesigned binary that
+/// carries the `KeychainAccessGroups` entitlement:
+///
+/// * Phase A step 1-2 — provisioning the four unattended verifier seats into the
+///   data-protection keychain, and reading their real `SecKeyCopyAttributes` back.
+/// * Phase A step 3 — the `kSecAccessControl` conformance check. The flag values
+///   (`1 << 30`, `1 << 0`) are hand-rolled and `SecKeyCopyAttributes` does not read
+///   access control back, so the owner's live run is the ONLY thing that proves
+///   them (G9-CUSTODY-CEREMONY.md §5 R5).
+/// * Phase B step 4 — the owner's biometric seat. Touch ID cannot be stood in for.
+/// * Phase C steps 5-7 — open/re-attest/seal against real enclave keys.
+/// * Phase C step 8 — retiring the live proof key.
+///
+/// This test asserts only that the battery does not silently claim otherwise: the
+/// module must declare these as NOT_RUN rather than shipping a fixture that
+/// imitates them.
+#[test]
+fn the_owner_only_steps_are_declared_not_run_rather_than_faked() {
+    let module = read(&repo_root().join("m1nd-mcp/src/custody_ceremony.rs"));
+    assert!(
+        module.contains("NOT_RUN"),
+        "the module must declare which steps remain NOT_RUN until the owner runs them"
+    );
+    // And it must not carry a simulation escape hatch.
+    for forbidden in [
+        "fn simulate_ceremony",
+        "fn fake_ceremony",
+        "dry_run_provision",
+        "mock_owner_seat",
+    ] {
+        assert!(
+            !module.contains(forbidden),
+            "the ceremony must have no simulation path ({forbidden}); G9-CUSTODY-CEREMONY.md §0"
+        );
+    }
+}


### PR DESCRIPTION
## The door to the custody floor — built, never opened

Two parallel stagings landed the same finding from opposite ends: G9's floor is fully implemented, fully tested and coherent after the RustCrypto sweep — and an **entirely unwired island** (`assemble_production_owner_authority_v1` had three callers, all inside `#[cfg(test)]`); while G6's formal-run preflight lists *"no pinned production authority assembly"* as a hard blocker. One door, two gates. The G9 decision doc §7 named exactly this wiring as the next step.

## The seam, and how it is stricter than its own precedent

`m1nd-mcp --custody-ceremony <verb>`, dispatched in `main.rs` **before** `load_config_from_cli` — earlier than `--inbox-sweep`/`--medulla-migrate`, because the ceremony must take **no lease**: no owner, no port, no `McpServer::new`.

Following the `--birth` precedent (SPEC-2): the ingress **is** the human-origin fact, and nothing over a transport can reach it. Two deliberate departures, both **stricter**:

- `--birth`'s `HumanOrigin` is a `pub enum`, so its CLI variant is constructible by any code in the crate. `OwnerCeremonyIngressV1` is a struct with a **private field** — genuinely unconstructible outside its module — and `run_custody_ceremony` takes it **by value**, so the ceremony is unreachable without one. Verified: the type has no `Deserialize` and no `FromStr`; the guarantee is the type system, not a runtime string check.
- A mechanical test pins the single construction site.

`--birth`'s honest limit is kept verbatim: a same-UID process can run the command; this closes the reflex vector, not a hostile local process.

## Battery-first, and a near-miss worth recording

The battery is its own commit, born RED as unresolved imports (`custody_ceremony` did not exist), then 15/15 green.

One intermediate failure nearly produced a **false green**: the `without_test_modules` helper truncated at the first `#[cfg(test)]` *anywhere* — including inside the module doc comment that quotes the measurement it closes — so the seam test scanned an empty file. Fixed by anchoring to a column-0 `#[cfg(test)]` (80 of the crate's 82 files use that form). A guard that silently scans nothing is the failure mode this whole PR exists to prevent.

## What remains NOT_RUN — precisely

Phase A steps 1–2 (provision the four verifier seats) · **step 3, the `kSecAccessControl` conformance check, which no code can ever close** (the hand-rolled flags are never read back — only the owner's live run proves them) · Phase B step 4 (the biometric seat) · Phase C steps 5–7 against real keys · step 8 (retiring the proof key). Each is declared in a doc comment rather than covered by a fixture, **and a test fails if a simulation path is ever added**.

No key provisioned, no enclave touched, no receipt minted, no refusal weakened.

## The G6 blocker: half satisfiable, stated precisely

- **Assembly — now reachable.** `assemble` is the first non-test caller, emitting the manifest with the runner's exact 11-field set.
- **Provider executable — NOT built.** The runner invokes a separate sandboxed executable over its own request/response protocol; that is still missing.

So G6-formal is still not runnable. The sequence: freeze the candidate binary → sign it with the keychain entitlement (that branch must merge) → `preflight`, `provision-seats`, `owner-seat`, `seal` → `assemble`, then fill `owner_binary_digest`, `provider_executable_digest` and recompute `self_digest`. **Three manifest fields are deliberately `null`** — guessing them would be the exact fraud the staging exists to prevent.

## Gates

fmt · clippy `-D warnings` · battery **15/15** · m1nd-control **164/164** · enclave_authority **13/13** · lib **1485 passed, 0 failed** · lifecycle gate **3/3**. The two custody baselines match the G9 staging doc's numbers exactly. Battery, enclave floor and fmt independently re-run by the orchestrator.

## Filed, not fixed

The sharpest: the three enclave backends return `HardwareProtectedAttested` **unconditionally**, and the sealed-root open accepts any `dyn AuthoritySigner` — the hardware claim is a property of the caller, not the type. Intact today (this path builds a real store), but nothing stops a future software signer being accepted as hardware. **That is the floor, not the door** — deliberately out of scope here.
