### PR TITLE
ci(rust-gates): run the doctest sentinels no other gate reaches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
       # to linting, so a separate check pass was a full redundant compile.
       - name: Test every target
         run: cargo test --locked --workspace --all-targets
+      # `--all-targets` EXCLUDES doctests by construction, so the step above has
+      # never executed one. That is not a documentation detail here: all 13 of
+      # this workspace's doctests are `compile_fail` sentinels, and they are the
+      # only thing asserting that the candidate boundary stays shut — each one
+      # pins a symbol that must NOT be reachable from outside its crate. Being
+      # asserted and never run is how two of them rotted through the whole
+      # transplant era and were caught by a release audit instead of a PR
+      # (#505: `server::McpServer` and `session::SessionState::initialize` both
+      # reported "compiled successfully, but it's marked compile_fail"). This
+      # leg reuses the artifacts the step above already built — a rustdoc pass,
+      # not a compile — measured at ~10s wall, 0.12s of which is the tests.
+      - name: Run the doctests --all-targets cannot reach
+        run: cargo test --locked --workspace --doc
       - name: Deny clippy warnings
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
       - name: Verify formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,18 @@ Run these before you consider any change done. The blocking gate is **ubuntu + m
 
 ```bash
 cargo test --workspace --all-targets
+cargo test --workspace --doc                            # the sentinels --all-targets skips
 cargo clippy --workspace --all-targets -- -D warnings   # warnings fail the build
 cargo fmt --check
 ```
+
+The second line is not a duplicate of the first: `--all-targets` **excludes** doctests by
+construction, and every doctest in this workspace is a `compile_fail` sentinel guarding the
+candidate boundary — 13 of them, all in `m1nd-mcp`, each pinning a symbol that must not be
+reachable from outside its crate. Until 2026-07-30 nothing in CI executed them, which is how
+two rotted silently through the transplant era and surfaced in a release audit rather than a
+PR (#505). If you widen a visibility, this is the line that tells you. It costs ~10s on top of
+the run above (0.12s of it is the tests; the rest is rustdoc over artifacts already built).
 
 There is deliberately no standalone `cargo check` (clippy type-checks every target on its way
 to linting — a separate pass was a redundant full compile), and the `--release` workspace


### PR DESCRIPTION
`cargo test --workspace --all-targets` **excludes doctests by construction**, so the `rust-gates` test step has never executed one. Confirmed in the logs, not inferred: the ubuntu leg of run 30529035605 has 69 `Running` sections and zero `Doc-tests` sections.

That is not a documentation gap here. Every doctest in this workspace is a `compile_fail` sentinel — 13 of them, all in `m1nd-mcp` (`brain_runtime`, `project_brains`, `instance_registry`, `server`, `session`) — and they are the only thing asserting that the candidate boundary stays shut. Each pins a symbol that must **not** be reachable from outside its crate.

Asserted and never run is exactly how two of them rotted through the whole transplant era. `server::McpServer` and `session::SessionState::initialize` were both reporting *"Test compiled successfully, but it's marked compile_fail"* until #505 put the visibilities back and moved the transplant suites inside the wall they had been leaning on. A release audit caught that. A PR gate should have.

## The change

One step in `rust-gates`, after `Test every target`:

```yaml
- name: Run the doctests --all-targets cannot reach
  run: cargo test --locked --workspace --doc
```

It reuses the artifacts the test step already built, so it is a rustdoc pass and not a compile.

## Measured

On this branch's base (`3375d5bc`), warm tree:

```
   Doc-tests m1nd_mcp
running 13 tests
... 13 x "compile fail ... ok"
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```

`m1nd_control`, `m1nd_core`, `m1nd_ingest`, `m1nd_runnerd`: 0 doctests each, ok. Whole command 10.1s wall (`/usr/bin/time -p`, warm), 0.12s of it the tests. So the gate goes green today and costs ~10s per leg.

Gates run here: `cargo fmt --all --check` clean; `python3 -m unittest discover -s tests` → 150 tests, OK (1 skipped) — those read the workflow files, so a malformed step would have shown up there.

`AGENTS.md` gains the line in the gate block and the reason it is not a duplicate of the one above it.

## Provenance

Split out of #504 (cargo-nextest under `rust-gates`), which is closed — nextest measured slower on this workspace and its process-per-test model disarms an in-process serialization latch the suite depends on; the reasoning and the numbers are in that thread. The doctest hole was filed by that PR and deliberately left open because two sentinels were red at the time. #505 made them green, so it lands on its own.
