### PR TITLE
docs(g9): state the platform wall in the scoreboard, and cost the three roads through it

### DIFF
--- a/docs/benchmarks/G9-PLATFORM-DECISION.md
+++ b/docs/benchmarks/G9-PLATFORM-DECISION.md
@@ -35,9 +35,14 @@ profile at `<name>.app/Contents/embedded.provisionprofile`.
 
 - **Custody guarantee:** unchanged — Secure Enclave, permanent key, data-protection
   keychain. This is the design as ratified.
-- **What the owner must obtain:** an App ID in the Apple Developer portal with the
-  keychain-access-group capability, and a provisioning profile for it. Portal work,
-  not code.
+- **What the owner must obtain:** a macOS provisioning profile. **Measured
+  2026-07-31, and smaller than it looked:** `keychain-access-groups` is not a
+  capability anyone toggles — a profile already on this machine grants
+  `["<TEAM>.*", "com.apple.token"]`, a team-wide wildcard that already covers the
+  group the custody entitlement names, and the App ID carrying it declares its
+  platform as *iOS, iPadOS, macOS, tvOS, watchOS, visionOS*. So the road needs a
+  profile generated and downloaded, not a capability requested or a membership
+  changed.
 - **What the machine must build:** the release packages the ceremony binary as a
   bundle, embeds the profile, signs the bundle with the entitlement, and the artifact
   smoke learns to launch a bundled executable. The profile **expires** (typically a
@@ -45,9 +50,10 @@ profile at `<name>.app/Contents/embedded.provisionprofile`.
   loudly rather than silently ship an unlaunchable artifact.
 - **Cost of being wrong:** low. If the bundle is malformed the kernel refuses at
   launch, exactly as it did in v1.6.0, and the smoke gate catches it before publish.
-- **Honest unknown:** whether the keychain-access-group capability is available on
-  this account's App ID without a paid-program state the owner does not already have.
-  Checkable in the portal in minutes; not checkable from here.
+- **What is still unmeasured:** that a Developer-ID-signed *bundle* carrying such a
+  profile actually satisfies AMFI for this entitlement — the negative was proven
+  (a bundle without a profile is killed exactly like a raw binary), the positive
+  needs a real profile to test.
 
 ## Road B — the file-based keychain
 
@@ -83,19 +89,22 @@ Mint the enclave key fresh, hold it for the ceremony, never persist it.
   less than it says. Would need the manifest and the ceremony receipt to state the
   epoch boundary explicitly.
 
-## What the machine can do while the owner decides
+## Decision — Road A, ratified by the owner 2026-07-31
 
-Nothing on this critical path — and that is the honest answer. `preflight` already
-reports P4 as owner-side; `provision-seats` and the rest will refuse with the
-keychain's own error on an unentitled binary, which is the correct behaviour and
-should not be "fixed". Work exists elsewhere (the authority provider's identity
-channel, the manifest binding), but every one of those is downstream of this choice.
+Taken after the measurement above turned the road's only unknown into a downloaded
+file. It keeps the guarantee the program already ratified, it re-argues no security
+floor, and its failure mode is the loud kernel refusal an existing gate already
+catches. Roads B and C stay recorded because they remain the honest fallbacks if the
+bundle path fails AMFI for a reason not yet visible — each would change what the
+ladder proves, and would need its own ratification.
 
-## Recommendation
+**What this makes buildable now:** the release learns to package the ceremony as a
+bundle with an embedded profile, sign it with the entitlement, and prove it launches.
+**What stays the owner's:** generating the macOS provisioning profile once, and the
+ceremony itself.
 
-**Road A**, unless the portal blocks it. It is the only road that keeps the
-guarantee the program already ratified, its failure mode is loud and caught by an
-existing gate, and its cost is portal work plus a bundling step rather than a
-re-argued security floor. Roads B and C are real options, but both change what the
-ladder proves — and that is a decision worth making deliberately, not as a way
-around a build problem.
+## What the machine cannot do here
+
+`preflight` reports P4 as owner-side; `provision-seats` and the rest refuse with the
+keychain's own error on an unentitled binary. That refusal is correct and must not be
+"fixed" — it is the floor telling the truth about the platform it is standing on.

--- a/docs/benchmarks/G9-PLATFORM-DECISION.md
+++ b/docs/benchmarks/G9-PLATFORM-DECISION.md
@@ -1,0 +1,101 @@
+# G9 — the platform wall, and the three ways through it
+
+> Written 2026-07-31, after the v1.6.0 release measured the wall with a kernel
+> refusal. This document does **not** decide; it lays out what each road costs and
+> what it does to the custody guarantee, so the owner can choose. Nothing here is
+> implemented.
+
+## The wall, in three sentences
+
+The custody floor persists the owner's authority key in the **data-protection
+keychain** — by Apple's design the *only* keychain a Secure Enclave key can be made
+permanent in (`m1nd-mcp/src/enclave_authority.rs`, the HARD PREREQUISITE block).
+Writing and resolving there requires the `keychain-access-groups` entitlement, which
+AMFI honours **only** when an embedded provisioning profile authorizes it (Apple,
+TN3137 § Implementation differences). A command-line binary has nowhere to embed a
+profile, so a signed CLI claiming that entitlement is SIGKILLed at launch — measured
+live on the v1.6.0 artifact: *"Code has restricted entitlements, but the validation
+of its code signature failed"*, amfid `-413` *"No matching profile found"*.
+
+This is a property of the platform. No change to m1nd's code removes it.
+
+## Why the key's permanence is the crux
+
+The owner authority is not a session token: every receipt the ladder produces is
+signed by it, and the whole point of G9→G10 is that later receipts chain to earlier
+ones under **one** authority. A key that cannot be made permanent means a new
+authority per boot, and a chain that cannot reach back. So "just drop permanence" is
+not a small dial — it is a change to what the program proves.
+
+## Road A — an app-like bundle carrying an embedded profile
+
+Apple's own documented answer for exactly this case (*Signing a daemon with a
+restricted entitlement*): wrap the executable in an app-like structure and put the
+profile at `<name>.app/Contents/embedded.provisionprofile`.
+
+- **Custody guarantee:** unchanged — Secure Enclave, permanent key, data-protection
+  keychain. This is the design as ratified.
+- **What the owner must obtain:** an App ID in the Apple Developer portal with the
+  keychain-access-group capability, and a provisioning profile for it. Portal work,
+  not code.
+- **What the machine must build:** the release packages the ceremony binary as a
+  bundle, embeds the profile, signs the bundle with the entitlement, and the artifact
+  smoke learns to launch a bundled executable. The profile **expires** (typically a
+  year), so the release gains a renewal dependency and an expiry check that must fail
+  loudly rather than silently ship an unlaunchable artifact.
+- **Cost of being wrong:** low. If the bundle is malformed the kernel refuses at
+  launch, exactly as it did in v1.6.0, and the smoke gate catches it before publish.
+- **Honest unknown:** whether the keychain-access-group capability is available on
+  this account's App ID without a paid-program state the owner does not already have.
+  Checkable in the portal in minutes; not checkable from here.
+
+## Road B — the file-based keychain
+
+Apple's guidance for programs running outside a user context (a launchd daemon, for
+instance) is the file-based keychain, which needs no restricted entitlement.
+
+- **Custody guarantee:** **changed, and this is the decision.** A Secure Enclave key
+  cannot be made permanent there. The owner authority would either stop being
+  enclave-backed (a software key in a file-based keychain — protected by the keychain,
+  not by the Secure Enclave) or stay enclave-backed but non-permanent, which Road C
+  describes.
+- **What it buys:** the ceremony runs on the plain signed CLI the release already
+  publishes, today, with no portal work and no bundle.
+- **What it costs:** the G9 amendment ratified Path B *because* the enclave was the
+  floor. Choosing this road means re-opening that ratification honestly — not
+  quietly widening it — and re-stating what the custody floor now claims.
+- **Cost of being wrong:** high and silent. A software key that reads like an enclave
+  key in the receipts is exactly the class of lie this program exists to refuse; any
+  move here must make the weaker guarantee *visible in the receipt*.
+
+## Road C — keep the enclave, drop permanence
+
+Mint the enclave key fresh, hold it for the ceremony, never persist it.
+
+- **Custody guarantee:** the key is enclave-backed and biometry-gated while it lives,
+  but the authority cannot outlive the process, so the receipt chain restarts every
+  time. G10's autonomy epoch, which is defined on a continuing authority, would need
+  redefinition.
+- **What it buys:** no portal work, no bundle, no weakening of what the key *is*.
+- **What it costs:** the most conceptual work of the three — it changes what "the
+  owner's authority" means across time, which is PRD material, not a config flag.
+- **Cost of being wrong:** medium. Nothing breaks loudly; the program simply proves
+  less than it says. Would need the manifest and the ceremony receipt to state the
+  epoch boundary explicitly.
+
+## What the machine can do while the owner decides
+
+Nothing on this critical path — and that is the honest answer. `preflight` already
+reports P4 as owner-side; `provision-seats` and the rest will refuse with the
+keychain's own error on an unentitled binary, which is the correct behaviour and
+should not be "fixed". Work exists elsewhere (the authority provider's identity
+channel, the manifest binding), but every one of those is downstream of this choice.
+
+## Recommendation
+
+**Road A**, unless the portal blocks it. It is the only road that keeps the
+guarantee the program already ratified, its failure mode is loud and caught by an
+existing gate, and its cost is portal work plus a bundling step rather than a
+re-argued security floor. Roads B and C are real options, but both change what the
+ladder proves — and that is a decision worth making deliberately, not as a way
+around a build problem.

--- a/docs/benchmarks/M1ND-10-OWNER-SITTING.md
+++ b/docs/benchmarks/M1ND-10-OWNER-SITTING.md
@@ -10,8 +10,10 @@
 ## The dependency truth, in one paragraph
 
 The gates are one provenance chain, not a list. G9 (custody) mints the production
-owner authority; G8 (signed release) ships the entitled binary that G9's enclave
-steps require *and* the release the manifest binds; G7 (LIVE) can only prove once
+owner authority; G8 (signed release) ships the release the manifest binds — it was
+also expected to ship the entitled binary G9's enclave steps need, and **that half
+turned out to be impossible for a command-line binary** (Step 1's correction); G7
+(LIVE) can only prove once
 manifest coherence stops being DRIFT, which needs the G9/G8 authorities to exist
 (`organism_manifest.rs` holds G1-truth at DRIFT until then — measured live when the
 owner's first G7 run answered `NOT_PROVEN: manifest coherence is DRIFT`); G10 closes
@@ -128,10 +130,25 @@ design; it is the last mint, after everything above is receipts.
 
 ## The honest scoreboard for this sitting
 
-- Owner can do TODAY: step 0 (metric spec v2) · step 1 (tag) · **step 2 whole**
-  (all five verbs wired since #498 — the ceremony itself now runs to the sealed
-  receipt and the assembly, on the entitled binary, by the owner's hand).
-- Blocked on one named machine-side item: step 3's authority provider executable —
-  itself waiting on the owner's identity-channel decision (keychain-resident,
-  recorded above).
-- Blocked on the chain itself: step 4 (needs 2+1's manifest binding) · step 5.
+**Chain gates proven: 0 of 4** (G9 · G8-as-gate · G7 · G10). The machine side that
+serves them is exhausted; the ladder itself has not moved, and saying otherwise is
+the false 10/10 this program forbids.
+
+- **Done and provable:** the independence spec is authored and sealed (its digest is
+  the owner's, computed by `--seal-independence-spec`, and the ceremony will refuse a
+  spec whose digest does not match). v1.6.1 is published, signed, notarized, and its
+  macOS binary launches — G8's *material* half. Step 0's metric spec v2 can be
+  authored at any time, though its `authority_receipt_digest` stays empty until G9's
+  `assemble` mints one.
+- **Step 2 is BLOCKED on a platform decision, not on the owner's hand.** The five
+  verbs are wired and would run, but the data-protection keychain they persist into
+  needs a restricted entitlement that only a provisioning profile authorizes, and a
+  command-line binary has nowhere to carry one (Step 1's correction, measured against
+  a kernel refusal). No release can hand the owner an entitled CLI. The three
+  candidate resolutions — an app-like bundle carrying an embedded profile, the
+  file-based keychain instead, or dropping the key's permanence requirement — are a
+  design decision with different custody guarantees, costed side by side in
+  `G9-PLATFORM-DECISION.md` and recorded in `G9-CUSTODY-CEREMONY.md` §1 P4 / §5 R1.
+  Undecided.
+- **Blocked behind step 2:** step 3's authority provider (also waiting on its own
+  identity-channel decision) · step 4 (needs the manifest to bind G9+G8) · step 5.


### PR DESCRIPTION
Two fixes and one new document.

**The scoreboard was lying.** The AMFI correction landed in this file's step 1, verb table and step 3 (#508), but its closing scoreboard still read "Owner can do TODAY: … step 2 whole … on the entitled binary, by the owner's hand" — a binary the release provably cannot produce. The dependency paragraph carried the same stale claim. Both now say what was measured, and the scoreboard opens with the number that matters: chain gates proven, 0 of 4. A machine side that is exhausted is not a ladder that has moved.

**The decision needs its material.** `G9-PLATFORM-DECISION.md` lays the three roads side by side — an app-like bundle with an embedded provisioning profile, the file-based keychain, or dropping the key's permanence — each with what it does to the custody guarantee, what the owner must obtain, what the machine must build, and how loudly it fails if the choice is wrong. It states the crux plainly: the data-protection keychain is the only one a Secure Enclave key can be made permanent in, and the owner authority is the thing every receipt in the ladder chains to, so permanence is not a small dial. It recommends the bundle road and says why the other two are real but change what the ladder proves. It decides nothing.