### PR TITLE
release: prepare v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
+## [1.6.1] — 2026-07-30
+
+1.6.0 was tagged but never published: its macOS binaries could not launch, and the
+installed-artifact gate refused to let them through. This release is that fix, and it
+carries everything 1.6.0 contained.
+
 ### Fixed
 
 - **The macOS binaries run again.** The 1.6.0 release signed them with the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-core"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "axum",
  "clap",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-runnerd"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "axum",
  "clap",

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -43,7 +43,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.6.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.1" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -28,8 +28,8 @@ embed = ["m1nd-core/embed"]
 
 [dependencies]
 m1nd-control = { path = "../m1nd-control", version = "0.2.0" }
-m1nd-core = { path = "../m1nd-core", version = "1.6.0" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.0" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.1" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/m1nd-runnerd/Cargo.toml
+++ b/m1nd-runnerd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-runnerd"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "The m1nd runner daemon (F2.5c): the ONLY spawner. Executes pinned spawn missions in an isolated git worktree, runs the gate, and emits mission letters on the chain — never `landed`."
 license = "MIT"
@@ -12,7 +12,7 @@ publish = false
 # side record (§1f) + the shared-secret filename — `default-features = false` keeps
 # axum/reqwest/embed OUT of this dependency edge (we bring our own below); the
 # runnerd is a CLIENT of the owner's contract, so the wire types must be the owner's.
-m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.0", default-features = false }
+m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.1", default-features = false }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",


### PR DESCRIPTION
1.6.0 was tagged but never published: its macOS binaries claimed a restricted entitlement, the kernel killed them at launch, and the installed-artifact smoke refused to let them through. #508 fixed the signing; this is the version bump that lets it ship.

Bumps core / ingest / mcp / runnerd to 1.6.1 with their cross-crate pins, refreshes the lockfile for exactly those four, and moves the npm package. m1nd-control stays at 0.2.0 — it is unchanged since the 1.6.0 preparation and a bump without a change would be noise in the registry.

The changelog folds the macOS fix into a [1.6.1] section that states plainly why 1.6.0 has no published artifacts.