### PR TITLE
fix(readme): drop the dead CodeRooms badge that broke the repo front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<p align="center">
-  <a href="https://coderooms.com/github/maxkle1nz/m1nd">
-    <img src="https://coderooms.com/api/badge/github/maxkle1nz/m1nd.svg?layout=card&amp;theme=signal&amp;density=standard&amp;accent=green&amp;radius=10&amp;width=700&amp;bg=%2307111f&amp;blocks=identity%3Aroom%3A%3Amark%3A22c55e%2Cmembers%3Amembers%3A%3A%25E2%2597%2589%3Ae8edf3%2Conline%3Aonline%3A%3A%25E2%2597%2590%3A22c55e%2Cmessages%3Amessages%3A%3A%25E2%2589%25A1%3Ae8edf3%2Crooms%3Arooms%3A%3A%25E2%2596%25A4%3Ae8edf3%2Clatest_message%3Alatest%3A%3A%25E2%259C%258E%3A06b6d4&amp;brand=cta_row" alt="m1nd live room on CodeRooms — members, online now, and latest messages" width="700" />
-  </a>
-</p>
-
 🇬🇧 [English](README.md) | 🇧🇷 [Português](i18n/README.pt-BR.md) | 🇪🇸 [Español](i18n/README.es.md) | 🇮🇹 [Italiano](i18n/README.it.md) | 🇫🇷 [Français](i18n/README.fr.md) | 🇩🇪 [Deutsch](i18n/README.de.md) | 🇨🇳 [中文](i18n/README.zh.md) | 🇯🇵 [日本語](i18n/README.ja.md)
 
 <p align="center">
@@ -25,7 +19,6 @@
   <a href="https://registry.modelcontextprotocol.io/?search=io.github.maxkle1nz/m1nd"><img src="https://img.shields.io/badge/MCP_Registry-io.github.maxkle1nz%2Fm1nd-6d28d9" alt="MCP Registry — io.github.maxkle1nz/m1nd" /></a>
   <a href="https://glama.ai/mcp/servers/maxkle1nz/m1nd"><img src="https://glama.ai/mcp/servers/maxkle1nz/m1nd/badges/score.svg" alt="Glama score" /></a>
   <a href="https://docs.rs/m1nd-core"><img src="https://img.shields.io/docsrs/m1nd-core" alt="docs.rs" /></a>
-  <a href="https://coderooms.com/github/maxkle1nz/m1nd"><img src="https://coderooms.com/api/badge/github/maxkle1nz/m1nd.svg" alt="Join the room on CodeRooms" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The CodeRooms badge API (`/api/badge/github/maxkle1nz/m1nd.svg`) now returns 404. Since the card was the first element of the README, the repo front page opened on a broken image behind GitHub's camo proxy (which also reads as a wall of hex to anyone viewing the source). This removes both dead badge images; the room link can return as plain text if their API comes back.

Verified: `curl` on the badge URL returns 404 while coderooms.com itself is up; no other `coderooms.com/api` references remain in the file.