### PR TITLE
fix(enclave): read an absent keychain label as absent, not as a fatal open

### DIFF
--- a/docs/benchmarks/G9-CUSTODY-CEREMONY.md
+++ b/docs/benchmarks/G9-CUSTODY-CEREMONY.md
@@ -84,7 +84,16 @@ invents one. That is not convenience: a ceremony that fabricated its own seats w
    least three distinct domains, each permit carrying its `bound_context_digest` (sealed later as
    seat lineage). Provision is never open-or-create: an existing item under the same
    `kSecAttrLabel` fails closed, and the created key's real token/type/size are read back via
-   `SecKeyCopyAttributes` and attested against the framework's own constants.
+   `SecKeyCopyAttributes` and attested against the framework's own constants. The MIRROR case — an
+   ABSENT label on a fresh keychain, the only time provisioning is legitimate — must PROCEED to
+   create. Apple answers that no-match query with `errSecItemNotFound`, which `security-framework`
+   surfaces as `Err`; the guard originally misread that error as a fatal open and aborted, so on a
+   clean keychain no seat could ever be minted. Found live in the owner's first real G9 ceremony
+   against the entitled `m1nd-custody-ceremony.app` bundle (v1.6.2) — the software fake returns
+   `Ok(None)` on absent and never reproduced it — and fixed in `resolve_persisted_key` by routing
+   the search error through `classify_keychain_search_error`, which maps only `errSecItemNotFound`
+   to absent and keeps every other OSStatus fatal (a new signed release is required to carry the
+   fix onto an entitled bundle).
    - EXISTS: `provision_agent_enclave_seat` `enclave_authority.rs:187`;
      `EnclaveProvisioningPermitV1` `:136`; `EnclaveKeyAttestationV1::canonical` `:101`;
      duplicate guard via `resolve_persisted_key` `:1247`.

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -1316,7 +1316,7 @@ impl SecurityFrameworkEnclaveKeyStore {
             ItemClass, ItemSearchOptions, KeyClass, Limit, Reference, SearchResult,
         };
         let label = self.keychain_label(key_id);
-        let results = ItemSearchOptions::new()
+        let search = ItemSearchOptions::new()
             .class(ItemClass::key())
             .key_class(KeyClass::private())
             // SENTINEL: this ignore_legacy_keychains() (kSecUseDataProtectionKeychain)
@@ -1327,10 +1327,16 @@ impl SecurityFrameworkEnclaveKeyStore {
             .label(&label)
             .load_refs(true)
             .limit(Limit::Max(2))
-            .search()
-            .map_err(|error| {
-                EnclaveError::Open(format!("keychain item query for label '{label}': {error}"))
-            })?;
+            .search();
+        // A no-match query is NOT an empty Ok: Apple answers it with
+        // errSecItemNotFound, which security-framework surfaces as Err. Route the
+        // error arm through the classifier so ONLY that one OSStatus becomes the
+        // absent answer (Ok(None), the fresh-ceremony case) — every other error
+        // stays a fatal Open.
+        let results = match search {
+            Ok(results) => results,
+            Err(error) => return Self::classify_keychain_search_error(&error, &label),
+        };
         let mut resolved = None;
         for result in results {
             if let SearchResult::Ref(Reference::Key(key)) = result {
@@ -1343,6 +1349,39 @@ impl SecurityFrameworkEnclaveKeyStore {
             }
         }
         Ok(resolved)
+    }
+
+    /// Classify the error arm of the keychain search that backs
+    /// `resolve_persisted_key`'s never-open-or-create guard.
+    ///
+    /// Apple's `SecItemCopyMatching` returns `errSecItemNotFound` (SecBase.h,
+    /// OSStatus `-25300`) when NOTHING matches the query, and the `security-framework`
+    /// crate surfaces that as `Err`, not an empty `Ok`. For this guard that one status
+    /// IS the successful "no key is filed yet" answer, so it maps to `Ok(None)` — the
+    /// fresh-ceremony case, the only time provisioning is legitimate. EVERY other
+    /// OSStatus (access denied, missing entitlement, hardware fault, an ambiguous
+    /// keychain state) stays a fatal `EnclaveError::Open`.
+    ///
+    /// The catch is deliberately narrow. Widening it to "any error means absent" would
+    /// let a real keychain failure read as absence, and a never-open-or-create guard
+    /// that reads a live key as absent would mint a DUPLICATE seat over it. The line
+    /// between `-25300` and every other code is the entire security value here.
+    ///
+    /// Split out as a pure function of the OSStatus so this exact classification — the
+    /// logic that shipped wrong through v1.6.2 — is unit-testable without a Secure
+    /// Enclave: the software fake returns `Ok(None)` on absent and cannot reproduce
+    /// the real Apple `Err`, which is why six weeks of tests never caught it.
+    fn classify_keychain_search_error(
+        error: &security_framework::base::Error,
+        label: &str,
+    ) -> Result<Option<security_framework::key::SecKey>, EnclaveError> {
+        // UNFIXED (this commit): every error is fatal, including errSecItemNotFound —
+        // the behaviour v1.6.2 shipped and the owner's live ceremony hit. The seam is
+        // extracted here so the defect is falsifiable at all; the test above it is RED
+        // against this body and the next commit makes it GREEN.
+        Err(EnclaveError::Open(format!(
+            "keychain item query for label '{label}': {error}"
+        )))
     }
 
     /// Read the resolved key's REAL attributes via `SecKeyCopyAttributes` and prove
@@ -1712,6 +1751,60 @@ mod tests {
             application_label: format!("label-{key_id}"),
             access_control: EnclaveAccessControlV1::PrivateKeyUsageNonExportable,
             bound_context_digest: "ceremony-context-1".to_owned(),
+        }
+    }
+
+    // ---- classify_keychain_search_error ----
+    // The exact classification that shipped wrong through v1.6.2 (found live in the
+    // owner's G9 ceremony). The software fake returns Ok(None) on absent and CANNOT
+    // reproduce the real Apple Err(errSecItemNotFound) — fake and real diverge exactly
+    // here — so these drive the pure classifier directly with constructed OSStatus
+    // errors. No Secure Enclave, no keychain, no key: `Error::from_code` only wraps the
+    // integer status. This is the CI-runnable proof of the logic; the full provision ->
+    // restart -> open path stays owner-only on a real, entitled build.
+
+    #[test]
+    fn keychain_search_not_found_classifies_as_absent_not_fatal() {
+        // Apple's no-match answer is errSecItemNotFound (SecBase.h, OSStatus -25300).
+        // On a fresh ceremony the never-open-or-create guard MUST read this as
+        // "absent, proceed to create" (Ok(None)), never as a fatal Open — that abort
+        // is exactly what stopped v1.6.2 from minting any seat.
+        let not_found = security_framework::base::Error::from_code(
+            security_framework_sys::base::errSecItemNotFound,
+        );
+        let classified = SecurityFrameworkEnclaveKeyStore::classify_keychain_search_error(
+            &not_found,
+            "verifier-seat-alpha-v1",
+        );
+        assert!(
+            matches!(classified, Ok(None)),
+            "errSecItemNotFound (-25300) must classify as absent Ok(None), not a fatal error",
+        );
+    }
+
+    #[test]
+    fn keychain_search_other_errors_stay_fatal_open() {
+        // Every NON-not-found OSStatus is a real failure and must stay a fatal Open, so
+        // the guard never reads access-denied / missing-entitlement / cancelled /
+        // unavailable as "absent" and mints a duplicate over a live key. Representative
+        // spread, each != errSecItemNotFound: errSecAuthFailed -25293,
+        // errSecMissingEntitlement -34018, errSecNotAvailable -25291, errSecParam -50,
+        // errSecUserCanceled -128.
+        for code in [-25293_i32, -34018, -25291, -50, -128] {
+            assert_ne!(
+                code,
+                security_framework_sys::base::errSecItemNotFound,
+                "test fixture code must not be the not-found sentinel",
+            );
+            let error = security_framework::base::Error::from_code(code);
+            let classified = SecurityFrameworkEnclaveKeyStore::classify_keychain_search_error(
+                &error,
+                "verifier-seat-alpha-v1",
+            );
+            assert!(
+                matches!(classified, Err(EnclaveError::Open(_))),
+                "OSStatus {code} must stay a fatal Open error, not be swallowed as absent",
+            );
         }
     }
 

--- a/m1nd-mcp/src/enclave_authority.rs
+++ b/m1nd-mcp/src/enclave_authority.rs
@@ -1303,6 +1303,16 @@ impl SecurityFrameworkEnclaveKeyStore {
     /// never be ambiguous. This one query is also the production
     /// never-open-or-create duplicate guard.
     ///
+    /// `None` is NOT reached through an empty success. Apple answers a no-match query
+    /// with `errSecItemNotFound` and `security-framework` surfaces that as `Err`, so
+    /// the absent case arrives through the ERROR arm, not an empty `Ok`.
+    /// `classify_keychain_search_error` turns ONLY that one OSStatus into `Ok(None)`
+    /// and keeps every other error fatal. Do NOT "simplify" this back to a blanket
+    /// `.map_err(…)?` over `.search()`: that is the exact defect this guard shipped
+    /// with — on a fresh keychain (the only time provisioning is legitimate) the
+    /// duplicate guard aborted instead of proceeding to create, so no seat could be
+    /// minted. Found by the owner's live G9 ceremony against the entitled bundle.
+    ///
     /// The query is scoped to the data-protection keychain
     /// (`ignore_legacy_keychains`, i.e. `kSecUseDataProtectionKeychain`) so it sees
     /// the SAME scope `provision` writes into via `Location::DataProtectionKeychain`
@@ -1375,10 +1385,18 @@ impl SecurityFrameworkEnclaveKeyStore {
         error: &security_framework::base::Error,
         label: &str,
     ) -> Result<Option<security_framework::key::SecKey>, EnclaveError> {
-        // UNFIXED (this commit): every error is fatal, including errSecItemNotFound —
-        // the behaviour v1.6.2 shipped and the owner's live ceremony hit. The seam is
-        // extracted here so the defect is falsifiable at all; the test above it is RED
-        // against this body and the next commit makes it GREEN.
+        // ONLY errSecItemNotFound (SecBase.h, OSStatus -25300) means "no item matched"
+        // — the absent answer this never-open-or-create guard needs on a fresh
+        // ceremony. `security_framework_sys::base::errSecItemNotFound` is the named
+        // constant (already a direct dependency of this crate); `Error::code()`
+        // returns the OSStatus surfaced from `SecItemCopyMatching`.
+        if error.code() == security_framework_sys::base::errSecItemNotFound {
+            return Ok(None);
+        }
+        // Every OTHER status is a real failure (access denied, missing entitlement,
+        // hardware fault, …) and stays fatal — never widened to "any error means
+        // absent", which could mint a duplicate seat over a live key. Same message the
+        // pre-fix code emitted, minus the false abort on not-found.
         Err(EnclaveError::Open(format!(
             "keychain item query for label '{label}': {error}"
         )))


### PR DESCRIPTION
## What happened

The first live G9 custody ceremony, run by the owner on the signed, entitled
`m1nd-custody-ceremony.app` bundle from v1.6.2, could not provision a single seat:

```
custody_ceremony provision-seats  ->
{ "code": "custody_ceremony_platform_refused",
  "detail": "platform refused: enclave key open failed: keychain item query for label
             'world.m1nd.custody.g9.verifier-seat-alpha-v1': The specified item could not be
             found in the keychain." }
```

The refusal names its own cause: the item could not be found. Provisioning a seat that does
not exist yet is the correct state; the code treated it as a fatal error.

## Cause

`SecurityFrameworkEnclaveKeyStore::resolve_persisted_key` is the production
never-open-or-create duplicate guard — it asks the keychain whether a key is already filed
under the seat's `kSecAttrLabel`. Its doc comment claimed `None` means no such key exists.
It could never return `None` for that case:

- Apple's `SecItemCopyMatching` answers a query that matches nothing with `errSecItemNotFound`
  (OSStatus `-25300`, SecBase.h), not an empty result set.
- `security-framework` runs the status through `cvt`, which maps every non-`errSecSuccess`
  code to `Err` (`lib.rs`: `match err { errSecSuccess => Ok(()), err => Err(Error::from_code(err)) }`).
  `ItemSearchOptions::search()` propagates it with `?`. Its `Ok(vec![])` branch is unrelated —
  it only covers `SecItemCopyMatching` returning NULL when no `load_*` was requested, and this
  query sets `load_refs(true)`.
- The guard's `.map_err(...)?` therefore turned "absent" into a fatal `EnclaveError::Open`.

`provision` calls `resolve_persisted_key(...)?` before minting anything, so on a fresh keychain —
the only state in which provisioning is legitimate — the guard aborted instead of proceeding to
create, and no seat could ever be minted.

## Why six weeks of tests and the whole battery stayed green

The software stand-in (`MockEnclaveKeyStore`) returns `Ok(None)` for an absent key. Fake and
real Apple diverge exactly at the point the bug lives, so every test driving the fake agreed
with a floor that disagreed with the platform. The fake models the contract the code *believed*
it had. This is the false-green class, in a custody surface.

## The fix

The classification is extracted into a pure function of the OSStatus,
`classify_keychain_search_error`, and `resolve_persisted_key` routes the error arm through it:

- `errSecItemNotFound` -> `Ok(None)` (absent; proceed to create). The constant is
  `security_framework_sys::base::errSecItemNotFound` — already a direct dependency of this
  crate and used for the `SecKeyCopyAttributes` constants — not a magic number.
- every other OSStatus -> fatal `EnclaveError::Open`, with the same message as before.

The catch is deliberately narrow, and that narrowness is the security content. Widening it to
"any error means absent" would let access-denied, a missing entitlement, or a hardware fault
read as absence — and a never-open-or-create guard that reads a live key as absent would mint a
duplicate seat over a real one.

Unchanged on purpose: the refusal when a key IS present, the >1-match ambiguity refusal, the
`ignore_legacy_keychains` / `DataProtectionKeychain` SENTINEL pairing, and all access-control
and attestation logic. Verified byte-identical to `main`.

### Sibling call sites

`open` and `sign` also call `resolve_persisted_key` and then `.ok_or_else(...)`. They want
`None` and correctly fail closed on it, so they are left alone — and the fix makes them
*more* correct, not merely unaffected: before, an absent key never reached their `ok_or_else`,
because the generic query error short-circuited first, masking their precise message
("no persisted enclave key filed under label '<label>'") behind "keychain item query for
label '<label>': ...". Absence still fails closed in both; only the message that surfaces
becomes the accurate one.

## What is proven, and by whom

**CI proves** (`cargo test -p m1nd-mcp --lib enclave`, runs on every macOS leg):

- `keychain_search_not_found_classifies_as_absent_not_fatal` — `-25300` classifies as `Ok(None)`.
- `keychain_search_other_errors_stay_fatal_open` — `-25293`, `-34018`, `-25291`, `-50`, `-128`
  each stay a fatal `Open`.

Both drive the classifier directly with constructed OSStatus values (`Error::from_code` only
wraps the integer), so they need no Secure Enclave, no keychain and no key, and they cannot be
satisfied by the fake. Committed RED against the extracted-but-unfixed seam
(`test result: FAILED. 15 passed; 1 failed`) and GREEN with the fix
(`test result: ok. 16 passed; 0 failed`) — the RED commit is the first of the two here.

**Only the owner's machine can prove** the end-to-end ceremony: `provision-seats` actually
minting four seats against the real Secure Enclave on a signed, entitled bundle, and the
provision -> process restart -> `open`/`sign` persistence round trip. That requires hardware,
biometrics and an entitled artifact no CI runner and no agent has. No such run is claimed here,
and no `#[ignore]`d hardware test was added: it would need the same entitled bundle, so it would
prove nothing more than this note already states honestly.

Test gates run (targeted, macOS): `--lib enclave` 16 passed / 0 failed; `--lib custody_ceremony`
16 passed / 0 failed; `--test custody_ceremony_wiring` 18 passed / 0 failed — including the
guards that fail if a simulation path or a placeholder answer is ever introduced. `cargo fmt
--check` and `cargo clippy -p m1nd-mcp --all-targets -- -D warnings` both exit 0.

**Cross-platform:** the whole `enclave_authority` module is `#[cfg(target_os = "macos")]`
(`lib.rs:42`) and all three Security.framework crates sit under
`[target.'cfg(target_os = "macos")'.dependencies]`, so the linux and windows legs compile none
of this. Mirror-probed by flipping that gate off and rebuilding: every resulting error came from
`custody_ceremony.rs`'s own macos-gated references (themselves absent on non-macOS), and none
named the new helper or the new tests.

## Shipping

The fix reaches the owner's ceremony only through a **new signed release (v1.6.3)** — the
ceremony runs on `m1nd-custody-ceremony.app`, whose entitled, notarized bundle is built by the
release pipeline. A local build cannot substitute: it refuses at prerequisite P4. The live
ceremony stays blocked until that release is published.

`docs/benchmarks/G9-CUSTODY-CEREMONY.md` Phase A step 2 now documents the absent case beside
the duplicate case, and `resolve_persisted_key`'s doc comment states why the absent answer
arrives through the error arm — so the next reader does not "simplify" the classifier back into
the bug.
