### PR TITLE
release: prepare v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
+## [1.6.2] — 2026-07-31
+
+### Added — the custody ceremony gets an artifact it can actually run in
+
+- **A second macOS artifact: `m1nd-custody-ceremony.app`.** The G9 ceremony persists
+  the owner's authority key in the data-protection keychain, which needs an
+  entitlement macOS honours only under an embedded provisioning profile — and a
+  command-line binary has nowhere to carry one, as 1.6.0 discovered when the kernel
+  killed it. The release now builds a signed, notarized bundle from the same bytes as
+  the ordinary runtime, carrying the profile and the entitlement, and **proves it
+  launches** before publishing it. The ordinary `m1nd-mcp` stays unentitled and
+  launchable; a contract test pins both halves so neither can drift into the other.
+  Absent the profile secret the release says so and publishes no bundle, rather than
+  shipping one that would not run.
+
+### Fixed
+
+- **A brain actor could refuse a legitimate re-bind after its predecessor was
+  dropped.** Releasing an actor lowered its fence outside the lock a waiter parks on,
+  so no one could wait on it, and the acquiring path polled a cached answer — a
+  refusal, once cached, was re-read three hundred times and returned unchanged. The
+  release now signals under that lock and the bind waits on the signal, so a hand-off
+  no longer depends on winning a race. Proven by a test that re-binds on the very next
+  statement, with no sleep and no retry budget.
+
 ## [1.6.1] — 2026-07-30
 
 1.6.0 was tagged but never published: its macOS binaries could not launch, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-core"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "axum",
  "clap",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-runnerd"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "axum",
  "clap",

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -43,7 +43,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.6.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.2" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -28,8 +28,8 @@ embed = ["m1nd-core/embed"]
 
 [dependencies]
 m1nd-control = { path = "../m1nd-control", version = "0.2.0" }
-m1nd-core = { path = "../m1nd-core", version = "1.6.1" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.2" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/m1nd-runnerd/Cargo.toml
+++ b/m1nd-runnerd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-runnerd"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "The m1nd runner daemon (F2.5c): the ONLY spawner. Executes pinned spawn missions in an isolated git worktree, runs the gate, and emits mission letters on the chain — never `landed`."
 license = "MIT"
@@ -12,7 +12,7 @@ publish = false
 # side record (§1f) + the shared-secret filename — `default-features = false` keeps
 # axum/reqwest/embed OUT of this dependency edge (we bring our own below); the
 # runnerd is a CLIENT of the owner's contract, so the wire types must be the owner's.
-m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.1", default-features = false }
+m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.2", default-features = false }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",


### PR DESCRIPTION
Version bump for 1.6.2: core / ingest / mcp / runnerd to 1.6.2 with their cross-crate pins, lockfile refreshed for exactly those four, npm package moved. m1nd-control stays at 0.2.0 — unchanged since the 1.6.0 preparation, and a bump without a change would be noise in the registry.

The changelog's [1.6.2] section carries the two things this release exists for: the entitled custody-ceremony bundle, which gives the G9 ceremony an artifact macOS will actually launch, and the brain-actor release race — where a refusal, once cached, was re-read three hundred times and returned unchanged.