### PR TITLE
docs: eight generated system diagrams, one per claim in the README

### DIFF
--- a/.github/workflows/i18n-translate.yml
+++ b/.github/workflows/i18n-translate.yml
@@ -65,7 +65,7 @@ jobs:
             sed -i '${/^```$/d;}' /tmp/out.md
             # the translations live under i18n/, so root-relative links and assets need ../
             sed -i -E 's#\]\((CHANGELOG\.md|CONTRIBUTING\.md|EXAMPLES\.md|LICENSE|README\.md|docs/|llms-install\.md|\.github/)#](../\1#g' /tmp/out.md
-            sed -i -E 's#src="(\.github/|docs/)#src="../\1#g' /tmp/out.md
+            sed -i -E 's#(src|srcset)="(\.github/|docs/)#\1="../\2#g' /tmp/out.md
             # the language bar is injected mechanically, never trusted to the model
             { echo "$LANGBAR"; echo; cat /tmp/out.md; } > "i18n/README.$code.md"
             # refuse a truncated result: the translation must end near the license section

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Here is the part people take a second to believe. The graph that reads your repo
 
 It is two-phase, `transplant_preview` before `transplant_commit`, and the commit re-validates the hash of every file it planned to touch, so nothing lands on a repo that changed underneath it. The money zone of your repo (backend, schema, payments, CI) is protected server-side and fails closed. A refusal never touches a byte and teaches the retry: a collision names the occupant, an invalid module path names itself, a cross-crate move names both crate roots.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/transplant-two-phase-dark.svg">
+    <img src="docs/assets/diagrams/transplant-two-phase-light.svg" alt="transplant in two phases: preview plans the enlarged region with its dependencies and referrers; commit re-validates every planned file hash, writes atomically and returns a receipt naming refs_unresolved and state_left_behind. A commit onto a taken name is refused, the occupant is named and nothing is written." width="820">
+  </picture>
+</p>
+
+
 Measured on the real case: the whole-file edit cost 12,235 output tokens; the transplant cost 48 in and wrote 3 files in 1.3 seconds, with the crate compiling on the other side. rust-analyzer has had an issue open asking for cross-file moves since 2019.
 
 v1 boundaries, stated plainly: Rust only, top-level `fn` only, same crate, the destination file must already exist, and references born inside macros are invisible to it. Each boundary is deliberate and written down in [docs/TRANSPLANT-PRD.md](docs/TRANSPLANT-PRD.md), next to 13 test files that hold the verb to it.
@@ -82,11 +90,27 @@ v1 boundaries, stated plainly: Rust only, top-level `fn` only, same crate, the d
 
 Run several agents on the same repo and the graph becomes the place they coordinate. Every session registers as a presence, and when two of them are about to touch overlapping work, both get warned in their next orientation packet, before either lands a change. The system warns; you decide.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/presence-collision-dark.svg">
+    <img src="docs/assets/diagrams/presence-collision-light.svg" alt="two agents on the same brain: each session registers a presence with a TTL, and when their work overlaps the collision notice reaches the orientation package of both, before either one writes." width="820">
+  </picture>
+</p>
+
+
 Bounded work runs as missions, and missions answer for themselves in a way most human teams skip: every mission tool reports `non_claims`, the list of what was NOT proven. A claim cannot close on graph evidence alone. It takes a file read, a test run or a runtime probe, and the test that enforces this is named `graph_only_evidence_is_not_enough`.
 
 And the guardrails do not cry wolf. `xray_gate` can say `blocked` only from a boundary manifest a human ratified. Everything else arrives as a warning with a reason, so the agent never learns to ignore its own safety rail.
 
 Every brain also has a mailbox. An agent that finds a real defect outside its own mission does not fix it on the spot and does not swallow it: it drops a letter in that repo's box, on disk, next to the code. The next agent working that brain sweeps the box and starts out already knowing the defects other agents found, context attached. Knowledge of what is broken stops dying in chat scrollback. The sweep is a deliberate gesture (CLI or REST, never inside the query loop), so the letters inform the work instead of interrupting it.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/mailbox-dark.svg">
+    <img src="docs/assets/diagrams/mailbox-light.svg" alt="one agent finds a defect outside its own scope and writes a letter into .m1nd/inbox.jsonl on disk, beside the code; another agent sweeps that mailbox days later over CLI or REST, never inside the query loop, and starts its mission already knowing." width="820">
+  </picture>
+</p>
+
 
 ## Born agent-first
 
@@ -94,7 +118,23 @@ No account, no telemetry, and no API in the way, which is also why the graph ans
 
 The development of m1nd is not very normal either. Building it meant building a whole workflow where agents direct, verify and prove the work, and the logic of the product is aimed at the agent's pain, not the human's dashboard. When m1nd misbehaves in the field, the agents using it file the report, and a confirmed bug becomes a red test before the fix lands. Very few programs start from that in their initial design. So m1nd is born different: the verbs, the refusals and the packets are shaped for the reader that actually uses them, and you do not even have to remind the model the tool exists. `m1nd hosts apply` installs session hooks (`SessionStart`, `agentSpawn`, `TaskStart`, per host) that inject the orientation at spawn: your agent, and every subagent it spawns, starts oriented before anyone types a word.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/ambient-hooks-dark.svg">
+    <img src="docs/assets/diagrams/ambient-hooks-light.svg" alt="SessionStart, agentSpawn and TaskStart feed the ambient hook, which injects the north package (map, memory, trust and gaps) into the agent and its subagents. The first user prompt only arrives later." width="820">
+  </picture>
+</p>
+
+
 A brain per repository holds it together: one graph, its own memory, its own persistence, bound to one repo root. A served owner hosts many brains and routes each session to the right one; a session from a repo it does not host gets a typed refusal instead of wrong answers.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/brain-per-repo-dark.svg">
+    <img src="docs/assets/diagrams/brain-per-repo-light.svg" alt="one served owner on port 1337 serves one brain per repository root, each with its own graph and memory; agents attach as thin bridges that hold no graph and take no lease. A session from an unhosted repo receives a typed refusal instead of a wrong answer." width="820">
+  </picture>
+</p>
+
 
 ## What your agent gets
 
@@ -182,6 +222,14 @@ Two tools, `savings` and `resonate`, were deleted outright in beta (handlers, ty
 
 The closest neighbor I know is GitHub Copilot Memory (public preview, 2026): it stores facts with code citations and re-checks them against the current branch before use. That is real staleness detection, and it deserves the credit. It is also cloud-side, binary, and lives inside Copilot. What I have still not found anywhere is the rest of the verdict: a graded `act` / `reverify` / `abstain` with per-repo calibration, typed refusals that carry a repair plan, on a local graph that any MCP agent can share. I checked the public docs of Mem0, Zep, Letta, Cognee, Supermemory and Copilot Memory, as of July 2026. Know a closer one? Open an issue and I will link it here.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/verdict-gate-dark.svg">
+    <img src="docs/assets/diagrams/verdict-gate-light.svg" alt="the conformal gate as a funnel: about 9.2k predictions meet a single cut at alpha 0.10 and leave as act (13.5%), reverify (26%) or abstain (60%, the largest slice). Bar length is the measured share." width="820">
+  </picture>
+</p>
+
+
 ## Memory that knows when it is stale
 
 Most memory layers store text and hope. m1nd anchors memory to the graph. When an agent calls `memorize`, each claim's `evidence` path is resolved to the real code node, so the note surfaces whenever the agent touches that code, without anyone remembering it exists:
@@ -200,6 +248,14 @@ memorize({
 
 Because the memory is anchored, it can be audited against reality. `cross_verify` re-hashes every cited file and names which claims went stale because their code changed. Claims carry age and author, supersede older claims, and age out. This loop is proven live end to end in this repo: memorize, anchor, edit the cited file, watch the claim flag itself, survive a full re-ingest, auto-load on the next boot. Kill the process, start a fresh one, and the first `north` already carries the earlier session's claims with provenance attached.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/grounded-memory-dark.svg">
+    <img src="docs/assets/diagrams/grounded-memory-light.svg" alt="memorize stores claims with evidence and grounded_in anchors them to the cited code node at hash H1; when that code changes to H2, cross_verify compares the hashes and the claim marks itself stale, warning instead of asserting." width="820">
+  </picture>
+</p>
+
+
 ## One graph for code and knowledge (l1ght)
 
 l1ght is the second lane of the same engine: documents become graph nodes in the same activation space as code, so one query traverses both. It is not a bolted-on RAG folder. There are 7,400 lines of dedicated adapters in this tree: Markdown, HTML, PDF, plain text, RST and JSON, plus scholarly routes for BibTeX, DOI/Crossref, JATS papers, RFCs and patents.
@@ -213,6 +269,14 @@ Different people get different products out of the same lane:
 - A vibecoder's pile of chat exports and scattered notes stops being a folder and becomes memory the agent actually consults mid-edit.
 
 Same binary, same MCP verbs, same trust layer. `seek` on a mixed graph returns code and documents in one ranked answer.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/diagrams/l1ght-lane-dark.svg">
+    <img src="docs/assets/diagrams/l1ght-lane-light.svg" alt="one graph with two lanes: document nodes as circles (paper with DOI, RFC, design note) joined by typed edges to code nodes as squares, with the real ingest routes labelled. A single seek crosses both lanes and returns one ranked answer." width="820">
+  </picture>
+</p>
+
 
 ## When not to use m1nd
 

--- a/docs/assets/diagrams/ambient-hooks-dark.svg
+++ b/docs/assets/diagrams/ambient-hooks-dark.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 784" width="920" height="784" role="img">
+<title>ambient hooks at spawn</title>
+<desc>A session opening. The host fires three events on the timeline at the bottom, SessionStart, agentSpawn and TaskStart, each feeding the ambient hook above. The hook injects the north package, carrying the map, the memory, the trust and the gaps, into the agent and its subagents, which are therefore born oriented. The first user prompt arrives only later, marked further right on the same timeline.</desc>
+<rect x="0" y="0" width="920" height="784" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">ambient_hooks</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">the host fires at spawn and the north package is injected, so the agent is</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">oriented before the first prompt</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="80" y="178" width="248" height="88" fill="#161B22"/>
+<rect x="80" y="178" width="248" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="204" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">ambient hook</text>
+<text x="204" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">injects north</text>
+<rect x="616" y="178" width="264" height="112" fill="#161B22"/>
+<rect x="616" y="178" width="264" height="112" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="616" y1="214" x2="616" y2="254" stroke="#161B22" stroke-width="10"/>
+<text x="748" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">north package</text>
+<text x="748" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">map · memory</text>
+<text x="748" y="265" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">trust · gaps</text>
+<text x="472" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">injects</text>
+<line x1="328" y1="222" x2="604" y2="222" stroke="#687585" stroke-width="4"/>
+<polygon points="616,222 602,215 602,229" fill="#687585"/>
+<rect x="616" y="386" width="264" height="88" fill="#161B22"/>
+<rect x="616" y="386" width="264" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="728" y1="386" x2="768" y2="386" stroke="#161B22" stroke-width="10"/>
+<text x="748" y="421" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">agent + subagent</text>
+<text x="748" y="447" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">born oriented</text>
+<line x1="748" y1="290" x2="748" y2="374" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="748,386 741,372 755,372" fill="#687585"/>
+<line x1="40" y1="586" x2="880" y2="586" stroke="#687585" stroke-width="4"/>
+<line x1="168" y1="572" x2="168" y2="600" stroke="#687585" stroke-width="4"/>
+<text x="168" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">SessionStart</text>
+<line x1="168" y1="530" x2="168" y2="568" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="360" y1="572" x2="360" y2="600" stroke="#687585" stroke-width="4"/>
+<text x="360" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">agentSpawn</text>
+<line x1="360" y1="530" x2="360" y2="568" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="552" y1="572" x2="552" y2="600" stroke="#687585" stroke-width="4"/>
+<text x="552" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">TaskStart</text>
+<line x1="552" y1="530" x2="552" y2="568" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="168" y1="530" x2="552" y2="530" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="204" y1="530" x2="204" y2="278" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<polygon points="204,266 197,280 211,280" fill="#687585"/>
+<line x1="792" y1="572" x2="792" y2="600" stroke="#98A2AE" stroke-width="4"/>
+<text x="792" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">first prompt</text>
+<text x="792" y="654" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">(only now)</text>
+<text x="460" y="702" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">context arrives at spawn, not after the first prompt</text>
+<text x="460" y="728" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">map, memory, trust and gaps are already there when the session opens</text>
+</svg>

--- a/docs/assets/diagrams/ambient-hooks-light.svg
+++ b/docs/assets/diagrams/ambient-hooks-light.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 784" width="920" height="784" role="img">
+<title>ambient hooks at spawn</title>
+<desc>A session opening. The host fires three events on the timeline at the bottom, SessionStart, agentSpawn and TaskStart, each feeding the ambient hook above. The hook injects the north package, carrying the map, the memory, the trust and the gaps, into the agent and its subagents, which are therefore born oriented. The first user prompt arrives only later, marked further right on the same timeline.</desc>
+<rect x="0" y="0" width="920" height="784" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">ambient_hooks</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">the host fires at spawn and the north package is injected, so the agent is</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">oriented before the first prompt</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="80" y="178" width="248" height="88" fill="#ECEDE8"/>
+<rect x="80" y="178" width="248" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="204" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">ambient hook</text>
+<text x="204" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">injects north</text>
+<rect x="616" y="178" width="264" height="112" fill="#ECEDE8"/>
+<rect x="616" y="178" width="264" height="112" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="616" y1="214" x2="616" y2="254" stroke="#ECEDE8" stroke-width="10"/>
+<text x="748" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">north package</text>
+<text x="748" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">map · memory</text>
+<text x="748" y="265" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">trust · gaps</text>
+<text x="472" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">injects</text>
+<line x1="328" y1="222" x2="604" y2="222" stroke="#84867F" stroke-width="4"/>
+<polygon points="616,222 602,215 602,229" fill="#84867F"/>
+<rect x="616" y="386" width="264" height="88" fill="#ECEDE8"/>
+<rect x="616" y="386" width="264" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="728" y1="386" x2="768" y2="386" stroke="#ECEDE8" stroke-width="10"/>
+<text x="748" y="421" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">agent + subagent</text>
+<text x="748" y="447" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">born oriented</text>
+<line x1="748" y1="290" x2="748" y2="374" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="748,386 741,372 755,372" fill="#84867F"/>
+<line x1="40" y1="586" x2="880" y2="586" stroke="#84867F" stroke-width="4"/>
+<line x1="168" y1="572" x2="168" y2="600" stroke="#84867F" stroke-width="4"/>
+<text x="168" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">SessionStart</text>
+<line x1="168" y1="530" x2="168" y2="568" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="360" y1="572" x2="360" y2="600" stroke="#84867F" stroke-width="4"/>
+<text x="360" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">agentSpawn</text>
+<line x1="360" y1="530" x2="360" y2="568" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="552" y1="572" x2="552" y2="600" stroke="#84867F" stroke-width="4"/>
+<text x="552" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">TaskStart</text>
+<line x1="552" y1="530" x2="552" y2="568" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="168" y1="530" x2="552" y2="530" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="204" y1="530" x2="204" y2="278" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<polygon points="204,266 197,280 211,280" fill="#84867F"/>
+<line x1="792" y1="572" x2="792" y2="600" stroke="#5A6169" stroke-width="4"/>
+<text x="792" y="630" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">first prompt</text>
+<text x="792" y="654" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">(only now)</text>
+<text x="460" y="702" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">context arrives at spawn, not after the first prompt</text>
+<text x="460" y="728" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">map, memory, trust and gaps are already there when the session opens</text>
+</svg>

--- a/docs/assets/diagrams/brain-per-repo-dark.svg
+++ b/docs/assets/diagrams/brain-per-repo-dark.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 904" width="920" height="904" role="img">
+<title>one brain per repository</title>
+<desc>A topology. A single served owner on port 1337 serves three brains, one per repository root, each with its own graph and memory. Agents attach on the right as thin bridges that hold no graph and take no lease. Below, an agent whose repository is not hosted receives a typed refusal from reception, drawn in red: the system blocks instead of answering wrongly.</desc>
+<rect x="0" y="0" width="920" height="904" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">brain_per_repo</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">one served owner, one brain per repository root, and thin bridges that carry no</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">graph of their own</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="392" y="178" width="184" height="112" fill="#161B22"/>
+<rect x="392" y="178" width="184" height="112" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="392" y1="214" x2="392" y2="254" stroke="#161B22" stroke-width="10"/>
+<text x="484" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">brain A</text>
+<text x="484" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">~/projA</text>
+<text x="484" y="265" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">graph · memory</text>
+<rect x="392" y="322" width="184" height="112" fill="#161B22"/>
+<rect x="392" y="322" width="184" height="112" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="392" y1="358" x2="392" y2="398" stroke="#161B22" stroke-width="10"/>
+<text x="484" y="357" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">brain B</text>
+<text x="484" y="383" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">~/projB</text>
+<text x="484" y="409" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">graph · memory</text>
+<rect x="392" y="466" width="184" height="112" fill="#161B22"/>
+<rect x="392" y="466" width="184" height="112" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="392" y1="502" x2="392" y2="542" stroke="#161B22" stroke-width="10"/>
+<text x="484" y="501" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">brain C</text>
+<text x="484" y="527" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">~/projC</text>
+<text x="484" y="553" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">graph · memory</text>
+<rect x="40" y="334" width="216" height="88" fill="#161B22"/>
+<rect x="40" y="334" width="216" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="148" y="369" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">owner</text>
+<text x="148" y="395" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">served :1337</text>
+<text x="312" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="end">serves</text>
+<line x1="256" y1="378" x2="320" y2="378" stroke="#687585" stroke-width="4"/>
+<line x1="320" y1="378" x2="320" y2="234" stroke="#687585" stroke-width="4"/>
+<line x1="320" y1="234" x2="380" y2="234" stroke="#687585" stroke-width="4"/>
+<polygon points="392,234 378,227 378,241" fill="#687585"/>
+<line x1="256" y1="378" x2="320" y2="378" stroke="#687585" stroke-width="4"/>
+<line x1="320" y1="378" x2="320" y2="378" stroke="#687585" stroke-width="4"/>
+<line x1="320" y1="378" x2="380" y2="378" stroke="#687585" stroke-width="4"/>
+<polygon points="392,378 378,371 378,385" fill="#687585"/>
+<line x1="256" y1="378" x2="320" y2="378" stroke="#687585" stroke-width="4"/>
+<line x1="320" y1="378" x2="320" y2="522" stroke="#687585" stroke-width="4"/>
+<line x1="320" y1="522" x2="380" y2="522" stroke="#687585" stroke-width="4"/>
+<polygon points="392,522 378,515 378,529" fill="#687585"/>
+<rect x="728" y="194" width="152" height="88" fill="#161B22"/>
+<rect x="728" y="194" width="152" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="804" y="229" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">agent</text>
+<text x="804" y="255" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">bridge</text>
+<line x1="728" y1="238" x2="588" y2="238" stroke="#687585" stroke-width="4"/>
+<polygon points="576,238 590,231 590,245" fill="#687585"/>
+<rect x="728" y="338" width="152" height="88" fill="#161B22"/>
+<rect x="728" y="338" width="152" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="804" y="373" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">agent</text>
+<text x="804" y="399" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">bridge</text>
+<line x1="728" y1="382" x2="588" y2="382" stroke="#687585" stroke-width="4"/>
+<polygon points="576,382 590,375 590,389" fill="#687585"/>
+<rect x="728" y="482" width="152" height="88" fill="#161B22"/>
+<rect x="728" y="482" width="152" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="804" y="517" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">agent</text>
+<text x="804" y="543" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">bridge</text>
+<line x1="728" y1="526" x2="588" y2="526" stroke="#687585" stroke-width="4"/>
+<polygon points="576,526 590,519 590,533" fill="#687585"/>
+<rect x="392" y="682" width="192" height="88" fill="#161B22"/>
+<rect x="392" y="682" width="192" height="88" fill="none" stroke="#FF7B72" stroke-width="4"/>
+<line x1="468" y1="682" x2="508" y2="682" stroke="#161B22" stroke-width="10"/>
+<text x="488" y="717" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#FF7B72" text-anchor="middle">agent</text>
+<text x="488" y="743" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#FF7B72" text-anchor="middle">repo not hosted</text>
+<text x="180" y="648" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#FF7B72" text-anchor="start">reception → typed refusal</text>
+<line x1="148" y1="422" x2="148" y2="666" stroke="#FF7B72" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="148" y1="666" x2="488" y2="666" stroke="#FF7B72" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="488" y1="666" x2="488" y2="670" stroke="#FF7B72" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="488,682 481,668 495,668" fill="#FF7B72"/>
+<text x="488" y="802" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#FF7B72" text-anchor="middle">no wrong answer · state: blocked</text>
+<text x="460" y="850" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">a bridge holds no graph and no lease: it consumes the brain that covers its root</text>
+</svg>

--- a/docs/assets/diagrams/brain-per-repo-light.svg
+++ b/docs/assets/diagrams/brain-per-repo-light.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 904" width="920" height="904" role="img">
+<title>one brain per repository</title>
+<desc>A topology. A single served owner on port 1337 serves three brains, one per repository root, each with its own graph and memory. Agents attach on the right as thin bridges that hold no graph and take no lease. Below, an agent whose repository is not hosted receives a typed refusal from reception, drawn in red: the system blocks instead of answering wrongly.</desc>
+<rect x="0" y="0" width="920" height="904" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">brain_per_repo</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">one served owner, one brain per repository root, and thin bridges that carry no</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">graph of their own</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="392" y="178" width="184" height="112" fill="#ECEDE8"/>
+<rect x="392" y="178" width="184" height="112" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="392" y1="214" x2="392" y2="254" stroke="#ECEDE8" stroke-width="10"/>
+<text x="484" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">brain A</text>
+<text x="484" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">~/projA</text>
+<text x="484" y="265" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">graph · memory</text>
+<rect x="392" y="322" width="184" height="112" fill="#ECEDE8"/>
+<rect x="392" y="322" width="184" height="112" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="392" y1="358" x2="392" y2="398" stroke="#ECEDE8" stroke-width="10"/>
+<text x="484" y="357" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">brain B</text>
+<text x="484" y="383" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">~/projB</text>
+<text x="484" y="409" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">graph · memory</text>
+<rect x="392" y="466" width="184" height="112" fill="#ECEDE8"/>
+<rect x="392" y="466" width="184" height="112" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="392" y1="502" x2="392" y2="542" stroke="#ECEDE8" stroke-width="10"/>
+<text x="484" y="501" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">brain C</text>
+<text x="484" y="527" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">~/projC</text>
+<text x="484" y="553" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">graph · memory</text>
+<rect x="40" y="334" width="216" height="88" fill="#ECEDE8"/>
+<rect x="40" y="334" width="216" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="148" y="369" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">owner</text>
+<text x="148" y="395" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">served :1337</text>
+<text x="312" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="end">serves</text>
+<line x1="256" y1="378" x2="320" y2="378" stroke="#84867F" stroke-width="4"/>
+<line x1="320" y1="378" x2="320" y2="234" stroke="#84867F" stroke-width="4"/>
+<line x1="320" y1="234" x2="380" y2="234" stroke="#84867F" stroke-width="4"/>
+<polygon points="392,234 378,227 378,241" fill="#84867F"/>
+<line x1="256" y1="378" x2="320" y2="378" stroke="#84867F" stroke-width="4"/>
+<line x1="320" y1="378" x2="320" y2="378" stroke="#84867F" stroke-width="4"/>
+<line x1="320" y1="378" x2="380" y2="378" stroke="#84867F" stroke-width="4"/>
+<polygon points="392,378 378,371 378,385" fill="#84867F"/>
+<line x1="256" y1="378" x2="320" y2="378" stroke="#84867F" stroke-width="4"/>
+<line x1="320" y1="378" x2="320" y2="522" stroke="#84867F" stroke-width="4"/>
+<line x1="320" y1="522" x2="380" y2="522" stroke="#84867F" stroke-width="4"/>
+<polygon points="392,522 378,515 378,529" fill="#84867F"/>
+<rect x="728" y="194" width="152" height="88" fill="#ECEDE8"/>
+<rect x="728" y="194" width="152" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="804" y="229" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">agent</text>
+<text x="804" y="255" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">bridge</text>
+<line x1="728" y1="238" x2="588" y2="238" stroke="#84867F" stroke-width="4"/>
+<polygon points="576,238 590,231 590,245" fill="#84867F"/>
+<rect x="728" y="338" width="152" height="88" fill="#ECEDE8"/>
+<rect x="728" y="338" width="152" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="804" y="373" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">agent</text>
+<text x="804" y="399" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">bridge</text>
+<line x1="728" y1="382" x2="588" y2="382" stroke="#84867F" stroke-width="4"/>
+<polygon points="576,382 590,375 590,389" fill="#84867F"/>
+<rect x="728" y="482" width="152" height="88" fill="#ECEDE8"/>
+<rect x="728" y="482" width="152" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="804" y="517" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">agent</text>
+<text x="804" y="543" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">bridge</text>
+<line x1="728" y1="526" x2="588" y2="526" stroke="#84867F" stroke-width="4"/>
+<polygon points="576,526 590,519 590,533" fill="#84867F"/>
+<rect x="392" y="682" width="192" height="88" fill="#ECEDE8"/>
+<rect x="392" y="682" width="192" height="88" fill="none" stroke="#A81E22" stroke-width="4"/>
+<line x1="468" y1="682" x2="508" y2="682" stroke="#ECEDE8" stroke-width="10"/>
+<text x="488" y="717" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#A81E22" text-anchor="middle">agent</text>
+<text x="488" y="743" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#A81E22" text-anchor="middle">repo not hosted</text>
+<text x="180" y="648" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#A81E22" text-anchor="start">reception → typed refusal</text>
+<line x1="148" y1="422" x2="148" y2="666" stroke="#A81E22" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="148" y1="666" x2="488" y2="666" stroke="#A81E22" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="488" y1="666" x2="488" y2="670" stroke="#A81E22" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="488,682 481,668 495,668" fill="#A81E22"/>
+<text x="488" y="802" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#A81E22" text-anchor="middle">no wrong answer · state: blocked</text>
+<text x="460" y="850" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">a bridge holds no graph and no lease: it consumes the brain that covers its root</text>
+</svg>

--- a/docs/assets/diagrams/grounded-memory-dark.svg
+++ b/docs/assets/diagrams/grounded-memory-dark.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 976" width="920" height="976" role="img">
+<title>grounded memory going stale</title>
+<desc>A vertical state machine. A memorize call stores claims with their evidence, and an edge named grounded_in ties them to the code node they cite at hash H1. When that code changes to hash H2, cross_verify compares the hashes and the wire breaks with a 45 degree step labelled stale. The final state, framed in amber, is a claim marked stale that warns instead of asserting.</desc>
+<rect x="0" y="0" width="920" height="976" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">grounded_memory</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">a claim is anchored to the code it cites; when that code changes, the claim marks</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">itself stale</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="192" y="178" width="208" height="88" fill="#161B22"/>
+<rect x="192" y="178" width="208" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="276" y1="178" x2="316" y2="178" stroke="#161B22" stroke-width="10"/>
+<text x="296" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">memorize()</text>
+<text x="296" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">claims + evidence</text>
+<line x1="296" y1="266" x2="296" y2="342" stroke="#687585" stroke-width="4"/>
+<polygon points="296,354 289,340 303,340" fill="#687585"/>
+<text x="408" y="316" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">grounded_in → the cited code node</text>
+<rect x="224" y="354" width="144" height="88" fill="#161B22"/>
+<rect x="224" y="354" width="144" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="296" y="389" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">code node</text>
+<text x="296" y="415" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">hash H1</text>
+<line x1="296" y1="442" x2="296" y2="518" stroke="#687585" stroke-width="4"/>
+<polygon points="296,530 289,516 303,516" fill="#687585"/>
+<text x="408" y="492" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">the code changes: H1 ≠ H2</text>
+<rect x="184" y="530" width="232" height="88" fill="#161B22"/>
+<rect x="184" y="530" width="232" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="300" y="565" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">cross_verify()</text>
+<text x="300" y="591" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">compares the hashes</text>
+<line x1="296" y1="618" x2="296" y2="658" stroke="#E8A33D" stroke-width="4"/>
+<line x1="296" y1="658" x2="328" y2="690" stroke="#E8A33D" stroke-width="4"/>
+<line x1="328" y1="690" x2="328" y2="734" stroke="#E8A33D" stroke-width="4"/>
+<polygon points="328,746 321,732 335,732" fill="#E8A33D"/>
+<text x="352" y="672" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="start">stale</text>
+<text x="408" y="688" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="start">the anchor no longer holds</text>
+<rect x="184" y="746" width="296" height="88" fill="#161B22"/>
+<rect x="184" y="746" width="296" height="88" fill="none" stroke="#E8A33D" stroke-width="4"/>
+<text x="332" y="781" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#E8A33D" text-anchor="middle">claim: stale</text>
+<text x="332" y="807" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="middle">warns instead of asserting</text>
+<text x="460" y="898" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">45 degrees is the house sign for drift: the wire holds, its ground does not</text>
+<text x="460" y="924" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">it warns instead of answering from a claim it can no longer stand on</text>
+</svg>

--- a/docs/assets/diagrams/grounded-memory-light.svg
+++ b/docs/assets/diagrams/grounded-memory-light.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 976" width="920" height="976" role="img">
+<title>grounded memory going stale</title>
+<desc>A vertical state machine. A memorize call stores claims with their evidence, and an edge named grounded_in ties them to the code node they cite at hash H1. When that code changes to hash H2, cross_verify compares the hashes and the wire breaks with a 45 degree step labelled stale. The final state, framed in amber, is a claim marked stale that warns instead of asserting.</desc>
+<rect x="0" y="0" width="920" height="976" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">grounded_memory</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">a claim is anchored to the code it cites; when that code changes, the claim marks</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">itself stale</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="192" y="178" width="208" height="88" fill="#ECEDE8"/>
+<rect x="192" y="178" width="208" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="276" y1="178" x2="316" y2="178" stroke="#ECEDE8" stroke-width="10"/>
+<text x="296" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">memorize()</text>
+<text x="296" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">claims + evidence</text>
+<line x1="296" y1="266" x2="296" y2="342" stroke="#84867F" stroke-width="4"/>
+<polygon points="296,354 289,340 303,340" fill="#84867F"/>
+<text x="408" y="316" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">grounded_in → the cited code node</text>
+<rect x="224" y="354" width="144" height="88" fill="#ECEDE8"/>
+<rect x="224" y="354" width="144" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="296" y="389" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">code node</text>
+<text x="296" y="415" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">hash H1</text>
+<line x1="296" y1="442" x2="296" y2="518" stroke="#84867F" stroke-width="4"/>
+<polygon points="296,530 289,516 303,516" fill="#84867F"/>
+<text x="408" y="492" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">the code changes: H1 ≠ H2</text>
+<rect x="184" y="530" width="232" height="88" fill="#ECEDE8"/>
+<rect x="184" y="530" width="232" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="300" y="565" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">cross_verify()</text>
+<text x="300" y="591" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">compares the hashes</text>
+<line x1="296" y1="618" x2="296" y2="658" stroke="#7E4E00" stroke-width="4"/>
+<line x1="296" y1="658" x2="328" y2="690" stroke="#7E4E00" stroke-width="4"/>
+<line x1="328" y1="690" x2="328" y2="734" stroke="#7E4E00" stroke-width="4"/>
+<polygon points="328,746 321,732 335,732" fill="#7E4E00"/>
+<text x="352" y="672" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="start">stale</text>
+<text x="408" y="688" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="start">the anchor no longer holds</text>
+<rect x="184" y="746" width="296" height="88" fill="#ECEDE8"/>
+<rect x="184" y="746" width="296" height="88" fill="none" stroke="#7E4E00" stroke-width="4"/>
+<text x="332" y="781" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#7E4E00" text-anchor="middle">claim: stale</text>
+<text x="332" y="807" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="middle">warns instead of asserting</text>
+<text x="460" y="898" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">45 degrees is the house sign for drift: the wire holds, its ground does not</text>
+<text x="460" y="924" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">it warns instead of answering from a claim it can no longer stand on</text>
+</svg>

--- a/docs/assets/diagrams/l1ght-lane-dark.svg
+++ b/docs/assets/diagrams/l1ght-lane-dark.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 680" width="920" height="680" role="img">
+<title>the l1ght document lane</title>
+<desc>One graph with two lanes. The upper lane holds document nodes drawn as circles, a paper with a DOI, an RFC and a design note, joined by a dashed cites edge. The lower lane holds code nodes drawn as squares. Vertical connectors labelled with the real ingest routes, DOI slash Crossref, RFC and JATS, tie each document to its code. A seek query on the left crosses the horizontal wire through both lanes and returns a single ranked answer on the right.</desc>
+<rect x="0" y="0" width="920" height="680" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">l1ght_lane</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">one graph, two lanes: documents as circles, code as squares, and a single ranked</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">answer across both</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<text x="40" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">documents</text>
+<text x="40" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">code</text>
+<text x="280" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">paper · DOI</text>
+<line x1="280" y1="262" x2="280" y2="370" stroke="#687585" stroke-width="2"/>
+<line x1="280" y1="370" x2="280" y2="438" stroke="#687585" stroke-width="2"/>
+<circle cx="280" cy="234" r="28" fill="#161B22" stroke="#687585" stroke-width="4"/>
+<rect x="252" y="438" width="56" height="56" fill="#161B22" stroke="#687585" stroke-width="4"/>
+<text x="296" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">DOI/Crossref</text>
+<text x="280" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">mod A</text>
+<text x="460" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">RFC 9110</text>
+<line x1="460" y1="262" x2="460" y2="370" stroke="#687585" stroke-width="2"/>
+<line x1="460" y1="370" x2="460" y2="438" stroke="#687585" stroke-width="2"/>
+<circle cx="460" cy="234" r="28" fill="#161B22" stroke="#687585" stroke-width="4"/>
+<rect x="432" y="438" width="56" height="56" fill="#161B22" stroke="#687585" stroke-width="4"/>
+<text x="476" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">RFC</text>
+<text x="460" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">mod B</text>
+<text x="640" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">design note</text>
+<line x1="640" y1="262" x2="640" y2="370" stroke="#687585" stroke-width="2"/>
+<line x1="640" y1="370" x2="640" y2="438" stroke="#687585" stroke-width="2"/>
+<circle cx="640" cy="234" r="28" fill="#161B22" stroke="#687585" stroke-width="4"/>
+<rect x="612" y="438" width="56" height="56" fill="#161B22" stroke="#687585" stroke-width="4"/>
+<text x="656" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">JATS</text>
+<text x="640" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">mod C</text>
+<line x1="308" y1="234" x2="432" y2="234" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<text x="370" y="216" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">cites</text>
+<rect x="40" y="326" width="160" height="88" fill="#161B22"/>
+<rect x="40" y="326" width="160" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="120" y="361" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">seek()</text>
+<text x="120" y="387" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">one query</text>
+<rect x="720" y="326" width="160" height="88" fill="#161B22"/>
+<rect x="720" y="326" width="160" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="720" y1="350" x2="720" y2="390" stroke="#161B22" stroke-width="10"/>
+<text x="800" y="361" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">1 answer</text>
+<text x="800" y="387" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">ranked</text>
+<line x1="200" y1="370" x2="708" y2="370" stroke="#687585" stroke-width="4"/>
+<polygon points="720,370 706,363 706,377" fill="#687585"/>
+<text x="460" y="602" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">typed edges join the lanes: a paper cites an RFC, a module implements a spec</text>
+<text x="460" y="628" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">seek crosses both and returns one ranked answer, not two piles to reconcile</text>
+</svg>

--- a/docs/assets/diagrams/l1ght-lane-light.svg
+++ b/docs/assets/diagrams/l1ght-lane-light.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 680" width="920" height="680" role="img">
+<title>the l1ght document lane</title>
+<desc>One graph with two lanes. The upper lane holds document nodes drawn as circles, a paper with a DOI, an RFC and a design note, joined by a dashed cites edge. The lower lane holds code nodes drawn as squares. Vertical connectors labelled with the real ingest routes, DOI slash Crossref, RFC and JATS, tie each document to its code. A seek query on the left crosses the horizontal wire through both lanes and returns a single ranked answer on the right.</desc>
+<rect x="0" y="0" width="920" height="680" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">l1ght_lane</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">one graph, two lanes: documents as circles, code as squares, and a single ranked</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">answer across both</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<text x="40" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">documents</text>
+<text x="40" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">code</text>
+<text x="280" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">paper · DOI</text>
+<line x1="280" y1="262" x2="280" y2="370" stroke="#84867F" stroke-width="2"/>
+<line x1="280" y1="370" x2="280" y2="438" stroke="#84867F" stroke-width="2"/>
+<circle cx="280" cy="234" r="28" fill="#ECEDE8" stroke="#84867F" stroke-width="4"/>
+<rect x="252" y="438" width="56" height="56" fill="#ECEDE8" stroke="#84867F" stroke-width="4"/>
+<text x="296" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">DOI/Crossref</text>
+<text x="280" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">mod A</text>
+<text x="460" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">RFC 9110</text>
+<line x1="460" y1="262" x2="460" y2="370" stroke="#84867F" stroke-width="2"/>
+<line x1="460" y1="370" x2="460" y2="438" stroke="#84867F" stroke-width="2"/>
+<circle cx="460" cy="234" r="28" fill="#ECEDE8" stroke="#84867F" stroke-width="4"/>
+<rect x="432" y="438" width="56" height="56" fill="#ECEDE8" stroke="#84867F" stroke-width="4"/>
+<text x="476" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">RFC</text>
+<text x="460" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">mod B</text>
+<text x="640" y="178" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">design note</text>
+<line x1="640" y1="262" x2="640" y2="370" stroke="#84867F" stroke-width="2"/>
+<line x1="640" y1="370" x2="640" y2="438" stroke="#84867F" stroke-width="2"/>
+<circle cx="640" cy="234" r="28" fill="#ECEDE8" stroke="#84867F" stroke-width="4"/>
+<rect x="612" y="438" width="56" height="56" fill="#ECEDE8" stroke="#84867F" stroke-width="4"/>
+<text x="656" y="318" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">JATS</text>
+<text x="640" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">mod C</text>
+<line x1="308" y1="234" x2="432" y2="234" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<text x="370" y="216" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">cites</text>
+<rect x="40" y="326" width="160" height="88" fill="#ECEDE8"/>
+<rect x="40" y="326" width="160" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="120" y="361" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">seek()</text>
+<text x="120" y="387" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">one query</text>
+<rect x="720" y="326" width="160" height="88" fill="#ECEDE8"/>
+<rect x="720" y="326" width="160" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="720" y1="350" x2="720" y2="390" stroke="#ECEDE8" stroke-width="10"/>
+<text x="800" y="361" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">1 answer</text>
+<text x="800" y="387" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">ranked</text>
+<line x1="200" y1="370" x2="708" y2="370" stroke="#84867F" stroke-width="4"/>
+<polygon points="720,370 706,363 706,377" fill="#84867F"/>
+<text x="460" y="602" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">typed edges join the lanes: a paper cites an RFC, a module implements a spec</text>
+<text x="460" y="628" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">seek crosses both and returns one ranked answer, not two piles to reconcile</text>
+</svg>

--- a/docs/assets/diagrams/mailbox-dark.svg
+++ b/docs/assets/diagrams/mailbox-dark.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 624" width="920" height="624" role="img">
+<title>the per-brain mailbox</title>
+<desc>A flow between agents. Agent A, on mission X, finds a defect outside its own scope and writes a letter into .m1nd/inbox.jsonl, an append-only file on disk beside the code. Agent B, days later, sweeps that mailbox over CLI or REST, never inside the query loop, and its mission starts already knowing about the defect.</desc>
+<rect x="0" y="0" width="920" height="624" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">mailbox</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">an agent leaves a letter on disk; another agent, days later, starts its mission</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">already knowing</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="40" y="178" width="200" height="88" fill="#161B22"/>
+<rect x="40" y="178" width="200" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="140" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">agent A</text>
+<text x="140" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">mission X</text>
+<rect x="344" y="178" width="232" height="88" fill="#161B22"/>
+<rect x="344" y="178" width="232" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="344" y1="202" x2="344" y2="242" stroke="#161B22" stroke-width="10"/>
+<text x="460" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">.m1nd/inbox.jsonl</text>
+<text x="460" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">append-only</text>
+<rect x="680" y="178" width="200" height="88" fill="#161B22"/>
+<rect x="680" y="178" width="200" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="780" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">agent B</text>
+<text x="780" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">days later</text>
+<text x="292" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">writes</text>
+<line x1="240" y1="222" x2="332" y2="222" stroke="#687585" stroke-width="4"/>
+<polygon points="344,222 330,215 330,229" fill="#687585"/>
+<text x="628" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">sweeps</text>
+<line x1="680" y1="222" x2="588" y2="222" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="576,222 590,215 590,229" fill="#687585"/>
+<text x="140" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">finds a defect</text>
+<text x="140" y="334" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">outside its scope</text>
+<text x="460" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">on disk, beside the code</text>
+<text x="780" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">CLI or REST,</text>
+<text x="780" y="334" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">never in the query loop</text>
+<rect x="344" y="390" width="240" height="88" fill="#161B22"/>
+<rect x="344" y="390" width="240" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="444" y1="390" x2="484" y2="390" stroke="#161B22" stroke-width="10"/>
+<text x="464" y="425" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">the mission starts</text>
+<text x="464" y="451" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">already knowing</text>
+<line x1="780" y1="362" x2="780" y2="434" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="780" y1="434" x2="596" y2="434" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="584,434 598,427 598,441" fill="#687585"/>
+<text x="460" y="542" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">a letter on disk outlives the session, the context window and its author</text>
+<text x="460" y="568" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">recorded where the code lives, for the owner of that system to fix in due time</text>
+</svg>

--- a/docs/assets/diagrams/mailbox-light.svg
+++ b/docs/assets/diagrams/mailbox-light.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 624" width="920" height="624" role="img">
+<title>the per-brain mailbox</title>
+<desc>A flow between agents. Agent A, on mission X, finds a defect outside its own scope and writes a letter into .m1nd/inbox.jsonl, an append-only file on disk beside the code. Agent B, days later, sweeps that mailbox over CLI or REST, never inside the query loop, and its mission starts already knowing about the defect.</desc>
+<rect x="0" y="0" width="920" height="624" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">mailbox</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">an agent leaves a letter on disk; another agent, days later, starts its mission</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">already knowing</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="40" y="178" width="200" height="88" fill="#ECEDE8"/>
+<rect x="40" y="178" width="200" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="140" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">agent A</text>
+<text x="140" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">mission X</text>
+<rect x="344" y="178" width="232" height="88" fill="#ECEDE8"/>
+<rect x="344" y="178" width="232" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="344" y1="202" x2="344" y2="242" stroke="#ECEDE8" stroke-width="10"/>
+<text x="460" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">.m1nd/inbox.jsonl</text>
+<text x="460" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">append-only</text>
+<rect x="680" y="178" width="200" height="88" fill="#ECEDE8"/>
+<rect x="680" y="178" width="200" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="780" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">agent B</text>
+<text x="780" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">days later</text>
+<text x="292" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">writes</text>
+<line x1="240" y1="222" x2="332" y2="222" stroke="#84867F" stroke-width="4"/>
+<polygon points="344,222 330,215 330,229" fill="#84867F"/>
+<text x="628" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">sweeps</text>
+<line x1="680" y1="222" x2="588" y2="222" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="576,222 590,215 590,229" fill="#84867F"/>
+<text x="140" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">finds a defect</text>
+<text x="140" y="334" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">outside its scope</text>
+<text x="460" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">on disk, beside the code</text>
+<text x="780" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">CLI or REST,</text>
+<text x="780" y="334" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">never in the query loop</text>
+<rect x="344" y="390" width="240" height="88" fill="#ECEDE8"/>
+<rect x="344" y="390" width="240" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="444" y1="390" x2="484" y2="390" stroke="#ECEDE8" stroke-width="10"/>
+<text x="464" y="425" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">the mission starts</text>
+<text x="464" y="451" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">already knowing</text>
+<line x1="780" y1="362" x2="780" y2="434" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="780" y1="434" x2="596" y2="434" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="584,434 598,427 598,441" fill="#84867F"/>
+<text x="460" y="542" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">a letter on disk outlives the session, the context window and its author</text>
+<text x="460" y="568" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">recorded where the code lives, for the owner of that system to fix in due time</text>
+</svg>

--- a/docs/assets/diagrams/presence-collision-dark.svg
+++ b/docs/assets/diagrams/presence-collision-dark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 608" width="920" height="608" role="img">
+<title>presence and collision</title>
+<desc>Two agents work on the same brain. Each session registers a presence with a time to live, drawn as arrows into the central brain box. When the work overlaps, a dashed amber path carries the collision notice down into the orientation package of both agents, before either one lands a change. The system warns; the human decides.</desc>
+<rect x="0" y="0" width="920" height="608" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">presence_collision</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">two sessions on the same brain register presence; the warning reaches both before</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">either one writes</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="336" y="178" width="256" height="88" fill="#161B22"/>
+<rect x="336" y="178" width="256" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="464" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">brain</text>
+<text x="464" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">presences[ ] · TTL</text>
+<rect x="40" y="178" width="200" height="88" fill="#161B22"/>
+<rect x="40" y="178" width="200" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="140" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">agent A</text>
+<text x="140" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">same brain</text>
+<rect x="680" y="178" width="200" height="88" fill="#161B22"/>
+<rect x="680" y="178" width="200" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="780" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">agent B</text>
+<text x="780" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">same brain</text>
+<text x="288" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">presence</text>
+<line x1="240" y1="222" x2="324" y2="222" stroke="#687585" stroke-width="4"/>
+<polygon points="336,222 322,215 322,229" fill="#687585"/>
+<text x="636" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">presence</text>
+<line x1="680" y1="222" x2="604" y2="222" stroke="#687585" stroke-width="4"/>
+<polygon points="592,222 606,215 606,229" fill="#687585"/>
+<text x="488" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="start">warns both, before either writes</text>
+<rect x="40" y="378" width="200" height="88" fill="#161B22"/>
+<rect x="40" y="378" width="200" height="88" fill="none" stroke="#E8A33D" stroke-width="4"/>
+<line x1="120" y1="378" x2="160" y2="378" stroke="#161B22" stroke-width="10"/>
+<text x="140" y="413" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="middle">orientation pkg</text>
+<text x="140" y="439" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="middle">collision</text>
+<rect x="680" y="378" width="200" height="88" fill="#161B22"/>
+<rect x="680" y="378" width="200" height="88" fill="none" stroke="#E8A33D" stroke-width="4"/>
+<line x1="760" y1="378" x2="800" y2="378" stroke="#161B22" stroke-width="10"/>
+<text x="780" y="413" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="middle">orientation pkg</text>
+<text x="780" y="439" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="middle">collision</text>
+<line x1="464" y1="266" x2="464" y2="338" stroke="#E8A33D" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="140" y1="338" x2="780" y2="338" stroke="#E8A33D" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="140" y1="338" x2="140" y2="366" stroke="#E8A33D" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="140,378 133,364 147,364" fill="#E8A33D"/>
+<line x1="780" y1="338" x2="780" y2="366" stroke="#E8A33D" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="780,378 773,364 787,364" fill="#E8A33D"/>
+<text x="460" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">the system warns; the human decides</text>
+<text x="460" y="556" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">each session is a presence with a TTL; the notice rides in the orientation package</text>
+</svg>

--- a/docs/assets/diagrams/presence-collision-light.svg
+++ b/docs/assets/diagrams/presence-collision-light.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 608" width="920" height="608" role="img">
+<title>presence and collision</title>
+<desc>Two agents work on the same brain. Each session registers a presence with a time to live, drawn as arrows into the central brain box. When the work overlaps, a dashed amber path carries the collision notice down into the orientation package of both agents, before either one lands a change. The system warns; the human decides.</desc>
+<rect x="0" y="0" width="920" height="608" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">presence_collision</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">two sessions on the same brain register presence; the warning reaches both before</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">either one writes</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="336" y="178" width="256" height="88" fill="#ECEDE8"/>
+<rect x="336" y="178" width="256" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="464" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">brain</text>
+<text x="464" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">presences[ ] · TTL</text>
+<rect x="40" y="178" width="200" height="88" fill="#ECEDE8"/>
+<rect x="40" y="178" width="200" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="140" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">agent A</text>
+<text x="140" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">same brain</text>
+<rect x="680" y="178" width="200" height="88" fill="#ECEDE8"/>
+<rect x="680" y="178" width="200" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="780" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">agent B</text>
+<text x="780" y="239" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">same brain</text>
+<text x="288" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">presence</text>
+<line x1="240" y1="222" x2="324" y2="222" stroke="#84867F" stroke-width="4"/>
+<polygon points="336,222 322,215 322,229" fill="#84867F"/>
+<text x="636" y="200" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">presence</text>
+<line x1="680" y1="222" x2="604" y2="222" stroke="#84867F" stroke-width="4"/>
+<polygon points="592,222 606,215 606,229" fill="#84867F"/>
+<text x="488" y="310" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="start">warns both, before either writes</text>
+<rect x="40" y="378" width="200" height="88" fill="#ECEDE8"/>
+<rect x="40" y="378" width="200" height="88" fill="none" stroke="#7E4E00" stroke-width="4"/>
+<line x1="120" y1="378" x2="160" y2="378" stroke="#ECEDE8" stroke-width="10"/>
+<text x="140" y="413" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="middle">orientation pkg</text>
+<text x="140" y="439" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="middle">collision</text>
+<rect x="680" y="378" width="200" height="88" fill="#ECEDE8"/>
+<rect x="680" y="378" width="200" height="88" fill="none" stroke="#7E4E00" stroke-width="4"/>
+<line x1="760" y1="378" x2="800" y2="378" stroke="#ECEDE8" stroke-width="10"/>
+<text x="780" y="413" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="middle">orientation pkg</text>
+<text x="780" y="439" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="middle">collision</text>
+<line x1="464" y1="266" x2="464" y2="338" stroke="#7E4E00" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="140" y1="338" x2="780" y2="338" stroke="#7E4E00" stroke-width="4" stroke-dasharray="10 8"/>
+<line x1="140" y1="338" x2="140" y2="366" stroke="#7E4E00" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="140,378 133,364 147,364" fill="#7E4E00"/>
+<line x1="780" y1="338" x2="780" y2="366" stroke="#7E4E00" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="780,378 773,364 787,364" fill="#7E4E00"/>
+<text x="460" y="530" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">the system warns; the human decides</text>
+<text x="460" y="556" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">each session is a presence with a TTL; the notice rides in the orientation package</text>
+</svg>

--- a/docs/assets/diagrams/transplant-two-phase-dark.svg
+++ b/docs/assets/diagrams/transplant-two-phase-dark.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 1248" width="920" height="1248" role="img">
+<title>transplant, the two-phase move</title>
+<desc>A sequence across three lanes: agent, m1nd server and filesystem. The agent calls transplant_preview and the server plans the enlarged region with its dependencies and referrers, returning a plan. The agent then calls transplant_commit; the server re-validates every planned file hash, writes atomically, and returns a receipt naming refs_unresolved and state_left_behind. A final branch in red shows a commit onto a taken name being refused, with the occupant named, the state blocked and nothing written.</desc>
+<rect x="0" y="0" width="920" height="1248" fill="#161B22"/>
+<line x1="150" y1="242" x2="150" y2="1022" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="460" y1="242" x2="460" y2="1022" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="780" y1="242" x2="780" y2="1022" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">transplant_two_phase</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">preview plans the move, commit re-checks every file hash before writing and</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">returns an honest receipt</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="48" y="178" width="208" height="64" fill="#161B22"/>
+<rect x="48" y="178" width="208" height="64" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="152" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">agent</text>
+<rect x="360" y="178" width="208" height="64" fill="#161B22"/>
+<rect x="360" y="178" width="208" height="64" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="464" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">m1nd server</text>
+<rect x="680" y="178" width="208" height="64" fill="#161B22"/>
+<rect x="680" y="178" width="208" height="64" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="784" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#F2F4EF" text-anchor="middle">filesystem</text>
+<text x="305" y="286" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">1  transplant_preview()</text>
+<line x1="150" y1="302" x2="448" y2="302" stroke="#687585" stroke-width="4"/>
+<polygon points="460,302 446,295 446,309" fill="#687585"/>
+<rect x="312" y="342" width="296" height="88" fill="#161B22"/>
+<rect x="312" y="342" width="296" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="312" y1="366" x2="312" y2="406" stroke="#161B22" stroke-width="10"/>
+<text x="460" y="377" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">plans the enlarged region,</text>
+<text x="460" y="403" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">its deps and its referrers</text>
+<text x="305" y="470" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">2  plan</text>
+<line x1="460" y1="486" x2="162" y2="486" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="150,486 164,479 164,493" fill="#687585"/>
+<text x="305" y="534" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">3  transplant_commit()</text>
+<line x1="150" y1="550" x2="448" y2="550" stroke="#687585" stroke-width="4"/>
+<polygon points="460,550 446,543 446,557" fill="#687585"/>
+<rect x="304" y="590" width="320" height="64" fill="#161B22"/>
+<rect x="304" y="590" width="320" height="64" fill="none" stroke="#687585" stroke-width="4"/>
+<line x1="304" y1="602" x2="304" y2="642" stroke="#161B22" stroke-width="10"/>
+<text x="464" y="625" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">re-validates every file hash</text>
+<text x="620" y="694" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">4  atomic write</text>
+<line x1="460" y1="710" x2="768" y2="710" stroke="#687585" stroke-width="4"/>
+<polygon points="780,710 766,703 766,717" fill="#687585"/>
+<text x="620" y="758" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">ok</text>
+<line x1="780" y1="774" x2="472" y2="774" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="460,774 474,767 474,781" fill="#687585"/>
+<text x="305" y="822" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="middle">5  receipt</text>
+<line x1="460" y1="838" x2="162" y2="838" stroke="#687585" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="150,838 164,831 164,845" fill="#687585"/>
+<line x1="40" y1="870" x2="880" y2="870" stroke="#687585" stroke-width="2" stroke-dasharray="10 8"/>
+<text x="305" y="918" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#FF7B72" text-anchor="middle">6  commit on a taken name</text>
+<line x1="150" y1="934" x2="448" y2="934" stroke="#FF7B72" stroke-width="4"/>
+<polygon points="460,934 446,927 446,941" fill="#FF7B72"/>
+<text x="305" y="982" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#FF7B72" text-anchor="middle">REFUSE</text>
+<line x1="460" y1="998" x2="162" y2="998" stroke="#FF7B72" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="150,998 164,991 164,1005" fill="#FF7B72"/>
+<rect x="152" y="1054" width="624" height="64" fill="#161B22"/>
+<rect x="152" y="1054" width="624" height="64" fill="none" stroke="#FF7B72" stroke-width="4"/>
+<line x1="152" y1="1066" x2="152" y2="1106" stroke="#161B22" stroke-width="10"/>
+<text x="464" y="1089" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#FF7B72" text-anchor="middle">the occupant is named · state: blocked · nothing was written</text>
+<text x="460" y="1166" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">solid = call · dashed = return · red = typed refusal</text>
+<text x="460" y="1192" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">the receipt names what did not travel: refs_unresolved and state_left_behind</text>
+</svg>

--- a/docs/assets/diagrams/transplant-two-phase-light.svg
+++ b/docs/assets/diagrams/transplant-two-phase-light.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 1248" width="920" height="1248" role="img">
+<title>transplant, the two-phase move</title>
+<desc>A sequence across three lanes: agent, m1nd server and filesystem. The agent calls transplant_preview and the server plans the enlarged region with its dependencies and referrers, returning a plan. The agent then calls transplant_commit; the server re-validates every planned file hash, writes atomically, and returns a receipt naming refs_unresolved and state_left_behind. A final branch in red shows a commit onto a taken name being refused, with the occupant named, the state blocked and nothing written.</desc>
+<rect x="0" y="0" width="920" height="1248" fill="#ECEDE8"/>
+<line x1="150" y1="242" x2="150" y2="1022" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="460" y1="242" x2="460" y2="1022" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<line x1="780" y1="242" x2="780" y2="1022" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">transplant_two_phase</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">preview plans the move, commit re-checks every file hash before writing and</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">returns an honest receipt</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="48" y="178" width="208" height="64" fill="#ECEDE8"/>
+<rect x="48" y="178" width="208" height="64" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="152" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">agent</text>
+<rect x="360" y="178" width="208" height="64" fill="#ECEDE8"/>
+<rect x="360" y="178" width="208" height="64" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="464" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">m1nd server</text>
+<rect x="680" y="178" width="208" height="64" fill="#ECEDE8"/>
+<rect x="680" y="178" width="208" height="64" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="784" y="213" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" fill="#14181C" text-anchor="middle">filesystem</text>
+<text x="305" y="286" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">1  transplant_preview()</text>
+<line x1="150" y1="302" x2="448" y2="302" stroke="#84867F" stroke-width="4"/>
+<polygon points="460,302 446,295 446,309" fill="#84867F"/>
+<rect x="312" y="342" width="296" height="88" fill="#ECEDE8"/>
+<rect x="312" y="342" width="296" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="312" y1="366" x2="312" y2="406" stroke="#ECEDE8" stroke-width="10"/>
+<text x="460" y="377" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">plans the enlarged region,</text>
+<text x="460" y="403" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">its deps and its referrers</text>
+<text x="305" y="470" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">2  plan</text>
+<line x1="460" y1="486" x2="162" y2="486" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="150,486 164,479 164,493" fill="#84867F"/>
+<text x="305" y="534" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">3  transplant_commit()</text>
+<line x1="150" y1="550" x2="448" y2="550" stroke="#84867F" stroke-width="4"/>
+<polygon points="460,550 446,543 446,557" fill="#84867F"/>
+<rect x="304" y="590" width="320" height="64" fill="#ECEDE8"/>
+<rect x="304" y="590" width="320" height="64" fill="none" stroke="#84867F" stroke-width="4"/>
+<line x1="304" y1="602" x2="304" y2="642" stroke="#ECEDE8" stroke-width="10"/>
+<text x="464" y="625" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">re-validates every file hash</text>
+<text x="620" y="694" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">4  atomic write</text>
+<line x1="460" y1="710" x2="768" y2="710" stroke="#84867F" stroke-width="4"/>
+<polygon points="780,710 766,703 766,717" fill="#84867F"/>
+<text x="620" y="758" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">ok</text>
+<line x1="780" y1="774" x2="472" y2="774" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="460,774 474,767 474,781" fill="#84867F"/>
+<text x="305" y="822" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="middle">5  receipt</text>
+<line x1="460" y1="838" x2="162" y2="838" stroke="#84867F" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="150,838 164,831 164,845" fill="#84867F"/>
+<line x1="40" y1="870" x2="880" y2="870" stroke="#84867F" stroke-width="2" stroke-dasharray="10 8"/>
+<text x="305" y="918" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#A81E22" text-anchor="middle">6  commit on a taken name</text>
+<line x1="150" y1="934" x2="448" y2="934" stroke="#A81E22" stroke-width="4"/>
+<polygon points="460,934 446,927 446,941" fill="#A81E22"/>
+<text x="305" y="982" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#A81E22" text-anchor="middle">REFUSE</text>
+<line x1="460" y1="998" x2="162" y2="998" stroke="#A81E22" stroke-width="4" stroke-dasharray="10 8"/>
+<polygon points="150,998 164,991 164,1005" fill="#A81E22"/>
+<rect x="152" y="1054" width="624" height="64" fill="#ECEDE8"/>
+<rect x="152" y="1054" width="624" height="64" fill="none" stroke="#A81E22" stroke-width="4"/>
+<line x1="152" y1="1066" x2="152" y2="1106" stroke="#ECEDE8" stroke-width="10"/>
+<text x="464" y="1089" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#A81E22" text-anchor="middle">the occupant is named · state: blocked · nothing was written</text>
+<text x="460" y="1166" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">solid = call · dashed = return · red = typed refusal</text>
+<text x="460" y="1192" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">the receipt names what did not travel: refs_unresolved and state_left_behind</text>
+</svg>

--- a/docs/assets/diagrams/verdict-gate-dark.svg
+++ b/docs/assets/diagrams/verdict-gate-dark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 696" width="920" height="696" role="img">
+<title>the conformal verdict gate</title>
+<desc>A funnel. About 9.2 thousand predictions enter on the left and meet a single vertical cut, the conformal gate at alpha 0.10. Three bars on the right carry the outcome, their lengths proportional to the measured shares: act at 13.5 percent which the agent may act on, reverify at 26 percent where a human re-confirms first, and abstain at 60 percent, the largest slice and the honest exit of a weak signal.</desc>
+<rect x="0" y="0" width="920" height="696" fill="#161B22"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#F2F4EF" text-anchor="start">verdict_gate</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">the conformal gate as an honest funnel: one cut at alpha 0.10 separates act from</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">everything else</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#687585" stroke-width="2"/>
+<rect x="40" y="330" width="224" height="88" fill="#161B22"/>
+<rect x="40" y="330" width="224" height="88" fill="none" stroke="#687585" stroke-width="4"/>
+<text x="152" y="365" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" fill="#F2F4EF" text-anchor="middle">n ≈ 9.2k</text>
+<text x="152" y="391" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">predictions in</text>
+<line x1="264" y1="374" x2="380" y2="374" stroke="#687585" stroke-width="4"/>
+<polygon points="392,374 378,367 378,381" fill="#687585"/>
+<text x="400" y="186" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">one cut · α = 0.10</text>
+<text x="440" y="222" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#F2F4EF" text-anchor="start">act · 13.5% · ≈ 1.24k</text>
+<rect x="440" y="236" width="48" height="32" fill="#F2F4EF"/>
+<text x="440" y="306" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">the agent may act on it</text>
+<text x="440" y="350" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#E8A33D" text-anchor="start">reverify · 26% · ≈ 2.4k</text>
+<rect x="440" y="364" width="96" height="32" fill="#E8A33D"/>
+<text x="440" y="434" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">a human re-confirms before acting</text>
+<text x="440" y="478" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">abstain · 60% · ≈ 5.5k</text>
+<rect x="440" y="492" width="232" height="32" fill="#98A2AE"/>
+<text x="440" y="562" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="start">the honest exit of a weak signal</text>
+<line x1="392" y1="210" x2="392" y2="532" stroke="#687585" stroke-width="4"/>
+<text x="460" y="614" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">bar length is the measured share, not decoration</text>
+<text x="460" y="640" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#98A2AE" text-anchor="middle">abstain is the largest slice: the system says it does not know instead of guessing</text>
+</svg>

--- a/docs/assets/diagrams/verdict-gate-light.svg
+++ b/docs/assets/diagrams/verdict-gate-light.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 696" width="920" height="696" role="img">
+<title>the conformal verdict gate</title>
+<desc>A funnel. About 9.2 thousand predictions enter on the left and meet a single vertical cut, the conformal gate at alpha 0.10. Three bars on the right carry the outcome, their lengths proportional to the measured shares: act at 13.5 percent which the agent may act on, reverify at 26 percent where a human re-confirms first, and abstain at 60 percent, the largest slice and the honest exit of a weak signal.</desc>
+<rect x="0" y="0" width="920" height="696" fill="#ECEDE8"/>
+<text x="40" y="46" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" fill="#14181C" text-anchor="start">verdict_gate</text>
+<text x="40" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">the conformal gate as an honest funnel: one cut at alpha 0.10 separates act from</text>
+<text x="40" y="102" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">everything else</text>
+<line x1="40" y1="130" x2="880" y2="130" stroke="#84867F" stroke-width="2"/>
+<rect x="40" y="330" width="224" height="88" fill="#ECEDE8"/>
+<rect x="40" y="330" width="224" height="88" fill="none" stroke="#84867F" stroke-width="4"/>
+<text x="152" y="365" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" fill="#14181C" text-anchor="middle">n ≈ 9.2k</text>
+<text x="152" y="391" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">predictions in</text>
+<line x1="264" y1="374" x2="380" y2="374" stroke="#84867F" stroke-width="4"/>
+<polygon points="392,374 378,367 378,381" fill="#84867F"/>
+<text x="400" y="186" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">one cut · α = 0.10</text>
+<text x="440" y="222" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#14181C" text-anchor="start">act · 13.5% · ≈ 1.24k</text>
+<rect x="440" y="236" width="48" height="32" fill="#14181C"/>
+<text x="440" y="306" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">the agent may act on it</text>
+<text x="440" y="350" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#7E4E00" text-anchor="start">reverify · 26% · ≈ 2.4k</text>
+<rect x="440" y="364" width="96" height="32" fill="#7E4E00"/>
+<text x="440" y="434" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">a human re-confirms before acting</text>
+<text x="440" y="478" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">abstain · 60% · ≈ 5.5k</text>
+<rect x="440" y="492" width="232" height="32" fill="#5A6169"/>
+<text x="440" y="562" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="start">the honest exit of a weak signal</text>
+<line x1="392" y1="210" x2="392" y2="532" stroke="#84867F" stroke-width="4"/>
+<text x="460" y="614" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">bar length is the measured share, not decoration</text>
+<text x="460" y="640" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" fill="#5A6169" text-anchor="middle">abstain is the largest slice: the system says it does not know instead of guessing</text>
+</svg>

--- a/tools/diagrams/README.md
+++ b/tools/diagrams/README.md
@@ -1,0 +1,41 @@
+# System diagrams
+
+The eight diagrams in the README and the wiki are build artifacts, not
+hand-drawn files. `build.mjs` emits all sixteen SVGs (each scene in a dark and a
+light variant) into `docs/assets/diagrams/`, and `validate.mjs` is the gate.
+
+```sh
+node tools/diagrams/build.mjs        # writes docs/assets/diagrams/*.svg
+node tools/diagrams/validate.mjs     # exit 0 = the set is valid
+```
+
+Both accept an output directory as the first argument if you want to render
+somewhere else.
+
+## Why generated
+
+The first pass was hand-written SVG with absolute coordinates. Text width was
+never measured, so labels crossed frames and each other; fixing one collision
+pushed the next one sideways, and the gate counted 81 typography violations
+across the set.
+
+The generator sizes every box from the text it carries (the monospace advance is
+exactly 0.6em for the SF Mono / Menlo stack it names), places every label in a
+gutter measured to hold it, and emits both themes from a single geometry pass.
+Overlap is no longer a defect to fix; it is a state the layout cannot reach.
+
+## What the gate checks
+
+The palette (twelve hexes, nothing else), well-formed XML, a viewBox, `<title>`
+and `<desc>` for readers without sight, no gradients or filters or animation, no
+decorative opacity, under 60 KB per file, and typography: text inside the canvas,
+text never crossing a frame, at least 8 px between a label and the box around it,
+and no two labels overlapping. The validator estimates text width more
+conservatively (0.62em) than the generator draws it (0.60em), so a pass there
+leaves slack in the real render.
+
+## Editing
+
+Change the scene functions in `build.mjs`, re-run both commands, and commit the
+regenerated SVGs. Do not hand-edit the files under `docs/assets/diagrams/`: the
+next build overwrites them.

--- a/tools/diagrams/build.mjs
+++ b/tools/diagrams/build.mjs
@@ -1,0 +1,483 @@
+// Deterministic layout for the m1nd system diagrams.
+//
+// Every box is sized FROM its text (monospace advance is exact), every label
+// sits in a gutter measured to hold it, and both themes come out of one
+// geometry pass. Overlap is not a defect patched here; it cannot be expressed.
+import { writeFileSync, mkdirSync } from "fs";
+
+const W = 920;
+const ADV = 0.6;            // advance per character, SF Mono / Menlo at 1em
+const FONT = "ui-monospace, SFMono-Regular, Menlo, monospace";
+const tw = (s, size = 16) => [...s].length * size * ADV;
+const snap = v => Math.round(v / 8) * 8;
+const esc = s => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const THEMES = {
+  dark:  { field: "#161B22", ink: "#F2F4EF", sec: "#98A2AE", amber: "#E8A33D", red: "#FF7B72", wire: "#687585" },
+  light: { field: "#ECEDE8", ink: "#14181C", sec: "#5A6169", amber: "#7E4E00", red: "#A81E22", wire: "#84867F" },
+};
+
+const PADX = 24, PADY = 18, LH = 26;
+
+function boxSize(lines, minW = 0) {
+  const wid = Math.max(minW, ...lines.map(l => tw(l.t, l.size ?? 16)));
+  return { w: snap(wid + PADX * 2), h: snap(lines.length * LH + PADY * 2) };
+}
+
+function E(c) {
+  const o = [], bg = [];
+  const api = {
+    out: o,
+    bg,
+    text(x, y, s, { size = 16, fill = c.ink, anchor = "start" } = {}) {
+      o.push(`<text x="${x}" y="${y}" font-family="${FONT}" font-size="${size}" fill="${fill}" text-anchor="${anchor}">${esc(s)}</text>`);
+    },
+    // The frame is a real rect; a bite is a piece of the field cutting through
+    // the stroke, so the opening is honest and the box keeps measurable bounds.
+    frame(x, y, w, h, stroke, bite) {
+      o.push(`<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="none" stroke="${stroke}" stroke-width="4"/>`);
+      if (!bite) return;
+      const { side, at = 0.5, len = 40 } = bite;
+      if (side === "left" || side === "right") {
+        const bx = side === "left" ? x : x + w, by = y + h * at;
+        o.push(`<line x1="${bx}" y1="${by - len / 2}" x2="${bx}" y2="${by + len / 2}" stroke="${c.field}" stroke-width="10"/>`);
+      } else {
+        const by = side === "top" ? y : y + h, bx = x + w * at;
+        o.push(`<line x1="${bx - len / 2}" y1="${by}" x2="${bx + len / 2}" y2="${by}" stroke="${c.field}" stroke-width="10"/>`);
+      }
+    },
+    box(x, y, lines, { stroke = c.wire, bite = null, minW = 0, align = "center" } = {}) {
+      const { w, h } = boxSize(lines, minW);
+      o.push(`<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="${c.field}"/>`);
+      api.frame(x, y, w, h, stroke, bite);
+      lines.forEach((l, i) => {
+        const size = l.size ?? 16, by = y + PADY + 17 + i * LH;
+        if (align === "center") api.text(x + w / 2, by, l.t, { size, fill: l.fill ?? c.ink, anchor: "middle" });
+        else api.text(x + PADX, by, l.t, { size, fill: l.fill ?? c.ink });
+      });
+      return { x, y, w, h, cx: x + w / 2, cy: y + h / 2, r: x + w, b: y + h };
+    },
+    boxAt(cx, y, lines, opt = {}) {
+      const { w } = boxSize(lines, opt.minW ?? 0);
+      return api.box(snap(cx - w / 2), y, lines, opt);
+    },
+    line(x1, y1, x2, y2, { stroke = c.wire, dashed = false, width = 4, back = false } = {}) {
+      const s = `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${stroke}" stroke-width="${width}"${dashed ? ' stroke-dasharray="10 8"' : ""}/>`;
+      (back ? bg : o).push(s);
+    },
+    tri(x, y, dir, stroke = c.wire) {
+      const s = 7, l = 14;
+      const p = { r: `${x},${y} ${x - l},${y - s} ${x - l},${y + s}`,
+                  l: `${x},${y} ${x + l},${y - s} ${x + l},${y + s}`,
+                  d: `${x},${y} ${x - s},${y - l} ${x + s},${y - l}`,
+                  u: `${x},${y} ${x - s},${y + l} ${x + s},${y + l}` }[dir];
+      o.push(`<polygon points="${p}" fill="${stroke}"/>`);
+    },
+    arrowH(x1, x2, y, opt = {}) {
+      const dir = x2 > x1 ? "r" : "l";
+      api.line(x1, y, dir === "r" ? x2 - 12 : x2 + 12, y, opt);
+      api.tri(x2, y, dir, opt.stroke ?? c.wire);
+    },
+    arrowV(x, y1, y2, opt = {}) {
+      const dir = y2 > y1 ? "d" : "u";
+      api.line(x, y1, x, dir === "d" ? y2 - 12 : y2 + 12, opt);
+      api.tri(x, y2, dir, opt.stroke ?? c.wire);
+    },
+    elbowHVH(x1, y1, xm, x2, y2, opt = {}) {
+      api.line(x1, y1, xm, y1, opt);
+      api.line(xm, y1, xm, y2, opt);
+      api.arrowH(xm, x2, y2, opt);
+    },
+    circle(cx, cy, r, stroke = c.wire) {
+      o.push(`<circle cx="${cx}" cy="${cy}" r="${r}" fill="${c.field}" stroke="${stroke}" stroke-width="4"/>`);
+    },
+    square(cx, cy, s, stroke = c.wire) {
+      o.push(`<rect x="${cx - s / 2}" y="${cy - s / 2}" width="${s}" height="${s}" fill="${c.field}" stroke="${stroke}" stroke-width="4"/>`);
+    },
+    bar(x, y, w, h, fill) {
+      o.push(`<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="${fill}"/>`);
+    },
+  };
+  return api;
+}
+
+function wrap(s, max) {
+  const out = [];
+  let cur = "";
+  for (const wd of s.split(" ")) {
+    if ((cur + " " + wd).trim().length > max) { out.push(cur.trim()); cur = wd; }
+    else cur += " " + wd;
+  }
+  if (cur.trim()) out.push(cur.trim());
+  return out;
+}
+
+function head(e, c, title, subtitle) {
+  e.text(40, 46, title, { size: 22 });
+  const sub = wrap(subtitle, 82);
+  sub.forEach((l, i) => e.text(40, 78 + i * 24, l, { size: 16, fill: c.sec }));
+  const ruleY = 78 + sub.length * 24 + 4;
+  e.line(40, ruleY, W - 40, ruleY, { width: 2 });
+  return ruleY + 48;
+}
+
+function foot(e, c, y, lines) {
+  const flat = lines.flatMap(l => wrap(l, 82));
+  flat.forEach((l, i) => e.text(W / 2, y + i * 26, l, { size: 16, fill: c.sec, anchor: "middle" }));
+  return y + flat.length * 26 + 20;
+}
+
+/* ------------------------------------------------------------------ scenes */
+
+const scenes = {};
+
+scenes["transplant-two-phase"] = c => {
+  const e = E(c);
+  const y = head(e, c, "transplant_two_phase",
+    "preview plans the move, commit re-checks every file hash before writing and returns an honest receipt");
+  const lane = [150, 460, 780];
+  const heads = ["agent", "m1nd server", "filesystem"].map((t, i) =>
+    e.boxAt(lane[i], y, [{ t, size: 18 }], { minW: 160 }));
+  const top = heads[0].b;
+  let row = top + 60;
+
+  const step = (a, b, label, opt = {}) => {
+    e.text((lane[a] + lane[b]) / 2, row - 16, label, { size: 16, fill: opt.stroke ?? c.ink, anchor: "middle" });
+    e.arrowH(lane[a], lane[b], row, opt);
+    row += 64;
+  };
+  const note = (i, lines) => {
+    const b = e.boxAt(lane[i], row - 24, lines, { bite: { side: "left", at: 0.5 } });
+    row = b.b + 56;
+  };
+
+  step(0, 1, "1  transplant_preview()");
+  note(1, [{ t: "plans the enlarged region," }, { t: "its deps and its referrers" }]);
+  step(1, 0, "2  plan", { dashed: true });
+  step(0, 1, "3  transplant_commit()");
+  note(1, [{ t: "re-validates every file hash" }]);
+  step(1, 2, "4  atomic write");
+  step(2, 1, "ok", { dashed: true });
+  step(1, 0, "5  receipt", { dashed: true });
+
+  const sep = row - 32;
+  e.line(40, sep, W - 40, sep, { width: 2, dashed: true });
+  row = sep + 64;
+  step(0, 1, "6  commit on a taken name", { stroke: c.red });
+  step(1, 0, "REFUSE", { stroke: c.red, dashed: true });
+
+  const bottom = row - 40;
+  lane.forEach(x => e.line(x, top, x, bottom, { width: 2, dashed: true, back: true }));
+  const rb = e.boxAt(W / 2, bottom + 32, [
+    { t: "the occupant is named · state: blocked · nothing was written", fill: c.red },
+  ], { stroke: c.red, bite: { side: "left", at: 0.5 } });
+
+  const end = foot(e, c, rb.b + 48, [
+    "solid = call · dashed = return · red = typed refusal",
+    "the receipt names what did not travel: refs_unresolved and state_left_behind",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "transplant, the two-phase move",
+    desc: "A sequence across three lanes: agent, m1nd server and filesystem. The agent calls transplant_preview and the server plans the enlarged region with its dependencies and referrers, returning a plan. The agent then calls transplant_commit; the server re-validates every planned file hash, writes atomically, and returns a receipt naming refs_unresolved and state_left_behind. A final branch in red shows a commit onto a taken name being refused, with the occupant named, the state blocked and nothing written.",
+  };
+};
+
+scenes["brain-per-repo"] = c => {
+  const e = E(c);
+  const y = head(e, c, "brain_per_repo",
+    "one served owner, one brain per repository root, and thin bridges that carry no graph of their own");
+
+  const mk = n => [{ t: `brain ${n}`, size: 18 }, { t: `~/proj${n}`, fill: c.sec }, { t: "graph · memory", fill: c.sec }];
+  const bw = boxSize(mk("A")).w;
+  const brains = ["A", "B", "C"].map((n, i) =>
+    e.box(392, y + i * 144, mk(n), { bite: { side: "left", at: 0.5 } }));
+
+  const owner = e.box(40, brains[1].cy - 44, [{ t: "owner", size: 18 }, { t: "served :1337", fill: c.sec }], { minW: 168 });
+  const trunk = owner.r + 64;
+  e.text(trunk - 8, owner.y - 16, "serves", { size: 16, fill: c.sec, anchor: "end" });
+  brains.forEach(b => e.elbowHVH(owner.r, owner.cy, trunk, b.x, b.cy));
+
+  brains.forEach(b => {
+    const br = e.box(W - 40 - 152, b.y + 16, [{ t: "agent", size: 16 }, { t: "bridge", fill: c.sec }], { minW: 104 });
+    e.arrowH(br.x, b.r, br.cy);
+  });
+
+  const lastB = brains[2].b;
+  const bad = e.box(392, lastB + 104, [
+    { t: "agent", size: 18, fill: c.red }, { t: "repo not hosted", fill: c.red },
+  ], { stroke: c.red, minW: bw - PADX * 2, bite: { side: "top", at: 0.5 } });
+  e.text(owner.cx + 32, lastB + 70, "reception → typed refusal", { size: 16, fill: c.red });
+  e.line(owner.cx, owner.b, owner.cx, lastB + 88, { stroke: c.red, dashed: true });
+  e.line(owner.cx, lastB + 88, bad.cx, lastB + 88, { stroke: c.red, dashed: true });
+  e.arrowV(bad.cx, lastB + 88, bad.y, { stroke: c.red, dashed: true });
+  e.text(bad.cx, bad.b + 32, "no wrong answer · state: blocked", { size: 16, fill: c.red, anchor: "middle" });
+
+  const end = foot(e, c, bad.b + 80, [
+    "a bridge holds no graph and no lease: it consumes the brain that covers its root",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "one brain per repository",
+    desc: "A topology. A single served owner on port 1337 serves three brains, one per repository root, each with its own graph and memory. Agents attach on the right as thin bridges that hold no graph and take no lease. Below, an agent whose repository is not hosted receives a typed refusal from reception, drawn in red: the system blocks instead of answering wrongly.",
+  };
+};
+
+scenes["verdict-gate"] = c => {
+  const e = E(c);
+  const y = head(e, c, "verdict_gate",
+    "the conformal gate as an honest funnel: one cut at alpha 0.10 separates act from everything else");
+
+  const inb = e.box(40, y + 152, [{ t: "n ≈ 9.2k", size: 20 }, { t: "predictions in", fill: c.sec }], { minW: 176 });
+  const gate = 392, barX = gate + 48, BAR = 380;
+  e.arrowH(inb.r, gate, inb.cy);
+  e.text(gate + 8, y + 8, "one cut · α = 0.10", { size: 16, fill: c.sec });
+
+  const rows = [
+    { k: "act",      pct: 0.135, n: "≈ 1.24k", fill: c.ink,   note: "the agent may act on it" },
+    { k: "reverify", pct: 0.26,  n: "≈ 2.4k",  fill: c.amber, note: "a human re-confirms before acting" },
+    { k: "abstain",  pct: 0.60,  n: "≈ 5.5k",  fill: c.sec,   note: "the honest exit of a weak signal" },
+  ];
+  let ry = y + 44;
+  const first = ry + 12;
+  let lastBar = 0;
+  rows.forEach(r => {
+    e.text(barX, ry, `${r.k} · ${Math.round(r.pct * 1000) / 10}% · ${r.n}`, { size: 16, fill: r.fill });
+    e.bar(barX, ry + 14, snap(BAR * r.pct), 32, r.fill);
+    e.text(barX, ry + 84, r.note, { size: 16, fill: c.sec });
+    lastBar = ry + 46;
+    ry += 128;
+  });
+  e.line(gate, first - 24, gate, lastBar + 8, { width: 4 });
+
+  const end = foot(e, c, ry + 8, [
+    "bar length is the measured share, not decoration",
+    "abstain is the largest slice: the system says it does not know instead of guessing",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "the conformal verdict gate",
+    desc: "A funnel. About 9.2 thousand predictions enter on the left and meet a single vertical cut, the conformal gate at alpha 0.10. Three bars on the right carry the outcome, their lengths proportional to the measured shares: act at 13.5 percent which the agent may act on, reverify at 26 percent where a human re-confirms first, and abstain at 60 percent, the largest slice and the honest exit of a weak signal.",
+  };
+};
+
+scenes["grounded-memory"] = c => {
+  const e = E(c);
+  let y = head(e, c, "grounded_memory",
+    "a claim is anchored to the code it cites; when that code changes, the claim marks itself stale");
+
+  const CX = 296, LX = 408;
+  const link = (label, { jog = false } = {}) => {
+    const from = y, to = y + (jog ? 128 : 88);
+    if (jog) {
+      const m = from + 40;
+      e.line(CX, from, CX, m, { stroke: c.amber });
+      e.line(CX, m, CX + 32, m + 32, { stroke: c.amber });
+      e.line(CX + 32, m + 32, CX + 32, to - 12, { stroke: c.amber });
+      e.tri(CX + 32, to, "d", c.amber);
+      e.text(CX + 56, m + 14, "stale", { size: 16, fill: c.amber });
+    } else e.arrowV(CX, from, to);
+    if (label) e.text(LX, from + (to - from) / 2 + 6, label, { size: 16, fill: jog ? c.amber : c.sec });
+    y = to;
+  };
+
+  let b = e.boxAt(CX, y, [{ t: "memorize()", size: 18 }, { t: "claims + evidence", fill: c.sec }],
+    { bite: { side: "top", at: 0.5 } });
+  y = b.b;
+  link("grounded_in → the cited code node");
+  b = e.boxAt(CX, y, [{ t: "code node", size: 18 }, { t: "hash H1", fill: c.sec }]); y = b.b;
+  link("the code changes: H1 ≠ H2");
+  b = e.boxAt(CX, y, [{ t: "cross_verify()", size: 18 }, { t: "compares the hashes", fill: c.sec }]); y = b.b;
+  link("the anchor no longer holds", { jog: true });
+  b = e.boxAt(CX + 32, y, [
+    { t: "claim: stale", size: 18, fill: c.amber }, { t: "warns instead of asserting", fill: c.amber },
+  ], { stroke: c.amber });
+
+  const end = foot(e, c, b.b + 64, [
+    "45 degrees is the house sign for drift: the wire holds, its ground does not",
+    "it warns instead of answering from a claim it can no longer stand on",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "grounded memory going stale",
+    desc: "A vertical state machine. A memorize call stores claims with their evidence, and an edge named grounded_in ties them to the code node they cite at hash H1. When that code changes to hash H2, cross_verify compares the hashes and the wire breaks with a 45 degree step labelled stale. The final state, framed in amber, is a claim marked stale that warns instead of asserting.",
+  };
+};
+
+scenes["mailbox"] = c => {
+  const e = E(c);
+  const y = head(e, c, "mailbox",
+    "an agent leaves a letter on disk; another agent, days later, starts its mission already knowing");
+
+  const A = e.box(40, y, [{ t: "agent A", size: 18 }, { t: "mission X", fill: c.sec }], { minW: 152 });
+  const file = e.boxAt(W / 2, y, [{ t: ".m1nd/inbox.jsonl", size: 18 }, { t: "append-only", fill: c.sec }],
+    { bite: { side: "left", at: 0.5 } });
+  const B = e.box(W - 40 - A.w, y, [{ t: "agent B", size: 18 }, { t: "days later", fill: c.sec }], { minW: 152 });
+
+  e.text((A.r + file.x) / 2, A.cy - 22, "writes", { size: 16, fill: c.sec, anchor: "middle" });
+  e.arrowH(A.r, file.x, A.cy);
+  e.text((file.r + B.x) / 2, A.cy - 22, "sweeps", { size: 16, fill: c.sec, anchor: "middle" });
+  e.arrowH(B.x, file.r, A.cy, { dashed: true });
+
+  const n = A.b + 44;
+  e.text(A.cx, n, "finds a defect", { size: 16, fill: c.sec, anchor: "middle" });
+  e.text(A.cx, n + 24, "outside its scope", { size: 16, fill: c.sec, anchor: "middle" });
+  e.text(file.cx, n, "on disk, beside the code", { size: 16, fill: c.sec, anchor: "middle" });
+  e.text(B.cx, n, "CLI or REST,", { size: 16, fill: c.sec, anchor: "middle" });
+  e.text(B.cx, n + 24, "never in the query loop", { size: 16, fill: c.sec, anchor: "middle" });
+
+  const start = e.boxAt(W / 2, n + 80, [{ t: "the mission starts", size: 18 }, { t: "already knowing", fill: c.sec }],
+    { bite: { side: "top", at: 0.5 } });
+  e.line(B.cx, B.b + 96, B.cx, start.cy, { dashed: true });
+  e.arrowH(B.cx, start.r, start.cy, { dashed: true });
+
+  const end = foot(e, c, start.b + 64, [
+    "a letter on disk outlives the session, the context window and its author",
+    "recorded where the code lives, for the owner of that system to fix in due time",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "the per-brain mailbox",
+    desc: "A flow between agents. Agent A, on mission X, finds a defect outside its own scope and writes a letter into .m1nd/inbox.jsonl, an append-only file on disk beside the code. Agent B, days later, sweeps that mailbox over CLI or REST, never inside the query loop, and its mission starts already knowing about the defect.",
+  };
+};
+
+scenes["presence-collision"] = c => {
+  const e = E(c);
+  const y = head(e, c, "presence_collision",
+    "two sessions on the same brain register presence; the warning reaches both before either one writes");
+
+  const brain = e.boxAt(W / 2, y, [{ t: "brain", size: 18 }, { t: "presences[ ] · TTL", fill: c.sec }], { minW: 208 });
+  const A = e.box(40, y, [{ t: "agent A", size: 18 }, { t: "same brain", fill: c.sec }], { minW: 152 });
+  const B = e.box(W - 40 - A.w, y, [{ t: "agent B", size: 18 }, { t: "same brain", fill: c.sec }], { minW: 152 });
+
+  e.text((A.r + brain.x) / 2, A.cy - 22, "presence", { size: 16, fill: c.sec, anchor: "middle" });
+  e.arrowH(A.r, brain.x, A.cy);
+  e.text((brain.r + B.x) / 2, A.cy - 22, "presence", { size: 16, fill: c.sec, anchor: "middle" });
+  e.arrowH(B.x, brain.r, A.cy);
+
+  e.text(brain.cx + 24, brain.b + 44, "warns both, before either writes", { size: 16, fill: c.amber });
+  const wY = brain.b + 112, warn = [{ t: "orientation pkg", fill: c.amber }, { t: "collision", fill: c.amber }];
+  const wA = e.box(40, wY, warn, { stroke: c.amber, minW: 152, bite: { side: "top", at: 0.5 } });
+  const wB = e.box(W - 40 - wA.w, wY, warn, { stroke: c.amber, minW: 152, bite: { side: "top", at: 0.5 } });
+  const trunk = brain.b + 72;
+  e.line(brain.cx, brain.b, brain.cx, trunk, { stroke: c.amber, dashed: true });
+  e.line(wA.cx, trunk, wB.cx, trunk, { stroke: c.amber, dashed: true });
+  e.arrowV(wA.cx, trunk, wA.y, { stroke: c.amber, dashed: true });
+  e.arrowV(wB.cx, trunk, wB.y, { stroke: c.amber, dashed: true });
+
+  const end = foot(e, c, wA.b + 64, [
+    "the system warns; the human decides",
+    "each session is a presence with a TTL; the notice rides in the orientation package",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "presence and collision",
+    desc: "Two agents work on the same brain. Each session registers a presence with a time to live, drawn as arrows into the central brain box. When the work overlaps, a dashed amber path carries the collision notice down into the orientation package of both agents, before either one lands a change. The system warns; the human decides.",
+  };
+};
+
+scenes["ambient-hooks"] = c => {
+  const e = E(c);
+  const y = head(e, c, "ambient_hooks",
+    "the host fires at spawn and the north package is injected, so the agent is oriented before the first prompt");
+
+  const hook = e.boxAt(200, y, [{ t: "ambient hook", size: 18 }, { t: "injects north", fill: c.sec }], { minW: 200 });
+  const pkg = e.box(W - 40 - 264, y, [
+    { t: "north package", size: 18 }, { t: "map · memory", fill: c.sec }, { t: "trust · gaps", fill: c.sec },
+  ], { minW: 216, bite: { side: "left", at: 0.5 } });
+  e.text((hook.r + pkg.x) / 2, hook.cy - 22, "injects", { size: 16, fill: c.sec, anchor: "middle" });
+  e.arrowH(hook.r, pkg.x, hook.cy);
+
+  const born = e.box(pkg.x, pkg.b + 96, [{ t: "agent + subagent", size: 18 }, { t: "born oriented", fill: c.sec }],
+    { minW: 216, bite: { side: "top", at: 0.5 } });
+  e.arrowV(pkg.cx, pkg.b, born.y, { dashed: true });
+
+  const lineY = Math.max(born.b, hook.b) + 112;
+  const bus = lineY - 56;
+  e.line(40, lineY, W - 40, lineY, { width: 4 });
+  const ticks = [{ x: 168, t: "SessionStart" }, { x: 360, t: "agentSpawn" }, { x: 552, t: "TaskStart" }];
+  ticks.forEach(t => {
+    e.line(t.x, lineY - 14, t.x, lineY + 14, { width: 4 });
+    e.text(t.x, lineY + 44, t.t, { size: 16, anchor: "middle" });
+    e.line(t.x, bus, t.x, lineY - 18, { dashed: true, width: 2 });
+  });
+  e.line(ticks[0].x, bus, ticks[2].x, bus, { dashed: true, width: 2 });
+  e.arrowV(hook.cx, bus, hook.b, { dashed: true, width: 2 });
+  e.line(792, lineY - 14, 792, lineY + 14, { stroke: c.sec, width: 4 });
+  e.text(792, lineY + 44, "first prompt", { size: 16, fill: c.sec, anchor: "middle" });
+  e.text(792, lineY + 68, "(only now)", { size: 16, fill: c.sec, anchor: "middle" });
+
+  const end = foot(e, c, lineY + 116, [
+    "context arrives at spawn, not after the first prompt",
+    "map, memory, trust and gaps are already there when the session opens",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "ambient hooks at spawn",
+    desc: "A session opening. The host fires three events on the timeline at the bottom, SessionStart, agentSpawn and TaskStart, each feeding the ambient hook above. The hook injects the north package, carrying the map, the memory, the trust and the gaps, into the agent and its subagents, which are therefore born oriented. The first user prompt arrives only later, marked further right on the same timeline.",
+  };
+};
+
+scenes["l1ght-lane"] = c => {
+  const e = E(c);
+  const y = head(e, c, "l1ght_lane",
+    "one graph, two lanes: documents as circles, code as squares, and a single ranked answer across both");
+
+  const cols = [
+    { cx: 280, doc: "paper · DOI", route: "DOI/Crossref", code: "mod A" },
+    { cx: 460, doc: "RFC 9110",    route: "RFC",          code: "mod B" },
+    { cx: 640, doc: "design note", route: "JATS",         code: "mod C" },
+  ];
+  const docY = y + 56, wireY = docY + 136, codeY = wireY + 96;
+
+  e.text(40, docY - 56, "documents", { size: 16, fill: c.sec });
+  e.text(40, codeY + 64, "code", { size: 16, fill: c.sec });
+  cols.forEach(col => {
+    e.text(col.cx, docY - 56, col.doc, { size: 16, anchor: "middle" });
+    e.line(col.cx, docY + 28, col.cx, wireY, { width: 2 });
+    e.line(col.cx, wireY, col.cx, codeY - 28, { width: 2 });
+    e.circle(col.cx, docY, 28);
+    e.square(col.cx, codeY, 56);
+    e.text(col.cx + 16, docY + 84, col.route, { size: 16, fill: c.sec });
+    e.text(col.cx, codeY + 64, col.code, { size: 16, anchor: "middle" });
+  });
+  e.line(cols[0].cx + 28, docY, cols[1].cx - 28, docY, { dashed: true, width: 2 });
+  e.text((cols[0].cx + cols[1].cx) / 2, docY - 18, "cites", { size: 16, fill: c.sec, anchor: "middle" });
+
+  const seek = e.box(40, wireY - 44, [{ t: "seek()", size: 18 }, { t: "one query", fill: c.sec }], { minW: 112 });
+  const ans = e.box(W - 40 - 160, wireY - 44, [{ t: "1 answer", size: 18 }, { t: "ranked", fill: c.sec }],
+    { minW: 112, bite: { side: "left", at: 0.5 } });
+  e.arrowH(seek.r, ans.x, wireY);
+
+  const end = foot(e, c, codeY + 136, [
+    "typed edges join the lanes: a paper cites an RFC, a module implements a spec",
+    "seek crosses both and returns one ranked answer, not two piles to reconcile",
+  ]);
+  return {
+    h: snap(end + 8), body: [...e.bg, ...e.out].join("\n"),
+    title: "the l1ght document lane",
+    desc: "One graph with two lanes. The upper lane holds document nodes drawn as circles, a paper with a DOI, an RFC and a design note, joined by a dashed cites edge. The lower lane holds code nodes drawn as squares. Vertical connectors labelled with the real ingest routes, DOI slash Crossref, RFC and JATS, tie each document to its code. A seek query on the left crosses the horizontal wire through both lanes and returns a single ranked answer on the right.",
+  };
+};
+
+/* ------------------------------------------------------------------- build */
+
+const OUT = process.argv[2] ?? "docs/assets/diagrams";
+mkdirSync(OUT, { recursive: true });
+let n = 0;
+for (const [name, fn] of Object.entries(scenes)) {
+  for (const [theme, c] of Object.entries(THEMES)) {
+    const s = fn(c);
+    writeFileSync(`${OUT}/${name}-${theme}.svg`,
+`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${s.h}" width="${W}" height="${s.h}" role="img">
+<title>${esc(s.title)}</title>
+<desc>${esc(s.desc)}</desc>
+<rect x="0" y="0" width="${W}" height="${s.h}" fill="${c.field}"/>
+${s.body}
+</svg>
+`);
+    n++;
+  }
+}
+console.log(`emitted ${n} SVGs`);

--- a/tools/diagrams/validate.mjs
+++ b/tools/diagrams/validate.mjs
@@ -1,0 +1,77 @@
+// Gate mecânico dos UMLs visuais do m1nd. EXIT 0 = pass.
+import { readFileSync, existsSync, statSync } from "fs";
+import { execSync } from "child_process";
+
+const SCENES = ["transplant-two-phase","brain-per-repo","verdict-gate","grounded-memory",
+                "mailbox","presence-collision","ambient-hooks","l1ght-lane"];
+const THEMES = ["dark","light"];
+// Paleta medida do brief gen-008 (dark + light) — nenhum hex fora disto.
+const ALLOW = new Set(["#161B22","#F2F4EF","#98A2AE","#E8A33D","#FF7B72","#687585",
+                       "#ECEDE8","#14181C","#5A6169","#7E4E00","#A81E22","#84867F"].map(s=>s.toUpperCase()));
+const OUT = process.argv[2] ?? "docs/assets/diagrams";
+let fails = [];
+for (const s of SCENES) for (const t of THEMES) {
+  const p = `${OUT}/${s}-${t}.svg`;
+  if (!existsSync(p)) { fails.push(`${p}: MISSING`); continue; }
+  const kb = statSync(p).size/1024;
+  if (kb > 60) fails.push(`${p}: ${kb.toFixed(1)}KB > 60KB`);
+  const src = readFileSync(p, "utf8");
+  try { execSync(`xmllint --noout ${p}`, {stdio:"pipe"}); } catch { fails.push(`${p}: not well-formed XML`); }
+  if (!/viewBox=/.test(src)) fails.push(`${p}: no viewBox`);
+  if (!/<title[\s>]/.test(src)) fails.push(`${p}: no <title>`);
+  if (!/<desc[\s>]/.test(src)) fails.push(`${p}: no <desc>`);
+  if (/linearGradient|radialGradient|<filter|<animate|feGaussian/i.test(src)) fails.push(`${p}: forbidden effect`);
+  for (const m of src.toUpperCase().matchAll(/#[0-9A-F]{6}\b/g))
+    if (!ALLOW.has(m[0])) fails.push(`${p}: hex fora da paleta ${m[0]}`);
+  const op = [...src.matchAll(/opacity="([^"]+)"/g)].filter(m => m[1] !== "1" && m[1] !== "0");
+  if (op.length) fails.push(`${p}: decorative opacity`);
+
+  // Tipografia (regra do diretor, 2026-07-30): letras nunca encostam em moldura,
+  // nunca estouram o canvas, nunca se sobrepõem. Larguras estimadas por classe de
+  // fonte (mono 0.62em/char, sans 0.55em/char) — aproximação deliberadamente folgada.
+  const vb = /viewBox="0 0 (\d+) (\d+)"/.exec(src);
+  const W = vb ? +vb[1] : 920;
+  const texts = [];
+  for (const m of src.matchAll(/<text\b([^>]*)>([^<]*)<\/text>/g)) {
+    const a = m[1], content = m[2].trim();
+    if (!content) continue;
+    const gx = /\bx="(-?[\d.]+)"/.exec(a), gy = /\by="(-?[\d.]+)"/.exec(a);
+    if (!gx || !gy) continue;
+    const size = +(/font-size="([\d.]+)"/.exec(a)?.[1] ?? 16);
+    const mono = /monospace/.test(a);
+    const anchor = /text-anchor="(\w+)"/.exec(a)?.[1] ?? "start";
+    const w = content.length * size * (mono ? 0.62 : 0.55);
+    const x = +gx[1], y = +gy[1];
+    const x0 = anchor === "middle" ? x - w / 2 : anchor === "end" ? x - w : x;
+    texts.push({ content, x0, x1: x0 + w, yTop: y - size, yBot: y + size * 0.25, size });
+  }
+  for (const t of texts) {
+    if (t.x0 < 8 || t.x1 > W - 8)
+      fails.push(`${p}: texto estoura o canvas: "${t.content}" [${t.x0.toFixed(0)}..${t.x1.toFixed(0)}] vs [8..${W - 8}]`);
+  }
+  const rects = [...src.matchAll(/<rect\b[^>]*\bfill="none"[^>]*>/g)].map(r => {
+    const g = k => +(new RegExp(`\\b${k}="(-?[\\d.]+)"`).exec(r[0])?.[1] ?? NaN);
+    return { x: g("x"), y: g("y"), w: g("width"), h: g("height") };
+  }).filter(r => !Number.isNaN(r.x) && r.w >= 48 && r.h >= 32);
+  const PAD = 8;
+  for (const t of texts) for (const r of rects) {
+    const cy = (t.yTop + t.yBot) / 2;
+    if (cy < r.y || cy > r.y + r.h) continue;
+    const overlap = Math.min(t.x1, r.x + r.w) - Math.max(t.x0, r.x);
+    if (overlap <= 0) continue;
+    const inside = t.x0 >= r.x && t.x1 <= r.x + r.w;
+    if (!inside)
+      fails.push(`${p}: texto atravessa moldura: "${t.content}" [${t.x0.toFixed(0)}..${t.x1.toFixed(0)}] vs caixa [${r.x}..${r.x + r.w}]`);
+    else if (t.x0 - r.x < PAD || r.x + r.w - t.x1 < PAD)
+      fails.push(`${p}: padding < ${PAD}px na caixa: "${t.content}" (folgas ${(t.x0 - r.x).toFixed(0)}/${(r.x + r.w - t.x1).toFixed(0)})`);
+  }
+  for (let i = 0; i < texts.length; i++) for (let j = i + 1; j < texts.length; j++) {
+    const a = texts[i], b = texts[j];
+    const vOver = Math.min(a.yBot, b.yBot) - Math.max(a.yTop, b.yTop);
+    const hOver = Math.min(a.x1, b.x1) - Math.max(a.x0, b.x0);
+    if (vOver > Math.min(a.size, b.size) * 0.5 && hOver > 4)
+      fails.push(`${p}: colisão de textos: "${a.content}" × "${b.content}" (sobrepõem ${hOver.toFixed(0)}px)`);
+  }
+}
+if (fails.length) { console.error("GATE FAIL:\n" + fails.join("\n")); process.exit(1); }
+console.log(`GATE PASS: ${SCENES.length*2} SVGs válidos, paleta travada, sem efeitos.`);


### PR DESCRIPTION
Each hard-to-believe claim in the README now carries a diagram beside the paragraph that makes it: two-phase transplant, the conformal verdict gate, grounded memory going stale, the per-brain mailbox, presence collisions, ambient hooks at spawn, one brain per repository, and the l1ght document lane.

They are **generated**, not drawn. `tools/diagrams/build.mjs` sizes every box from the text it carries (monospace advance is exact), places each label in a gutter measured to hold it, and emits the dark and light variants from a single geometry pass; `tools/diagrams/validate.mjs` gates palette, grid, `<title>`/`<desc>`, effects, file size and typography (text inside the canvas, never crossing a frame, 8px minimum padding, no label collisions). The hand-written first pass had 81 typography violations across the set; the generator cannot express them.

Themes are served with `<picture>` + `prefers-color-scheme`, and the i18n post-processing step now rewrites `srcset` paths too, so the translated READMEs under `i18n/` resolve the assets correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)