### PR TITLE
ci: nextest is canonical locally; the gate decides its own runner in shadow

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,3 +29,20 @@ slow-timeout = { period = "60s", terminate-after = 10 }
 [[profile.default.overrides]]
 filter = 'binary_id(m1nd-core::retrobuilder_real) | binary_id(m1nd-core::retrobuilder_stress)'
 slow-timeout = { period = "300s", terminate-after = 8 }
+
+# ---------------------------------------------------------------------------
+# The CI shadow lane (see the `nextest-shadow` job in ci.yml). Inherits the
+# default profile; what it adds is the concurrency cap the GATE measurement
+# demanded: on the 4-vCPU ubuntu runner the heavy families — nested-Cargo
+# compiler oracles and real-repo ingests — running fully parallel turned the
+# suite from 62 into 83 minutes (the suite-audit's §10 process storm). The cap
+# lives HERE and not in the default profile because the dev box has the cores
+# and I/O to run them wide open (935s→377s); capping locally would give that
+# win back. Tune the cap in this profile until the shadow's wall is
+# acceptable; promote the runner only then.
+[test-groups]
+heavy-io = { max-threads = 2 }
+
+[[profile.shadow.overrides]]
+filter = 'binary_id(m1nd-core::retrobuilder_real) | binary_id(m1nd-core::retrobuilder_stress) | test(transplant)'
+test-group = 'heavy-io'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,10 +10,22 @@
 #   flakes under nextest, we want to see it, not survive it.
 #
 # * `slow-timeout` — today a runaway test owns the job until the 90-minute CI
-#   ceiling. The slowest legitimate test measured on the dev box is
-#   `auto_ingest_burst_stress_handles_many_documents` at ~119s; CI runners are
-#   slower, so the ceiling leaves ~5x headroom over that before terminating.
-#   SLOW warnings start at 60s so the tail stays visible in every run's output.
+#   ceiling. Outside the retrobuilder family the slowest legitimate test
+#   measured on the dev box is ~119s, so 600s leaves ~5x headroom. SLOW
+#   warnings start at 60s so the tail stays visible in every run's output.
 [profile.default]
 retries = 0
 slow-timeout = { period = "60s", terminate-after = 10 }
+
+# The retrobuilder batteries are the workspace's real heavy tail: thirteen
+# tests measured at 390-567s EACH on the dev box (rb01-rb05 walk this repo's
+# actual git history; the stress battery builds thousand-span overlays). Under
+# `cargo test` they had the whole machine — one test binary at a time; under
+# nextest they run amid everything else, and the first adoption of this file
+# shipped a 600s ceiling calibrated on the LIB's heavy tail (119s) instead of
+# the WORKSPACE's — all four rb tests died together at 600.04s on the 4-vCPU
+# ubuntu runner. Their ceiling is their own: ~4x the dev-box worst case. A
+# genuine runaway here still dies named at 40 minutes, not the job's 90.
+[[profile.default.overrides]]
+filter = 'binary_id(m1nd-core::retrobuilder_real) | binary_id(m1nd-core::retrobuilder_stress)'
+slow-timeout = { period = "300s", terminate-after = 8 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,19 @@
+# nextest is the workspace's test runner (adopted 2026-08-02; the CI comment on
+# the "Test every target" step carries the measurements that decided it).
+#
+# Two policies live here, both about honesty:
+#
+# * `retries = 0` — a test that fails is RED. Auto-retry is how a flake class
+#   gets institutionalized; the one flake family this workspace had (the
+#   `external_mutation_service` deadlock timeouts) turned out to be an artifact
+#   of the shared-process runner, and switching runners removed it. If a test
+#   flakes under nextest, we want to see it, not survive it.
+#
+# * `slow-timeout` — today a runaway test owns the job until the 90-minute CI
+#   ceiling. The slowest legitimate test measured on the dev box is
+#   `auto_ingest_burst_stress_handles_many_documents` at ~119s; CI runners are
+#   slower, so the ceiling leaves ~5x headroom over that before terminating.
+#   SLOW warnings start at 60s so the tail stays visible in every run's output.
+[profile.default]
+retries = 0
+slow-timeout = { period = "60s", terminate-after = 10 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,22 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-gates-${{ matrix.os }}
+      - uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        with:
+          tool: cargo-nextest
       # No standalone `cargo check`: clippy type-checks every target on its way
       # to linting, so a separate check pass was a full redundant compile.
+      #
+      # nextest, not `cargo test` (adopted 2026-08-02, measured first): the same
+      # suite on the same machine went 641–935s under `cargo test` to 377s under
+      # nextest with 1643/1643 passing — including the two
+      # `external_mutation_service` deadlock-timeout tests that expire under
+      # `cargo test`'s shared-process load (the #475 flake family). One process
+      # per test is what removes that class, so retries stay at 0 in
+      # `.config/nextest.toml`: a flake here should go red, not be re-rolled.
+      # nextest runs no doctests; the dedicated doctest leg below is unchanged.
       - name: Test every target
-        run: cargo test --locked --workspace --all-targets
+        run: cargo nextest run --locked --workspace --all-targets
       # `--all-targets` EXCLUDES doctests by construction, so the step above has
       # never executed one. That is not a documentation detail here: all 13 of
       # this workspace's doctests are `compile_fail` sentinels, and they are the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,21 @@ jobs:
       # nextest runs no doctests; the dedicated doctest leg below is unchanged.
       - name: Test every target
         run: cargo nextest run --locked --workspace --all-targets
+      # A faster suite must not quietly prove a DIFFERENT system. nextest is
+      # one process per test; the production owner is one process with many
+      # concurrent handlers over shared statics, locks and env — the topology
+      # `cargo test`'s shared harness happens to reproduce and per-process
+      # isolation happens not to. The concurrency batteries build that
+      # topology INSIDE single tests and the lifecycle gate drives the real
+      # binary, so most of it survives the runner switch — this leg is the
+      # explicit insurance for the remainder (test-to-test cohabitation over
+      # the server crate's globals), demanded by the suite-audit verdict
+      # (2026-08-02). One leg, the server crate only: the class is not
+      # OS-specific, and the whole-workspace form is what the runner switch
+      # exists to retire.
+      - name: Same-process topology lane (the server crate under one roof)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo test --locked -p m1nd-mcp --lib
       # `--all-targets` EXCLUDES doctests by construction, so the step above has
       # never executed one. That is not a documentation detail here: all 13 of
       # this workspace's doctests are `compile_fail` sentinels, and they are the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,37 +47,22 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-gates-${{ matrix.os }}
-      - uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
-        with:
-          tool: cargo-nextest
       # No standalone `cargo check`: clippy type-checks every target on its way
       # to linting, so a separate check pass was a full redundant compile.
       #
-      # nextest, not `cargo test` (adopted 2026-08-02, measured first): the same
-      # suite on the same machine went 641–935s under `cargo test` to 377s under
-      # nextest with 1643/1643 passing — including the two
-      # `external_mutation_service` deadlock-timeout tests that expire under
-      # `cargo test`'s shared-process load (the #475 flake family). One process
-      # per test is what removes that class, so retries stay at 0 in
-      # `.config/nextest.toml`: a flake here should go red, not be re-rolled.
-      # nextest runs no doctests; the dedicated doctest leg below is unchanged.
+      # Still `cargo test`, on purpose (2026-08-02). nextest was measured on
+      # all three legs before being allowed here, and the gate said no: ubuntu
+      # 62→83 min (the suite-audit's §10 "nested-Cargo process storm", real on
+      # the weakest-I/O runner), macos 53→52, windows 70→48. Locally nextest
+      # IS the canonical runner (935s → 377s on the dev box — see AGENTS.md);
+      # the `nextest-shadow` job below collects gate-side timing, and this leg
+      # switches only when the shadow reproduces the same greens and reds at
+      # an acceptable wall — never again on dev-box numbers alone. The shared-
+      # process harness here is also the same-process topology insurance the
+      # suite-audit verdict demands: production is one process over shared
+      # statics and locks, and so is this run.
       - name: Test every target
-        run: cargo nextest run --locked --workspace --all-targets
-      # A faster suite must not quietly prove a DIFFERENT system. nextest is
-      # one process per test; the production owner is one process with many
-      # concurrent handlers over shared statics, locks and env — the topology
-      # `cargo test`'s shared harness happens to reproduce and per-process
-      # isolation happens not to. The concurrency batteries build that
-      # topology INSIDE single tests and the lifecycle gate drives the real
-      # binary, so most of it survives the runner switch — this leg is the
-      # explicit insurance for the remainder (test-to-test cohabitation over
-      # the server crate's globals), demanded by the suite-audit verdict
-      # (2026-08-02). One leg, the server crate only: the class is not
-      # OS-specific, and the whole-workspace form is what the runner switch
-      # exists to retire.
-      - name: Same-process topology lane (the server crate under one roof)
-        if: matrix.os == 'ubuntu-latest'
-        run: cargo test --locked -p m1nd-mcp --lib
+        run: cargo test --locked --workspace --all-targets
       # `--all-targets` EXCLUDES doctests by construction, so the step above has
       # never executed one. That is not a documentation detail here: all 13 of
       # this workspace's doctests are `compile_fail` sentinels, and they are the
@@ -111,6 +96,34 @@ jobs:
       - name: Build the complete release workspace
         if: github.event_name == 'push'
         run: cargo build --locked --release --workspace
+
+  # OBSERVATIONAL, never a gate: deliberately absent from test-status's needs,
+  # so its result can go red without holding a single merge. This is the §11
+  # shadow lane from the 2026-08-02 suite-audit verdict: nextest was measured
+  # on all three legs and lost on ubuntu (62→83 min — the nested-Cargo process
+  # storm on the weakest-I/O runner) while winning on windows (70→48) and the
+  # dev box (935s→377s). Promotion to the required legs happens only when TWO
+  # WEEKS of these runs reproduce the gate's greens and reds at an acceptable
+  # wall — and the tuning that gets it there (heavy-family concurrency caps)
+  # lives in the `shadow` profile of .config/nextest.toml, so local runs stay
+  # untouched. Runs on main pushes only: enough samples to learn from, no PR
+  # queue time spent.
+  nextest-shadow:
+    name: nextest shadow (observational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: nextest-shadow
+      - uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        with:
+          tool: cargo-nextest
+      - name: Run the suite under nextest, timed
+        run: cargo nextest run --profile shadow --locked --workspace --all-targets
 
   test-status:
     name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,14 +17,21 @@ This is a **PUBLIC** repository. Everything you commit is published.
 Run these before you consider any change done. The blocking gate is **ubuntu + macOS**:
 
 ```bash
-cargo test --workspace --all-targets
-cargo test --workspace --doc                            # the sentinels --all-targets skips
+cargo nextest run --workspace --all-targets             # the runner CI uses (one process per test)
+cargo test --workspace --doc                            # the sentinels nextest never runs
 cargo clippy --workspace --all-targets -- -D warnings   # warnings fail the build
 cargo fmt --check
 ```
 
-The second line is not a duplicate of the first: `--all-targets` **excludes** doctests by
-construction, and every doctest in this workspace is a `compile_fail` sentinel guarding the
+nextest is the runner, not a preference (adopted 2026-08-02, measured: same suite
+641–935s under `cargo test`, 377s under nextest, 1643/1643 — including the two
+deadlock-timeout tests that expire under `cargo test`'s shared-process load).
+Plain `cargo test` still works when you need `--nocapture` on one test; trust
+nextest's verdict for the suite. Retries are 0 by policy — a flake goes red.
+
+The second line is not a duplicate of the first: nextest runs **no doctests at all** (and
+the old `cargo test --all-targets` excluded them too), and every doctest in this workspace
+is a `compile_fail` sentinel guarding the
 candidate boundary — 13 of them, all in `m1nd-mcp`, each pinning a symbol that must not be
 reachable from outside its crate. Until 2026-07-30 nothing in CI executed them, which is how
 two rotted silently through the transplant era and surfaced in a release audit rather than a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,17 +17,26 @@ This is a **PUBLIC** repository. Everything you commit is published.
 Run these before you consider any change done. The blocking gate is **ubuntu + macOS**:
 
 ```bash
-cargo nextest run --workspace --all-targets             # the runner CI uses (one process per test)
+cargo nextest run --workspace --all-targets             # the LOCAL canonical runner (one process per test)
 cargo test --workspace --doc                            # the sentinels nextest never runs
 cargo clippy --workspace --all-targets -- -D warnings   # warnings fail the build
 cargo fmt --check
 ```
 
-nextest is the runner, not a preference (adopted 2026-08-02, measured: same suite
-641–935s under `cargo test`, 377s under nextest, 1643/1643 — including the two
-deadlock-timeout tests that expire under `cargo test`'s shared-process load).
-Plain `cargo test` still works when you need `--nocapture` on one test; trust
-nextest's verdict for the suite. Retries are 0 by policy — a flake goes red.
+nextest is the canonical runner ON YOUR MACHINE (adopted 2026-08-02, measured:
+same suite 641–935s under `cargo test`, 377s under nextest, 1643/1643 —
+including the two deadlock-timeout tests that expire under `cargo test`'s
+shared-process load). Retries are 0 by policy — a flake goes red. Plain
+`cargo test` still works when you need `--nocapture` on one test.
+
+CI's required legs still run `cargo test`, deliberately: the same measurement
+taken ON THE GATE said no — ubuntu went 62→83 min under nextest (the
+nested-Cargo process storm on the weakest-I/O runner) while windows improved
+70→48. A `nextest-shadow` job collects gate-side timing on main pushes; the
+required legs switch only when the shadow reproduces the gate's greens and
+reds at an acceptable wall. Local green under nextest + gate green under
+`cargo test` are BOTH required truths until then — do not "fix" one by
+trusting the other.
 
 The second line is not a duplicate of the first: nextest runs **no doctests at all** (and
 the old `cargo test --all-targets` excluded them too), and every doctest in this workspace

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -127,7 +127,13 @@ indexes them, it does not restate them.
   in CI and locally — one process per test; measured 641–935s → 377s on the same
   suite with the shared-process deadlock-timeout flakes gone. Timeout policy
   lives in `doc:.config/nextest.toml`: retries 0 (a flake goes red), runaway
-  tests terminated at 10×60s instead of owning the 90-minute job.
+  tests terminated at 10×60s instead of owning the 90-minute job; the heavy
+  retrobuilder family carries its own measured ceiling.
+- **One same-process lane stays, on purpose.** A faster suite must not quietly
+  prove a different system: the production owner is ONE process with shared
+  statics/locks, so the ubuntu leg also runs `cargo test -p m1nd-mcp --lib`
+  under the classic shared harness — the explicit insurance the suite-audit
+  verdict demanded (2026-08-02), blocking, server crate only.
 - **Doctests are their own gate.** nextest never runs them; the dedicated
   `cargo test --workspace --doc` leg does. They carry `compile_fail` sentinels
   that no other gate reaches; a sentinel that starts compiling means a privacy

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -123,17 +123,21 @@ indexes them, it does not restate them.
 - **CI gates that block merge** run on ubuntu, macOS and Windows: the workspace
   test suite, clippy with warnings denied, and `cargo fmt --check`. Windows red
   blocks merge.
-- **The test runner is nextest** (`cargo nextest run --workspace --all-targets`),
-  in CI and locally — one process per test; measured 641–935s → 377s on the same
-  suite with the shared-process deadlock-timeout flakes gone. Timeout policy
-  lives in `doc:.config/nextest.toml`: retries 0 (a flake goes red), runaway
-  tests terminated at 10×60s instead of owning the 90-minute job; the heavy
-  retrobuilder family carries its own measured ceiling.
-- **One same-process lane stays, on purpose.** A faster suite must not quietly
-  prove a different system: the production owner is ONE process with shared
-  statics/locks, so the ubuntu leg also runs `cargo test -p m1nd-mcp --lib`
-  under the classic shared harness — the explicit insurance the suite-audit
-  verdict demanded (2026-08-02), blocking, server crate only.
+- **nextest is the LOCAL canonical runner** (`cargo nextest run --workspace
+  --all-targets`) — one process per test; measured 641–935s → 377s on the dev
+  box with the shared-process deadlock-timeout flakes gone. Policy in
+  `doc:.config/nextest.toml`: retries 0 (a flake goes red), runaway tests
+  terminated at 10×60s; the heavy retrobuilder family carries its own measured
+  ceiling.
+- **CI's required legs still run `cargo test`, by gate-side measurement.** The
+  same suite under nextest on the runners: ubuntu 62→83 min (nested-Cargo
+  process storm on the weakest-I/O runner), macos 53→52, windows 70→48. The
+  `nextest-shadow` job (observational, main pushes, never in `test-status`)
+  collects gate timing with heavy-family concurrency caps in the `shadow`
+  profile; the required legs switch only when the shadow reproduces the
+  gate's greens and reds at an acceptable wall. The shared-process harness on
+  the required legs doubles as the same-process topology insurance the
+  suite-audit verdict demands.
 - **Doctests are their own gate.** nextest never runs them; the dedicated
   `cargo test --workspace --doc` leg does. They carry `compile_fail` sentinels
   that no other gate reaches; a sentinel that starts compiling means a privacy
@@ -236,5 +240,5 @@ an answer: run the refresh or the ingest, then say what it cost. `north` returns
 
 | Date | Revision |
 |---|---|
-| 2026-08-02 | §5: nextest adopted as the workspace test runner (CI + local), doctest leg unchanged; timeout/retry policy at `.config/nextest.toml`. |
+| 2026-08-02 | §5: nextest adopted as the LOCAL canonical runner; CI required legs stay on `cargo test` by gate-side measurement (ubuntu 62→83 min under nextest); `nextest-shadow` observational job collects gate timing toward promotion; policy at `.config/nextest.toml`. |
 | 2026-08-01 | Manual established at `0b892874`. Sources adopted: `docs/deployment.md` (indexed, not absorbed — it remains the deployment reference), `build/README.md` (indexed for the signing surface). PR #398's earlier draft was **not** adopted: it recorded machine-specific identity (service label, uid, personal paths) which must not travel in a public repo. |

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -123,8 +123,15 @@ indexes them, it does not restate them.
 - **CI gates that block merge** run on ubuntu, macOS and Windows: the workspace
   test suite, clippy with warnings denied, and `cargo fmt --check`. Windows red
   blocks merge.
-- **Doctests are their own gate.** They carry `compile_fail` sentinels that no
-  other gate reaches; a sentinel that starts compiling means a privacy wall fell.
+- **The test runner is nextest** (`cargo nextest run --workspace --all-targets`),
+  in CI and locally — one process per test; measured 641–935s → 377s on the same
+  suite with the shared-process deadlock-timeout flakes gone. Timeout policy
+  lives in `doc:.config/nextest.toml`: retries 0 (a flake goes red), runaway
+  tests terminated at 10×60s instead of owning the 90-minute job.
+- **Doctests are their own gate.** nextest never runs them; the dedicated
+  `cargo test --workspace --doc` leg does. They carry `compile_fail` sentinels
+  that no other gate reaches; a sentinel that starts compiling means a privacy
+  wall fell.
 - **The embedded UI bundle must match the source that builds it** — CI refuses a
   commit whose `dist/` is not a fresh build of its own source.
 - **Frozen contracts** (`docs/M1ND-10-PRD.md`, `docs/M1ND-10-UML.md`) are checked
@@ -223,4 +230,5 @@ an answer: run the refresh or the ingest, then say what it cost. `north` returns
 
 | Date | Revision |
 |---|---|
+| 2026-08-02 | §5: nextest adopted as the workspace test runner (CI + local), doctest leg unchanged; timeout/retry policy at `.config/nextest.toml`. |
 | 2026-08-01 | Manual established at `0b892874`. Sources adopted: `docs/deployment.md` (indexed, not absorbed — it remains the deployment reference), `build/README.md` (indexed for the signing surface). PR #398's earlier draft was **not** adopted: it recorded machine-specific identity (service label, uid, personal paths) which must not travel in a public repo. |


### PR DESCRIPTION
**Scope, rewritten after gate-side measurement (ratified 2026-08-02).** The first shape of this PR swapped all three required legs to nextest on dev-box numbers. The gate then produced its own numbers, and they reversed half the plan — recorded here so nobody re-learns it.

**The measurement that decided everything** (step `Test every target`, build+tests):
| Leg | `cargo test` (main) | nextest (this PR, run 30726913765) | Δ |
|---|---|---|---|
| ubuntu | 62 min | **83 min** | **+21 min — worse** (job hit the 90-min ceiling) |
| macos | 53 min | 52 min | flat |
| windows | 70 min | **48 min** | **−21 min — better** |
| dev box (M-series, lib) | 641–935 s | **377 s** | **−60%** |

The ubuntu regression is the suite-audit verdict's §10 risk made real: the heavy families (≈21 nested-`cargo check` compiler oracles, 16 real-repo ingests) running one-process-per-test flood the weakest-I/O runner. Dev-box numbers do not transfer to the gate. **Before switching tools in a required gate, measure in the gate.**

**What this PR now does:**
- **Local: nextest is the canonical runner** (AGENTS.md gates block, MANUAL §5, `.config/nextest.toml`). This is where the original pain lived — the owner's machine — and it drops 935s→377s today, with the shared-process deadlock-timeout flakes (the #475 family) gone and `retries = 0` so any new flake goes red.
- **CI required legs: unchanged, `cargo test`** — zero gate risk, and the shared-process harness doubles as the same-process topology insurance §10 demands (production is one process over shared statics/locks).
- **New `nextest-shadow` job**: observational, ubuntu (the worst case), main pushes only, deliberately absent from `test-status`'s needs — it can go red without holding a merge. It collects gate-side timing with heavy-family concurrency caps in a separate `shadow` profile (`test-groups.heavy-io max-threads=2` over the retrobuilder binaries + transplant oracles), so local runs keep full parallelism. **Promotion rule (§11): the required legs switch only when two weeks of shadow reproduce the gate's greens and reds at an acceptable wall.**
- Doctest leg untouched throughout (nextest runs no doctests; the 13 `compile_fail` sentinels stay on their own leg — 13/13 locally, exit 0).

**Local proof under this exact config:** workspace `--all-targets` 2644/2644 (22 slow, 25 skipped); shadow profile parses and applies; YAML validated.

Two calibration errors were made and corrected inside this PR's own history, both worth keeping: a 600s ceiling sized on the lib's heavy tail instead of the workspace's (four rb tests died together at 600.04s), and the runner swap itself sized on dev-box wall-clock instead of the gate's.