### PR TITLE
fix(release): ship the macOS runtime unentitled so it can launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,30 +568,53 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12"
 
           # 2) sign with hardened runtime + secure timestamp (notarization requires
-          #    both) AND the keychain-access-groups entitlement.
+          #    both) and NO entitlements — deliberately.
           #
-          #    The entitlement is NOT cosmetic. The G9 custody floor persists the
-          #    owner's authority key in the data-protection keychain — the only
-          #    keychain a Secure Enclave key can be permanent in — and an unentitled
-          #    binary cannot persist or resolve it at all, so `open`/`sign` fail
-          #    closed. Signing without it shipped a binary structurally incapable of
-          #    running the owner's custody ceremony, invisible until the ceremony
-          #    failed at its first step (measured 2026-07-29 while staging G9).
-          #    See build/m1nd-mcp.entitlements.plist and the HARD PREREQUISITE block
-          #    in m1nd-mcp/src/enclave_authority.rs.
+          #    `keychain-access-groups` is a RESTRICTED entitlement. AMFI honours it
+          #    only when an embedded provisioning profile authorizes it, and a raw
+          #    Mach-O executable has nowhere to embed one: a profile lives at
+          #    `Contents/embedded.provisionprofile` INSIDE a bundle. Apple states the
+          #    rule in TN3137 (On Mac keychain APIs and implementations,
+          #    § Implementation differences): the data-protection keychain access
+          #    groups are built from code signing entitlements, and "These
+          #    entitlements must be authorized by a provisioning profile. Your
+          #    program needs an app-like bundle structure in which to embed that
+          #    profile. This is standard for app and app extensions but not for
+          #    command-line tools."
+          #
+          #    v1.6.0 shipped the entitlement and the kernel SIGKILLed the product at
+          #    launch while every signature check still passed — `codesign --verify
+          #    --strict` ok, notarization Accepted, spctl "Notarized Developer ID",
+          #    the entitlement provably on the bytes. The artifact smoke caught it:
+          #    `--version` died with SIGKILL on both macOS legs. AMFI's reason, from
+          #    the kernel log: "Code has restricted entitlements, but the validation
+          #    of its code signature failed", with amfid reporting
+          #    AppleMobileFileIntegrityError -413 "No matching profile found".
+          #    Measured 2026-07-30 on the exact v1.6.0 artifact; the same bytes
+          #    re-signed without the entitlement launch and print their version.
+          #
+          #    So the custody entitlement CANNOT ride on the shipped raw binary. G9
+          #    prerequisite P4 is owner-side — see build/README.md and
+          #    docs/benchmarks/G9-CUSTODY-CEREMONY.md §1 P4.
           codesign --force --timestamp --options runtime \
-            --entitlements build/m1nd-mcp.entitlements.plist \
             --sign "$APPLE_SIGNING_IDENTITY" "$BIN_PATH"
           codesign --verify --strict --verbose=2 "$BIN_PATH"
-          # Prove the entitlement actually landed on the shipped bytes. This check is
-          # NOT belt-and-braces: `codesign` parses entitlements with AMFIUnserializeXML,
-          # and when that parse fails (an XML comment anywhere in the plist is enough —
-          # `plutil -lint` accepts what AMFI rejects) it prints the error, signs the
-          # binary WITHOUT the entitlement, and still exits 0. Measured 2026-07-29.
-          # Without this grep the ceremony breaks and the release stays green.
-          codesign -d --entitlements - "$BIN_PATH" 2>/dev/null \
-            | grep -q "keychain-access-groups" \
-            || { echo "::error::signed binary carries no keychain-access-groups entitlement — the G9 custody ceremony would fail closed"; exit 1; }
+          # Refuse the regression in the direction that actually kills the product.
+          # A provisioning-profile-restricted entitlement on a raw executable leaves
+          # every downstream signature check green and the binary unlaunchable, so
+          # the ban has to be mechanical, not remembered.
+          if codesign -d --entitlements - "$BIN_PATH" 2>/dev/null \
+            | grep -qE 'keychain-access-groups|application-identifier|com\.apple\.developer\.'; then
+            echo "::error::signed binary claims a provisioning-profile-restricted entitlement — AMFI SIGKILLs a raw executable that does (build/README.md)"
+            exit 1
+          fi
+          # And prove the signed bytes LAUNCH, at the point of the decision. The
+          # runner is native for this target, so this costs one process — and it is
+          # the check that would have failed v1.6.0 in the signing step instead of
+          # two jobs downstream. It does not replace the artifact smoke, which
+          # exercises the archived bytes after a full round trip.
+          "$BIN_PATH" --version >/dev/null \
+            || { echo "::error::the signed binary does not launch — see the restricted-entitlement note above"; exit 1; }
 
           # 3) notarize (a bare executable is submitted zipped; stapling is not
           #    possible for a raw binary, so Gatekeeper resolves the ticket online)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
+### Fixed
+
+- **The macOS binaries run again.** The 1.6.0 release signed them with the
+  `keychain-access-groups` entitlement; macOS killed them at launch. That entitlement is
+  *restricted* — the kernel honours it only when an embedded provisioning profile authorizes it,
+  and a plain command-line binary has nowhere to carry one. Every signature check still passed,
+  which is why nothing upstream noticed until the installed-artifact smoke ran `--version` and got
+  a `SIGKILL`. macOS runtimes now ship signed, notarized and unentitled; the release refuses to
+  sign a binary that claims a restricted entitlement, and proves the signed bytes launch before
+  they are packaged. The G9 custody ceremony's keychain prerequisite is correspondingly an
+  owner-side step now, recorded where the runbook states it.
+
 ## [1.6.0] — 2026-07-30
 
 ### Added — the brain finds you, and the owner's ceremonies have their doors

--- a/build/README.md
+++ b/build/README.md
@@ -2,40 +2,114 @@
 
 ## `m1nd-mcp.entitlements.plist`
 
-**A HARD PREREQUISITE for the G9 Secure Enclave custody ceremony, not a nicety.**
+**The release does NOT sign with this file, and must not. It is kept for the
+owner-side, bundled signing the G9 custody ceremony needs (prerequisite P4).**
 
-The custody floor persists the owner's authority key in the **data-protection
-keychain** (`Location::DataProtectionKeychain`) — the only keychain a Secure
-Enclave key can be made permanent in — and scopes both the provisioning write and
-`resolve_persisted_key` to it via `kSecUseDataProtectionKeychain`. See the
-`HARD PREREQUISITE` block above the real Security.framework key store in
-`m1nd-mcp/src/enclave_authority.rs`.
+An earlier version of this document asserted the opposite — that threading
+`--entitlements` through `release.yml` was what made the shipped binary capable of
+the ceremony. That was wrong, and the correction below is measured, not reasoned.
 
-An unsigned or **unentitled** binary cannot persist or resolve that key at all:
-`open`/`sign` fail closed. Before this file existed, `release.yml` signed with
-`--options runtime` and **no `--entitlements`**, so the shipped, notarized binary
-was structurally incapable of running the owner's ceremony — a gap invisible until
-the ceremony would have failed at its first step. Measured 2026-07-29 while staging
-G9; the release step now passes the entitlement **and proves it landed on the
-shipped bytes** (a signature that silently dropped it would leave the ceremony
-broken and the release green).
+### What was measured, 2026-07-30
 
-`4KLJ4N9D5K` is the Developer ID team the release already signs with
-(`Developer ID Application: … (4KLJ4N9D5K)`).
+Release run `30556058443` (tag `v1.6.0`) signed both macOS binaries with
+`--options runtime --entitlements build/m1nd-mcp.entitlements.plist`. Everything a
+signature check can ask, passed: `codesign --verify --strict` reported *valid on
+disk* and *satisfies its Designated Requirement*, notarization returned
+`status: Accepted`, `spctl -a` answered *accepted, source=Notarized Developer ID*,
+and `codesign -d --entitlements -` showed the entitlement on the shipped bytes.
+
+The binaries could not run. The installed-artifact smoke failed on both macOS legs
+with
+
+```
+release artifact smoke refused: Command '[…/runtime/m1nd-mcp', '--version']' died with <Signals.SIGKILL: 9>.
+```
+
+Running that exact downloaded artifact on an Apple Silicon Mac (macOS 15.6)
+reproduces it — exit 137 — and the kernel says why:
+
+```
+taskgated-helper  Disallowing m1nd-mcp because no eligible provisioning profiles found
+amfid             m1nd-mcp not valid: Error Domain=AppleMobileFileIntegrityError Code=-413
+                  "No matching profile found"
+kernel (AppleMobileFileIntegrity)  AMFI: When validating m1nd-mcp:
+                  Code has restricted entitlements, but the validation of its code
+                  signature failed.
+                  Unsatisfied Entitlements:
+kernel            proc …: load code signature error 4 for file "m1nd-mcp"
+```
+
+The entitlement is the whole cause, isolated by an A/B on the same bytes:
+re-signed ad-hoc **without** entitlements the binary launches and prints its
+version; re-signed ad-hoc **with** this plist it is SIGKILLed again. Wrapping it in
+a minimal `.app` bundle does not help either — without an
+`embedded.provisionprofile` inside that bundle the kill is identical.
+
+### What Apple actually requires
+
+`keychain-access-groups` is a *restricted* entitlement: AMFI honours it only when a
+provisioning profile authorizes it. TN3137, *On Mac keychain APIs and
+implementations*, § Implementation differences, states the rule and its consequence
+for tools like this one:
+
+> macOS builds the list of data protection keychain access groups available to your
+> program from its code signing entitlements. […] These entitlements must be
+> authorized by a provisioning profile. Your program needs an app-like bundle
+> structure in which to embed that profile. This is standard for app and app
+> extensions but not for command-line tools.
+
+A raw Mach-O executable has nowhere to put a profile — it lives at
+`Contents/embedded.provisionprofile` inside a bundle — so a shipped, non-bundled
+`m1nd-mcp` cannot carry this entitlement and remain runnable. Apple's own workaround
+for exactly this case is *Signing a daemon with a restricted entitlement*: wrap the
+standalone executable in an app-like structure whose profile authorizes the
+entitlement. That is a packaging and Apple-Developer-portal decision belonging to
+the owner, not a byte the release pipeline can add.
+
+The same technote also fixes the other half of P4: the data-protection keychain is
+"only available to programs running in a user context", so the ceremony is run by
+hand from a login session, never from a `launchd` daemon.
+
+### What the release does instead
+
+`release.yml` signs with `--options runtime --timestamp` and **no entitlements**,
+then refuses, mechanically:
+
+1. any provisioning-profile-restricted entitlement on the signed output
+   (`keychain-access-groups`, `application-identifier`, `com.apple.developer.*`) —
+   the check now points the other way, because the direction that kills the product
+   is *claiming* one; and
+2. a binary that does not launch — `"$BIN_PATH" --version` runs on the native
+   runner right after signing.
+
+The installed-artifact smoke is unchanged and stays exactly as strict. It is what
+caught this, and the two checks above only move the same failure earlier.
+
+### What this leaves open for G9
+
+Prerequisite P4 is now **owner-side**. The shipped binary fails closed at the
+keychain, by design and with its own name
+(`custody_ceremony_keychain_entitlement_missing`) — that is the honest answer, not
+a regression. The ceremony still needs a binary that *is* authorized, which means
+the owner signs locally against a profile, or the ceremony surface ships as a
+bundle. Recorded, undecided, in `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §1 P4 and
+§5 R1; this PR does not choose for the owner.
 
 ### This file is a custody surface
 
-It is deliberately **minimal** — one entitlement, one group. Every entry widens
-what a signed binary may do, so adding to it is a **security decision**, never a
-build tweak.
+It is deliberately **minimal** — one entitlement, one group, unchanged by this
+correction. Every entry widens what a signed binary may do, so adding to it is a
+**security decision**, never a build tweak. `4KLJ4N9D5K` is the Developer ID team
+the release signs with (`Developer ID Application: … (4KLJ4N9D5K)`).
 
 ### Why the plist carries no comments
 
 `codesign` parses entitlements with `AMFIUnserializeXML`, which **rejects XML
-comments anywhere in the file** — including inside `<dict>`. `plutil -lint`
-accepts them, so a commented plist lints clean and then fails at signing time with
+comments anywhere in the file** — including inside `<dict>`. `plutil -lint` accepts
+them, so a commented plist lints clean and then fails at signing time with
 `Failed to parse entitlements: AMFIUnserializeXML: syntax error`. Worse, that
 failure does **not** set a non-zero exit on `codesign`: the binary signs *without*
 the entitlement and the pipeline looks green. Both facts were proven by signing a
-probe binary rather than assumed — which is why the rationale lives in this README
-and the release step verifies the entitlement is present on the output.
+probe binary rather than assumed (2026-07-29), and they still hold for whoever
+signs this plist onto a bundled build — the trap is in `codesign`, not in the
+release.

--- a/docs/benchmarks/G9-CUSTODY-CEREMONY.md
+++ b/docs/benchmarks/G9-CUSTODY-CEREMONY.md
@@ -44,7 +44,7 @@ prerequisite P4, which is the honest form of "this did not run".
 | P1 | Apple Silicon / T2 Mac with a Secure Enclave, owner physically present | owner's machine | — |
 | P2 | Touch ID enrolled for the owner | owner's machine | — |
 | P3 | macOS build target — the module is `#[cfg(target_os = "macos")]` and absent by construction elsewhere, so the assembly stays NOT_INSTALLED and fails closed rather than falling back to software | **satisfied** | `m1nd-mcp/src/lib.rs:36-37` |
-| P4 | Binary codesigned with a **`KeychainAccessGroups` entitlement**. Secure Enclave keys can only be made permanent in the data-protection keychain; an unsigned or unentitled binary cannot persist *or* resolve the key, so `provision`/`open`/`sign` all fail closed | **release: satisfied** (#469 — plist present, `--entitlements` threaded and verified on the signed output, `.github/workflows/release.yml:583`/`:592`); **any local build: absent by construction**, and every custody verb refuses naming this prerequisite. UNPROVEN until the owner's run — see §5 R1 | `m1nd-mcp/src/enclave_authority.rs:1149-1157`, `:1425`, `build/README.md` |
+| P4 | Binary codesigned with a **`KeychainAccessGroups` entitlement**. Secure Enclave keys can only be made permanent in the data-protection keychain; an unsigned or unentitled binary cannot persist *or* resolve the key, so `provision`/`open`/`sign` all fail closed | **UNSATISFIED, and NOT satisfiable by the release — owner-side.** #469 threaded `--entitlements` into the signing step; the resulting v1.6.0 binary was SIGKILLed by AMFI at launch, because `keychain-access-groups` is a *restricted* entitlement and a raw executable has nowhere to embed the provisioning profile that would authorize it (measured 2026-07-30, run `30556058443`; Apple's rule: TN3137 § Implementation differences). The release now signs WITHOUT it and refuses one on the output, so **every** shipped and local build fails closed here, naming the prerequisite. Closing P4 needs an owner-side decision — a locally signed profile-authorized build, or shipping the ceremony surface as a bundle — see §5 R1 | `m1nd-mcp/src/enclave_authority.rs:1197-1222`, `:1489`, `build/README.md`, `.github/workflows/release.yml:570-617` |
 | P5 | A `0700`, non-symlink, device/inode-pinned protected root directory for the sealed slots | code ready, root not provisioned | `SealedProtectedRootV1::open` — `m1nd-mcp/src/enclave_authority.rs:441` |
 | P6 | Custody dependency pins intact — `security-framework =3.7.0` (feature `OSX_10_15`), `security-framework-sys =2.17.0`, `core-foundation =0.10.1`. **These are custody surface; never bump them opportunistically** | **satisfied** | `m1nd-mcp/Cargo.toml:112-114` |
 | P7 | Crypto stack coherent after the RustCrypto sweep (#464) | **satisfied, measured** (see §6) | — |
@@ -237,16 +237,34 @@ Two properties are worth stating because they are load-bearing rather than incid
 
 ## 5. Residual engineering, ranked by blocking-ness
 
-- **R1 (CLOSED for the release binary; still UNPROVEN until the ceremony runs).** When this was
-  written the repo had no `.entitlements` file and `release.yml` codesigned with no
-  `--entitlements` flag, so the signed release binary was structurally incapable of running this
-  ceremony. #469 added `build/m1nd-mcp.entitlements.plist`, threaded `--entitlements` through the
-  signing step (`.github/workflows/release.yml:583`) and **verifies the entitlement landed on the
-  shipped bytes** (`:592`) — because `codesign` exits 0 while silently dropping an entitlement it
-  failed to parse. What remains: no build has yet PROVEN it by persisting and resolving a real key,
-  which only the owner's run does. A locally-built binary carries no entitlement at all, so every
-  custody verb on one refuses naming P4 — the correct answer, surfaced as
-  `custody_ceremony_keychain_entitlement_missing` rather than an opaque OSStatus.
+- **R1 (OPEN, and the release cannot close it — reopened 2026-07-30 by measurement).** The
+  original entry said the signed release binary was structurally incapable of running this
+  ceremony because `release.yml` passed no `--entitlements`. #469 added
+  `build/m1nd-mcp.entitlements.plist` and threaded the flag through — and that is where the
+  reasoning was wrong. `keychain-access-groups` is a **restricted** entitlement: AMFI honours it
+  only when an embedded provisioning profile authorizes it, and a raw Mach-O executable has
+  nowhere to embed one (a profile lives at `Contents/embedded.provisionprofile` inside a bundle).
+  Apple states it in TN3137 § Implementation differences — those entitlements "must be authorized
+  by a provisioning profile. Your program needs an app-like bundle structure in which to embed
+  that profile. This is standard for app and app extensions but not for command-line tools."
+  The consequence was measured, not inferred: release run `30556058443` (tag `v1.6.0`) signed,
+  notarized (`Accepted`) and verified both macOS binaries with the entitlement provably on the
+  bytes, and the **installed-artifact smoke then failed on both macOS legs** with `--version`
+  dying on `SIGKILL`. The exact artifact reproduces it off-CI (exit 137); the kernel's reason is
+  "Code has restricted entitlements, but the validation of its code signature failed", with amfid
+  reporting `-413 "No matching profile found"`. Same bytes re-signed without the entitlement run.
+  A minimal `.app` wrapper without an `embedded.provisionprofile` is killed identically.
+  **So the release ships unentitled** (`.github/workflows/release.yml:570-617`: no
+  `--entitlements`, a refusal if any restricted entitlement appears on the output, and a launch
+  check on the signed bytes). Every build — shipped or local — therefore refuses at P4, surfaced
+  as `custody_ceremony_keychain_entitlement_missing` rather than an opaque OSStatus, which is the
+  honest answer and not a regression.
+  **What remains open is a decision only the owner can make**, and this document does not make it:
+  the ceremony needs a binary whose entitlement *is* authorized — either the owner signs a build
+  locally against a profile he holds, or the ceremony surface ships inside an app-like bundle
+  (Apple's own workaround for this case is *Signing a daemon with a restricted entitlement*).
+  Whichever path, P4 is owner-side, and the persistence proof — a real key persisted and resolved
+  across a process restart — still happens only in the owner's run.
 - **R2 (CLOSED).** The ceremony surface exists and all five verbs reach the floor — §4. The one
   thing no surface can supply is the owner's hand.
 - **R3 (open — blocking for the ladder, not for the ceremony).** `assemble` is now a production

--- a/docs/benchmarks/M1ND-10-OWNER-SITTING.md
+++ b/docs/benchmarks/M1ND-10-OWNER-SITTING.md
@@ -30,13 +30,21 @@ This is pure owner authorship — nothing blocks it, and nothing else can produc
 
 ## Step 1 — cut the release tag (G8's material half)
 
-The release pipeline is ready: Developer ID signing + notarization (#433) and the
-custody entitlement on the shipped bytes (#469 — before it, the notarized binary was
-structurally incapable of the enclave ceremony; the release step now proves the
-entitlement landed by reading the signed output). Tagging produces the **entitled
-binary** the G9 steps below must run on. Run `/release-parity` first (crates.io ↔
-npm), then tag. G8 the *gate* also wants the manifest to bind this release — that
-binding is the same manifest work G7 waits on; the tag itself is not blocked.
+The release pipeline is ready: Developer ID signing + notarization (#433). Run
+`/release-parity` first (crates.io ↔ npm), then tag. G8 the *gate* also wants the
+manifest to bind this release — that binding is the same manifest work G7 waits on;
+the tag itself is not blocked.
+
+**Correction, measured 2026-07-30 — tagging does NOT produce an entitled binary,
+and cannot.** #469 signed the release with the `keychain-access-groups` entitlement;
+the v1.6.0 run then failed, because that entitlement is *restricted* and AMFI
+SIGKILLs a raw executable that claims one without an embedded provisioning profile —
+which a non-bundled binary has nowhere to hold (Apple, TN3137). The release now
+signs without it. Prerequisite **P4 is owner-side**: the G9 verbs below will refuse
+on the tagged binary, by name, until you run them on a build whose entitlement is
+authorized by a profile you hold, or the ceremony surface ships as a bundle. That
+choice is yours and undecided — `G9-CUSTODY-CEREMONY.md` §1 P4 and §5 R1 carry the
+evidence, and `build/README.md` carries the kernel log.
 
 ## Step 2 — the G9 custody ceremony (`G9-CUSTODY-CEREMONY.md` is the full runbook)
 
@@ -46,7 +54,7 @@ state today, from `custody_ceremony.rs::run_custody_ceremony`:
 
 | Verb | State today | What it does |
 |---|---|---|
-| `preflight` | **RUNS** — reports every prerequisite, exit 0 only when ready | run it first, on the entitled binary, at the protected root |
+| `preflight` | **RUNS** — reports every prerequisite, exit 0 only when ready | run it first, at the protected root; on the tagged binary it will report P4 unsatisfied (see Step 1) |
 | `provision-seats` | **RUNS** — mints the four verifier seats + the sealing seat in the enclave-backed store, stages each record; re-provisioning refuses (`custody_ceremony_seats_already_staged`) | mint the seats; on an unentitled binary the keychain's own refusal surfaces, named |
 | `owner-seat` | **RUNS, owner-only** — mints the biometric seat with the biometry-gated access control (Touch ID fires at key USE, by the ACL); an unattended invocation is still refused *as unattended* on every platform, before the platform floor | the biometric seat — irreducibly the owner's finger |
 | `seal` | **RUNS** — only over a complete staged ceremony (4 seats + sealing seat + owner seat), binds the owner's independence spec and constitution digest, writes the sealed receipt, consumes the staging | seal seats + lineage + spec digests into the ceremony receipt |
@@ -55,9 +63,10 @@ state today, from `custody_ceremony.rs::run_custody_ceremony`:
 **The door↔floor wiring landed (#498).** Every verb now reaches the real enclave
 floor; two owner-held inputs joined the CLI (`--custody-independence-spec`,
 `--custody-constitution-digest` — the ceremony READS the owner's spec, it never
-builds one). What remains true: real execution needs the owner, the entitled
-binary, and the Mac — every missing precondition refuses closed with its own
-name, and no agent path can perform any of it.
+builds one). What remains true: real execution needs the owner, the Mac, and an
+entitled binary that **the release cannot produce** (Step 1's correction) — every
+missing precondition refuses closed with its own name, and no agent path can perform
+any of it.
 
 **Before the first verb, seal the spec (P9).** The independence spec is written by
 hand, and every custody verb refuses one whose declared digest is not the digest of
@@ -95,7 +104,8 @@ consumer channel is its **identity**: three preflight fields
 request, the sandbox denies every owner-held path, and the assembly's
 `self_digest` covers the provider's own digest — so the provider cannot embed
 what is computed from it. A binary config-trailer is ruled out by measurement (it
-voids the macOS signature and with it the keychain entitlement). The working
+voids the macOS signature; the shipped binary carries no entitlement to void, per
+Step 1's correction, but an invalid signature is disqualifying on its own). The working
 direction, pending the owner's veto: **keychain-resident provider identity**,
 filed by the custody ceremony itself — the only channel that survives both the
 sandbox (mach-lookup is allowed) and codesigning, and it keeps the signed binary

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -1204,6 +1204,22 @@ impl Error for EnclaveError {}
 // would fail closed. This is a precondition of the owner's ceremony, not a
 // runtime nicety.
 //
+// The PUBLISHED binary does not and cannot satisfy it — corrected here after
+// measurement, 2026-07-30. `keychain-access-groups` is a restricted entitlement
+// that AMFI honours only when an embedded provisioning profile authorizes it, and
+// a raw executable has nowhere to embed one (Apple, TN3137 § Implementation
+// differences: those entitlements "must be authorized by a provisioning profile.
+// Your program needs an app-like bundle structure in which to embed that
+// profile"). v1.6.0 shipped the entitlement on the raw binary and the kernel
+// SIGKILLed it at launch — "Code has restricted entitlements, but the validation
+// of its code signature failed", amfid -413 "No matching profile found" — so the
+// release now signs WITHOUT it and refuses one on the output. Prerequisite P4 is
+// therefore owner-side (a locally signed, profile-authorized or bundled build);
+// see `build/README.md` and `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §1 P4.
+// TN3137 also bounds where the ceremony can run at all: the data-protection
+// keychain is "only available to programs running in a user context", never a
+// `launchd` daemon.
+//
 // Custody is keyed by `kSecAttrLabel` (the high-level `GenerateKeyOptions` exposes
 // no `kSecAttrApplicationTag`): `provision` sets a distinct label per key and
 // refuses a label already present (never-open-or-create); `open` resolves by that

--- a/m1nd-mcp/tests/custody_ceremony_wiring.rs
+++ b/m1nd-mcp/tests/custody_ceremony_wiring.rs
@@ -275,9 +275,11 @@ fn the_owner_seat_step_refuses_when_unattended() {
 /// **An unentitled or unsigned binary fails closed with the honest error.**
 /// Secure Enclave keys are only permanent in the data-protection keychain, which
 /// an unentitled binary can neither write nor resolve — so provision, open and
-/// sign all fail. The release now signs with the entitlement
-/// (`build/m1nd-mcp.entitlements.plist`), but a locally-built binary will not have
-/// it, and the failure must NAME that cause instead of surfacing a raw OSStatus.
+/// sign all fail. This is the state of EVERY build the project ships: the released
+/// binary is signed without the entitlement, because a raw executable that claims
+/// this restricted entitlement is SIGKILLed by AMFI at launch (measured 2026-07-30,
+/// `build/README.md`), and a locally-built binary carries no signature at all. So
+/// the failure must NAME that cause instead of surfacing a raw OSStatus.
 ///
 /// Tested at the classifier, not by provisioning: producing the real failure means
 /// touching the enclave, which §0 prohibits.


### PR DESCRIPTION
## The failure, measured

Release run `30556058443` (tag `v1.6.0`) built and signed both macOS binaries successfully, and
then shipped a product that could not start.

| Job | Result |
|---|---|
| `Build once (x86_64-apple-darwin)` / `(aarch64-apple-darwin)` | **success** — signature replaced with `--options runtime --entitlements build/m1nd-mcp.entitlements.plist`, `codesign --verify --strict` *valid on disk* + *satisfies its Designated Requirement*, notarization `status: Accepted`, entitlement-landed grep passed (it is a hard check — the step would have failed otherwise) |
| `Installed artifact smoke (macos-x86_64)` / `(macos-aarch64)` | **failure**, identically: `release artifact smoke refused: Command '[…/runtime/m1nd-mcp', '--version']' died with <Signals.SIGKILL: 9>.` |
| `Installed artifact smoke (linux-x86_64)` | success |

## The AMFI evidence

The published artifact was downloaded and run on an Apple Silicon Mac (macOS 15.6). It reproduces:
exit **137**. Before that, `spctl -a -vvv` answered *accepted, source=Notarized Developer ID*, and
`codesign -d --entitlements -` showed `keychain-access-groups → <TEAMID>.world.m1nd.custody` on the
bytes. The kernel log from the moment of the kill:

```
taskgated-helper[…] [com.apple.ManagedClient:ProvisioningProfiles] Disallowing m1nd-mcp because no eligible provisioning profiles found
amfid[…] …/m1nd-mcp not valid: Error Domain=AppleMobileFileIntegrityError Code=-413 "No matching profile found" UserInfo={…, NSLocalizedDescription=No matching profile found}
kernel[…] (AppleMobileFileIntegrity) AMFI: When validating …/m1nd-mcp:
  Code has restricted entitlements, but the validation of its code signature failed.
Unsatisfied Entitlements:
kernel[…] mac_vnode_check_signature: …/m1nd-mcp: code signature validation failed fatally: …
kernel[…] proc …: load code signature error 4 for file "m1nd-mcp"
kernel[…] (AppleSystemPolicy) ASP: Security policy would not allow process: …
```

The entitlement is the whole cause, isolated by an A/B over the **same bytes**:

| Same binary, re-signed | Result |
|---|---|
| ad-hoc, `--options runtime`, **no** entitlements | launches, prints `m1nd-mcp 1.6.0 (…)`, exit 0 |
| ad-hoc, `--options runtime`, **with** `build/m1nd-mcp.entitlements.plist` | **SIGKILL** (exit 137), AMFI: *Code has restricted entitlements…* |
| wrapped in a minimal `.app`, entitled, **no** `embedded.provisionprofile` | **SIGKILL** — bundling alone is not the missing piece |

## What Apple actually requires

`keychain-access-groups` is a **restricted** entitlement: AMFI honours it only when an embedded
provisioning profile authorizes it. Apple states the rule and its consequence for tools like this
one in **TN3137, *On Mac keychain APIs and implementations*, § Implementation differences**
(<https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains>):

> macOS builds the list of data protection keychain access groups available to your program from
> its code signing entitlements. […] **These entitlements must be authorized by a provisioning
> profile. Your program needs an app-like bundle structure in which to embed that profile. This is
> standard for app and app extensions but not for command-line tools.**

A raw Mach-O executable has nowhere to put a profile — it lives at
`Contents/embedded.provisionprofile` inside a bundle. Apple's documented workaround for exactly
this case is *Signing a daemon with a restricted entitlement*
(<https://developer.apple.com/documentation/xcode/signing-a-daemon-with-a-restricted-entitlement>):
wrap the standalone executable in an app-like structure whose profile authorizes the entitlement.
That is a packaging and developer-portal decision, not a byte a release pipeline can add.

The same technote bounds the ceremony independently of signing: the data-protection keychain is
*"only available to programs running in a user context"* — never from a `launchd` daemon.

So of the four candidates, the answer is (c): the entitlement is genuinely required for the
data-protection keychain **and** genuinely unbundleable on a shipped raw binary.

## The fix, and why it is safe

`.github/workflows/release.yml` signs with the hardened runtime and a secure timestamp, and **no
entitlements**. The single check it had is replaced by two, both stricter about the failure that
actually occurred:

1. **Refuse any provisioning-profile-restricted entitlement on the signed output** —
   `keychain-access-groups`, `application-identifier`, `com.apple.developer.*`. The old grep proved
   the entitlement had *landed*; the direction that kills the product is claiming one at all, and
   that ban is now mechanical rather than remembered.
2. **Prove the signed bytes launch** — `"$BIN_PATH" --version` immediately after signing. Each macOS
   target builds on a native runner, so this costs one process, and it is the check that would have
   failed 1.6.0 in the signing step instead of two jobs downstream.

**The installed-artifact smoke is untouched and stays exactly as strict.** It is what caught this;
the two checks above only move the same failure earlier.

### The custody surface

`build/m1nd-mcp.entitlements.plist` is **unchanged, byte for byte** — nothing is added, widened, or
removed. Only its consumer changes: the release no longer signs with it. It remains the entitlement
the G9 ceremony needs, on a build that can legally carry it. Nothing in this PR grants any binary a
capability it did not have; it removes a claim the platform was refusing to honour.

## The consequence, recorded and not decided

Prerequisite **P4 is owner-side**. The shipped binary fails closed at the keychain with its own name
(`custody_ceremony_keychain_entitlement_missing`) — the honest answer, not a regression. Closing P4
needs a decision only the owner makes: sign a ceremony build locally against a profile he holds, or
ship the ceremony surface as a bundle. This PR does not choose, it records:

- `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §1 P4 — was "release: satisfied"; now unsatisfied and
  not satisfiable by the release, with the measurement.
- `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §5 R1 — reopened, with the reasoning error named.
- `docs/benchmarks/M1ND-10-OWNER-SITTING.md` Step 1 — tagging does not produce an entitled binary.
- `build/README.md` — the HARD PREREQUISITE block asserted the opposite; rewritten against the
  measurement, with the kernel log and the Apple quote.
- `m1nd-mcp/src/enclave_authority.rs` — the fail-closed claim is still true (TN3137: the access
  group list is built from entitlements), so it stands; what is corrected is the implication that
  the published binary satisfies it.

## Gates

- `cargo fmt --check` — clean.
- `cargo clippy -p m1nd-mcp --all-targets -- -D warnings` — exit 0, zero diagnostics.
- `cargo test -p m1nd-mcp --test custody_ceremony_wiring` — 18 passed, 0 failed.
- `python3 -m unittest discover -s tests` — 150 tests, OK (1 skipped). No contract test pins the
  signing step's entitlement, so no contract ratchet was touched.

## What is proven locally, and what is not

Proven here, on this hardware:

- the exact 1.6.0 artifact reproduces the SIGKILL, with the kernel's reason quoted above;
- the same bytes signed the new way launch and print their version;
- the new step's own logic, run end to end with an ad-hoc identity standing in for the signing
  certificate: the new path passes both refusals and launches (exit 0); the old path trips the
  restricted-entitlement refusal and exits 1.

**Not proven, and only a real tagged release can:** the last mile — a genuine Developer ID signature
over the new command line, notarized, packaged, downloaded and smoked by CI. The owner's certificate
was deliberately not touched, so `-s -` stood in for `--sign "$APPLE_SIGNING_IDENTITY"` throughout.
Nothing about the Developer ID path changed except the removal of `--entitlements`, and the failing
artifact's own `codesign --verify --strict` / `spctl` results show the Developer ID signature itself
was never the problem — but that is an inference from the evidence, not a green pipeline.

Also unproven, and unprovable without the owner: whether `com.apple.security.application-groups`
would have worked instead. Ad-hoc signed it launches (so it is not AMFI-restricted in that
configuration), but whether it authorizes a data-protection keychain access group without a profile,
and whether it stays unrestricted under a Developer ID signature, could not be tested here — and
guessing on the critical path would have risked discovering the answer at the next tag.
