### PR TITLE
ci: pay the Pages supply-chain TODO and fix the i18n workflow parse

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -37,14 +37,28 @@ jobs:
         run: |
           npm ci
           npm run build
-      - name: Refuse an unpinned wiki or Pages supply chain
-        shell: bash
+      # Supply chain PROVEN 2026-07-30: the three Pages actions below are pinned to
+      # the immutable commit SHAs of their latest releases, resolved through the
+      # GitHub API (releases/latest -> git tag object -> commit):
+      #   actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  (v6.0.0)
+      #   actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  (v5.0.0)
+      #   actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  (v5.0.0)
+      # The mdbook/mdbook-mermaid item in the old TODO is not applicable: the wiki
+      # is pre-built and version-controlled under wiki-build/, so no cargo install
+      # runs in CI at all. The artifact is assembled here, in the unprivileged job,
+      # so the privileged deploy below still checks nothing out and runs no scripts.
+      - name: Assemble the Pages artifact (site + pre-built wiki)
         run: |
-          echo "::error title=Pages supply chain NOT_PROVEN::TODO: record verified immutable SHAs for actions/configure-pages, actions/upload-pages-artifact, and actions/deploy-pages, plus exact mdbook and mdbook-mermaid versions/digests. Mutable tags and latest cargo installs are forbidden."
-          exit 1
+          mkdir -p _site
+          cp -R m1nd-demo/dist/. _site/
+          cp -R wiki-build _site/wiki
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
 
   deploy:
-    name: Privileged Pages deploy (fail-closed placeholder)
+    name: Privileged Pages deploy (pinned, no checkout)
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -53,11 +67,6 @@ jobs:
     environment:
       name: github-pages
     steps:
-      # No checkout, package install, or repository script may run in this job.
-      # TODO: replace this literal refusal only after the three Pages action SHAs
-      # are independently verified and recorded in the repository.
-      - name: Refuse deployment while action pins are NOT_PROVEN
-        shell: bash
-        run: |
-          echo "::error title=Pages deploy NOT_PROVEN::Immutable Pages action SHAs are not recorded locally; deployment remains fail-closed."
-          exit 1
+      # No checkout, package install, or repository script runs in this job: the
+      # only step is the pinned deploy action consuming the artifact from build.
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/i18n-translate.yml
+++ b/.github/workflows/i18n-translate.yml
@@ -44,10 +44,8 @@ jobs:
           for code in "${!LANGS[@]}"; do
             lang="${LANGS[$code]}"
             echo "translating -> $code ($lang)"
-            jq -n --arg sys "$SYSTEM_PROMPT" \
-                  --arg usr "Translate the following README into $lang:
-
-$(cat README.md)" \
+            { echo "Translate the following README into $lang:"; echo; cat README.md; } > /tmp/user.txt
+            jq -n --arg sys "$SYSTEM_PROMPT" --rawfile usr /tmp/user.txt \
                   '{model: "openai/gpt-4o", max_tokens: 14000, messages: [{role:"system",content:$sys},{role:"user",content:$usr}]}' \
               > /tmp/req.json
             for attempt in 1 2 3; do

--- a/tests/test_m1nd10_ci_security_contract.py
+++ b/tests/test_m1nd10_ci_security_contract.py
@@ -443,11 +443,24 @@ class CiSecurityContractTests(unittest.TestCase):
             index += 1
         self.assertGreaterEqual(compiled, 1)
 
-    def test_pages_is_split_and_fails_closed_without_unverified_pins(self):
+    def test_pages_is_split_and_its_pins_are_proven(self):
+        # The old debt marker ("Pages supply chain NOT_PROVEN") was paid on
+        # 2026-07-30: the three Pages actions are pinned to the commit SHAs of
+        # their latest releases, resolved through the GitHub API. The ratchet
+        # only tightens: the declaration must bind to the exact pinned bytes,
+        # so silently moving a privileged pin while keeping the PROVEN claim
+        # turns this red. Upgrading an action is a deliberate two-file gesture.
         workflow = self.text(".github/workflows/deploy-wiki.yml")
         self.assert_immutable_uses(".github/workflows/deploy-wiki.yml")
         self.assertIn("contents: read", workflow)
-        self.assertIn("Pages supply chain NOT_PROVEN", workflow)
+        self.assertIn("Supply chain PROVEN", workflow)
+        self.assertNotIn("NOT_PROVEN", workflow)
+        for pinned in (
+            "actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d",
+            "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9",
+            "actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",
+        ):
+            self.assertIn(pinned, workflow)
         deploy = workflow.split("\n  deploy:\n", 1)[1]
         self.assertNotIn("actions/checkout", deploy)
         self.assertNotIn("npm ", deploy)


### PR DESCRIPTION
Two CI repairs, no product code touched.

**Site deploy was failing closed on purpose**: the supply-chain gate landed with an unpaid TODO, so every Pages run since has refused (the last three runs, including two before the copy PR). Paid in full: `actions/configure-pages@45bfe01…` (v6.0.0), `actions/upload-pages-artifact@fc324d3…` (v5.0.0), `actions/deploy-pages@cd2ce8f…` (v5.0.0), all resolved to immutable commit SHAs via the GitHub API and recorded next to the pins. The mdbook item is retired as not applicable: the wiki ships pre-built under `wiki-build/` and no cargo install runs in CI. The artifact (site dist + wiki) is assembled in the unprivileged build job; the privileged deploy job still checks nothing out and runs a single pinned action.

**i18n workflow never parsed**: a heredoc line sat at column 1 inside a YAML literal block. The user prompt now goes through a temp file and `jq --rawfile`. Validated with a local YAML parse.

After merge: the Pages deploy should go green and m1nd.world serves the new copy; the i18n run can be re-fired via workflow_dispatch if the README-path trigger does not re-fire on its own.