### PR TITLE
fix(ingest): an unreadable directory cannot kill a birth

### DIFF
--- a/m1nd-ingest/src/lib.rs
+++ b/m1nd-ingest/src/lib.rs
@@ -176,7 +176,22 @@ fn discovery_policy_fingerprint(
     } else {
         root.as_path()
     };
+    // An unreadable SCAN ROOT is fatal — there is nothing to fingerprint and
+    // silence would lie. An unreadable entry DEEPER in the tree is not: it can
+    // contain neither a readable control file nor an ingestable source, so it
+    // is skipped with a notice. A real birth ceremony died whole on a
+    // `.secrets/` directory owned by another user (2026-08-02) before this
+    // distinction existed.
+    if scan_root.is_dir() {
+        std::fs::read_dir(scan_root).map_err(|error| {
+            M1ndError::Io(std::io::Error::other(format!(
+                "policy control walk cannot open the scan root {}: {error}",
+                scan_root.display()
+            )))
+        })?;
+    }
     let mut controls = BTreeMap::<String, String>::new();
+    let mut skipped_unreadable_paths = 0u64;
     let iter = walkdir::WalkDir::new(scan_root)
         .follow_links(false)
         .into_iter()
@@ -190,11 +205,14 @@ fn discovery_policy_fingerprint(
                 && !skip_dirs.iter().any(|skip| skip == name.as_ref())
         });
     for entry in iter {
-        let entry = entry.map_err(|error| {
-            M1ndError::Io(std::io::Error::other(format!(
-                "policy control walk failed: {error}"
-            )))
-        })?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                eprintln!("[m1nd ingest] skipping unreadable path in policy control walk: {error}");
+                skipped_unreadable_paths += 1;
+                continue;
+            }
+        };
         if !entry.file_type().is_file() {
             continue;
         }
@@ -301,6 +319,11 @@ fn discovery_policy_fingerprint(
                 controls.insert("global-git-exclude-config".into(), "UNSET".into());
             }
         }
+    }
+    if skipped_unreadable_paths > 0 {
+        eprintln!(
+            "[m1nd ingest] policy control walk skipped {skipped_unreadable_paths} unreadable path(s); nothing under an unreadable directory is fingerprinted or ingested"
+        );
     }
     let build_features = active_pipeline_features();
     let encoded = serde_json::to_vec(&(
@@ -1914,6 +1937,46 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("m1nd-ingest-{name}-{nonce}"))
+    }
+
+    /// The second gatehouse kill of 2026-08-02, one layer below the first: a
+    /// REAL repo carried a `.secrets/` directory owned by another user
+    /// (mode 700, and listed in the repo's own `.gitignore`), and the birth
+    /// ceremony died whole on `policy control walk failed: … Permission
+    /// denied`. An unreadable directory can contain neither a readable
+    /// control file nor an ingestable source, so skipping it is semantically
+    /// safe and deterministic — the ceremony must survive, count the skip,
+    /// and say so. Root-level unreadability stays fatal: nothing at all can
+    /// be ingested then, and silence would be a lie.
+    #[test]
+    #[cfg(unix)]
+    fn an_unreadable_subdirectory_does_not_abort_the_ingest() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = temp_ingest_dir("unreadable-subdir");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "pub fn a() -> u32 { 1 }\n").unwrap();
+        let sealed = root.join(".secrets");
+        fs::create_dir_all(&sealed).unwrap();
+        fs::write(sealed.join("token"), "shh").unwrap();
+        fs::set_permissions(&sealed, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = Ingestor::new(IngestConfig {
+            root: root.clone(),
+            ..IngestConfig::default()
+        })
+        .ingest();
+
+        // Restore permissions before asserting so the tempdir can be cleaned
+        // up even when the assertion fails.
+        fs::set_permissions(&sealed, fs::Permissions::from_mode(0o755)).unwrap();
+        let (graph, _stats) = result.expect(
+            "an unreadable subdirectory must be skipped and counted, never abort the ingest",
+        );
+        assert!(
+            graph.num_nodes() > 0,
+            "the readable half of the repo must still produce a graph"
+        );
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/m1nd-ingest/src/walker.rs
+++ b/m1nd-ingest/src/walker.rs
@@ -276,6 +276,17 @@ impl DirectoryWalker {
         // include_dotfiles escape hatch. The filter_entry below preserves the hardcoded
         // skip_dirs + is_noise_dir_name pruning so noise dirs are dropped even in a repo with
         // NO .gitignore.
+        // An unreadable SCAN ROOT is fatal (nothing at all can be discovered,
+        // and an empty walk would silently claim an empty repo). An unreadable
+        // entry DEEPER in the tree is skipped below — it can contain nothing
+        // ingestable, and a whole birth ceremony once died on a foreign-owned
+        // `.secrets/` directory (2026-08-02).
+        std::fs::read_dir(&root_canonical).map_err(|error| {
+            M1ndError::Io(std::io::Error::other(format!(
+                "directory walk cannot open the scan root {}: {error}",
+                root_canonical.display()
+            )))
+        })?;
         let filter_root = root_canonical.clone();
         let skip_dirs = self.skip_dirs.clone();
         let include_dotfiles = self.include_dotfiles;
@@ -305,7 +316,20 @@ impl DirectoryWalker {
             .build();
 
         for entry in walk {
-            let entry = Self::require_walk_entry(&root_canonical, entry)?;
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    // The root was proven readable above; anything failing
+                    // here is a deeper unreadable path, which can contain
+                    // nothing ingestable. Skip it loudly instead of killing
+                    // the whole discovery.
+                    eprintln!(
+                        "[m1nd ingest] skipping unreadable path under {}: {error}",
+                        root_canonical.display()
+                    );
+                    continue;
+                }
+            };
 
             // ignore::DirEntry::file_type is Option (None for stdin/errors) — skip non-files.
             if !entry.file_type().is_some_and(|ft| ft.is_file()) {
@@ -381,18 +405,6 @@ impl DirectoryWalker {
             files,
             commit_groups,
             vcs,
-        })
-    }
-
-    fn require_walk_entry(
-        root: &Path,
-        entry: Result<ignore::DirEntry, ignore::Error>,
-    ) -> M1ndResult<ignore::DirEntry> {
-        entry.map_err(|error| {
-            M1ndError::Io(std::io::Error::other(format!(
-                "directory walk failed under {}: {error}",
-                root.display()
-            )))
         })
     }
 
@@ -825,20 +837,34 @@ mod tests {
     }
 
     #[test]
-    fn walk_entry_error_is_fatal() {
-        let root = Path::new("/governed/root");
-        let error = ignore::Error::WithPath {
-            path: root.join("unreadable"),
-            err: Box::new(ignore::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                "injected walk-entry failure",
-            ))),
-        };
-
-        assert_io_error(
-            DirectoryWalker::require_walk_entry(root, Err(error)),
-            "injected walk-entry failure",
-        );
+    fn unreadable_scan_root_is_fatal() {
+        // The 2026-08-02 inversion: a deeper unreadable entry is now skipped
+        // (it can contain nothing ingestable — pinned end to end by
+        // `an_unreadable_subdirectory_does_not_abort_the_ingest` in lib.rs),
+        // but the SCAN ROOT itself stays fatal: an empty walk over a root we
+        // cannot open would silently claim an empty repo.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let root = std::env::temp_dir().join(format!(
+                "m1nd-walker-unreadable-root-{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o000)).unwrap();
+            let result =
+                DirectoryWalker::new(Vec::new(), Vec::new(), false, Vec::new()).walk(&root);
+            std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755)).unwrap();
+            std::fs::remove_dir_all(&root).ok();
+            let error = result.expect_err("an unreadable scan root must be a hard error");
+            assert!(
+                error.to_string().contains("cannot open the scan root"),
+                "the error must name the root refusal, got: {error}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Gatehouse kill #2, found by the HQ agent minutes after #529 unblocked him** — one layer below the first: `m1nd init --birth` on a real repo died whole on `policy control walk failed: … .secrets: Permission denied` — a directory owned by another user, mode 700, and listed in the repo's own `.gitignore`.

**Why the walk hit it at all:** the policy walk exists to COLLECT ignore files, so it cannot obey them. But an unreadable directory can contain neither a readable control file nor an ingestable source — aborting on it protects nothing and kills every repo with a `.secrets`, a foreign-owned `node_modules`, or a broken mount.

**The law, both walks, same shape as #529:**
- **Scan root unreadable → still fatal**, now with a named refusal (`cannot open the scan root`): an empty walk over an unopenable root would silently claim an empty repo.
- **Deeper unreadable entry → skipped, counted, reported** (`skipped_unreadable_paths`, notice per path + summary). Deterministic: same tree + same permissions = same fingerprint.
- The old `walk_entry_error_is_fatal` pin is deliberately inverted — replaced by two pins of the new law (fatal-root + e2e ingest over a mode-000 subdir).

**Proof:** the e2e test reproduced the field error verbatim RED before the fix; a ceremony over a fixture with an unreadable subdir now births 6 nodes / 8 edges with three honest skip notices. m1nd-ingest 305/305; fmt+clippy clean.

Item #2 of the 1.6.4 gatehouse family. Blocks the house's own GATE 3 (HQ birth) — selfhost refresh after merge unblocks it immediately.