### PR TITLE
fix(runtime): wait on the brain-actor release signal instead of racing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,19 @@ Always run `cargo fmt` and `cargo clippy --workspace -- -D warnings` before fini
 If a test flakes under parallel build-cache contention (e.g. `retrobuilder_real`), re-run
 it in isolation (`cargo test -p m1nd-core --test retrobuilder_real`) before concluding.
 
+**Brain-actor hand-off is a signal, never a poll.** A brain session's single-writer fence
+(`actor_active`) is lowered by the OUTGOING owner, and `BrainActorHandle::drop` hands that
+shutdown to a *detached guardian thread* — so when a registry drops, the fence it held is
+still up, and clears at an instant the next binder cannot predict. The bound bind therefore
+waits on the cell's release signal (`BrainSessionCell::wait_for_actor_release`) instead of
+deciding that race on first read. Never answer `brain session already has an active actor
+owner` with a longer wait, a retry budget, or `#[ignore]`: a refusal from the bound bind is
+CACHED in `bound_runtime` for the life of the registry, so a retry loop can only re-read its
+own refusal — which is exactly how a 300×100ms spin sat in `host_for_brain` looking like a
+mitigation while burning 30s and failing anyway. `SOURCE_MATRIX_SERIAL` (the source-recovery
+matrix latch) survives only as a LOAD limiter and no longer guards correctness, so a
+process-per-test runner no longer breaks that family by giving each test its own copy.
+
 **A gate is evidence only about the tree it ran in.** Cargo's metadata hash does not encode
 the source path, so two checkouts sharing one `CARGO_TARGET_DIR` emit the same artifact name
 and one can link the other's binary. Measured across parallel worktrees on 2026-07-27/28: a

--- a/m1nd-mcp/src/brain_runtime.rs
+++ b/m1nd-mcp/src/brain_runtime.rs
@@ -139,6 +139,34 @@ impl BrainSessionCell {
         self.actor_active.load(Ordering::Acquire)
     }
 
+    /// Block until this cell's single-writer fence is clear, and report whether
+    /// it is. This is the hand-off signal between two owners of one brain
+    /// session, and the reason it has to exist: [`BrainActorHandle::drop`]
+    /// transfers shutdown to a *detached guardian thread*, so when `drop`
+    /// returns the outgoing owner still holds the fence and lowers it at an
+    /// instant the next binder cannot predict. A binder that reads
+    /// `actor_active` once and refuses is deciding a scheduling race, not a
+    /// safety question.
+    ///
+    /// The wait parks on the same storage mutex and condvar
+    /// [`BrainActorActivation::release`] takes when it lowers the fence, so no
+    /// wakeup can land in the window between the predicate check and the park.
+    /// `timeout` bounds a fence that never clears (a genuinely stuck owner);
+    /// a healthy hand-off returns the moment release publishes, not on a tick.
+    pub(crate) fn wait_for_actor_release(&self, timeout: Duration) -> bool {
+        let started = Instant::now();
+        let mut guard = self.state.lock();
+        while self.actor_active.load(Ordering::Acquire) {
+            let Some(remaining) = timeout.checked_sub(started.elapsed()) else {
+                break;
+            };
+            if self.available.wait_for(&mut guard, remaining).timed_out() {
+                break;
+            }
+        }
+        !self.actor_active.load(Ordering::Acquire)
+    }
+
     pub(crate) fn lock(&self) -> BrainSessionGuard<'_> {
         self.read().unwrap_or_else(|error| panic!("{error}"))
     }
@@ -348,8 +376,21 @@ struct BrainActorActivation {
 impl BrainActorActivation {
     fn release(&mut self) {
         if self.active {
+            // Lower the fence while holding the storage mutex a waiter parks
+            // on. `wait_for_actor_release` checks `actor_active` under that
+            // same mutex and only then parks; clearing the flag outside it
+            // would let the store and the notification both land inside that
+            // window, and the waiter would sleep through the very event it
+            // asked for. Holding the mutex here is what makes the release a
+            // signal instead of a state change somebody has to poll for.
+            //
+            // No guard can be outstanding while the fence is up (`claim_actor`
+            // drains them before raising it), so this is never contended by a
+            // long-lived reader.
+            let guard = self.cell.state.lock();
             self.cell.actor_active.store(false, Ordering::Release);
             self.active = false;
+            drop(guard);
             self.cell.available.notify_all();
         }
     }
@@ -4604,12 +4645,11 @@ mod tests {
         assert!(session.try_lock().is_none());
         injector.enabled.store(false, Ordering::SeqCst);
 
-        let deadline = std::time::Instant::now() + OBSERVE_BUDGET;
-        while session.is_actor_active() && std::time::Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(20));
-        }
+        // Wait on the release the guardian publishes, not on a tick: the fence
+        // is lowered under the cell's storage mutex and announced on its
+        // condvar, so this returns the instant recovery completes.
         assert!(
-            !session.is_actor_active(),
+            session.wait_for_actor_release(OBSERVE_BUDGET),
             "guardian did not stop and release the actor after recovery: {:?}",
             lock_unpoisoned(&health).last_persistence_error
         );

--- a/m1nd-mcp/src/external_mutation_service.rs
+++ b/m1nd-mcp/src/external_mutation_service.rs
@@ -7069,11 +7069,13 @@ mod tests {
 
     /// The source recovery matrix spawns real brain-actor threads and drives
     /// restart cycles whose previous owner releases *asynchronously* — the actor
-    /// thread must drain and drop before `actor_active` clears. Running several of
-    /// these fixtures at once starves that drain on a loaded CI runner, so the
-    /// restart bind in `host_for_brain` can miss even its 30s wait. Serialize the
-    /// family so only one source matrix fixture is live at a time: each cycle's
-    /// actor is free to release before the next one binds. A poisoned latch is
+    /// thread must drain and drop before `actor_active` clears. Correctness of
+    /// that hand-off no longer depends on this latch: the bound bind waits on
+    /// the cell's own release signal (`BrainSessionCell::wait_for_actor_release`),
+    /// so a starved drain is waited out rather than mistaken for a live owner.
+    /// The latch stays as a LOAD limiter — each fixture is a full brain runtime
+    /// with real checkpoint I/O, and running the family several-at-a-time on a
+    /// two-core runner buys nothing but contention. A poisoned latch is
     /// irrelevant (it carries no state), so recover from it.
     static SOURCE_MATRIX_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -7342,23 +7344,15 @@ mod tests {
                 self.runtime_root.join("source-replay-project-brains"),
                 None,
             ));
-            // The previous host's actor owner releases asynchronously; on slow
-            // shared runners the new bind can race that release, so wait for it.
-            let reconciliation_brain_id = {
-                let mut attempt = 0;
-                loop {
-                    match actor_registry.bound_brain_id_for_target(Arc::clone(&brain)) {
-                        Ok(id) => break id,
-                        Err(_) if attempt < 300 => {
-                            attempt += 1;
-                            std::thread::sleep(std::time::Duration::from_millis(100));
-                        }
-                        Err(error) => {
-                            panic!("source replay actor id after {attempt} waits: {error:?}")
-                        }
-                    }
-                }
-            };
+            // The previous host's actor owner releases on a detached guardian
+            // thread, so the fence it holds is still up when its registry drops.
+            // The bind itself now waits on that release signal, so this is one
+            // call with no retry budget of its own — and the retry budget it
+            // replaces never worked: `bound_runtime` caches the first answer,
+            // so every re-ask read back the same refusal for 30 seconds.
+            let reconciliation_brain_id = actor_registry
+                .bound_brain_id_for_target(Arc::clone(&brain))
+                .expect("source replay actor identity after owner hand-off");
             assert_eq!(
                 reconciliation_brain_id, self.host.reconciliation_brain_id,
                 "source actor identity must survive restart"

--- a/m1nd-mcp/src/project_brains.rs
+++ b/m1nd-mcp/src/project_brains.rs
@@ -80,6 +80,18 @@ use crate::runtime_jobs::{
 /// specifies ("before the owner hosts brain #5"). Override via the constructor.
 pub const DEFAULT_WARM_BRAIN_CAP: usize = 4;
 
+/// How long the bound bind waits for a PREVIOUS owner of the same brain session
+/// to finish releasing its single-writer fence.
+///
+/// `BrainActorHandle::drop` hands shutdown to a detached guardian thread, so the
+/// outgoing owner's fence is still up when `drop` returns. The incoming bind
+/// waits on the cell's release signal (`wait_for_actor_release`) rather than
+/// deciding that scheduling race on first read — a refusal here is CACHED in
+/// `bound_runtime` for the life of the registry, so asking again could never
+/// change the answer and the loss would be permanent. This is a ceiling on a
+/// fence that never clears, not a delay: a healthy hand-off costs the wakeup.
+const BOUND_ACTOR_HANDOFF_GRACE: Duration = Duration::from_secs(30);
+
 /// Store-dir manifest: records which project root a store belongs to, so a
 /// warm-boot can verify the fingerprint really is this root's brain (hash
 /// collisions and moved directories resolve to an honest miss, never a silent
@@ -1006,6 +1018,12 @@ impl ProjectBrainRegistry {
     ) -> M1ndResult<Arc<BrainActorHandle>> {
         if bound {
             let opened = self.bound_runtime.get_or_init(|| {
+                // A previous owner of this same cell may still be releasing its
+                // single-writer fence on a detached guardian thread. Wait for
+                // the release signal before claiming; the guard below is the
+                // authority either way, so a fence that never clears still
+                // refuses with exactly the same typed error.
+                target.wait_for_actor_release(BOUND_ACTOR_HANDOFF_GRACE);
                 // This is the one explicit pre-actor compatibility guard.
                 // `lock_mut_before_actor()` double-checks the ownership fence,
                 // so a foreign/duplicate actor cannot be adopted silently by
@@ -2141,6 +2159,46 @@ mod external_mutation_actor_binding_tests {
         state.workspace_root = Some(workspace_root.to_string_lossy().into_owned());
         state.ingest_roots = vec![workspace_root.to_string_lossy().into_owned()];
         Arc::new(BrainSessionCell::new(state))
+    }
+
+    /// The hand-off between two owners of one brain session, with no timing
+    /// tolerance anywhere in the test.
+    ///
+    /// `BrainActorHandle::drop` transfers shutdown to a DETACHED guardian
+    /// thread, so when `drop` returns the previous owner still holds the
+    /// single-writer fence and clears it at an instant no caller can predict.
+    /// A binder that reads `actor_active` once and refuses therefore loses a
+    /// pure scheduling race — and loses it permanently, because the refusal is
+    /// cached in the registry's `bound_runtime` cell, so re-asking can never
+    /// change the answer. The bind waits on the release SIGNAL instead.
+    #[test]
+    fn bound_bind_waits_out_the_previous_owners_detached_release() {
+        let temp = tempfile::tempdir().expect("actor handoff tempdir");
+        let bound_root = temp.path().join("bound-owner");
+        std::fs::create_dir_all(&bound_root).expect("bound root");
+        let bound = session_cell(&temp.path().join("bound-runtime"), &bound_root);
+
+        let first = ProjectBrainRegistry::new(temp.path().join("first-brains"), None);
+        let first_id = first
+            .bound_brain_id_for_target(Arc::clone(&bound))
+            .expect("first bound actor identity");
+
+        // Drop WITHOUT `shutdown`: this is the only path that leaves the fence
+        // to a guardian thread, and it is exactly what a fixture teardown does.
+        drop(first);
+
+        // Re-bind on the very next statement — no sleep, no retry budget.
+        let second = ProjectBrainRegistry::new(temp.path().join("second-brains"), None);
+        let second_id = second
+            .bound_brain_id_for_target(Arc::clone(&bound))
+            .expect("re-bind must wait for the previous owner's release");
+        assert_eq!(
+            first_id, second_id,
+            "actor identity must survive the hand-off"
+        );
+        second
+            .shutdown(TEST_PERSISTING_ACTOR_SHUTDOWN_GRACE)
+            .expect("shutdown the re-bound owner");
     }
 
     #[test]


### PR DESCRIPTION
## The defect

`m1nd-mcp/src/external_mutation_service.rs:7357` failed on loaded Windows/macOS
runners with:

```
source replay actor id after 300 waits: PersistenceFailed("bound brain actor refused: brain session already has an active actor owner")
```

Measured twice on real CI, on diffs that touch nothing near this code:
2026-07-30 under a process-per-test runner (both macOS legs and Windows, same
test, same line) and 2026-07-31 under the ordinary runner on Windows in #512
(`test result: FAILED. 1522 passed; 1 failed; 17 ignored; finished in 963.24s`).

## The ownership lifecycle

Who sets the owner, who clears it, on which thread, and what a waiter can
observe in between:

| step | who | thread | fence |
|---|---|---|---|
| claim | `BrainSessionCell::claim_actor` — drains pre-actor guards under the storage mutex, then CAS `actor_active: false -> true` | the binder's | UP |
| hold | the actor thread owns the checked-out `SessionState`; every compat reader (`read`, `try_lock`, `lock_mut_before_actor`) refuses with `ActorAlreadyActive` | actor | UP |
| graceful stop | `stop_while_paused` sends `Stop`, joins, stops the heartbeat, then `activation.release()` | the stopper's | DOWN, **synchronously** |
| **drop** | `BrainActorHandle::drop` moves join + activation + heartbeat into a **detached guardian thread**, which sends `Stop`, waits for the reply, joins, and only then calls `activation.release()` | guardian | still UP when `drop` returns; DOWN at an unpredictable later instant |

The repo already asserted the middle of that last row —
`dropping_last_handle_delegates_in_doubt_recovery_to_a_guardian` asserts
`session.is_actor_active()` immediately after `drop(actor)`.

What a waiter could observe in between: **nothing but the flag itself**.
`release()` did `actor_active.store(false)` outside the storage mutex and then
`notify_all()`, so a condvar wait was not even sound — the store and the
notification could both land between a waiter's predicate check and its park.
The only way to see the release was to poll for it.

And the poll could not work. `ProjectBrainRegistry::runtime_for_target`'s bound
branch opens through `bound_runtime.get_or_init(...)`, so the FIRST answer —
including a refusal — is cached for the life of the registry. The 300x100ms
spin in `host_for_brain` re-read its own cached refusal 300 times, burned 30
seconds and failed with the error it started with. `after 300 waits` in the CI
log is the signature of that: a genuine re-probe would have succeeded on the
second tick, because the guardian only has to drain an idle actor.

## Product vs harness: harness-only exposure, product-side gap

**Verdict: a real client cannot reach this refusal from a legitimate handle
drop; the missing capability it exposed is product code.**

Evidence for harness-only:

- Every product path that stops an actor calls `stop_while_paused()` and
  therefore releases synchronously *before* the handle is dropped: shutdown
  phase 2 (`project_brains.rs`, both the hosted loop and the bound runtime) and
  the eviction gate (`insert_with_eviction`, which additionally proves idleness
  by strong-count before removing the map entry).
- The guardian path is reached only when a handle is dropped *without* a prior
  stop. In the product that is process teardown, or an error path abandoning a
  just-started handle — neither is followed by a re-bind of the same cell in the
  same process.
- The owner holds ONE registry per process and `bound_runtime` is a `OnceLock`,
  so the bound actor is claimed once per process. There is no in-process
  "restart the registry against the same cell" motion in the product; the birth
  ceremony's staging registry (`brain_birth.rs`) quiesces with `shutdown` and
  then drops the cell entirely.
- The test harness is the only caller that binds the same `BrainSessionCell`
  from successive registries. The seam that bit: `pending_recovery_is_empty`
  builds a throwaway registry, binds the restarted cell, and drops the registry
  **without** `shutdown` — a detached guardian — and the test then re-binds the
  same cell two statements later.

The product-side gap is real, though, and it is what the fix closes: the release
published no signal anybody could wait on, and the one bind that has to survive
a hand-off cached its refusal forever.

## The fix

1. `BrainActorActivation::release` lowers the fence **while holding the storage
   mutex a waiter parks on**, then notifies. That is what turns the release from
   a state change into a signal: no wakeup can land in the window between a
   waiter's predicate check and its park. Nothing can be contending that mutex
   while the fence is up — `claim_actor` drains every guard before raising it.
2. `BrainSessionCell::wait_for_actor_release(timeout) -> bool` is the other half:
   a condvar wait on that exact predicate, returning the moment release
   publishes rather than on a tick.
3. The acquiring path waits on it. `runtime_for_target`'s bound branch waits for
   the previous owner's release before claiming (`BOUND_ACTOR_HANDOFF_GRACE`,
   30s). `lock_mut_before_actor()` remains the authority immediately after, so a
   fence that never clears still refuses with exactly the same typed error — the
   single-writer invariant is untouched, only the race is gone. The wait sits
   inside `get_or_init`, so a hand-off can no longer poison the cache.
4. The inert spin in `host_for_brain` is deleted: one call, no retry budget.
5. `dropping_last_handle_delegates_in_doubt_recovery_to_a_guardian` waits on the
   signal instead of sleeping in 20ms increments.

`SOURCE_MATRIX_SERIAL` is **kept**. It never guarded correctness across fixtures
(each holds its own cell, so cross-fixture `ActorAlreadyActive` was never
possible); its real effect was reducing CPU load so the guardian got scheduled
promptly, which masked the intra-test race. It survives as what it actually is —
a load limiter for a family of full brain runtimes doing real checkpoint I/O —
and its doc comment now says so, including the consequence the field asked for:
a process-per-test runner no longer breaks the family by giving each test a
private copy of the latch.

## Proof it bites

`project_brains::external_mutation_actor_binding_tests::bound_bind_waits_out_the_previous_owners_detached_release`
forces the interleaving with **no timing tolerance anywhere**: bind a cell, drop
the registry without `shutdown` (the only path that leaves the fence to a
guardian), then re-bind the same cell on the very next statement — no sleep, no
retry budget — and assert the identity survives.

RED against the previous code, 5/5, with the exact CI message:

```
panicked at m1nd-mcp/src/project_brains.rs:2176:14:
re-bind must wait for the previous owner's release: PersistenceFailed("bound brain actor refused: brain session already has an active actor owner")
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 0.78s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 0.76s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 0.80s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 0.76s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 0.80s
```

GREEN with the fix, 5/5:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 1.55s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 1.58s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 1.55s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 1.57s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 1.57s
```

**What this test covers and what it does not.** It reproduces the exact
interleaving — a re-bind that arrives before the guardian has finished — with
zero scheduling grace, which is a strictly harsher condition than any runner
load can produce. It does not reproduce *starvation* (a guardian that cannot get
CPU at all); nothing short of a scheduler fixture can, and the wait is bounded
by the same 30s the old spin nominally allowed.

## Repeated contention runs

`cargo test -p m1nd-mcp --lib source_outer_cut -- --test-threads=8`, five times,
on a box carrying sibling gates (`load averages: 6.12 6.71 7.30`):

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 31.86s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 32.02s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 31.90s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 32.13s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1617 filtered out; finished in 31.58s
```

The whole eight-test `SourceMatrixFixture` family, same flags, five times:

```
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1610 filtered out; finished in 57.32s
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1610 filtered out; finished in 57.24s
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1610 filtered out; finished in 56.89s
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1610 filtered out; finished in 56.23s
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1610 filtered out; finished in 56.60s
```

Honest note on that number: `--test-threads=8` does not actually run those eight
concurrently, because `SOURCE_MATRIX_SERIAL` still serializes them. Under this
fix the parallelism would be safe; the latch is kept for load, so the contention
these runs measure is CPU pressure from the rest of the machine, not
family-internal parallelism. The deterministic test above is the real proof.

## Gates

Targeted, per this change's surface:

```
external_mutation_service::   47 passed; 0 failed
project_brains::              21 passed; 0 failed
brain_runtime::               42 passed; 0 failed
mcp_http::                    37 passed; 0 failed
http_server::                 31 passed; 0 failed; 5 ignored
owner_security_config::        7 passed; 0 failed
project_brain_runtime_internal_tests::  8 passed; 0 failed
cargo clippy -p m1nd-mcp --all-targets -- -D warnings   exit 0
cargo fmt --check                                       exit 0
```

No `cfg`-gated code is touched, so no mirror-probe applies.

## Declared debt

- The `OnceLock` caching in `runtime_for_target`'s bound branch is left in place.
  The wait now sits inside it, so a hand-off can no longer poison it, but a bind
  that exhausts the grace still caches its refusal for the life of the registry.
  That is a degenerate condition (a fence that never clears is a real hang, not a
  race), and unpoisoning it means changing the cache's type and the three
  `get()` readers in `bound_runtime_health` / `runtime_health_snapshots` /
  `shutdown` — out of scope here, named rather than silently carried.
- The hosted-brain bind (`runtime_for_parts`) keeps the fail-fast read. It has no
  known exposure (the eviction gate stops synchronously and drops the cell), so
  it is deliberately untouched rather than changed on symmetry alone.
