### PR TITLE
feat(release): ship the custody ceremony as a signed, entitled bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,6 +632,310 @@ jobs:
             || { echo "signed binary does not carry a Developer ID authority" >&2; exit 1; }
           security delete-keychain "$KEYCHAIN" || true
           echo "macOS runtime signed + notarized"
+      # The SECOND macOS artifact, and the only one allowed to carry the custody
+      # entitlement. The ordinary runtime above stays unentitled forever: AMFI
+      # SIGKILLs a raw executable that claims a restricted entitlement, which is
+      # what killed v1.6.0. Apple's own answer for exactly this case (Signing a
+      # daemon with a restricted entitlement) is an app-like bundle with the
+      # authorizing profile at Contents/embedded.provisionprofile — the road the
+      # owner ratified, docs/benchmarks/G9-PLATFORM-DECISION.md.
+      #
+      # The two artifacts are checked against OPPOSITE contracts and neither
+      # refusal is relaxed for the other: the runtime for the ABSENCE of a
+      # restricted entitlement plus a launch, this bundle for its PRESENCE plus a
+      # launch. The bundle is built from the bytes the build step already
+      # produced — copied, never rebuilt — and it is deliberately outside the
+      # signed candidate/release file set, the same posture the verified-updater
+      # receipts hold: the ordinary download is untouched by it.
+      #
+      # The profile is an owner input, not a repo file. It is generated once in
+      # the Apple Developer portal and held in APPLE_CUSTODY_PROFILE_BASE64; with
+      # that secret absent this step SKIPS LOUDLY and publishes nothing, because
+      # a bundle without a profile is killed exactly like the raw binary was and
+      # a silently-unentitled "ceremony" artifact is worse than no artifact.
+      - name: Package, sign, and prove the entitled custody-ceremony bundle
+        id: custody-bundle
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          APPLE_CUSTODY_PROFILE_BASE64: ${{ secrets.APPLE_CUSTODY_PROFILE_BASE64 }}
+          BIN_PATH: target/${{ matrix.target }}/release/m1nd-mcp
+          ENTITLEMENTS: build/m1nd-mcp.entitlements.plist
+          APP_BUNDLE: ${{ runner.temp }}/m1nd-custody-ceremony.app
+          PROFILE: ${{ runner.temp }}/custody.provisionprofile
+          PROFILE_PLIST: ${{ runner.temp }}/custody-profile.plist
+          MATRIX_ARTIFACT: ${{ matrix.artifact }}
+          RELEASE_VERSION: ${{ needs.tag-guard.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_CUSTODY_PROFILE_BASE64:-}" ] \
+            || [ -z "${APPLE_CERT_P12_BASE64:-}" ] \
+            || [ -z "${APPLE_API_KEY_P8_BASE64:-}" ]; then
+            echo "::warning title=No custody-ceremony bundle::APPLE_CUSTODY_PROFILE_BASE64 or the Apple signing secrets are absent — this release publishes NO entitled ceremony artifact. The ordinary m1nd-mcp runtime is unaffected and stays unentitled; G9 prerequisite P4 stays unsatisfied (docs/benchmarks/G9-CUSTODY-CEREMONY.md §1 P4)."
+            exit 0
+          fi
+
+          # 1) the owner's profile, decoded to its plist so it can be READ before
+          #    anything is built, signed or published
+          printf '%s' "$APPLE_CUSTODY_PROFILE_BASE64" | base64 --decode > "$PROFILE"
+          security cms -D -i "$PROFILE" > "$PROFILE_PLIST"
+
+          # 2) refuse every profile that would produce a bundle the kernel kills,
+          #    and derive the bundle identity FROM the entitlement instead of
+          #    guessing it. Each refusal names what it read.
+          rm -rf "$APP_BUNDLE"
+          python3 - <<'PY'
+          import os
+          import plistlib
+          import re
+          from datetime import datetime, timedelta, timezone
+          from pathlib import Path
+
+          # The margin is a refusal to ship an artifact that is already
+          # effectively dead — not a promise about its shelf life. An embedded
+          # profile expires (Apple issues them for about a year) and the bundle
+          # stops launching the moment it does, so the artifact is only good
+          # until the date this step prints. Thirty days is the window in which
+          # the owner can notice, regenerate and re-tag without the ceremony
+          # surface ever being unavailable.
+          MARGIN_DAYS = 30
+
+          temp = Path(os.environ["RUNNER_TEMP"])
+          entitlements = plistlib.loads(Path(os.environ["ENTITLEMENTS"]).read_bytes())
+          groups = entitlements.get("keychain-access-groups") or []
+          if len(groups) != 1:
+              raise SystemExit(
+                  "the custody entitlement must declare exactly one keychain access "
+                  f"group; it declares {len(groups)}"
+              )
+          group = groups[0]
+          team, _, bundle_id = group.partition(".")
+          if not re.fullmatch(r"[A-Z0-9]{10}", team) or not re.fullmatch(
+              r"[A-Za-z0-9][A-Za-z0-9.-]*", bundle_id
+          ):
+              raise SystemExit(
+                  f"the keychain access group {group!r} is not <TEAM>.<bundle-id>, so no "
+                  "bundle identifier can be derived from it"
+              )
+
+          # The bundle identifier IS the access group's own suffix. That is not a
+          # convention: a program's default data-protection keychain access group
+          # is its application-identifier, so a bundle identified this way asks
+          # for exactly the group the entitlement grants, and the App ID the
+          # owner's profile must cover is <TEAM>.<bundle-id> by construction.
+          # Regenerate the profile for a different App ID and this step refuses
+          # rather than shipping a bundle the kernel will kill.
+          profile = plistlib.loads(Path(os.environ["PROFILE_PLIST"]).read_bytes())
+
+          expires = profile.get("ExpirationDate")
+          if not isinstance(expires, datetime):
+              raise SystemExit("the custody provisioning profile carries no ExpirationDate")
+          if expires.tzinfo is None:
+              expires = expires.replace(tzinfo=timezone.utc)
+          remaining = expires - datetime.now(timezone.utc)
+          if remaining < timedelta(days=MARGIN_DAYS):
+              raise SystemExit(
+                  f"the custody provisioning profile expires {expires.isoformat()} "
+                  f"({remaining.days} days from now) and the release refuses under "
+                  f"{MARGIN_DAYS} days: the bundle stops launching when the profile "
+                  "does. Generate a fresh profile, update the secret, re-tag."
+              )
+
+          if profile.get("ProvisionedDevices"):
+              raise SystemExit(
+                  "the custody provisioning profile is device-scoped (ProvisionedDevices) "
+                  "— a development profile authorizes only enrolled Macs, and this bundle "
+                  "is signed and launch-proven on a CI runner that is not one of them. "
+                  "Generate the macOS Developer ID profile instead."
+              )
+
+          platforms = profile.get("Platform") or []
+          if platforms and not {"OSX", "macOS"}.intersection(platforms):
+              raise SystemExit(
+                  f"the custody provisioning profile declares platforms {platforms!r}; "
+                  "the ceremony bundle is macOS"
+              )
+
+          def covers(granted: str, wanted: str) -> bool:
+              if granted.endswith("*"):
+                  return wanted.startswith(granted[:-1])
+              return granted == wanted
+
+          granted = profile.get("Entitlements") or {}
+          profile_team = granted.get("com.apple.developer.team-identifier")
+          if profile_team is None:
+              profile_team = (profile.get("TeamIdentifier") or [None])[0]
+          if profile_team != team:
+              raise SystemExit(
+                  "the custody provisioning profile belongs to a different team than the "
+                  "entitlement's access group; the profile and build/m1nd-mcp.entitlements.plist "
+                  "must name the same team"
+              )
+
+          granted_groups = granted.get("keychain-access-groups") or []
+          if not any(covers(value, group) for value in granted_groups):
+              raise SystemExit(
+                  f"the custody provisioning profile does not authorize the access group "
+                  f"{group!r}; without that authorization AMFI kills the bundle exactly as "
+                  "it killed the raw v1.6.0 binary"
+              )
+
+          app_id = granted.get("application-identifier") or granted.get(
+              "com.apple.application-identifier"
+          )
+          if app_id is None:
+              raise SystemExit(
+                  "the custody provisioning profile grants no application-identifier"
+              )
+          if not covers(app_id, f"{team}.{bundle_id}"):
+              raise SystemExit(
+                  f"the custody provisioning profile is issued for App ID {app_id!r}, which "
+                  f"does not cover the bundle identifier {bundle_id!r} derived from the "
+                  "entitlement's access group. Regenerate the profile for that App ID, or "
+                  "move the access group in build/m1nd-mcp.entitlements.plist — they travel "
+                  "together."
+              )
+
+          app = Path(os.environ["APP_BUNDLE"])
+          (app / "Contents" / "MacOS").mkdir(parents=True)
+          release_version = os.environ["RELEASE_VERSION"]
+          numeric = re.match(r"\d+(?:\.\d+){0,2}", release_version)
+          if numeric is None:
+              raise SystemExit(f"release version {release_version!r} has no numeric prefix")
+          plistlib.dump(
+              {
+                  "CFBundleExecutable": os.environ["BINARY_NAME"],
+                  "CFBundleIdentifier": bundle_id,
+                  "CFBundleInfoDictionaryVersion": "6.0",
+                  "CFBundleName": app.stem,
+                  "CFBundlePackageType": "APPL",
+                  "CFBundleShortVersionString": numeric.group(0),
+                  "CFBundleVersion": numeric.group(0),
+              },
+              (app / "Contents" / "Info.plist").open("wb"),
+          )
+          (temp / "custody-bundle-id").write_text(bundle_id, encoding="utf-8")
+          (temp / "custody-access-group").write_text(group, encoding="utf-8")
+          (temp / "custody-profile-expiry").write_text(
+              expires.isoformat(), encoding="utf-8"
+          )
+          PY
+
+          BUNDLE_ID="$(cat "$RUNNER_TEMP/custody-bundle-id")"
+          CUSTODY_GROUP="$(cat "$RUNNER_TEMP/custody-access-group")"
+          PROFILE_EXPIRES="$(cat "$RUNNER_TEMP/custody-profile-expiry")"
+
+          # 3) the bundle: the SAME bytes the build produced, plus the profile in
+          #    the one place AMFI reads it
+          cp "$BIN_PATH" "$APP_BUNDLE/Contents/MacOS/$BINARY_NAME"
+          cp "$PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"
+          rm -f "$PROFILE" "$PROFILE_PLIST"
+
+          # 4) ephemeral keychain holding only the Developer ID certificate
+          KEYCHAIN="$RUNNER_TEMP/m1nd-custody-signing.keychain-db"
+          KEYCHAIN_PASS="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          printf '%s' "$APPLE_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/custody-cert.p12"
+          security import "$RUNNER_TEMP/custody-cert.p12" -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN" >/dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$RUNNER_TEMP/custody-cert.p12"
+
+          # 5) sign the bundle WITH the entitlement — the inverse of the runtime
+          #    above, and legal only because the profile inside authorizes it
+          codesign --force --timestamp --options runtime \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$APPLE_SIGNING_IDENTITY" "$APP_BUNDLE"
+          codesign --verify --strict --verbose=2 "$APP_BUNDLE"
+          if ! codesign -d --entitlements - "$APP_BUNDLE" 2>/dev/null | grep -qF "$CUSTODY_GROUP"; then
+            echo "::error::the ceremony bundle does not carry the custody access group — an unentitled bundle cannot run the G9 ceremony and must never be published as one"
+            exit 1
+          fi
+          SIGNATURE="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1)"
+          case "$SIGNATURE" in
+            *"Authority=Developer ID Application"*) ;;
+            *) echo "::error::the ceremony bundle does not carry a Developer ID authority"; exit 1 ;;
+          esac
+          case "$SIGNATURE" in
+            *"Identifier=$BUNDLE_ID"*) ;;
+            *) echo "::error::codesign recorded an identifier other than $BUNDLE_ID — the signed identity must equal the identifier the profile covers"; exit 1 ;;
+          esac
+
+          # 6) prove it LAUNCHES, on the native runner, after signing. This is the
+          #    whole lesson of v1.6.0: a signature that verifies is not a binary
+          #    that runs, and AMFI's verdict on a restricted entitlement is only
+          #    observable at launch.
+          BUNDLED_EXE="$APP_BUNDLE/Contents/MacOS/$BINARY_NAME"
+          VERSION_OUTPUT="$("$BUNDLED_EXE" --version)" || {
+            echo "::error::the signed ceremony bundle does not launch — AMFI refused the restricted entitlement. Read the kernel log: the usual causes are a profile that does not authorize the access group and a profile issued for another App ID."
+            exit 1
+          }
+          case "$VERSION_OUTPUT" in
+            *"$RELEASE_VERSION"*) ;;
+            *) echo "::error::the bundled executable reports '$VERSION_OUTPUT', not release $RELEASE_VERSION"; exit 1 ;;
+          esac
+
+          # 7) notarize and STAPLE — a bundle can hold the ticket a raw binary
+          #    cannot, so the owner's Mac needs no online check to launch it
+          printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/CustodyAuthKey.p8"
+          ditto -c -k --keepParent "$APP_BUNDLE" "$RUNNER_TEMP/custody-notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/custody-notarize.zip" \
+            --key "$RUNNER_TEMP/CustodyAuthKey.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait --timeout 30m
+          rm -f "$RUNNER_TEMP/CustodyAuthKey.p8" "$RUNNER_TEMP/custody-notarize.zip"
+          xcrun stapler staple "$APP_BUNDLE"
+          xcrun stapler validate "$APP_BUNDLE"
+          codesign --verify --strict --verbose=2 "$APP_BUNDLE"
+
+          # 8) package with ditto (the only container that preserves a bundle's
+          #    permissions, symlinks and signature) and prove the round trip:
+          #    what the owner unzips is what was signed, and it still launches
+          BUNDLE_ZIP="m1nd-custody-ceremony-${MATRIX_ARTIFACT#m1nd-mcp-}.zip"
+          ditto -c -k --keepParent --sequesterRsrc "$APP_BUNDLE" "$BUNDLE_ZIP"
+          ROUND_TRIP="$RUNNER_TEMP/custody-round-trip"
+          rm -rf "$ROUND_TRIP"
+          mkdir -p "$ROUND_TRIP"
+          ditto -x -k "$BUNDLE_ZIP" "$ROUND_TRIP"
+          UNPACKED="$ROUND_TRIP/$(basename "$APP_BUNDLE")"
+          codesign --verify --strict --verbose=2 "$UNPACKED"
+          "$UNPACKED/Contents/MacOS/$BINARY_NAME" --version >/dev/null \
+            || { echo "::error::the packaged ceremony bundle does not launch after a round trip"; exit 1; }
+          rm -rf "$ROUND_TRIP"
+          security delete-keychain "$KEYCHAIN" || true
+
+          # 9) the ordinary runtime must be exactly as the step above left it —
+          #    the two artifacts share bytes on disk and nothing else
+          if codesign -d --entitlements - "$BIN_PATH" 2>/dev/null \
+            | grep -qE 'keychain-access-groups|application-identifier|com\.apple\.developer\.'; then
+            echo "::error::the shipped runtime acquired a restricted entitlement while the bundle was built — it would be SIGKILLed at launch"
+            exit 1
+          fi
+          "$BIN_PATH" --version >/dev/null \
+            || { echo "::error::the shipped runtime stopped launching while the bundle was built"; exit 1; }
+
+          echo "built=true" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Custody-ceremony bundle::$BUNDLE_ZIP signed, notarized and stapled. Its embedded profile expires $PROFILE_EXPIRES — the bundle stops launching then, so re-tag before that date."
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: steps.custody-bundle.outputs.built == 'true'
+        with:
+          name: m1nd-custody-ceremony-${{ matrix.target }}
+          path: m1nd-custody-ceremony-*.zip
+          if-no-files-found: error
+          # Longer than the runtime artifacts' 14 days on purpose: this one is
+          # deliberately not promoted into the Release, so the run IS where the
+          # owner fetches it, and the ceremony is scheduled by a human.
+          retention-days: 90
       - name: Stage updater-facing Unix runtime
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -697,6 +697,13 @@ jobs:
           from datetime import datetime, timedelta, timezone
           from pathlib import Path
 
+
+          def refuse(message: str) -> None:
+              # A failed release must say why where the operator looks first.
+              print(f"::error title=Custody-ceremony bundle refused::{message}")
+              raise SystemExit(1)
+
+
           # The margin is a refusal to ship an artifact that is already
           # effectively dead — not a promise about its shelf life. An embedded
           # profile expires (Apple issues them for about a year) and the bundle
@@ -710,7 +717,7 @@ jobs:
           entitlements = plistlib.loads(Path(os.environ["ENTITLEMENTS"]).read_bytes())
           groups = entitlements.get("keychain-access-groups") or []
           if len(groups) != 1:
-              raise SystemExit(
+              refuse(
                   "the custody entitlement must declare exactly one keychain access "
                   f"group; it declares {len(groups)}"
               )
@@ -719,7 +726,7 @@ jobs:
           if not re.fullmatch(r"[A-Z0-9]{10}", team) or not re.fullmatch(
               r"[A-Za-z0-9][A-Za-z0-9.-]*", bundle_id
           ):
-              raise SystemExit(
+              refuse(
                   f"the keychain access group {group!r} is not <TEAM>.<bundle-id>, so no "
                   "bundle identifier can be derived from it"
               )
@@ -735,12 +742,12 @@ jobs:
 
           expires = profile.get("ExpirationDate")
           if not isinstance(expires, datetime):
-              raise SystemExit("the custody provisioning profile carries no ExpirationDate")
+              refuse("the custody provisioning profile carries no ExpirationDate")
           if expires.tzinfo is None:
               expires = expires.replace(tzinfo=timezone.utc)
           remaining = expires - datetime.now(timezone.utc)
           if remaining < timedelta(days=MARGIN_DAYS):
-              raise SystemExit(
+              refuse(
                   f"the custody provisioning profile expires {expires.isoformat()} "
                   f"({remaining.days} days from now) and the release refuses under "
                   f"{MARGIN_DAYS} days: the bundle stops launching when the profile "
@@ -748,7 +755,7 @@ jobs:
               )
 
           if profile.get("ProvisionedDevices"):
-              raise SystemExit(
+              refuse(
                   "the custody provisioning profile is device-scoped (ProvisionedDevices) "
                   "— a development profile authorizes only enrolled Macs, and this bundle "
                   "is signed and launch-proven on a CI runner that is not one of them. "
@@ -756,8 +763,10 @@ jobs:
               )
 
           platforms = profile.get("Platform") or []
-          if platforms and not {"OSX", "macOS"}.intersection(platforms):
-              raise SystemExit(
+          if platforms and not {"osx", "macos"}.intersection(
+              str(value).casefold() for value in platforms
+          ):
+              refuse(
                   f"the custody provisioning profile declares platforms {platforms!r}; "
                   "the ceremony bundle is macOS"
               )
@@ -772,7 +781,7 @@ jobs:
           if profile_team is None:
               profile_team = (profile.get("TeamIdentifier") or [None])[0]
           if profile_team != team:
-              raise SystemExit(
+              refuse(
                   "the custody provisioning profile belongs to a different team than the "
                   "entitlement's access group; the profile and build/m1nd-mcp.entitlements.plist "
                   "must name the same team"
@@ -780,7 +789,7 @@ jobs:
 
           granted_groups = granted.get("keychain-access-groups") or []
           if not any(covers(value, group) for value in granted_groups):
-              raise SystemExit(
+              refuse(
                   f"the custody provisioning profile does not authorize the access group "
                   f"{group!r}; without that authorization AMFI kills the bundle exactly as "
                   "it killed the raw v1.6.0 binary"
@@ -790,11 +799,11 @@ jobs:
               "com.apple.application-identifier"
           )
           if app_id is None:
-              raise SystemExit(
+              refuse(
                   "the custody provisioning profile grants no application-identifier"
               )
           if not covers(app_id, f"{team}.{bundle_id}"):
-              raise SystemExit(
+              refuse(
                   f"the custody provisioning profile is issued for App ID {app_id!r}, which "
                   f"does not cover the bundle identifier {bundle_id!r} derived from the "
                   "entitlement's access group. Regenerate the profile for that App ID, or "
@@ -807,7 +816,7 @@ jobs:
           release_version = os.environ["RELEASE_VERSION"]
           numeric = re.match(r"\d+(?:\.\d+){0,2}", release_version)
           if numeric is None:
-              raise SystemExit(f"release version {release_version!r} has no numeric prefix")
+              refuse(f"release version {release_version!r} has no numeric prefix")
           plistlib.dump(
               {
                   "CFBundleExecutable": os.environ["BINARY_NAME"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,14 @@ The four verbs now reach the real floor, which means a run on any unentitled bin
 build — refuses at the keychain naming prerequisite P4. That refusal is the correct answer and
 must never be worked around: `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §5 R1.
 
+**One artifact IS entitled, and it changes nothing above.** The release builds a second macOS
+artifact, `m1nd-custody-ceremony.app` (the same binary bytes in an app-like bundle with the owner's
+provisioning profile embedded), because a restricted entitlement on a raw executable is SIGKILLed
+by the kernel — `build/README.md`. It exists so the OWNER can run the ceremony; the four verbs stay
+the owner's on it exactly as on any other build, and `preflight` stays the only one an agent may
+run. Agents do not build it, do not sign it, and never handle the profile: it is a repository
+secret the release step reads and deletes.
+
 **`--seal-independence-spec <PATH>` is NOT one of these verbs.** It sits next to them in the CLI
 and serves the same ceremony, but it seals a DOCUMENT: it reads the owner's hand-authored
 `IndependenceSpecV1`, fills `independence_spec_digest` from the digest of that spec's own core,

--- a/build/README.md
+++ b/build/README.md
@@ -2,12 +2,14 @@
 
 ## `m1nd-mcp.entitlements.plist`
 
-**The release does NOT sign with this file, and must not. It is kept for the
-owner-side, bundled signing the G9 custody ceremony needs (prerequisite P4).**
+**The release signs exactly one artifact with this file — the custody-ceremony
+`.app` bundle — and must never sign the ordinary `m1nd-mcp` runtime with it.**
+The two artifacts carry opposite contracts, and the reason is measured, not
+reasoned; the correction below is the measurement.
 
-An earlier version of this document asserted the opposite — that threading
-`--entitlements` through `release.yml` was what made the shipped binary capable of
-the ceremony. That was wrong, and the correction below is measured, not reasoned.
+An earlier version of this document asserted that threading `--entitlements`
+through `release.yml` was what made the shipped binary capable of the ceremony.
+That was wrong.
 
 ### What was measured, 2026-07-30
 
@@ -63,17 +65,17 @@ A raw Mach-O executable has nowhere to put a profile — it lives at
 `m1nd-mcp` cannot carry this entitlement and remain runnable. Apple's own workaround
 for exactly this case is *Signing a daemon with a restricted entitlement*: wrap the
 standalone executable in an app-like structure whose profile authorizes the
-entitlement. That is a packaging and Apple-Developer-portal decision belonging to
-the owner, not a byte the release pipeline can add.
+entitlement. The packaging half of that is the release's, and is below; the
+profile half stays the owner's — nothing in this pipeline can mint one.
 
 The same technote also fixes the other half of P4: the data-protection keychain is
 "only available to programs running in a user context", so the ceremony is run by
 hand from a login session, never from a `launchd` daemon.
 
-### What the release does instead
+### Artifact 1 — the ordinary `m1nd-mcp` runtime, unentitled forever
 
-`release.yml` signs with `--options runtime --timestamp` and **no entitlements**,
-then refuses, mechanically:
+`release.yml` signs it with `--options runtime --timestamp` and **no
+entitlements**, then refuses, mechanically:
 
 1. any provisioning-profile-restricted entitlement on the signed output
    (`keychain-access-groups`, `application-identifier`, `com.apple.developer.*`) —
@@ -83,24 +85,81 @@ then refuses, mechanically:
    runner right after signing.
 
 The installed-artifact smoke is unchanged and stays exactly as strict. It is what
-caught this, and the two checks above only move the same failure earlier.
+caught this, and the two checks above only move the same failure earlier. This is
+the artifact every user downloads, and nothing about the ceremony may ever weaken
+these two refusals.
 
-### What this leaves open for G9
+### Artifact 2 — `m1nd-custody-ceremony.app`, the only entitled artifact
 
-Prerequisite P4 is now **owner-side**. The shipped binary fails closed at the
-keychain, by design and with its own name
-(`custody_ceremony_keychain_entitlement_missing`) — that is the honest answer, not
-a regression. The ceremony still needs a binary that *is* authorized, which means
-the owner signs locally against a profile, or the ceremony surface ships as a
-bundle. Recorded, undecided, in `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §1 P4 and
-§5 R1; this PR does not choose for the owner.
+Apple's own workaround for this case — *Signing a daemon with a restricted
+entitlement* — is to wrap the executable in an app-like structure whose embedded
+profile authorizes the entitlement. The owner ratified that road
+(`docs/benchmarks/G9-PLATFORM-DECISION.md`, Road A), so `release.yml` builds a
+**second** macOS artifact per target, from the **same bytes** the build step
+already produced:
+
+```
+m1nd-custody-ceremony.app/Contents/Info.plist
+m1nd-custody-ceremony.app/Contents/MacOS/m1nd-mcp
+m1nd-custody-ceremony.app/Contents/embedded.provisionprofile
+m1nd-custody-ceremony.app/Contents/_CodeSignature/CodeResources
+```
+
+signed **with** this plist, notarized, stapled, and published as
+`m1nd-custody-ceremony-macos-<arch>.zip`. It is a CI artifact of the release run
+(retained 90 days, longer than the runtime artifacts), deliberately **outside** the
+signed candidate/release file set — the same posture the verified-updater receipts
+already hold — because it exists only when the owner supplies a profile, and the
+candidate's bytes must not depend on a secret.
+
+Four properties are load-bearing:
+
+- **The profile is an owner input, never a repo file.** It lives in the repository
+  secret `APPLE_CUSTODY_PROFILE_BASE64`, is decoded to `$RUNNER_TEMP`, read, copied
+  into the bundle, and deleted, exactly as `APPLE_CERT_P12_BASE64` is handled. With
+  the secret absent the step **skips loudly** (`::warning`) and publishes nothing —
+  a bundle without a profile is SIGKILLed exactly like the raw binary was, so an
+  unentitled artifact wearing the ceremony's name would be worse than no artifact.
+- **The bundle identifier is derived, not invented.** It is the access group's own
+  suffix, because a program's default data-protection keychain access group *is*
+  its application-identifier: identified this way, the bundle asks for exactly the
+  group this plist grants. The consequence is a coupling the release enforces —
+  the profile must be issued for the App ID `<team>.<that suffix>` (a team wildcard
+  covers it), and if the owner ever regenerates the profile for a different App ID
+  the bundle identifier must move with it. The release **refuses** the mismatch
+  instead of publishing a bundle the kernel will kill.
+- **A signature that verifies is not a binary that runs.** After signing, the step
+  launches `Contents/MacOS/m1nd-mcp --version` on the native runner, checks the
+  version it prints is this release's, and repeats both after packaging and
+  unpacking. That is the check v1.6.0 did not have.
+- **The profile expires, and the bundle dies with it.** The step reads
+  `ExpirationDate` out of the profile (`security cms -D` → plist) and **fails the
+  release** when it is under **30 days** away, naming the date it read. Thirty days
+  is not a claim about the artifact's shelf life — that is the expiry itself, which
+  the run prints as a `::notice`; it is the window in which the owner can notice,
+  regenerate and re-tag without the ceremony surface ever being unavailable. Two
+  more profile shapes are refused for the same reason (a silent death later beats
+  no artifact now): a device-scoped development profile, which authorizes only
+  enrolled Macs and not the runner that must launch-prove the bundle, and a profile
+  whose platform list is not macOS.
+
+### What is still unproven
+
+That a Developer-ID-signed **bundle** with a real profile satisfies AMFI for this
+entitlement. The negative is measured — a bundle *without* a profile is killed
+exactly like the raw binary — and the positive needs a profile no agent can
+create. It is proven or disproven loudly by the launch check above, on the first
+tagged release with the secret set, before anything is published.
 
 ### This file is a custody surface
 
-It is deliberately **minimal** — one entitlement, one group, unchanged by this
-correction. Every entry widens what a signed binary may do, so adding to it is a
-**security decision**, never a build tweak. `4KLJ4N9D5K` is the Developer ID team
-the release signs with (`Developer ID Application: … (4KLJ4N9D5K)`).
+It is deliberately **minimal** — one entitlement, one group, and it is the same
+file it was before the bundle existed: the second artifact added **zero** bytes to
+it. Every entry widens what a signed binary may do, so adding to it is a
+**security decision**, never a build tweak — and it now also decides the bundle's
+identity, so an edit here moves the App ID the owner's profile must cover.
+`4KLJ4N9D5K` is the Developer ID team the release signs with
+(`Developer ID Application: … (4KLJ4N9D5K)`).
 
 ### Why the plist carries no comments
 

--- a/docs/benchmarks/G9-CUSTODY-CEREMONY.md
+++ b/docs/benchmarks/G9-CUSTODY-CEREMONY.md
@@ -44,7 +44,7 @@ prerequisite P4, which is the honest form of "this did not run".
 | P1 | Apple Silicon / T2 Mac with a Secure Enclave, owner physically present | owner's machine | — |
 | P2 | Touch ID enrolled for the owner | owner's machine | — |
 | P3 | macOS build target — the module is `#[cfg(target_os = "macos")]` and absent by construction elsewhere, so the assembly stays NOT_INSTALLED and fails closed rather than falling back to software | **satisfied** | `m1nd-mcp/src/lib.rs:36-37` |
-| P4 | Binary codesigned with a **`KeychainAccessGroups` entitlement**. Secure Enclave keys can only be made permanent in the data-protection keychain; an unsigned or unentitled binary cannot persist *or* resolve the key, so `provision`/`open`/`sign` all fail closed | **UNSATISFIED, and NOT satisfiable by the release — owner-side.** #469 threaded `--entitlements` into the signing step; the resulting v1.6.0 binary was SIGKILLed by AMFI at launch, because `keychain-access-groups` is a *restricted* entitlement and a raw executable has nowhere to embed the provisioning profile that would authorize it (measured 2026-07-30, run `30556058443`; Apple's rule: TN3137 § Implementation differences). The release now signs WITHOUT it and refuses one on the output, so **every** shipped and local build fails closed here, naming the prerequisite. Closing P4 needs an owner-side decision — a locally signed profile-authorized build, or shipping the ceremony surface as a bundle — see §5 R1 | `m1nd-mcp/src/enclave_authority.rs:1197-1222`, `:1489`, `build/README.md`, `.github/workflows/release.yml:570-617` |
+| P4 | Binary codesigned with a **`KeychainAccessGroups` entitlement**. Secure Enclave keys can only be made permanent in the data-protection keychain; an unsigned or unentitled binary cannot persist *or* resolve the key, so `provision`/`open`/`sign` all fail closed | **UNSATISFIED until the owner supplies one file — then the release ships the entitled artifact itself.** #469 threaded `--entitlements` onto the raw binary and AMFI SIGKILLed the v1.6.0 product at launch: `keychain-access-groups` is *restricted*, and a raw executable has nowhere to embed the provisioning profile that would authorize it (measured 2026-07-30, run `30556058443`; TN3137 § Implementation differences). Road A is ratified (`G9-PLATFORM-DECISION.md`), so the release now builds a **second** macOS artifact — `m1nd-custody-ceremony.app`, the same binary bytes inside an app-like bundle with the profile at `Contents/embedded.provisionprofile`, signed WITH the entitlement, notarized, stapled, and proven to launch before publication. The ordinary `m1nd-mcp` stays unentitled and keeps refusing one. **The owner's remaining act is one-time and off-machine:** generate a macOS **Developer ID** provisioning profile for the App ID whose suffix is the access group in `build/m1nd-mcp.entitlements.plist`, and paste it base64-encoded into the repository secret `APPLE_CUSTODY_PROFILE_BASE64`. Without that secret the release publishes NO ceremony artifact and says so loudly; local builds keep failing closed here, naming P4 | `m1nd-mcp/src/enclave_authority.rs:1197-1222`, `:1489`, `build/README.md`, `.github/workflows/release.yml:539-935` |
 | P5 | A `0700`, non-symlink, device/inode-pinned protected root directory for the sealed slots | code ready, root not provisioned | `SealedProtectedRootV1::open` — `m1nd-mcp/src/enclave_authority.rs:441` |
 | P6 | Custody dependency pins intact — `security-framework =3.7.0` (feature `OSX_10_15`), `security-framework-sys =2.17.0`, `core-foundation =0.10.1`. **These are custody surface; never bump them opportunistically** | **satisfied** | `m1nd-mcp/Cargo.toml:112-114` |
 | P7 | Crypto stack coherent after the RustCrypto sweep (#464) | **satisfied, measured** (see §6) | — |
@@ -58,6 +58,15 @@ Each step names what already exists (with `file:line`) and what is missing. All 
 to the repo root. `enclave_authority.rs` means `m1nd-mcp/src/enclave_authority.rs`, and
 `custody_ceremony.rs` means `m1nd-mcp/src/custody_ceremony.rs` — the door, which is where every
 WIRED line below points.
+
+**Where the owner runs these.** Not from the ordinary `m1nd-mcp` on `PATH` — that one is
+deliberately unentitled and refuses at the keychain, naming P4. The verbs are run from the
+ceremony bundle published by the release run for the tag, `m1nd-custody-ceremony-macos-<arch>.zip`,
+unzipped anywhere the owner likes:
+`m1nd-custody-ceremony.app/Contents/MacOS/m1nd-mcp --custody-ceremony <verb>`. It is the same
+executable and the same CLI — nothing about the verbs, the ingress or the refusals changes; only
+the signature around it does. Prerequisite P4 above names the one-time step that makes the release
+produce it.
 
 The ceremony reads the seats it provisions out of the owner's `IndependenceSpecV1` (P9) and never
 invents one. That is not convenience: a ceremony that fabricated its own seats would make step 6's
@@ -237,7 +246,8 @@ Two properties are worth stating because they are load-bearing rather than incid
 
 ## 5. Residual engineering, ranked by blocking-ness
 
-- **R1 (OPEN, and the release cannot close it — reopened 2026-07-30 by measurement).** The
+- **R1 (the machine half is BUILT; one owner file remains — reopened 2026-07-30 by
+  measurement, road ratified and implemented 2026-07-31).** The
   original entry said the signed release binary was structurally incapable of running this
   ceremony because `release.yml` passed no `--entitlements`. #469 added
   `build/m1nd-mcp.entitlements.plist` and threaded the flag through — and that is where the
@@ -254,17 +264,30 @@ Two properties are worth stating because they are load-bearing rather than incid
   "Code has restricted entitlements, but the validation of its code signature failed", with amfid
   reporting `-413 "No matching profile found"`. Same bytes re-signed without the entitlement run.
   A minimal `.app` wrapper without an `embedded.provisionprofile` is killed identically.
-  **So the release ships unentitled** (`.github/workflows/release.yml:570-617`: no
+  **So the ordinary runtime ships unentitled** (`.github/workflows/release.yml:539-634`: no
   `--entitlements`, a refusal if any restricted entitlement appears on the output, and a launch
-  check on the signed bytes). Every build — shipped or local — therefore refuses at P4, surfaced
-  as `custody_ceremony_keychain_entitlement_missing` rather than an opaque OSStatus, which is the
-  honest answer and not a regression.
-  **What remains open is a decision only the owner can make**, and this document does not make it:
-  the ceremony needs a binary whose entitlement *is* authorized — either the owner signs a build
-  locally against a profile he holds, or the ceremony surface ships inside an app-like bundle
-  (Apple's own workaround for this case is *Signing a daemon with a restricted entitlement*).
-  Whichever path, P4 is owner-side, and the persistence proof — a real key persisted and resolved
-  across a process restart — still happens only in the owner's run.
+  check on the signed bytes). Every raw binary — shipped or local — therefore refuses at P4,
+  surfaced as `custody_ceremony_keychain_entitlement_missing` rather than an opaque OSStatus, which
+  is the honest answer and not a regression.
+  **The decision was made and the machine half is built.** The owner ratified Road A on
+  2026-07-31 (`G9-PLATFORM-DECISION.md`): the ceremony surface ships inside an app-like bundle,
+  Apple's own workaround for this case (*Signing a daemon with a restricted entitlement*). The
+  release now produces `m1nd-custody-ceremony.app` per macOS target — the SAME binary bytes, the
+  profile at `Contents/embedded.provisionprofile`, signed WITH the entitlement, notarized,
+  stapled, launch-proven on the runner before and after packaging, and published as
+  `m1nd-custody-ceremony-macos-<arch>.zip` outside the signed candidate byte set. The ordinary
+  runtime is untouched and stays unentitled.
+  **What is left is one owner file and one owner run.** The profile cannot be minted by this
+  pipeline: the owner generates a macOS **Developer ID** provisioning profile for the App ID whose
+  suffix is the access group in `build/m1nd-mcp.entitlements.plist` and puts it, base64-encoded,
+  in the repository secret `APPLE_CUSTODY_PROFILE_BASE64`. Absent it the release publishes no
+  ceremony artifact and warns; present it, the release refuses to publish one whose profile is
+  expired (or within 30 days of it), device-scoped, non-macOS, or issued for an App ID the derived
+  bundle identifier does not match. **Still unproven, and only a tagged release can prove it:**
+  that a Developer-ID-signed bundle with a real profile satisfies AMFI for this entitlement — the
+  negative was measured (a bundle without a profile dies exactly like the raw binary), the
+  positive is decided by the launch check on the first such release. And the persistence proof — a
+  real key persisted and resolved across a process restart — still happens only in the owner's run.
 - **R2 (CLOSED).** The ceremony surface exists and all five verbs reach the floor — §4. The one
   thing no surface can supply is the owner's hand.
 - **R3 (open — blocking for the ladder, not for the ceremony).** `assemble` is now a production

--- a/docs/benchmarks/M1ND-10-OWNER-SITTING.md
+++ b/docs/benchmarks/M1ND-10-OWNER-SITTING.md
@@ -10,8 +10,9 @@
 ## The dependency truth, in one paragraph
 
 The gates are one provenance chain, not a list. G9 (custody) mints the production
-owner authority; G8 (signed release) ships the entitled binary that G9's enclave
-steps require *and* the release the manifest binds; G7 (LIVE) can only prove once
+owner authority; G8 (signed release) ships the release the manifest binds — and,
+since 2026-07-31, the entitled ceremony *bundle* G9's enclave steps require, which a
+command-line binary could never be (Step 1); G7 (LIVE) can only prove once
 manifest coherence stops being DRIFT, which needs the G9/G8 authorities to exist
 (`organism_manifest.rs` holds G1-truth at DRIFT until then — measured live when the
 owner's first G7 run answered `NOT_PROVEN: manifest coherence is DRIFT`); G10 closes
@@ -35,26 +36,58 @@ The release pipeline is ready: Developer ID signing + notarization (#433). Run
 manifest to bind this release — that binding is the same manifest work G7 waits on;
 the tag itself is not blocked.
 
-**Correction, measured 2026-07-30 — tagging does NOT produce an entitled binary,
-and cannot.** #469 signed the release with the `keychain-access-groups` entitlement;
-the v1.6.0 run then failed, because that entitlement is *restricted* and AMFI
-SIGKILLs a raw executable that claims one without an embedded provisioning profile —
-which a non-bundled binary has nowhere to hold (Apple, TN3137). The release now
-signs without it. Prerequisite **P4 is owner-side**: the G9 verbs below will refuse
-on the tagged binary, by name, until you run them on a build whose entitlement is
-authorized by a profile you hold, or the ceremony surface ships as a bundle. That
-choice is yours and undecided — `G9-CUSTODY-CEREMONY.md` §1 P4 and §5 R1 carry the
-evidence, and `build/README.md` carries the kernel log.
+**Correction, measured 2026-07-30 — the tagged `m1nd-mcp` binary is NOT entitled,
+and cannot be.** #469 signed the release with the `keychain-access-groups`
+entitlement; the v1.6.0 run then failed, because that entitlement is *restricted*
+and AMFI SIGKILLs a raw executable that claims one without an embedded provisioning
+profile — which a non-bundled binary has nowhere to hold (Apple, TN3137). The
+ordinary binary now ships unentitled and stays that way.
+
+**And the resolution, 2026-07-31 — the tag now produces a SECOND artifact that is
+entitled, once you supply one file.** Road A is ratified
+(`G9-PLATFORM-DECISION.md`) and built: the release wraps the same binary bytes in
+`m1nd-custody-ceremony.app`, embeds your provisioning profile, signs the bundle
+WITH the entitlement, notarizes, staples, proves it launches, and publishes
+`m1nd-custody-ceremony-macos-<arch>.zip` as an artifact of the release run.
+
+**Do this once, before the tag** (it is the whole of the machine's remaining ask):
+
+1. In the Apple Developer portal, generate a **macOS** provisioning profile of type
+   **Developer ID** for the App ID whose suffix is the access group named in
+   `build/m1nd-mcp.entitlements.plist` — a team wildcard App ID already covers it,
+   so this is a profile to generate and download, not a capability to request. It
+   must not be a *development* profile: those are scoped to enrolled devices, and
+   the release refuses one by name because the artifact is launch-proven on a
+   machine that is not yours.
+2. `base64 -i <the .provisionprofile>` into the repository secret
+   **`APPLE_CUSTODY_PROFILE_BASE64`**, next to the `APPLE_CERT_*` / `APPLE_API_*`
+   secrets the signing step already uses.
+3. Tag. With the secret absent the release still succeeds and simply warns that no
+   ceremony artifact was published; with it present, the release fails loudly rather
+   than publish a bundle that would not launch — including if the profile is expired
+   or within 30 days of expiring, which it prints along with the date it read.
+
+The profile expires (Apple issues them for about a year) and the bundle stops
+launching when it does — the release run prints the expiry as a notice. Re-tagging
+with a fresh profile is what renews it.
 
 ## Step 2 — the G9 custody ceremony (`G9-CUSTODY-CEREMONY.md` is the full runbook)
 
 The CLI door exists on `main` (#473): `--custody-ceremony <verb>` dispatches before
-any config loads, on a private-field ingress no agent path can construct. Verb
-state today, from `custody_ceremony.rs::run_custody_ceremony`:
+any config loads, on a private-field ingress no agent path can construct.
+
+**Run them from the ceremony bundle, not from `m1nd-mcp` on `PATH`.** Unzip the
+release run's `m1nd-custody-ceremony-macos-<arch>.zip` and drive the same CLI at
+`m1nd-custody-ceremony.app/Contents/MacOS/m1nd-mcp --custody-ceremony <verb>`. Same
+executable, same verbs, same refusals — the only difference is the signature around
+it, which is what makes the keychain answer instead of refusing. The plain binary
+still refuses at P4 by name, and that refusal is correct.
+
+Verb state today, from `custody_ceremony.rs::run_custody_ceremony`:
 
 | Verb | State today | What it does |
 |---|---|---|
-| `preflight` | **RUNS** — reports every prerequisite, exit 0 only when ready | run it first, at the protected root; on the tagged binary it will report P4 unsatisfied (see Step 1) |
+| `preflight` | **RUNS** — reports every prerequisite, exit 0 only when ready | run it first, at the protected root; its P4 line stays `UNPROVEN` on every build by construction — this report never touches the keychain, so only the next verb can tell you whether the profile really authorized the entitlement (see Step 1) |
 | `provision-seats` | **RUNS** — mints the four verifier seats + the sealing seat in the enclave-backed store, stages each record; re-provisioning refuses (`custody_ceremony_seats_already_staged`) | mint the seats; on an unentitled binary the keychain's own refusal surfaces, named |
 | `owner-seat` | **RUNS, owner-only** — mints the biometric seat with the biometry-gated access control (Touch ID fires at key USE, by the ACL); an unattended invocation is still refused *as unattended* on every platform, before the platform floor | the biometric seat — irreducibly the owner's finger |
 | `seal` | **RUNS** — only over a complete staged ceremony (4 seats + sealing seat + owner seat), binds the owner's independence spec and constitution digest, writes the sealed receipt, consumes the staging | seal seats + lineage + spec digests into the ceremony receipt |
@@ -64,9 +97,9 @@ state today, from `custody_ceremony.rs::run_custody_ceremony`:
 floor; two owner-held inputs joined the CLI (`--custody-independence-spec`,
 `--custody-constitution-digest` — the ceremony READS the owner's spec, it never
 builds one). What remains true: real execution needs the owner, the Mac, and an
-entitled binary that **the release cannot produce** (Step 1's correction) — every
-missing precondition refuses closed with its own name, and no agent path can perform
-any of it.
+entitled artifact — which the release **now produces**, as the ceremony bundle, once
+the profile secret is set (Step 1). Every missing precondition still refuses closed
+with its own name, and no agent path can perform any of it.
 
 **Before the first verb, seal the spec (P9).** The independence spec is written by
 hand, and every custody verb refuses one whose declared digest is not the digest of
@@ -128,10 +161,23 @@ design; it is the last mint, after everything above is receipts.
 
 ## The honest scoreboard for this sitting
 
-- Owner can do TODAY: step 0 (metric spec v2) · step 1 (tag) · **step 2 whole**
-  (all five verbs wired since #498 — the ceremony itself now runs to the sealed
-  receipt and the assembly, on the entitled binary, by the owner's hand).
-- Blocked on one named machine-side item: step 3's authority provider executable —
-  itself waiting on the owner's identity-channel decision (keychain-resident,
-  recorded above).
-- Blocked on the chain itself: step 4 (needs 2+1's manifest binding) · step 5.
+**Chain gates proven: 0 of 4** (G9 · G8-as-gate · G7 · G10). No ceremony has run;
+nothing below moves that number.
+
+- **Done and provable:** v1.6.1 is published, signed, notarized, and its macOS
+  binary launches — G8's *material* half. Step 0's metric spec v2 can be authored at
+  any time, though its `authority_receipt_digest` stays empty until G9's `assemble`
+  mints one.
+- **Step 2 is no longer platform-blocked; it is waiting on one owner file.** The
+  wall was real — a restricted entitlement on a command-line binary is SIGKILLed by
+  the kernel — and Road A went through it: the release builds and proves the entitled
+  ceremony bundle, and the ordinary binary stays unentitled. What the machine cannot
+  do is mint the profile that authorizes it. Generate the macOS Developer ID profile,
+  set `APPLE_CUSTODY_PROFILE_BASE64`, tag: the run either publishes a launch-proven
+  ceremony bundle or fails saying exactly why. Then step 2 is five verbs and your
+  hand.
+- **Unproven until that tag:** that a Developer-ID-signed bundle with a real profile
+  satisfies AMFI for this entitlement. Only the negative is measured today. The
+  release's own launch check decides it, before anything is published.
+- **Blocked behind step 2:** step 3's authority provider (also waiting on its own
+  identity-channel decision) · step 4 (needs the manifest to bind G9+G8) · step 5.

--- a/m1nd-mcp/src/custody_ceremony.rs
+++ b/m1nd-mcp/src/custody_ceremony.rs
@@ -489,9 +489,12 @@ pub fn preflight(protected_root: &Path) -> PreflightReportV1 {
         check(
             "P4",
             "UNPROVEN",
-            "KeychainAccessGroups entitlement — proven only by the ceremony itself. The \
-             release signs with build/m1nd-mcp.entitlements.plist; a locally built binary \
-             does not, and will fail closed naming this prerequisite",
+            "KeychainAccessGroups entitlement — proven only by a verb that touches the \
+             keychain, never by this report. The release signs ONE artifact with \
+             build/m1nd-mcp.entitlements.plist: the m1nd-custody-ceremony.app bundle, \
+             whose embedded provisioning profile is what authorizes it. The plain \
+             m1nd-mcp binary and every local build carry no entitlement and will fail \
+             closed naming this prerequisite",
         ),
         protected_root_check(protected_root),
         check(

--- a/tests/test_m1nd10_ci_security_contract.py
+++ b/tests/test_m1nd10_ci_security_contract.py
@@ -142,6 +142,64 @@ class CiSecurityContractTests(unittest.TestCase):
         self.assertIn("placeholder UI artifact is forbidden", build)
         self.assertIn("UI digest mismatch", build)
 
+    def test_the_two_macos_artifacts_keep_opposite_entitlement_contracts(self):
+        # v1.6.0 signed the shipped runtime with keychain-access-groups and the
+        # kernel SIGKILLed it: a restricted entitlement is honoured only when an
+        # embedded provisioning profile authorizes it, and a raw executable has
+        # nowhere to hold one. The release therefore ships TWO macOS artifacts
+        # with OPPOSITE contracts, and neither refusal may be relaxed for the
+        # other. build/README.md carries the measurement.
+        build = self.job(".github/workflows/release.yml", "build")
+        runtime, _, bundle = build.partition(
+            "- name: Package, sign, and prove the entitled custody-ceremony bundle"
+        )
+        self.assertTrue(bundle, "the custody-ceremony bundle step is gone")
+
+        # 1. the ordinary runtime: no entitlements on the signing command, a
+        #    mechanical refusal if one appears anyway, and a launch proof.
+        self.assertIn(
+            "codesign --force --timestamp --options runtime \\\n"
+            '            --sign "$APPLE_SIGNING_IDENTITY" "$BIN_PATH"',
+            runtime,
+            "the shipped runtime must be signed with no entitlements at all",
+        )
+        self.assertIn(
+            "keychain-access-groups|application-identifier|com\\.apple\\.developer\\.",
+            runtime,
+        )
+        self.assertIn('"$BIN_PATH" --version', runtime)
+
+        # 2. the bundle: the entitlement and the profile live here and only here.
+        for token in (
+            # the profile is an owner secret, never a repo file, and its absence
+            # publishes NOTHING rather than a silently-unentitled lookalike
+            "secrets.APPLE_CUSTODY_PROFILE_BASE64",
+            "::warning title=No custody-ceremony bundle",
+            # Apple's own layout for a restricted entitlement on a daemon
+            'cp "$PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"',
+            '--entitlements "$ENTITLEMENTS"',
+            # the profile constrains the bundle identity; a mismatch is refused
+            # rather than shipped as a bundle the kernel will kill
+            "does not cover the bundle identifier",
+            "MARGIN_DAYS = 30",
+            "ExpirationDate",
+            "ProvisionedDevices",
+            # a signature that verifies is not a binary that runs
+            '"$BUNDLED_EXE" --version',
+            "does not launch after a round trip",
+            # and the runtime must leave this step exactly as it entered it
+            "acquired a restricted entitlement while the bundle was built",
+        ):
+            self.assertIn(token, bundle, f"custody bundle lost its contract: {token}")
+        self.assertNotIn("cargo build", bundle)
+
+        # 3. the bundle is published only when it was really built, and never
+        #    enters the signed candidate byte set (the same posture the
+        #    verified-updater receipts hold).
+        self.assertIn("steps.custody-bundle.outputs.built == 'true'", bundle)
+        assembly = self.job(".github/workflows/release.yml", "candidate-assembly")
+        self.assertNotIn("m1nd-custody-ceremony", assembly)
+
     def test_npm_package_is_packed_once_and_promoted_as_candidate_bytes(self):
         workflow = self.text(".github/workflows/release.yml")
         candidate = self.text("scripts/m1nd10_release_candidate.py")


### PR DESCRIPTION
## Two artifacts, two purposes

v1.6.0 signed the shipped `m1nd-mcp` with `keychain-access-groups` and the kernel SIGKILLed it: AMFI honours a restricted entitlement **only** when an embedded provisioning profile authorizes it, and a raw Mach-O executable has nowhere to hold one. #508 stripped the entitlement so the product launches — that is correct and it **stays**. The ordinary runtime is unentitled forever, and its two existing refusals (no restricted entitlement on the signed bytes, `--version` must succeed after signing) are untouched.

But the G9 ceremony persists the owner's authority key in the data-protection keychain — per TN3137 the only keychain a Secure Enclave key can be made permanent in — and reaching it needs exactly that entitlement. Apple's documented answer (*Signing a daemon with a restricted entitlement*) is an app-like bundle with the profile at `Contents/embedded.provisionprofile`. The owner ratified that road.

So the release now builds a **second** macOS artifact per target, from the **same binary bytes** the build step just produced — never a second `cargo build`:

```
m1nd-custody-ceremony.app/Contents/Info.plist
m1nd-custody-ceremony.app/Contents/MacOS/m1nd-mcp
m1nd-custody-ceremony.app/Contents/embedded.provisionprofile
m1nd-custody-ceremony.app/Contents/_CodeSignature/CodeResources
```

signed **with** the entitlement, notarized, stapled, published as `m1nd-custody-ceremony-macos-<arch>.zip`. It is a run artifact (90-day retention), deliberately **outside** the signed candidate/release byte set — the same posture the verified-updater receipts already hold — because it exists only when the owner supplies a profile, and the candidate's bytes must not depend on a secret.

The two artifacts are checked against **opposite** contracts and neither refusal is relaxed for the other: the runtime for the ABSENCE of a restricted entitlement plus a launch, the bundle for its PRESENCE plus a launch. A final guard re-checks the runtime after the bundle is built, so a future edit cannot sign the shipped binary in place.

## The profile is a secret-shaped owner input

`APPLE_CUSTODY_PROFILE_BASE64`, handled exactly like `APPLE_CERT_P12_BASE64`: decoded into the runner's temp dir, read, embedded, deleted. **With the secret absent the step skips loudly** (`::warning`) and publishes no artifact — a bundle without a profile is SIGKILLed identically to the raw binary, so an unentitled artifact wearing the ceremony's name would be worse than none.

## The launch proof

After signing, `Contents/MacOS/m1nd-mcp --version` runs on the native runner and must print this release's version; the same launch is repeated on the unpacked copy after `ditto` packaging. That is the whole lesson of v1.6.0 — a signature that verifies is not a binary that runs, and AMFI's verdict on a restricted entitlement is observable only at launch.

## The expiry refusal, margin 30 days

The step decodes the profile (`security cms -D -i`), reads `ExpirationDate`, and **fails the release** when it is under 30 days away, naming the date it read. The margin is not a claim about the artifact's shelf life — that is the expiry itself, which the run prints as a `::notice`; it is the window in which the owner can notice, regenerate and re-tag without the ceremony surface being unavailable. Two neighbouring shapes are refused for the same reason: a device-scoped development profile (authorizes only enrolled Macs, not the runner that must launch-prove the bundle) and a profile whose platform list is not macOS.

## Bundle identity is derived, and coupled

`CFBundleIdentifier` is the access group's own suffix from `build/m1nd-mcp.entitlements.plist` — because a program's default data-protection keychain access group *is* its application-identifier, so the bundle asks for exactly the group the entitlement grants. The release therefore checks the profile's `application-identifier` covers it (wildcards honoured) and that the profile's team matches, and **refuses a mismatch** rather than publishing a bundle the kernel will kill. Regenerate the profile for a different App ID and the identifier must move with it; the plist is the single source and an edit there moves both.

The entitlements plist itself gained **zero** bytes: it is the same one-entitlement, one-group file, now signing exactly one artifact.

## Proven here vs unproven until a tagged release

Proven locally, with the step body **extracted from the workflow** (not retyped) and two deltas that are exactly "needs the owner's Apple credentials" (ad-hoc identity instead of Developer ID; no notarization/stapling):

- the bundle layout above, and an ad-hoc-signed bundle that **launches** from `Contents/MacOS/` and still launches after the `ditto` round trip;
- `CFBundleIdentifier` and codesign's recorded `Identifier=` agree with the derivation;
- all nine refusals fire with their own message — expired, near-expiry, missing `ExpirationDate`, device-scoped, non-macOS, wrong team, group not authorized, App ID not covering the identifier — plus the loud skip when the secret is absent;
- the expiry parser was cross-checked against real profiles: it agrees with `plutil` on the date, field for field;
- `python3 -m unittest discover -s tests` (151 tests), `cargo fmt --check`, `cargo clippy -p m1nd-mcp --all-targets -- -D warnings`, the custody door and wiring batteries.

**Unproven, and only a tagged release with the secret set can prove it:** that a Developer-ID-signed *bundle* carrying a real profile satisfies AMFI for this entitlement. Only the negative is measured (a bundle *without* a profile dies exactly like the raw binary). The launch check decides the positive loudly, before anything is published. Also unproven here: notarization and stapling of the bundle, and whether AMFI additionally wants an `application-identifier` entitlement — if it does, the launch check fails the release with the kernel's own reason rather than shipping something dead.

## The owner's one-time action

Generate a **macOS Developer ID** provisioning profile for the App ID whose suffix is the access group in `build/m1nd-mcp.entitlements.plist` (the team wildcard already covers the group — this is a profile to generate, not a capability to request), base64 it into the repository secret `APPLE_CUSTODY_PROFILE_BASE64`, and tag. Not a *development* profile: those are device-scoped and refused by name.

## Contract test

`test_the_two_macos_artifacts_keep_opposite_entitlement_contracts` pins both halves — the runtime's unentitled signing command and its two refusals (previously unpinned), and the bundle's secret gating, loud skip, profile embedding, expiry margin, device-scope check, identity coupling, launch proofs, conditional publish, and its exclusion from the candidate assembly. Mutation-checked against three regressions.

## Docs

`build/README.md` (the signing surface's rationale, now two artifacts), `docs/benchmarks/G9-CUSTODY-CEREMONY.md` §1 P4, §2 and §5 R1, `docs/benchmarks/M1ND-10-OWNER-SITTING.md` steps 1 and 2 and the scoreboard (step 2 stops being platform-blocked and becomes "waiting on one owner file"), and one paragraph in `AGENTS.md` so no agent reads the entitled artifact as an invitation — the four verbs stay the owner's, `preflight` stays the only one an agent may run. `preflight`'s own P4 message stopped being true after #508 (it claimed the release signs the binary with the plist) and now names which artifact carries it.

**Ordering note:** this branch is cut from `main`. PR #511 (`docs/g9-platform-wall`) edits the same two hunks of `M1ND-10-OWNER-SITTING.md`; whichever lands second needs a one-gesture rebase.
