### PR TITLE
fix(ingest): a degenerate reference cannot kill a birth

### DIFF
--- a/m1nd-ingest/src/extract/tree_sitter_ext.rs
+++ b/m1nd-ingest/src/extract/tree_sitter_ext.rs
@@ -559,6 +559,16 @@ impl TreeSitterExtractor {
             if self.config.import_kinds.contains(&kind) && self.is_import_node(node, source) {
                 let targets = self.extract_import_target(node, source);
                 for target in targets {
+                    // The full-text fallback splits on quotes, so a whitespace
+                    // string literal in the source (`replace(/\s+/g," ")`) can
+                    // come back as a target of pure whitespace — which becomes
+                    // the invalid endpoint `ref:: ` and killed a real birth
+                    // ceremony (2026-08-02). A blank reference names nothing;
+                    // drop it here, at the producer.
+                    let target = target.trim();
+                    if target.is_empty() {
+                        continue;
+                    }
                     let ref_id = format!("ref::{}", target);
                     edges.push(ExtractedEdge {
                         source: file_id.to_string(),
@@ -577,7 +587,11 @@ impl TreeSitterExtractor {
             // We still recurse into children so that nested calls inside
             // argument lists are also detected with the same enclosing caller.
             if self.config.call_kinds.contains(&kind) {
-                if let Some(callee) = self.extract_callee(node, source) {
+                if let Some(callee) = self
+                    .extract_callee(node, source)
+                    .map(|callee| callee.trim().to_string())
+                    .filter(|callee| !callee.is_empty())
+                {
                     let caller = parent_id.as_deref().unwrap_or(file_id);
                     let ref_id = format!("ref::{}", callee);
                     edges.push(ExtractedEdge {
@@ -1718,6 +1732,41 @@ mod tests {
         for child in node.named_children(&mut cursor) {
             dump_node(&child, src, out, depth + 1);
         }
+    }
+
+    /// A birth ceremony died on a REAL html file for this (2026-08-02, the HQ
+    /// repo): an inline `<script>` is an import_kind, its structured targets
+    /// come back empty, and the full-text fallback splits the script body on
+    /// quotes — so a JS string literal `" "` became import target `" "`,
+    /// edge `ref:: `, and the ingest validator refused the WHOLE payload.
+    /// Every emitted reference must be non-whitespace; the degenerate ones are
+    /// dropped, never emitted.
+    #[test]
+    fn html_inline_script_with_whitespace_string_literals_emits_no_blank_refs() {
+        // The exact minimal shape bisected from the real file: a call chain
+        // ending in `replace(/\s+/g," ")` inside a function body — the
+        // structured collector finds no clean identifier, the full-text
+        // fallback splits on quotes, and the `" "` literal becomes a target.
+        let src = b"<!doctype html><html><head><script>\nfunction idOf(c){return c.querySelector(\".name\").textContent.trim().replace(/\\s+/g,\" \")}\n</script></head><body></body></html>";
+        let ext = EmbeddedExtractor::html_embedded();
+        let result = ext.extract(src, "file::page.html").unwrap();
+        let blank: Vec<_> = result
+            .edges
+            .iter()
+            .filter(|e| {
+                e.target
+                    .strip_prefix("ref::")
+                    .is_some_and(|t| t.trim().is_empty())
+            })
+            .collect();
+        assert!(
+            blank.is_empty(),
+            "no edge may carry a blank ref target; got {:?}",
+            blank
+                .iter()
+                .map(|e| (&e.source, &e.target, &e.relation))
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/m1nd-ingest/src/lib.rs
+++ b/m1nd-ingest/src/lib.rs
@@ -1579,13 +1579,18 @@ impl Ingestor {
         for (source_key, edge) in &all_edges {
             cancellation.check()?;
             if !is_valid_external_id(&edge.source) || !is_valid_external_id(&edge.target) {
-                return Err(M1ndError::InvalidParams {
-                    tool: "ingest".into(),
-                    detail: format!(
-                        "extractor emitted invalid edge endpoint {:?} -> {:?} ({}) for source {source_key:?}",
-                        edge.source, edge.target, edge.relation
-                    ),
-                });
+                // One degenerate edge must never abort the whole ingest: a
+                // REAL birth ceremony died on `ref:: ` from an html inline
+                // script (2026-08-02) — a brain refused to be born over one
+                // blank href-shaped reference. Invalid nodes were already
+                // skipped-and-counted a few lines up; edges now get the same
+                // treatment, and the count is reported after the loop.
+                eprintln!(
+                    "[m1nd ingest] skipping invalid edge endpoint {:?} -> {:?} ({}) for source {source_key:?}",
+                    edge.source, edge.target, edge.relation
+                );
+                skipped_invalid_edges += 1;
+                continue;
             }
 
             if edge.target.starts_with("ref::") {


### PR DESCRIPTION
**The first dogfood bug of the fresh 1.6.3, found by the HQ agent within the hour** — and it is exactly the funnel class the release exists to kill: `m1nd init --birth` on a repo containing an ordinary html file ABORTED with `extractor emitted invalid edge endpoint "file::corte-paypal.html" -> "ref:: " (imports)`.

**Diagnosis, bisected on the real file:** an inline `<script>` is an import_kind; its structured targets come back empty; the full-text fallback splits the script body on quotes — so the JS string literal in `replace(/\\s+/g," ")` became import target `" "`, edge `ref:: `, and the ingest validator refused the WHOLE payload. Any web repo with that idiom cannot be born.

**Fix, two layers:**
- **Producer**: config-based import targets and callees are trimmed, blanks dropped — at the one `walk_ast` seam every tree-sitter language shares.
- **Validator**: an invalid edge endpoint is skipped and counted (`skipped_invalid_edges` — the counter and its end-of-ingest report already existed; invalid NODES already got exactly this treatment) instead of aborting. One bad edge costs one edge, never the brain.

**Proof:** extractor test = the bisected minimal shape from the real file, RED before the producer fix; the real repo's ceremony now births 9 nodes / 12 edges end to end where it refused before. m1nd-ingest 305/305; fmt+clippy clean.

**Filed, not fixed here** (project inbox): the JS extractor also mints ~40 FALSE 'imports' from plain var declarations and member expressions on the same real file (`ref::KEY`, `ref::.card.tap`…) — noise, not a killer; its own change.

First of the 1.6.4 gatehouse family (blocks the HQ agent's GATE 3 — the house's own adoption). After merge: selfhost refresh unblocks the HQ birth immediately; the published 1.6.4 carries it to strangers with the rest of the family.