### PR TITLE
release: prepare v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-07-30
+
+### Added — the brain finds you, and the owner's ceremonies have their doors
+
+- **`--attach auto` asks a second question.** Discovery used to match only your own runtime root;
+  now, failing that, it finds any live serve owner whose declared ingest root *covers the repo you
+  are standing in* — including from a git worktree, which resolves to its main repository for
+  discovery while the true caller root still travels on the wire. The bearer token follows the
+  *discovered* owner's runtime root. Ambiguity fails closed naming every candidate, and a
+  runtime-root match still wins. One central always-on owner is now found from inside its own
+  projects instead of each repo starting an empty brain.
+- **A repo with no brain has a real, human-gated path: `m1nd init --birth <repo>`.** The birth
+  ceremony creates a per-project brain on a served owner. Every wire client is refused with
+  `human_gesture_required` — an agent's honest move is to offer the command and stop. The staged
+  brain is quiesced before the committing rename, so the gesture is atomic on every platform.
+- **The G9 custody ceremony CLI**: `--custody-ceremony <verb>` (preflight · provision-seats ·
+  owner-seat · seal · assemble), one-shot and offline, on an ingress no MCP or REST payload can
+  construct. All five verbs reach the real Secure Enclave floor; every missing precondition —
+  entitlement, presence, platform, staged state — refuses closed with its own name, and an
+  unattended invocation is refused *as unattended* before any platform question.
+
+### Fixed
+
+- **Restored plasticity now lands in both engines.** The friendly boot imported learned weights
+  into one engine while queries strengthened through the other, so the first strengthening after a
+  restart mis-dated its recency. Both boot paths now restore both engines.
+- **Owner-proxy REST verbs answer on their designed path.** `mission_spawn`, `candidate_naming`
+  and `curation_spawn` are intercepted ahead of the generic authority floor gate — previously a
+  seating error left a verb dead behind a 403 on the route built for it. A table-driven guard now
+  makes the seating exhaustive in both directions, so a new proxy verb cannot ship unseated.
+- **The embedded web UI bundle is provably the one its source builds.** CI refuses a commit whose
+  `dist/` does not byte-match a fresh build, and the accessibility smoke became its own required
+  lane.
+
 ### Changed — the binary snapshot's encoding is now pinned, and a partial read is refused
 
 - **`bincode` moved from 1.3 to 2.0, with the on-disk encoding held fixed.** Every call site

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-control"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ed25519-dalek",
  "p256",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-core"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "axum",
  "clap",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-runnerd"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "axum",
  "clap",

--- a/m1nd-control/Cargo.toml
+++ b/m1nd-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-control"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Canonical control-plane contracts for m1nd."
 license = "MIT"

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -43,7 +43,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.5.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.0" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -27,9 +27,9 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-control = { path = "../m1nd-control", version = "0.1.0" }
-m1nd-core = { path = "../m1nd-core", version = "1.5.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.5.0" }
+m1nd-control = { path = "../m1nd-control", version = "0.2.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.0" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/m1nd-runnerd/Cargo.toml
+++ b/m1nd-runnerd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-runnerd"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "The m1nd runner daemon (F2.5c): the ONLY spawner. Executes pinned spawn missions in an isolated git worktree, runs the gate, and emits mission letters on the chain — never `landed`."
 license = "MIT"
@@ -12,7 +12,7 @@ publish = false
 # side record (§1f) + the shared-secret filename — `default-features = false` keeps
 # axum/reqwest/embed OUT of this dependency edge (we bring our own below); the
 # runnerd is a CLIENT of the owner's contract, so the wire types must be the owner's.
-m1nd-mcp = { path = "../m1nd-mcp", version = "1.5.0", default-features = false }
+m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.0", default-features = false }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",


### PR DESCRIPTION
Version bump for the 1.6.0 release: m1nd-core / m1nd-ingest / m1nd-mcp / m1nd-runnerd to 1.6.0, m1nd-control to 0.2.0 (it changed four times since its published 0.1.0 — a stale registry pin would have built the published mcp against an old control), cross-crate pins updated, lockfile refreshed for exactly those five, npm package to 1.6.0.

The changelog folds everything accumulated under [Unreleased] into [1.6.0] and adds the arc's headline entries: the second discovery question of --attach auto, the human-gated birth ceremony, the G9 custody ceremony CLI with all five verbs on the real enclave floor, the both-engines plasticity restore, the owner-proxy seating guard, and the bundle-provenance gate with its accessibility lane.

Tagging v1.6.0 on the merge commit triggers the release pipeline: signed + notarized macOS binaries carrying the keychain entitlement the custody ceremony requires, crates.io + npm publishes.