### PR TITLE
test: build the lightning check — 57s over the never-cut core, never the gate

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -46,3 +46,29 @@ heavy-io = { max-threads = 2 }
 [[profile.shadow.overrides]]
 filter = 'binary_id(m1nd-core::retrobuilder_real) | binary_id(m1nd-core::retrobuilder_stress) | test(transplant)'
 test-group = 'heavy-io'
+
+# ---------------------------------------------------------------------------
+# The LIGHTNING lane — a fast day-to-day CHECK, deliberately NOT the merge
+# gate (ratified with that exact condition, 2026-08-02). Its selector is the
+# never-cut core from docs/TEST-PORTFOLIO.md §4: lifecycle, checkpoint
+# fault-injection, byte continuity, birth e2e, the runtime-exclusion gate,
+# schema/parity/seating, reception guards and the fail-closed authority
+# family. Run it through `scripts/lightning_check.sh`, which adds the two
+# proofs nextest cannot carry (the compile_fail doctest leg and the lean
+# no-default-features check) and prints, on every run, what this lane does
+# NOT prove. The merge gate remains the FULL suite on three OSes, always.
+[profile.lightning]
+default-filter = '''
+binary_id(m1nd-mcp::persist_runtime_root)
+| binary_id(m1nd-mcp::checkpoint_store)
+| binary_id(m1nd-mcp::first_graph_is_born)
+| binary_id(m1nd-core::snapshot_bin_continuity)
+| binary_id(m1nd-core::snapshot_bin_roundtrip)
+| test(ingest_excludes_runtime_state)
+| test(every_tool_input_schema_is_top_level_object)
+| test(live_schema_registry_and_policy_route_inventory_are_exactly_equal)
+| test(rest_route_verb_seating_is_exhaustive_on_both_sides_of_the_floor_gate)
+| test(catalog_minimal_arguments_validate_against_live_schema)
+| test(reception)
+| test(fail_closed)
+'''

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -146,6 +146,12 @@ indexes them, it does not restate them.
   manifest: what each family proves, its lane and budget, the fifteen
   never-cut families, and the safe order for any reduction. A test leaves the
   portfolio only through that file's registry, never through a cleanup PR.
+- **The lightning check buys ~57s by NOT proving** real-history retrieval,
+  compiler oracles, stress, wide properties, or any other OS — it is a
+  day-to-day signal (`cmd:scripts/lightning_check.sh`), never "the tests
+  passed"; the merge gate is the full suite on three OSes, and the never-cut
+  fifteen live in `doc:docs/TEST-PORTFOLIO.md` §3. (Built 2026-08-02; taught
+  as the canonical fast loop only after the owner's stamp.)
 - **The embedded UI bundle must match the source that builds it** — CI refuses a
   commit whose `dist/` is not a fresh build of its own source.
 - **Frozen contracts** (`docs/M1ND-10-PRD.md`, `docs/M1ND-10-UML.md`) are checked

--- a/docs/TEST-PORTFOLIO.md
+++ b/docs/TEST-PORTFOLIO.md
@@ -89,16 +89,28 @@ seating · MCP top-level schema · windows path/fs/process · the 13
 `compile_fail` doctests · lean `default-features=false` · docs coupling ·
 a11y as a separate proof · eslint actually executed · `m1nd-ui/dist` drift.
 
-## 4. The lightning proposal (AWAITS OWNER RATIFICATION — not active)
+## 4. The lightning lane (BUILT — canonical status awaits the owner's stamp)
 
-Selector sketch (nextest filterset, to be pinned as `[profile.lightning]`):
-lifecycle + checkpoint + continuity + parity/schema/seating + birth e2e +
-runtime-exclusion + lean edge + doctests leg + per-touched-surface wings.
-Measured components sum to **~60–120s hot** on the dev box — under the 180s
-ceiling with room for wings. What it deliberately omits (still on merge):
-retrobuilder, transplant oracles, 10k stress, wide proptests, full grammar
-matrix, browser fixtures. **Activating it changes what the fast loop
-promises; that is the owner's signature, not a config change.**
+Ratified 2026-08-02 (Paco) with one non-negotiable design condition, built
+and measured the same day; **taught as the day-to-day path only after the
+owner's stamp** — until then it exists and works, and nothing points agents
+at it as "the" loop.
+
+- Selector pinned as `[profile.lightning]` in `.config/nextest.toml`; the
+  command is `scripts/lightning_check.sh`, which adds the two proofs nextest
+  cannot carry (the 13 `compile_fail` sentinels, the lean
+  `no-default-features` check).
+- **Measured on the dev box: 57s hot** (82 selected tests of 2,674 — the
+  never-cut core is ~3% of the suite; 16.3s nextest + 0.36s doctests + lean
+  check + incremental overhead). Warm-after-branch-switch: 190s. Ceiling: 180s
+  hot, per ratification.
+- **The design condition, verbatim in mechanism:** the script prints on EVERY
+  run that it is not the merge gate and exactly what it does not prove; the
+  merge gate remains the full suite on three OSes, unchanged; MANUAL §5
+  carries the one-line cost statement with the pointer here.
+- What it deliberately omits (all still on merge): retrobuilder over real
+  history, transplant compiler oracles, 10k-op stress, wide proptests, the
+  full grammar matrix, browser suites, every other OS.
 
 ## 5. Safe order (ratified; where we are)
 

--- a/scripts/lightning_check.sh
+++ b/scripts/lightning_check.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The LIGHTNING CHECK — the fast day-to-day signal over the never-cut core.
+#
+# THIS IS NOT THE MERGE GATE. It exists so the loop between two edits costs
+# minutes, not an hour — and it buys that speed by NOT running most of the
+# suite. The merge gate remains the FULL suite on three OSes, without
+# exception; "the lightning passed" is never "the tests passed". The lane's
+# contract, selector and budget live in docs/TEST-PORTFOLIO.md §4.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(bash scripts/cargo_target_dir.sh)}"
+
+start=$SECONDS
+# The never-cut core (selector pinned in .config/nextest.toml).
+cargo nextest run --profile lightning --workspace --all-targets
+# The two proofs nextest cannot carry:
+# the 13 compile_fail sentinels (the candidate boundary)…
+cargo test --locked -p m1nd-mcp --doc
+# …and the lean edge feature unification hides from every workspace build.
+cargo check --locked -p m1nd-mcp --no-default-features
+elapsed=$(( SECONDS - start ))
+
+echo
+echo "LIGHTNING CHECK PASSED in ${elapsed}s — a fast day-to-day signal, NOT the merge gate."
+echo "Deliberately NOT proven here: retrieval over this repo's real history (retrobuilder),"
+echo "the transplant compiler oracles, 10k-op stress, wide property runs, the full grammar"
+echo "matrix, the browser suites, and every OS that is not this machine."
+echo "The merge gate is the FULL suite on 3 OSes. Portfolio + the never-cut fifteen:"
+echo "docs/TEST-PORTFOLIO.md"


### PR DESCRIPTION
**The lightning lane, built under its ratified design condition** (2026-08-02) — relanded from #525/#526 via cherry-pick onto fresh main (the stacked branch conflicted structurally with #524's squash; content identical, ancestry clean).

- `[profile.lightning]` pins the never-cut core selector: **82 tests of 2,674** (~3% of the suite — the families that paid for themselves with real incidents).
- `scripts/lightning_check.sh` composes the three proofs (nextest core + the 13 `compile_fail` sentinels + the lean edge) and **prints on every run what it does NOT prove**, with the pointer to the portfolio and the fifteen.
- **Measured hot: 57s** (ratified ceiling 180s); warm-after-branch-switch 190s.
- The merge gate is untouched: full suite, three OSes, no exception.
- **Canonical day-to-day status awaits the owner's stamp** — MANUAL §5 records built-awaiting-stamp; no doc points agents at this as "the" loop yet.