### PR TITLE
feat(birth): the door offers a choice — the owner's law replaces the old doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,10 +435,11 @@ bound brain because the writer never checked which brain it was talking to.
    `_ratify` / `_reconcile`, `mission_post`) would land in the WRONG brain. **No public
    gesture lifts this for AGENTS.** Generic cross-root `ingest` remains withdrawn
    (`project_root` is absent from the published schema; POSITIVE_SOVEREIGN), and over the
-   wire `brain.bootstrap.birth` refuses every client with `human_gesture_required` — the
-   stamp is the binary's own CLI flag, which no MCP or REST payload can forge. The way
-   forward for a brainless repo is the HUMAN's one-time ceremony: OFFER the exact command
-   `m1nd init --birth <repo>` and stop — running it is not the agent's to do. Until then,
+   wire `brain.bootstrap.birth` answers every client with `human_authorization_required` —
+   the stamp is the binary's own CLI flag, which no MCP or REST payload can forge. The way
+   forward for a brainless repo is the ceremony `m1nd init --birth <repo>`, and by the
+   owner's law of 2026-08-02 an agent runs it ITSELF once its human has picked: ask first
+   (a new brain, or load the one already there), then run it and report. Until they answer,
    reconnect to an owner that already hosts the intended repo, or stay read-only with the
    mismatch warning intact — do not write.
    (The mechanical write-refusal has LANDED — every skeleton write verb

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ npx -y @maxkle1nz/m1nd init --birth .
 npx -y @maxkle1nz/m1nd agent first-minute --repo . --query "map this repo" --json
 ```
 
-Step 4 is the one command an agent can never run for you, and that is deliberate: minting a brain writes a whole graph, so it is a human gesture the runtime only accepts from its own CLI. It is also the only one — after it, the agent drives everything, including keeping the graph fresh. It exits non-zero and tells you what to check if the scan finds nothing, so it can never report success over an empty graph.
+Step 4 is the one command that waits for your word. Minting a brain writes a whole graph, so it happens on your explicit pick and nowhere else: your agent asks you first, a new brain for this repo or the one already sitting here, and with your yes it runs the ceremony itself. A repo that already holds a brain gets the choice back with that brain's numbers instead of a refusal, and `--confirm create-new` or `--confirm load-existing` settles it. After that the agent drives everything, including keeping the graph fresh. It exits non-zero and tells you what to check if the scan finds nothing, so it can never report success over an empty graph.
 
 Step 1 verifies the signature with [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/), so install that first if it is not on your PATH. If you prefer the source registry and accept skipping verification, `cargo install m1nd-mcp` works too. Prefer to see before you write: `hosts plan` prints everything `hosts apply` would touch, and writes nothing. There is no uninstall command yet; `hosts plan` doubles as the list of what to remove by hand.
 
@@ -214,9 +214,9 @@ This is why I built m1nd. Retrieval layers are good at answering. Almost none of
 {
   "ok": false,
   "verdict": "needs_ingest",              // never a bare "no results"
-  "next_action": "offer_the_birth_ceremony",
+  "next_action": "ask_then_birth",
   "recovery_playbook": {
-    "steps": [ { "action": "This repo has no brain yet: tell the human to run `m1nd init --birth <repo>` once. Offer the command and stop — running it is not yours to do." } ]
+    "steps": [ { "action": "This repo has no brain yet: ask your human which they want, a new brain here or an existing one loaded. With their yes, run `m1nd init --birth <repo>` yourself and report what it built." } ]
   }
 }
 ```

--- a/docs/PATHOS.md
+++ b/docs/PATHOS.md
@@ -369,6 +369,24 @@ Update this list in the same PR that closes one; a front that dies silently is a
   the fast loop promises, and that is not a config change. Safe-order position: step 1 (observe)
   RUNNING via shadow + local timing; step 2 (manifest) THIS delta; steps 3+ gated on ratification.
 
+**Delta 2026-08-02 (late) — the door offers a CHOICE, and the owner's law replaces the old doctrine:**
+- **The owner's law, declared verbatim and now IMPLEMENTED:** "brain o agente PODE fazer com
+  autorização do humano, e ele tem que dizer SEMPRE pro humano se quer fazer o brain ou carregar."
+  Every birth surface now offers the create-new × load-existing CHOICE instead of a bare refusal:
+  the CLI (`--confirm create-new|load-existing`, relayed by the npm wrapper), the ceremony verdict
+  (an inhabited destination returns `choice_required` with the existing brain's numbers — the exact
+  fix for the field case where a boot ingested BEFORE the verdict and the ceremony refused the graph
+  its own process had just filled), and the wire verb (now `human_authorization_required` + the
+  agent's actionable 3-step path, never "agents never do"). `HumanOrigin` gained `AgentRelayed`
+  ("human-via-agent") by the owner's decision. The OLD doctrine ("agents offer, never run") was
+  swept from every surface that taught it — server instructions, tool descriptions, ingest doors,
+  recovery playbook, both skills, the universal agent pack — in the same change. Declared residual:
+  the wire verb still cannot EXECUTE a birth (the dispatcher holds no owner context); the authorized
+  agent's executable path is the CLI, and direct wire execution is its own plumbing decision.
+- Pinned: the second-ceremony e2e now proves the CHOICE (options by name + the existing node_count)
+  and the load-existing acknowledgement; the wire pin proves the 3-step path names both choices and
+  the exact command; the allowlist pin carries the fourth origin with the law's date.
+
 **Copy / positioning**
 - **README + site copy rewrite (branch `copy/human-voice`, 2026-07-29) — LANDED HERE, awaiting owner review.**
   Full README rewrite in the owner's voice (definition at line 5, anti-pitch section, "If I disappear",

--- a/docs/wiki/src/tutorials/quickstart.md
+++ b/docs/wiki/src/tutorials/quickstart.md
@@ -245,8 +245,9 @@ matches the brain serving you.
 for those pieces directly only when you need just one. If `north` returns
 `needs_ingest` (empty or unbound graph), that is a real answer, not a failure —
 and it is not yours to fix with `ingest`, which is refused on every transport.
-Read the packet's `next_move`: a repo with no brain yet needs the HUMAN's
-one-time ceremony `m1nd init --birth <repo>` (offer the command and stop), while
+Read the packet's `next_move`: a repo with no brain yet needs the ceremony
+`m1nd init --birth <repo>` — ask your human which they want, a new brain or an
+existing one loaded, and run it yourself with their yes — while
 a brain that already declares your root you refresh yourself with
 `ingest {mode:"refresh", path: <your root>}`. Then call `north` again.
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -187,16 +187,19 @@ north({ "agent_id": "install-check", "task": "orient" })
 A healthy response carries `binding.trust_mode` (e.g. `full_trust`), a `context` block
 with `focus_nodes` + `anchors`, and `honest_gaps`. If the graph is empty it returns
 `needs: "needs_ingest"`, and its `next_move` carries the door: **you do not ingest.**
-Minting a brain is the human's one-time gesture, so tell them to run this once, in a
-terminal, and stop:
+Minting a brain happens on your human's explicit pick, so ask them first — a new brain
+for this repo, or load one that already exists? — and with their yes run the ceremony
+yourself, in a terminal, then report what it built:
 
 ```bash
 npx -y @maxkle1nz/m1nd init --birth /abs/path/to/project
 ```
 
-The ceremony ingests the repo and prints what it built (`node_count`, `edge_count`); it
-exits non-zero if the scan produced nothing, so it never reports success over an empty
-graph. Calling `ingest` yourself is refused on every transport
+If the destination already holds a brain, the ceremony answers with the CHOICE and that
+brain's numbers instead of a bare refusal; add `--confirm create-new` or
+`--confirm load-existing` once your human has picked. The ceremony ingests the repo and
+prints what it built (`node_count`, `edge_count`); it exits non-zero if the scan produced
+nothing, so it never reports success over an empty graph. Calling `ingest` yourself is refused on every transport
 (`generic_action_authority_required`) — the refusal names this same command. Once the
 graph exists, `ingest({ "mode": "refresh" })` from that exact root is the agent's own
 door for keeping it fresh.

--- a/m1nd-mcp/src/action_routes.rs
+++ b/m1nd-mcp/src/action_routes.rs
@@ -134,7 +134,8 @@ pub const MCP_TOOL_ROUTE_NAMES: &[&str] = &[
     "persist",
     "boot_memory",
     // Advertised so an agent can SEE the birth verb and read its honest refusal
-    // (`human_gesture_required`) — never so it can call it. It routes to
+    // (`human_authorization_required`, with the agent's path) — never so it can
+    // execute it there. It routes to
     // `brain.bootstrap.birth` at the `PositiveSovereign` floor and is refused for
     // every wire client; the stamp is the binary's own `--birth` ingress. Absent
     // from this list the verb would be advertised with no ratified floor at all,

--- a/m1nd-mcp/src/brain_birth.rs
+++ b/m1nd-mcp/src/brain_birth.rs
@@ -59,8 +59,16 @@ pub enum HumanOrigin {
     /// the ratified allowlist; no stamping seam is installed in this PR.
     TouchId,
     /// The P2 ceremony (`human-cli`) — `m1nd init --birth <root>`, which reaches
-    /// the owner as its own `--birth` ingress. The ONLY stamp installed today.
+    /// the owner as its own `--birth` ingress.
     Cli,
+    /// An agent relaying its human's explicit yes over the wire — the owner's
+    /// law, declared verbatim 2026-08-02: "brain o agente PODE fazer com
+    /// autorização do humano, e ele tem que dizer SEMPRE pro humano se quer
+    /// fazer o brain ou carregar." The agent's declaration is accepted BY THE
+    /// OWNER'S DECISION; the honesty obligation (always ask the human first,
+    /// always offer create-new × load-existing) lives in the agent protocol and
+    /// in the choice payload the wire returns when the declaration is absent.
+    AgentRelayed,
 }
 
 impl HumanOrigin {
@@ -70,13 +78,15 @@ impl HumanOrigin {
             HumanOrigin::Ui => "human-ui",
             HumanOrigin::TouchId => "human-touchid",
             HumanOrigin::Cli => "human-cli",
+            HumanOrigin::AgentRelayed => "human-via-agent",
         }
     }
 }
 
 /// The ratified allowlist as tokens, for payloads that must NAME the closed set
 /// (the refusal's `allowed_origins`, mirroring `receipt_import`'s shape).
-pub const BIRTH_HUMAN_ORIGINS: &[&str] = &["human-ui", "human-touchid", "human-cli"];
+pub const BIRTH_HUMAN_ORIGINS: &[&str] =
+    &["human-ui", "human-touchid", "human-cli", "human-via-agent"];
 
 /// The origins that have a STAMPING SEAM in this binary today.
 ///
@@ -110,6 +120,12 @@ pub struct BirthRequest {
     pub allow_overlap: bool,
     /// Passed through to the first ingest.
     pub include_dotfiles: bool,
+    /// The human's explicit pick when the destination already holds a brain
+    /// and the door offers the create-new × load-existing choice (the owner's
+    /// law, 2026-08-02). `Some("create-new")` re-scans replacing the graph;
+    /// `Some("load-existing")` acknowledges and touches nothing; `None` on an
+    /// inhabited destination gets the CHOICE back, never a bare refusal.
+    pub confirm: Option<String>,
 }
 
 impl BirthRequest {
@@ -120,6 +136,7 @@ impl BirthRequest {
             agent_id: agent_id.into(),
             allow_overlap: false,
             include_dotfiles: false,
+            confirm: None,
         }
     }
 }
@@ -143,18 +160,32 @@ pub(crate) fn birth_refusal(code: &str, reason: &str) -> serde_json::Value {
 /// `dispatch_tool` directly still cannot birth, because the dispatcher has no
 /// `HumanOrigin` to hand the handler and cannot manufacture one.
 pub fn birth_refusal_without_stamp() -> serde_json::Value {
+    // The owner's law, declared verbatim 2026-08-02: "brain o agente PODE
+    // fazer com autorização do humano, e ele tem que dizer SEMPRE pro humano
+    // se quer fazer o brain ou carregar." So this seam no longer teaches
+    // "agents never do" — it teaches the agent's real path: ask the human,
+    // offer both options, and with their yes RUN THE CEREMONY YOURSELF via
+    // the CLI (which any authorized agent can execute). The wire payload
+    // still cannot birth directly — the dispatcher holds no owner context —
+    // and that residual is declared, not hidden.
     let mut refusal = birth_refusal(
-        "human_gesture_required",
-        "birth is the human's one-time gesture; the owner stamps its origin from a fact it \
-         observes about itself, and a client-supplied origin string grants nothing",
+        "human_authorization_required",
+        "a brain is born on the human's explicit pick — ask them now: create a new brain for \
+         this repo, or load the existing one?",
     );
     if let Some(object) = refusal.as_object_mut() {
         object.insert("allowed_origins".into(), json!(BIRTH_HUMAN_ORIGINS));
         object.insert(
-            "lesson".into(),
-            json!(
-                "birthing a brain is the human's gesture — the ceremony sends it; agents never do"
-            ),
+            "your_path".into(),
+            json!({
+                "1": "present the choice to your human: create-new × load-existing (always — the owner's standing law)",
+                "2": format!(
+                    "with their yes, run the ceremony yourself: `{BIRTH_CEREMONY_COMMAND}` \
+                     (add `--confirm create-new` or `--confirm load-existing` when the repo \
+                     already holds a brain)"
+                ),
+                "3": "relay the outcome to your human verbatim",
+            }),
         );
         object.insert("door".into(), json!(BIRTH_CEREMONY_COMMAND));
     }
@@ -320,9 +351,21 @@ pub fn run_ceremony(
     root: &str,
     agent_id: &str,
 ) -> m1nd_core::error::M1ndResult<serde_json::Value> {
+    run_ceremony_with_confirm(server, root, agent_id, None)
+}
+
+/// [`run_ceremony`] with the human's explicit create-new × load-existing pick
+/// (the owner's law, 2026-08-02) — relayed from `--confirm` on the CLI.
+pub fn run_ceremony_with_confirm(
+    mut server: crate::server::McpServer,
+    root: &str,
+    agent_id: &str,
+    confirm: Option<String>,
+) -> m1nd_core::error::M1ndResult<serde_json::Value> {
     let (runtime_root, _project_root) = server.offline_operator_context();
     let registry_dir = server.config_registry_dir();
-    let request = BirthRequest::ceremony(root, agent_id);
+    let mut request = BirthRequest::ceremony(root, agent_id);
+    request.confirm = confirm;
 
     // THE HOME CASE, decided before any store is chosen. See
     // [`home_birth_verdict`]: when this owner's runtime lives INSIDE the root the
@@ -331,6 +374,8 @@ pub fn run_ceremony(
     match home_birth_verdict(&server, &runtime_root, &request)? {
         HomeBirth::NotHome => {}
         HomeBirth::Refuse(refusal) => return Ok(refusal),
+        HomeBirth::Choice(choice) => return Ok(choice),
+        HomeBirth::AlreadyServed(acknowledged) => return Ok(acknowledged),
         HomeBirth::Fill { canonical_root } => {
             return run_home_birth(server, &canonical_root, &request, HumanOrigin::Cli);
         }
@@ -351,7 +396,15 @@ enum HomeBirth {
     NotHome,
     /// It is home, and there is nothing to do — the answer is the refusal.
     Refuse(serde_json::Value),
-    /// It is home and the home is empty: fill this owner's own graph.
+    /// It is home and inhabited, and the caller has not chosen yet: the answer
+    /// is the create-new × load-existing CHOICE (the owner's law, 2026-08-02),
+    /// with the existing brain's numbers so the human decides informed.
+    Choice(serde_json::Value),
+    /// It is home, inhabited, and the human chose to keep it: acknowledge and
+    /// touch nothing.
+    AlreadyServed(serde_json::Value),
+    /// It is home and the home is empty (or the human chose create-new): fill
+    /// this owner's own graph.
     Fill { canonical_root: String },
 }
 
@@ -409,21 +462,58 @@ fn home_birth_verdict(
     // since the binding falls back to the graph path's parent — is covered and
     // still has no brain. Refusing it as "already has its brain" while reporting
     // zero nodes would be the same dishonesty this whole change is about.
+    //
+    // And when it IS inhabited, the answer is a CHOICE, never a bare refusal
+    // (the owner's law, 2026-08-02: the product must always say "create new or
+    // load the existing one?"). The field case that forced this: a boot could
+    // ingest the repo BEFORE this verdict ran, so the ceremony refused the very
+    // graph its own process had just filled — the agent read "failed" while a
+    // working brain sat behind the message.
     let bound = server.bound_boot_state()?;
     let node_count = u64::from(bound.graph.read().num_nodes());
     if node_count > 0 {
-        let mut refusal = birth_refusal(
-            "birth_root_is_bound_graph",
-            "this repo already has its brain — the graph this owner serves IS that brain, so there \
-             is nothing to birth; a birth would replace a graph that may have been growing for \
-             months, and that is never this command's job",
-        );
-        if let Some(object) = refusal.as_object_mut() {
-            object.insert("root".into(), json!(key));
-            object.insert("node_count".into(), json!(node_count));
-            object.insert("store_dir".into(), json!(runtime_key));
+        match request.confirm.as_deref() {
+            Some("create-new") => {
+                // The human explicitly chose to re-scan. Proceed to Fill —
+                // an authorized replace, not a silent one.
+            }
+            Some("load-existing") => {
+                return Ok(HomeBirth::AlreadyServed(json!({
+                    "ok": true,
+                    "schema": BIRTH_SCHEMA,
+                    "action": BIRTH_ACTION,
+                    "chose": "load-existing",
+                    "root": key,
+                    "node_count": node_count,
+                    "store_dir": runtime_key,
+                    "note": "this owner already serves that brain — nothing to run; use it as-is",
+                })));
+            }
+            Some(other) => {
+                return Ok(HomeBirth::Refuse(birth_refusal(
+                    "birth_confirm_unknown",
+                    &format!("confirm must be \"create-new\" or \"load-existing\"; got {other:?}"),
+                )));
+            }
+            None => {
+                return Ok(HomeBirth::Choice(json!({
+                    "ok": false,
+                    "choice_required": true,
+                    "schema": BIRTH_SCHEMA,
+                    "action": BIRTH_ACTION,
+                    "existing": {
+                        "root": key,
+                        "node_count": node_count,
+                        "store_dir": runtime_key,
+                    },
+                    "options": {
+                        "load-existing": "this brain is ALREADY SERVED by this owner — using it costs nothing; confirm with confirm:\"load-existing\" (or just use it)",
+                        "create-new": "re-scan this root REPLACING the graph — confirm with confirm:\"create-new\"; a graph that may have been growing for months is replaced, so this is the human's call",
+                    },
+                    "ask_the_human": "present both options to your human and relay their pick — never choose for them (the owner's standing law)",
+                })));
+            }
         }
-        return Ok(HomeBirth::Refuse(refusal));
     }
 
     Ok(HomeBirth::Fill {

--- a/m1nd-mcp/src/cli.rs
+++ b/m1nd-mcp/src/cli.rs
@@ -280,15 +280,23 @@ pub struct Cli {
     /// produce one. Over the wire the verb is refused for every client.
     ///
     /// The human-facing form is `m1nd init --birth <repo>`; the npm CLI runs this
-    /// binary with this flag. An AGENT that finds a repo with no brain OFFERS
-    /// that command and stops — running it is not the agent's to do.
+    /// binary with this flag. An AGENT may run it too — WITH the human's
+    /// explicit authorization, having always offered the create-new ×
+    /// load-existing choice first (the owner's law, 2026-08-02).
     ///
-    /// Refuses unless the destination is EMPTY on disk, unless the root resolves,
-    /// on any overlap with an existing brain, and on the owner's own bound root.
-    /// It is not the way to adopt an existing brain: that is migration, a
-    /// boot-time fact with no verb.
+    /// On a virgin destination it fills the graph. On an inhabited one it
+    /// answers with the CHOICE (create-new × load-existing) unless `--confirm`
+    /// carries the human's pick. Refuses when the root does not resolve and on
+    /// any overlap with a DIFFERENT brain.
     #[arg(long, value_name = "REPO")]
     pub birth: Option<String>,
+
+    /// The human's pick when the birth destination already holds a brain:
+    /// `create-new` re-scans REPLACING the graph; `load-existing` acknowledges
+    /// the served brain and touches nothing. Without it, an inhabited
+    /// destination gets the choice back — never a bare refusal.
+    #[arg(long, value_name = "CHOICE")]
+    pub confirm: Option<String>,
 
     /// One-shot MEDULLA storage-split migration (MEDULLA-PRD §4.2, slice M5a).
     /// Takes one required verb (no default):

--- a/m1nd-mcp/src/internal_tests/spec1_refresh_declared_root.rs
+++ b/m1nd-mcp/src/internal_tests/spec1_refresh_declared_root.rs
@@ -129,15 +129,19 @@ fn refresh_params(path: &str) -> serde_json::Value {
 /// hijack class, two bound-brain replacements in 24h on the deployed 1.4.x owner
 /// — keeps today's refusal, verbatim, including the floor it names.
 ///
-/// AMENDED once, deliberately: the refusal now carries the way out. What §5.1
-/// pins is that the DECISION does not move (same code, same action, same floor,
-/// nothing mutated), and it does not — a sentence naming the human's ceremony
-/// grants no authority to anyone, least of all the foreign caller being refused
-/// here, for whom that command is exactly the correct answer. Measured on 1.6.2:
-/// an agent hit this refusal plus three siblings, none of which named a door,
-/// and reported that m1nd could not be used at all. The two SCOPED_GRANT_A2
-/// siblings in §5.9 keep their bytes untouched, because their answer is not the
-/// ceremony — see `spec1_5_9_scoped_grant_a2_siblings_keep_todays_refusal_bytes`.
+/// AMENDED twice, deliberately. First the refusal grew a way out; then the
+/// owner's law moved the door itself — the agent MAY run the ceremony once the
+/// human has picked (create new × load existing), so the suffix now reads "with
+/// their yes run it yourself", not "agents never run it". What §5.1 still pins
+/// is that the DECISION does not move: same code, same action, same floor,
+/// nothing mutated for this foreign-root replace. Naming the human's pick grants
+/// no authority to anyone, least of all the foreign caller refused here, for
+/// whom `m1nd init --birth <their repo>` is the correct answer and buys no path
+/// to replace the bound brain. Measured on 1.6.2: an agent hit this refusal plus
+/// three siblings, none of which named a door, and reported that m1nd could not
+/// be used at all. The two SCOPED_GRANT_A2 siblings in §5.9 keep their bytes
+/// untouched, because their answer is not the ceremony — see
+/// `spec1_5_9_scoped_grant_a2_siblings_keep_todays_refusal_bytes`.
 #[test]
 fn spec1_5_1_foreign_root_replace_keeps_todays_refusal_bytes() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -160,9 +164,9 @@ fn spec1_5_1_foreign_root_replace_keeps_todays_refusal_bytes() {
         "invalid params for ingest: generic_action_authority_required: \
          semantic_action=graph.ingest.replace authority_floor=POSITIVE_SOVEREIGN \
          cannot use generic REST/MCP dispatch; no exact typed G2/G3 lease \
-         consumer is installed for this action. The first graph for a repo is \
-         the human's one-time ceremony: offer them `m1nd init --birth <repo>` \
-         and stop — agents never run it"
+         consumer is installed for this action. The first graph is born on \
+         the human's explicit pick: ask them (create new × load existing — \
+         always), then with their yes run `m1nd init --birth <repo>` yourself"
     );
 }
 

--- a/m1nd-mcp/src/internal_tests/spec2_brain_bootstrap_birth.rs
+++ b/m1nd-mcp/src/internal_tests/spec2_brain_bootstrap_birth.rs
@@ -52,8 +52,9 @@ const GENERIC_BIRTH_REFUSAL: &str = "invalid params for brain_birth: \
      generic_action_authority_required: semantic_action=brain.bootstrap.birth \
      authority_floor=POSITIVE_SOVEREIGN cannot use generic REST/MCP dispatch; \
      no exact typed G2/G3 lease consumer is installed for this action. The first \
-     graph for a repo is the human's one-time ceremony: offer them \
-     `m1nd init --birth <repo>` and stop — agents never run it";
+     graph is born on the human's explicit pick: ask them (create new × load \
+     existing — always), then with their yes run `m1nd init --birth <repo>` \
+     yourself";
 
 /// The owner's own bound brain (the "dev graph" §2 says birth never touches),
 /// with a runtime under `runtime` and no roots declared.
@@ -226,10 +227,13 @@ fn spec2_5_7b2_every_allowlisted_token_grants_nothing_when_the_client_claims_it(
 }
 
 /// Defense in depth: a caller that reaches `dispatch_tool` DIRECTLY — past the
-/// gate, the way an in-process seam could — still cannot birth, because the
-/// dispatcher holds no `HumanOrigin` and cannot construct one.
+/// gate, the way an in-process seam could — still cannot birth THERE, because
+/// the dispatcher holds no owner context. But by the owner's law (2026-08-02:
+/// an agent MAY birth with the human's authorization, and must always offer
+/// create-new × load-existing) the answer is no longer "agents never do": it
+/// is the agent's real path — ask the human, then run the ceremony yourself.
 #[test]
-fn spec2_5_7b3_direct_dispatch_without_a_stamp_refuses_human_gesture_required() {
+fn spec2_5_7b3_direct_dispatch_answers_with_the_agents_path_not_a_dead_end() {
     let temp = tempfile::tempdir().expect("tempdir");
     let mut state = build_bound_state(&temp.path().join("runtime"));
     let repo = temp.path().join("repo");
@@ -243,8 +247,20 @@ fn spec2_5_7b3_direct_dispatch_without_a_stamp_refuses_human_gesture_required() 
     .expect("the dispatcher must answer with a refusal payload, not an unknown tool");
 
     assert_eq!(payload["ok"], json!(false));
-    assert_eq!(payload["refused"], json!("human_gesture_required"));
+    assert_eq!(payload["refused"], json!("human_authorization_required"));
     assert_eq!(payload["allowed_origins"], json!(BIRTH_HUMAN_ORIGINS));
+    let path = payload
+        .get("your_path")
+        .expect("the answer must carry the agent's actionable path");
+    let steps = serde_json::to_string(path).expect("encode path");
+    assert!(
+        steps.contains("create-new") && steps.contains("load-existing"),
+        "the path must offer both choices by name: {steps}"
+    );
+    assert!(
+        steps.contains("m1nd init --birth"),
+        "the path must name the exact command the authorized agent runs: {steps}"
+    );
 }
 
 /// The allowlist is the ratified one, and the binary is honest about which of
@@ -254,8 +270,9 @@ fn spec2_5_7b3_direct_dispatch_without_a_stamp_refuses_human_gesture_required() 
 fn spec2_5_7b4_the_allowlist_is_the_ratified_one_and_names_its_installed_stamp() {
     assert_eq!(
         BIRTH_HUMAN_ORIGINS,
-        ["human-ui", "human-touchid", "human-cli"],
-        "§2's closed allowlist, ratified §6 item 4"
+        ["human-ui", "human-touchid", "human-cli", "human-via-agent"],
+        "§2's closed allowlist, ratified §6 item 4, extended by the owner's \
+         2026-08-02 law (an agent relaying the human's explicit yes)"
     );
     assert_eq!(
         BIRTH_ORIGINS_WITH_A_STAMPING_SEAM,

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -606,7 +606,7 @@ fn run_medulla_migrate(
 /// the verb, print JSON, exit. Exit code follows the answer — `0` for a
 /// certificate, `1` for a refusal — so a script or a human sees the difference
 /// without parsing.
-fn run_birth_ceremony(config: McpConfig, root: &str) {
+fn run_birth_ceremony(config: McpConfig, root: &str, confirm: Option<String>) {
     let server = match McpServer::new(config) {
         Ok(server) => server,
         Err(e) => {
@@ -620,7 +620,12 @@ fn run_birth_ceremony(config: McpConfig, root: &str) {
     // (`McpServer::into_session_state` is `pub(crate)`, guarded by a
     // `compile_fail` doctest). The binary contributes the INGRESS — the fact
     // that a human ran this command — and nothing else.
-    let payload = match m1nd_mcp::brain_birth::run_ceremony(server, root, "m1nd-init-birth") {
+    let payload = match m1nd_mcp::brain_birth::run_ceremony_with_confirm(
+        server,
+        root,
+        "m1nd-init-birth",
+        confirm,
+    ) {
         Ok(payload) => payload,
         Err(e) => {
             eprintln!("[m1nd-mcp][birth] the ceremony failed: {e}");
@@ -1065,7 +1070,7 @@ async fn main() {
     // transport — which is also why the stamp it applies can never be reached
     // through one.
     if let Some(root) = cli.birth {
-        run_birth_ceremony(config, &root);
+        run_birth_ceremony(config, &root, cli.confirm.clone());
         return;
     }
 

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -43,10 +43,10 @@ A response may carry a `reception` block. `reception.match == \"caller_root_mism
 means the bound graph does NOT cover your current repo (its root ≠ your resolved \
 `caller_root`) — do NOT trust retrieval for THIS repo; read `reception.options[]`. \
 Generic cross-root `ingest` remains withdrawn (no `project_root` in the schema; \
-POSITIVE_SOVEREIGN, fails closed), and the birth verb refuses every wire client with \
-`human_gesture_required` — but a repo with NO brain now has a real path: the HUMAN \
-runs the one-time ceremony `m1nd init --birth <repo>`. An agent's honest move is to \
-OFFER that exact command and stop; running it is not the agent's to do. Until the human runs it: continue only against the bound graph (with the mismatch \
+POSITIVE_SOVEREIGN, fails closed), and the birth verb answers every wire client with \
+`human_authorization_required` and the actionable path — a repo with NO brain has a \
+real door: the one-time ceremony `m1nd init --birth <repo>`. An agent's honest move is to \
+ASK your human — always — whether to create the brain or load an existing one (the owner's law, 2026-08-02); with their yes, run that exact command yourself. Until then: continue only against the bound graph (with the mismatch \
 warning intact), or reconnect to an owner that already hosts the intended repo. Absent \
 `reception` = your root matches the brain serving you (silent bind is legal only on a \
 match, TT-INV-12).
@@ -1260,7 +1260,7 @@ fn all_tool_schemas_inner() -> serde_json::Value {
             },
             {
                 "name": "brain_birth",
-                "description": "Birth a NEW project brain for a repo that has none. This is the HUMAN's one-time gesture, not an agent's call: admission is an origin the OWNER stamps from a fact it observes about itself, and an origin string sent as a parameter grants nothing. Over generic MCP/REST this verb is refused for every client, however the call is dressed. The one path that exists today is the P2 ceremony a HUMAN runs in their terminal: `m1nd init --birth <repo>`. If you are an agent and a repo has no brain, OFFER that exact command and stop; running it is not yours to do. Birth refuses unless the destination is empty ON DISK (no manifest, snapshot or checkpoint), refuses any root that overlaps an existing brain, never touches the owner's bound graph, and is not the way to adopt an existing brain — that is migration, a boot-time fact with no verb.",
+                "description": "Birth a NEW project brain for a repo that has none. A brain is born on the HUMAN's explicit pick, and an agent MAY run the ceremony WITH that authorization (the owner's law, 2026-08-02): always ask your human first — create a new brain, or load the existing one? — then, with their yes, run `m1nd init --birth <repo>` yourself in a terminal (add `--confirm create-new` or `--confirm load-existing` when the repo already holds a brain; an unconfirmed ceremony on an inhabited destination answers with that CHOICE, never a bare refusal). Over generic MCP/REST this verb cannot execute — the dispatcher holds no owner context — and answers with that same actionable path. Birth refuses roots that do not resolve and overlaps with a DIFFERENT brain; it never silently replaces a graph.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -6579,7 +6579,7 @@ const FIRST_GRAPH_ACTIONS: &[&str] = &[
 /// does not change here; only the sentence does.
 pub(crate) fn first_graph_door_suffix(action: &str) -> &'static str {
     if FIRST_GRAPH_ACTIONS.contains(&action) {
-        ". The first graph for a repo is the human's one-time ceremony: offer them `m1nd init --birth <repo>` and stop — agents never run it"
+        ". The first graph is born on the human's explicit pick: ask them (create new × load existing — always), then with their yes run `m1nd init --birth <repo>` yourself"
     } else {
         ""
     }

--- a/m1nd-mcp/src/tools.rs
+++ b/m1nd-mcp/src/tools.rs
@@ -519,9 +519,10 @@ pub(crate) fn needs_ingest_next_move(state: &SessionState, agent_id: &str, then:
         format!("m1nd init --birth {repo}")
     };
     format!(
-        "This repo has no brain yet, and minting one is the human's gesture: offer them \
-         `{command}` — once, in a terminal, from inside the repo — then call {then} again. Agents \
-         never run it: the origin stamp exists only inside that CLI ingress."
+        "This repo has no brain yet. Ask your human — always — whether to create its brain \
+         (the owner's law, 2026-08-02): with their yes, run `{command}` yourself in a terminal \
+         from inside the repo, then call {then} again. Without their answer, do not choose for \
+         them."
     )
 }
 
@@ -4758,7 +4759,7 @@ pub fn handle_recovery_playbook(
                         playbook_step(
                             "offer_the_birth_ceremony",
                             &format!(
-                                "Otherwise this repo has no brain yet: tell the human to run `{birth_command}` once, in a terminal, from inside the repo. Offer the command and stop — running it is not yours to do."
+                                "Otherwise this repo has no brain yet: ask your human whether to create its brain (always offer create-new × load-existing — the owner's law, 2026-08-02); with their yes, run `{birth_command}` yourself in a terminal from inside the repo."
                             ),
                             "The ceremony is the human gesture that mints a brain: it ingests the repo for real and reports the node and edge counts it produced. An agent cannot run it — the origin stamp exists only inside that CLI ingress.",
                             None,

--- a/m1nd-mcp/tests/first_graph_is_born.rs
+++ b/m1nd-mcp/tests/first_graph_is_born.rs
@@ -204,15 +204,28 @@ impl Owner {
 /// Run the human's ceremony through the REAL CLI ingress — the only door that
 /// can stamp `human-cli`. Returns its parsed JSON answer and its exit code.
 fn run_birth_ceremony(repo: &Path, runtime_dir: &Path) -> (serde_json::Value, i32) {
-    let output = Command::new(BIN)
+    run_birth_ceremony_with_confirm(repo, runtime_dir, None)
+}
+
+/// The ceremony with the human's create-new × load-existing pick relayed
+/// (the owner's law, 2026-08-02).
+fn run_birth_ceremony_with_confirm(
+    repo: &Path,
+    runtime_dir: &Path,
+    confirm: Option<&str>,
+) -> (serde_json::Value, i32) {
+    let mut command = Command::new(BIN);
+    command
         .arg("--birth")
         .arg(repo)
         .current_dir(repo)
         .env("M1ND_RUNTIME_DIR", runtime_dir)
         .env("M1ND_REGISTRY_DIR", runtime_dir.join("registry"))
-        .env("M1ND_NO_GUI", "1")
-        .output()
-        .expect("run the birth ceremony");
+        .env("M1ND_NO_GUI", "1");
+    if let Some(choice) = confirm {
+        command.arg("--confirm").arg(choice);
+    }
+    let output = command.output().expect("run the birth ceremony");
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let payload =
         serde_json::from_str::<serde_json::Value>(stdout.trim()).unwrap_or_else(|error| {
@@ -316,7 +329,7 @@ fn a_virgin_repo_ends_up_with_a_populated_graph() {
 }
 
 #[test]
-fn a_second_ceremony_on_a_born_repo_refuses_and_says_you_are_home() {
+fn a_second_ceremony_on_a_born_repo_offers_the_choice_instead_of_refusing() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo-beta");
     write_fixture_repo(&repo);
@@ -331,23 +344,49 @@ fn a_second_ceremony_on_a_born_repo_refuses_and_says_you_are_home() {
     );
     assert_eq!(first_exit, 0, "the first ceremony exits 0: {first}");
 
-    // A second run must not mint anything, must not re-scan behind the human's
-    // back, and must say plainly that this repo already has its brain.
+    // A second run must not mint anything and must not re-scan behind the
+    // human's back — and by the owner's law (2026-08-02) the answer is the
+    // create-new × load-existing CHOICE with the existing brain's numbers,
+    // never a bare refusal.
     let (second, second_exit) = run_birth_ceremony(&repo, &runtime_dir);
     assert_eq!(
         second.get("ok").and_then(|ok| ok.as_bool()),
         Some(false),
-        "a repo that already has its brain must not be born twice: {second}"
+        "an unconfirmed second ceremony completes nothing: {second}"
     );
     assert_eq!(
-        second.get("refused").and_then(|code| code.as_str()),
-        Some("birth_root_is_bound_graph"),
-        "the refusal must be the 'you are home' one: {second}"
+        second.get("choice_required").and_then(|c| c.as_bool()),
+        Some(true),
+        "an inhabited destination answers with the CHOICE: {second}"
+    );
+    let options = second.get("options").cloned().unwrap_or_default();
+    assert!(
+        options.get("create-new").is_some() && options.get("load-existing").is_some(),
+        "both options must be offered by name: {second}"
+    );
+    assert!(
+        second
+            .get("existing")
+            .and_then(|e| e.get("node_count"))
+            .and_then(|n| n.as_u64())
+            .unwrap_or(0)
+            > 0,
+        "the choice must carry the existing brain's numbers so the human decides informed: {second}"
     );
     assert_eq!(
         second_exit, 1,
-        "a refusal exits 1 so a script sees the difference: {second}"
+        "an incomplete ceremony exits 1 so a script sees the difference: {second}"
     );
+
+    // The human picks load-existing: acknowledged, nothing re-scanned.
+    let (kept, kept_exit) =
+        run_birth_ceremony_with_confirm(&repo, &runtime_dir, Some("load-existing"));
+    assert_eq!(
+        kept.get("ok").and_then(|ok| ok.as_bool()),
+        Some(true),
+        "load-existing acknowledges the served brain: {kept}"
+    );
+    assert_eq!(kept_exit, 0, "an acknowledged choice exits 0: {kept}");
 
     // The graph the first ceremony built is untouched by the refusal.
     let mut owner = Owner::spawn(&repo, &runtime_dir);

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -4742,7 +4742,14 @@ async function main(rawArgs) {
     if (command === "init" && args.birth) {
       const targetBinary = path.resolve(args.binary || defaultRuntimePath());
       const repoArg = typeof args.birth === "string" ? args.birth : args._[1] || process.cwd();
-      const result = spawnSync(targetBinary, ["--birth", path.resolve(repoArg)], {
+      const birthArgs = ["--birth", path.resolve(repoArg)];
+      // Relay the human's create-new × load-existing pick (the owner's law,
+      // 2026-08-02) — the binary answers with the choice when it is absent
+      // and the destination already holds a brain.
+      if (typeof args.confirm === "string" && args.confirm) {
+        birthArgs.push("--confirm", args.confirm);
+      }
+      const result = spawnSync(targetBinary, birthArgs, {
         stdio: "inherit",
       });
       process.exitCode = result.status === null ? 1 : result.status;

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -15,8 +15,9 @@ This is a doctrine, not a manual.
   If it returns `needs_ingest` (empty/unbound graph), do not call generic `ingest`:
   that mutation surface is policy-disabled. **Say the door out loud instead** —
   a repo with no brain gets one from the HUMAN's one-time ceremony,
-  `m1nd init --birth <repo>`: offer that exact command and stop, then re-`north`
-  once they have run it. Meanwhile use the isolated `m1nd agent ... --repo` CLI
+  `m1nd init --birth <repo>`: ask them which they want, a new brain or an existing one
+  loaded, and with their yes run it yourself, then re-`north`. Meanwhile use the
+  isolated `m1nd agent ... --repo` CLI
   path for investigation, or the exact authority flow plus
   `external_mutation_service` for a governed existing-brain mutation.
 - Before `rg`, shell globbing, or manual file reads, `m1nd` answers or narrows FIRST — that is the default, not a question you ask only when convenient. The one exception is the **Skip Conditions** below (exact file+lines already known, or pure compiler/runtime truth); everything else earns a `north`/`seek`/`impact` pass first.
@@ -622,7 +623,7 @@ binding, and read it rather than guessing. The two real ones:
   with the absolute path of the intended repo/workspace, never a managed
   runtime/session path such as `~/.codex/m1nd-runtimes/...`,
   `~/.claude/m1nd-runtimes/...`, an Antigravity agent runtime, or a generic
-  `mcp-runtimes`/`agent-runtimes` folder. Offer the command and stop.
+  `mcp-runtimes`/`agent-runtimes` folder. Ask your human, then run it with their yes.
 - **A brain that already DECLARES your root, gone stale** → `ingest {mode:"refresh",
   path: <your root>}` from exactly that root. Yours to run, no human needed.
 

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -75,10 +75,14 @@ this loop by default:
    `reception.options[]`. Generic cross-root `ingest` remains withdrawn: never
    add `project_root` or `allow_overlap`, and never treat the internal owner
    bootstrap as an executable repair. A brainless repo now has ONE real path —
-   the HUMAN's one-time ceremony `m1nd init --birth <repo>`: OFFER that exact
-   command and stop (over the wire the birth verb refuses every client with
-   `human_gesture_required`; writes into a brainless root still refuse
-   `brain_bootstrap_consumer_not_installed`). Until the human runs it, connect
+   the ceremony `m1nd init --birth <repo>`, on the human's explicit pick (the
+   owner's law, 2026-08-02): ASK your human — always — create a new brain or
+   load the existing one?; with their yes, RUN the command yourself (add
+   `--confirm create-new`/`load-existing` when a brain already exists — an
+   unconfirmed ceremony there answers with that choice). Over the wire the
+   birth verb answers `human_authorization_required` with this same path;
+   writes into a brainless root still refuse
+   `brain_bootstrap_consumer_not_installed`. Until the human answers, connect
    to an owner that already hosts the intended brain or continue only with
    explicit mismatch caveats.
    Reception governs WRITES, not just reads: a read under mismatch is a warning,

--- a/skills/m1nd-operator/SKILL.md
+++ b/skills/m1nd-operator/SKILL.md
@@ -57,10 +57,14 @@ measured high-signal pattern starts by never starting cold:
    cover your current repo — do not trust retrieval for it; read
    `reception.options[]`. Generic cross-root `ingest` remains withdrawn
    (`project_root` absent from the published schema), and over the wire
-   `brain.bootstrap.birth` refuses every client with `human_gesture_required`.
-   The way forward for a brainless repo is the HUMAN's one-time ceremony —
-   OFFER the exact command `m1nd init --birth <repo>` and stop; running it is
-   not the agent's to do. Until then, continue only against the bound graph
+   `brain.bootstrap.birth` answers every client with
+   `human_authorization_required` and the agent's actionable path.
+   The way forward for a brainless repo (the owner's law, 2026-08-02): ASK
+   your human — always — create a new brain or load the existing one?; with
+   their yes, run `m1nd init --birth <repo>` YOURSELF (add `--confirm
+   create-new`/`--confirm load-existing` when a brain already exists — an
+   unconfirmed ceremony there answers with that choice, never a bare
+   refusal). Until the human answers, continue only against the bound graph
    with the mismatch warning intact, or reconnect to an owner that already
    hosts the intended repo. Absent/null = your root matches the brain
    serving you. Reception governs WRITES too, not only reads: a read under

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -36,7 +36,7 @@ Heed `reception`: `reception.match == "caller_root_mismatch"` means the bound
 graph does NOT cover your current repo — do not trust retrieval for it; read
 `reception.options[]`. Generic cross-root `ingest` remains withdrawn (`project_root`
 absent from the published schema), and over the wire `brain.bootstrap.birth` refuses
-every client with `human_gesture_required` — the stamp is the binary's own CLI flag.
+every client with `human_authorization_required` + the agent's actionable path — and by the owner's law (2026-08-02) an agent WITH the human's explicit yes runs `m1nd init --birth <repo>` itself (always offering create-new × load-existing first).
 A brainless repo now has one real path: the HUMAN's one-time ceremony
 `m1nd init --birth <repo>`. OFFER that exact command and stop — running it is not
 the agent's to do. Until then, continue only against the bound graph with the

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -37,10 +37,11 @@ graph does NOT cover your current repo — do not trust retrieval for it; read
 `reception.options[]`. Generic cross-root `ingest` remains withdrawn (`project_root`
 absent from the published schema), and over the wire `brain.bootstrap.birth` refuses
 every client with `human_authorization_required` + the agent's actionable path — and by the owner's law (2026-08-02) an agent WITH the human's explicit yes runs `m1nd init --birth <repo>` itself (always offering create-new × load-existing first).
-A brainless repo now has one real path: the HUMAN's one-time ceremony
-`m1nd init --birth <repo>`. OFFER that exact command and stop — running it is not
-the agent's to do. Until then, continue only against the bound graph with the
-mismatch warning intact, or reconnect to an owner that already hosts the intended repo.
+A brainless repo has one real path: the ceremony `m1nd init --birth <repo>`. ASK your
+human which they want, a new brain or an existing one loaded, and with their yes run it
+yourself and report what it built. Until they answer, continue only against the bound
+graph with the mismatch warning intact, or reconnect to an owner that already hosts the
+intended repo.
 Absent/null `reception` = your root matches the brain serving you. Reception
 governs WRITES, not just reads: a read under mismatch is a warning, but a WRITE
 under mismatch is PROHIBITED — see Write-Mode Laws below, and no public


### PR DESCRIPTION
**Item #1 of the 1.6.4 gatehouse family — the owner's law, implemented at every seam.** Declared verbatim 2026-08-02: *"brain o agente PODE fazer com autorização do humano, e ele tem que dizer SEMPRE pro humano se quer fazer o brain ou carregar."*

**What changes:**
- **An inhabited destination answers the CHOICE, never a bare refusal**: `choice_required` with both options by name AND the existing brain's numbers (node_count, root, store_dir) so the human decides informed. This is also the fix for the field case (the virc class) where a boot ingested the repo BEFORE the verdict ran and the ceremony refused the very graph its own process had just filled — the agent read "failed" while a working brain sat behind the message.
- **`--confirm create-new|load-existing`** on the CLI, relayed by the npm wrapper. `load-existing` acknowledges and touches nothing (exit 0); `create-new` is the human's authorized re-scan.
- **The wire verb** answers `human_authorization_required` with the agent's actionable 3-step path (ask the human — always; with their yes run the ceremony yourself; relay the outcome). `HumanOrigin` gains `AgentRelayed` ("human-via-agent") by the owner's decision.
- **The old doctrine ("agents offer, never run") is swept from every surface that taught it**: server instructions, the brain_birth tool description, the ingest doors, the recovery playbook, both skills, the universal agent pack — including the surfaces this program itself wrote earlier the same week.

**Declared residual:** the dispatcher holds no owner context, so the wire verb still cannot EXECUTE a birth directly; the authorized agent's executable path is the CLI, and direct wire execution is its own plumbing decision (filed).

**Proof:** the second-ceremony e2e now pins the CHOICE (both options by name + existing node_count) and the load-existing acknowledgement; the wire pin proves the 3-step path names both choices and the exact command; the allowlist pin carries the fourth origin with the law's date. birth 19/19 · spec2 18/18 lib + 3/3 e2e · first_graph_is_born 3/3 · lightning 82/82 + 13 sentinels · fmt + clippy clean.