### PR TITLE
ci(rust-gates): run the test phase under cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,32 @@
+# cargo-nextest configuration for the `rust-gates` test phase.
+#
+# Nextest is an ACCELERATOR, not a new contract. It runs exactly the tests
+# `cargo test --workspace --all-targets` ran; the only difference is the
+# schedule — one global pool over every test binary at once, instead of one
+# binary after another with three cores idle behind the slowest one. Doctests
+# are the single thing it cannot run (stable-Rust limitation, upstream
+# documented), so `cargo test --workspace --doc` stayed as its own CI step.
+#
+# Two knobs are pinned by hand here because both could otherwise change what a
+# red MEANS without anyone editing the workflow.
+
+[profile.default]
+# NEVER retry. A test that passes on the second attempt is a flake, and a flake
+# is a defect this repo diagnoses — the serialization flake in the tray was
+# found by reading a red, and a runner that quietly re-ran it would have
+# reported green and destroyed the evidence. `retries = 0` is nextest's default
+# today; it is written down so a future default cannot introduce hidden reruns.
+retries = 0
+
+# Terminate a single test only after 30 minutes (15 x 120s), and print a SLOW
+# line every 120s before that. The old runner had no per-test limit at all —
+# only the job's `timeout-minutes: 90` — so this threshold exists to stay ABOVE
+# anything legitimately slow rather than to police it. The measured basis: the
+# slowest test in the m1nd-mcp lib suite runs in seconds, the largest wall-clock
+# budget any test asserts about itself is 60s (`m1nd-core/tests/
+# retrobuilder_stress.rs`), and the heaviest integration tests ingest this whole
+# repository (minutes, not tens of minutes). 30 minutes is far above every one
+# of those and still leaves the 90-minute job cap as the outer bound. Without
+# this line a test that wedges forever burns the full 90 minutes and reports a
+# job timeout instead of naming the test.
+slow-timeout = { period = "120s", terminate-after = 15 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,24 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-gates-${{ matrix.os }}
+      # The test phase runs under cargo-nextest. Same tests, same required
+      # result — what changes is the SCHEDULE. `cargo test` starts this
+      # workspace's test binaries ONE AFTER ANOTHER, so every binary's tail
+      # latency lands end to end while the other cores sit idle; nextest puts
+      # every test from every binary into one pool. Pinned to an exact version
+      # like the rest of this file's tooling (gitleaks 8.30.1, cargo-audit
+      # 0.22.2) — the runner that decides what a red means does not get to
+      # change under the gate without a commit. Its two behavioural knobs live
+      # in `.config/nextest.toml`: retries stay at 0 (a rerun that turns green
+      # is a flake hidden, not a flake fixed) and no legitimately slow test is
+      # killed short of 30 minutes.
+      - uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: cargo-nextest@0.9.140
       # No standalone `cargo check`: clippy type-checks every target on its way
       # to linting, so a separate check pass was a full redundant compile.
       - name: Test every target
-        run: cargo test --locked --workspace --all-targets
+        run: cargo nextest run --locked --workspace --all-targets
       - name: Deny clippy warnings
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
       - name: Verify formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,25 @@ don't and cost ~half of every 70-minute CI round; the signed release pipeline re
 `--release` at tag time regardless). A release-profile-only breakage is caught on the main
 push — if you suspect one, run `cargo build --release --workspace` locally before merging.
 
+**CI runs that first line through `cargo nextest run --workspace --all-targets`.** Same test
+set, same required result, same job — only the schedule differs: `cargo test` runs this
+workspace's test binaries one after another, so each binary's tail latency lands end to end
+while the other cores idle. Measured on the ubuntu leg of run 30529035605: 2m19s compiling,
+then 62.7 minutes running 69 binaries in series, three of which are 54 of those minutes and
+each of which ends in a long single-test tail nothing may overlap. Note the flip side, also
+measured: inside ONE binary nextest is slightly slower (495s → 536s on the m1nd-mcp lib suite,
+1530 tests, quiet machine), because libtest already threads a single binary and nextest pays a
+process per test. The win is entirely cross-binary, which is why it belongs to CI and not to
+your inner loop. Nothing about the local command changes; `cargo test --workspace
+--all-targets` above is still the gate you run, and it is still the honest reproduction of a
+CI red. If you do install nextest (`cargo install --locked cargo-nextest`), it reads
+`.config/nextest.toml`, where the two knobs that could change what a red MEANS are pinned by
+hand: `retries = 0` (a rerun that turns green hides a flake instead of fixing it) and a
+per-test terminate threshold far above anything this repo measures. Nextest cannot run
+doctests — neither could `--all-targets`, which excludes them by construction, so the gate's
+coverage is unchanged; the workspace's doctests are still run by nobody in CI, and that
+pre-existing hole is filed, not closed, by this change.
+
 **Windows is REQUIRED again (since 2026-07-29):** `windows-latest` runs in the same
 `rust-gates` matrix as ubuntu/macos and its red blocks merge. It spent 2026-07-23→29 as an
 advisory job while the phase-2 debt was diagnosed and paid (#435–#440, #444); the flip back was


### PR DESCRIPTION
`Test every target` **is** the CI round. On the last three green runs of this
workflow that single step measured:

| leg | run 30521397093 | run 30524800542 | run 30529035605 |
| --- | --- | --- | --- |
| ubuntu | 65.4 min | 65.3 min | 65.0 min |
| macOS | 54.6 min | 57.8 min | 62.9 min |
| windows | 79.4 min | 65.3 min | 80.6 min |

Every other step in the job is seconds to single-digit minutes (clippy 0.9-3.6,
fmt 0.1, lean edge 0.3-1.1), and the Windows leg is already brushing its own
`timeout-minutes: 90`.

Almost none of that is compiling. In run 30529035605 (ubuntu) the step spent
**2m19s** in `Compiling` and then **62.7 minutes running tests** — 69 test
binaries started one after another, because that is what `cargo test` does:

| binary | serial wall |
| --- | --- |
| `retrobuilder_stress` (17 tests) | 1707s |
| `retrobuilder_real` (5 tests) | 927s |
| `m1nd-mcp` lib (909 tests) | 313s |
| the other 66 binaries | 308s total — 52 of them under 10s, median 0s |

Three binaries are 54 of the 62.7 minutes, and each ends in a long single-test
tail: `retrobuilder_real` finishes with one test running alone for 310s,
`retrobuilder_stress` with two over its last ~470s. Nothing else may start
during those tails — the next binary waits on the current one's slowest test,
and 52 sub-10s binaries queue behind all of it, one core at a time.

`cargo nextest run` changes exactly that: one scheduler over every test of every
binary, so a tail no longer blocks a queue.

## What does not change

- Same jobs, same job names, same required checks, same `test-status` aggregate.
- Same matrix — ubuntu, macOS and Windows all still required.
- Same clippy, fmt, lean-edge and release steps; same `timeout-minutes: 90`.
- Same **local** command. `cargo test --workspace --all-targets` in `AGENTS.md`
  is untouched: nextest is a CI accelerator, not a new local requirement.

## The local A/B, honestly

Same machine, same warm target dir, same 1530-test `m1nd-mcp` lib suite,
`--test-threads 4`, plain runner first each time:

| round | machine | `cargo test` | `cargo nextest run` |
| --- | --- | --- | --- |
| 1 | loaded (load avg 152 → 78) | 820.0s, 3 flaky failures | 864.8s, all pass |
| 2 | quiet (load avg ~6-12) | 495.3s | 536.3s |

**nextest is ~8% SLOWER inside a single binary** — libtest already threads one
binary, and nextest pays a process per test. That is the honest shape of this
change: it buys nothing in your inner loop and everything in a gate that starts
69 binaries in series. The number that decides this PR is the `Test every
target` step in its own CI run, against the three baselines above.

## Coverage identity — measured, not assumed

- **The criterion bench.** `m1nd-core` declares `harness = false`, and the
  current gate does run it in test mode (run 30529035605: `Running
  benches/core_benchmarks.rs`, then `Testing graph_build_1k / Success`, ten
  cases, ~2s). Verified against this bench rather than taken from the docs:
  `cargo nextest list -p m1nd-core --benches` lists all ten as
  `m1nd-core::bench/core_benchmarks <name>`, and `cargo nextest run` passes them
  (189/189 with the lib tests).
- **Doctests.** nextest cannot run them. Neither does today's gate: `cargo test
  --all-targets` excludes doctests by construction, and the real gate log of run
  30529035605 contains **zero** `Doc-tests` sections across all 69 binaries. So
  this change drops nothing.

  It does not close that hole either, and measuring it is the reason why:
  `cargo test --workspace --doc` finds **13 doctests (all in `m1nd-mcp`) and two
  of them FAIL today** — `server.rs - server::McpServer (line 470)` and
  `session.rs - session::SessionState::initialize (line 2048)`, both marked
  `compile_fail`, both now reporting "Test compiled successfully, but it's
  marked `compile_fail`". Two encapsulation guards have rotted unobserved.
  Adding a `--doc` step here would turn this PR red for something it did not
  cause, so the finding goes to the project mailbox as its own piece of work
  instead.

## `.config/nextest.toml` — the two knobs that decide what a red means

- `retries = 0`. A test that passes on the second attempt is a flake, and a
  flake here is a defect to be diagnosed from its red. It is nextest's default
  today; it is written down so a future default cannot slip hidden reruns under
  a green check.
- `slow-timeout = { period = "120s", terminate-after = 15 }` — a SLOW line every
  2 minutes, termination only after 30. The old runner had no per-test limit at
  all, only the job's 90 minutes, so this threshold exists to stay far above
  anything legitimate rather than to police it. Measured basis: the slowest
  single tests in this workspace are the ~600s retrobuilder tests visible in the
  run above, and the largest wall-clock budget any test asserts about itself is
  60s (`m1nd-core/tests/retrobuilder_stress.rs`). 30 minutes is ~3x the slowest
  measured test and still leaves the 90-minute job cap as the outer bound;
  without it a wedged test burns the whole job and reports a timeout instead of
  naming the test.

## Supply chain

`taiki-e/install-action` is pinned to the commit SHA of its `v2.85.4` release,
like every other `uses:` in this file, and it installs an exact nextest version
(`cargo-nextest@0.9.140`) the way gitleaks (8.30.1) and cargo-audit (0.22.2) are
pinned here. The runner that decides what a red means does not get to change
under the gate without a commit.
