### PR TITLE
release: prepare v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,61 @@ All notable changes to m1nd are documented here. This project uses [Semantic Ver
 
 ## [Unreleased]
 
-## [1.6.2] — 2026-07-31
+## [1.6.3] — 2026-08-02
+
+1.6.2 was tagged but never published: its release run was refused by the
+immutable-registry gate (`m1nd-control@0.2.0` already existed on crates.io
+with different bytes — `cargo package` embeds the tagging commit in
+`.cargo_vcs_info.json`, so every new tag changes a crate's bytes even when
+its code did not change). This release carries everything 1.6.2 contained,
+bumps every published crate, and adds the week's first-value work.
+
+### Added
+
+- **A fresh repo can actually end up with a graph.** `m1nd init --birth <repo>`
+  now fills the runtime's own graph when the runtime lives at or inside the
+  repo (the solo topology), refuses a ceremony that would exit successfully
+  with zero nodes (`birth_produced_empty_graph`), and every refusal on the
+  first-contact path names the exact command that opens the door. Proven end
+  to end by a subprocess battery that walks virgin repo → ceremony → second
+  boot → served graph, in all three runtime layouts.
+- **The tool menu fits on one screen.** `tools/list` serves a core of 15
+  (the ratified 12 plus `help`/`doctor`/`recovery_playbook`); the other 127
+  registered verbs stay fully callable by name, `help` catalogs the FULL
+  registry at every tier, and `health.tool_surface_contract` states the
+  hidden count and the discovery rule outright. `M1ND_TOOL_TIER=full`
+  restores the old wall for operators who want it.
+- **`north` returns the code of its top focus nodes** — the symbol's own
+  lines when the node names one — under a caller-visible `code_budget_chars`,
+  closing the second hop agents used to make by hand after every orientation.
+- **m1nd records how it is used**: per-verb counters (names and counts only,
+  by mechanism nothing else can reach the file) in `verb_usage_state.json`,
+  surfaced through `report`.
+
+### Fixed
+
+- **Ingest no longer erases the Hebbian layer.** Re-ingesting a root now
+  carries the learned synaptic counters across the graph replacement; in
+  production every one of 73k+ edges had been sitting at zero because each
+  ingest was born zeroed and nothing re-imported the sidecar.
+- **A birth ceremony no longer ingests its own runtime.** With the runtime at
+  the repo root, the source walk swallowed the runtime's state files (32 of a
+  measured 39 nodes were checkpoint blobs and lease files) and the freshness
+  revalidation raced the live lease writers on Linux. The runtime's own files
+  are now excluded from the walk via the pipeline receipt, and a gate test
+  fails naming any new state file the exclusion misses.
+- **The first minute finds the owner that already holds the repo**
+  (`--attach auto` discovery), and an absent keychain label reads as absent
+  instead of aborting a fresh custody ceremony.
+
+### Known issues, carried openly
+
+- `trace` can report `file not in graph` for files the graph holds when the
+  stacktrace CWD differs from the ingest root (pinned by test, fix pending);
+  `search` has a known regex edge; `tremor`/`trust` answer empty on a fresh
+  graph with no history. All four are frozen pending prioritization.
+
+## [1.6.2] — 2026-07-31 (tagged, never published)
 
 ### Added — the custody ceremony gets an artifact it can actually run in
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "m1nd-control"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ed25519-dalek",
  "p256",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-core"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "bincode",
  "cargo_metadata",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-ingest"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-mcp"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "axum",
  "clap",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "m1nd-runnerd"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "axum",
  "clap",

--- a/m1nd-control/Cargo.toml
+++ b/m1nd-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-control"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Canonical control-plane contracts for m1nd."
 license = "MIT"

--- a/m1nd-core/Cargo.toml
+++ b/m1nd-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-core"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "Core graph engine and reasoning primitives for m1nd."
 license = "MIT"

--- a/m1nd-ingest/Cargo.toml
+++ b/m1nd-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-ingest"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "Language ingest and graph extraction pipeline for m1nd."
 license = "MIT"
@@ -43,7 +43,7 @@ tier2 = [
 ]
 
 [dependencies]
-m1nd-core = { path = "../m1nd-core", version = "1.6.2" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.3" }
 serde = { workspace = true }
 regex = "1"
 walkdir = "2"

--- a/m1nd-mcp/Cargo.toml
+++ b/m1nd-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-mcp"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "Local MCP runtime for coding agents: structural retrieval, change reasoning, document grounding, and continuity."
 license = "MIT"
@@ -27,9 +27,9 @@ serve = ["dep:axum", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:
 embed = ["m1nd-core/embed"]
 
 [dependencies]
-m1nd-control = { path = "../m1nd-control", version = "0.2.0" }
-m1nd-core = { path = "../m1nd-core", version = "1.6.2" }
-m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.2" }
+m1nd-control = { path = "../m1nd-control", version = "0.2.1" }
+m1nd-core = { path = "../m1nd-core", version = "1.6.3" }
+m1nd-ingest = { path = "../m1nd-ingest", version = "1.6.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }

--- a/m1nd-runnerd/Cargo.toml
+++ b/m1nd-runnerd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m1nd-runnerd"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 description = "The m1nd runner daemon (F2.5c): the ONLY spawner. Executes pinned spawn missions in an isolated git worktree, runs the gate, and emits mission letters on the chain — never `landed`."
 license = "MIT"
@@ -12,7 +12,7 @@ publish = false
 # side record (§1f) + the shared-secret filename — `default-features = false` keeps
 # axum/reqwest/embed OUT of this dependency edge (we bring our own below); the
 # runnerd is a CLIENT of the owner's contract, so the wire types must be the owner's.
-m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.2", default-features = false }
+m1nd-mcp = { path = "../m1nd-mcp", version = "1.6.3", default-features = false }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxkle1nz/m1nd",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "mcpName": "io.github.maxkle1nz/m1nd",
   "description": "Universal installer and agent pack for the m1nd MCP runtime.",
   "license": "MIT",


### PR DESCRIPTION
**The release the owner gated on perfection** (ratified 2026-08-02): everything unpublished 1.6.2 contained plus the week's first-value pivot, prepared under the release rite.

**Why 1.6.2 never shipped, and what this PR fixes about the rite:** the immutable-registry gate refused `m1nd-control@0.2.0` — its bytes change on EVERY tag (`cargo package` embeds the tagging commit in `.cargo_vcs_info.json`) even with zero code change. Rule now applied and recorded in the changelog: **every release bumps every published crate.** Workspace → 1.6.3, m1nd-control → 0.2.1, npm wrapper → 1.6.3, lock regenerated.

**What ships (changelog has the full honest entry):** first-value path (virgin repo → populated CLEAN graph, all 3 layouts, refusals name the door), the core menu of 15 (127 hidden-but-callable, `help` catalogs the full registry), `north` returns code, ingest keeps the Hebbian counters, per-verb telemetry — plus 1.6.2's custody app and actor re-bind fix. **Known issues carried openly:** trace path-identity, search regex, tremor/trust empty-without-history (frozen, named in the changelog).

**Local proof on this branch:** lightning check green (82/82 core + 13/13 sentinels + lean edge). Full proof is this PR's CI.

**After merge (the ratified rite, each gate reported):** tag `v1.6.3` on the exact main HEAD (the tag-guard demands it) → release pipeline (signed, notarized, SHA256SUMS) → **stranger-install proof on a virgin repo (gate #1, non-negotiable)** → owner serve refresh with rollback path (runbooks 6.3/6.4) → **needles-awake proof (gate #2: menu served, telemetry collecting)**. Any red stops the line.