### PR TITLE
fix(north): answer a caller_root_mismatch fast, with the human voice intact

### DIFF
--- a/m1nd-mcp/src/internal_tests/two_tier_project_brains.rs
+++ b/m1nd-mcp/src/internal_tests/two_tier_project_brains.rs
@@ -657,6 +657,61 @@ async fn reception_reports_the_closed_bootstrap_consumer_without_a_call() {
 }
 
 // ---------------------------------------------------------------------------
+// (6b) — a caller_root_mismatch is answered FAST, with the human voice intact.
+// ---------------------------------------------------------------------------
+
+/// The field kill (2026-08-02, Paco's probes): a north from a root the bound
+/// graph does not cover cost ≈47–55s on a 21k graph (activate ≈44s of it) only
+/// to return "this graph does not cover your repo" — a fact the reception knows
+/// from the caller_root header in microseconds. north now returns under
+/// mismatch BEFORE trust_selftest and orient/activate. The earlier attempt at
+/// this dropped the human_view voice card; this proves it survives — the card
+/// carries no statistics under a mismatch, so it needs no expensive step.
+///
+/// This harness's store serves medulla (brainless), so it exercises the
+/// COMPLEMENT: the fast path must NOT fire for a served-medulla caller (its
+/// doctrine beat is legitimate), and the full mismatch packet — with its
+/// project_brain_absent gap and human_view — must still compose. Together with
+/// the human_view unit test in server.rs (which drives a non-medulla mismatch),
+/// both sides of the guard are pinned.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_served_medulla_mismatch_keeps_its_full_beat_not_the_fast_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (owner, _bound_repo, _n0) = owner_with_bound_graph(tmp.path()).await;
+
+    let stranger = tmp.path().join("stranger-repo");
+    std::fs::create_dir_all(&stranger).expect("mk stranger");
+    let sid = owner.init_session(&stranger).await;
+    let north = owner
+        .tool(
+            &sid,
+            &stranger,
+            "north",
+            serde_json::json!({"agent_id": "stranger", "task": "orient"}),
+        )
+        .await;
+
+    assert_eq!(
+        north["reception"]["match"], "caller_root_mismatch",
+        "the mismatch is still declared: {north}"
+    );
+    // The served-medulla case is NOT the fast path: it keeps the full beat.
+    assert_ne!(
+        north["proof_state"], "reception_mismatch",
+        "a served-medulla mismatch keeps its full beat, not the bare fast path: {north}"
+    );
+    assert!(
+        north["human_view"].is_object(),
+        "the human voice card must be present on every mismatch: {north}"
+    );
+    let gaps = north["honest_gaps"].to_string();
+    assert!(
+        gaps.contains("project_brain_absent"),
+        "the served-medulla mismatch names project_brain_absent: {north}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (7) — THE EVICTION GATE (§C9.1, ladder R15). The interim owner-hosted topology
 // recreates the blast radius two-tier was built to kill: one owner holds N warm
 // brains, so an unbounded map + one crash loses N brains' state. Law: the warm

--- a/m1nd-mcp/src/server.rs
+++ b/m1nd-mcp/src/server.rs
@@ -5434,6 +5434,81 @@ fn handle_north(
         .unwrap_or(NORTH_CODE_BUDGET_CHARS)
         .clamp(NORTH_CODE_BUDGET_MIN, NORTH_CODE_BUDGET_MAX);
 
+    // FAST PATH — a caller_root_mismatch is answered before the expensive
+    // steps. Measured 2026-08-02 on the 21k-node served owner: the north for an
+    // uncovered caller cost ≈47–55s (activate/spread-activation is ≈44s of it,
+    // trust_selftest+handshake ≈5s), only to hand back "this graph does not
+    // cover your repo" — a fact the reception computes from the caller_root
+    // header in microseconds, and the human_view card carries WITHOUT any
+    // statistics (compose_human_view uses only the mismatch under a mismatch;
+    // trust_mode is irrelevant to it). So under mismatch we compose exactly
+    // {reception, human_view} and return — no trust_selftest, no orient, no
+    // spread-activation over a graph that is not the caller's. The medulla
+    // brainless case is left to the full path on purpose: a served medulla is a
+    // legitimate cross-project memory feed, so its beat still composes (that
+    // path already skips the orient, so it never paid the activate cost).
+    if !state.caller_root_is_brainless() {
+        if let Some(reception) = state.reception_verdict() {
+            if reception.get("match").and_then(|m| m.as_str()) == Some("caller_root_mismatch") {
+                let mismatch_next_move =
+                    "this owner serves a different repo; ingest your root or attach to an owner that covers it — see `reception.options`";
+                let human_view =
+                    crate::human_view::compose_human_view(&crate::human_view::HumanViewInput {
+                        // Under a mismatch the card IS the warning and carries no
+                        // statistics, so these graph/trust fields are unread —
+                        // pinned by `north_human_view_mismatch_is_the_warning`.
+                        trust_mode: "orientation_only",
+                        node_count: 0,
+                        memory_count: 0,
+                        ratified_blocks: 0,
+                        focus_activated: false,
+                        merge_wait: 0,
+                        bell_line: None,
+                        coherence_line: None,
+                        needs_ingest: false,
+                        reception_mismatch: Some(crate::human_view::ReceptionMismatch {
+                            honest: reception
+                                .get("honest")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("this graph does NOT cover your repo"),
+                            caller_root: reception
+                                .get("caller_root")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown"),
+                            bound_workspace: reception
+                                .get("bound_workspace")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown"),
+                        }),
+                        next_move: mismatch_next_move,
+                    });
+                let mut packet = serde_json::json!({
+                    "schema": "m1nd-north-packet-v0",
+                    "task": task,
+                    "reception": reception,
+                    "needs": null,
+                    "context": serde_json::Value::Null,
+                    "memory": [],
+                    "memory_exists": 0,
+                    "next_move": mismatch_next_move,
+                    "honest_gaps": [
+                        "the bound graph does not cover your repo — its orientation is WITHHELD rather than computed over a foreign graph (a mismatch is answered in milliseconds, not the ~50s a spread-activation over a 21k-node graph costs); see `reception`"
+                    ],
+                    "non_claims": [
+                        "north did not orient over this owner's graph because it does not cover your caller root.",
+                        "north does not ingest, mutate, or repair the graph.",
+                        "north does not replace compiler, tests, or local file truth.",
+                    ],
+                    "proof_state": "reception_mismatch",
+                });
+                if let Some(card) = human_view {
+                    packet["human_view"] = card;
+                }
+                return Ok(packet);
+            }
+        }
+    }
+
     // 1. BINDING — one trust_selftest gives the verdict + fingerprint + graph
     //    state + (when not full) the attached recovery_playbook. Reuse wholesale;
     //    it internally composes session_handshake + recovery_playbook already.
@@ -14255,6 +14330,52 @@ mod tests {
             );
         }
         assert_human_view_cap(card);
+    }
+
+    /// A NON-medulla caller_root_mismatch takes the fast path: the reception
+    /// answer, with the human voice card intact, WITHOUT running trust_selftest
+    /// or the spread-activation. Measured 2026-08-02: that orientation cost
+    /// ≈47–55s on the 21k served owner (activate ≈44s of it) to produce a
+    /// "does not cover your repo" the reception knew in microseconds. The
+    /// signature of the fast path is `proof_state == "reception_mismatch"` with
+    /// a null context and the mismatch voice card present. (The served-medulla
+    /// case keeps its full beat — pinned separately in two_tier_project_brains.)
+    #[test]
+    fn north_non_medulla_mismatch_takes_the_fast_path_with_the_voice_intact() {
+        let (_temp, mut state) = build_state_populated(false);
+        // Make this a PROJECT brain (not the medulla) so the fast path is live.
+        state.workspace_root_source = Some("project_brain_manifest".into());
+        state.caller_root = Some("/some/other/repo".into());
+
+        let out = bell_north_call(&mut state);
+
+        assert_eq!(
+            out["reception"]["match"], "caller_root_mismatch",
+            "the mismatch is declared: {out}"
+        );
+        assert_eq!(
+            out["proof_state"], "reception_mismatch",
+            "the fast path answers with the reception, not an orientation: {out}"
+        );
+        assert!(
+            out["context"].is_null(),
+            "no context is composed over a graph that does not cover the caller: {out}"
+        );
+        // The voice the earlier attempt dropped is present and correct.
+        let card = &out["human_view"];
+        assert_eq!(
+            card["state"], "mismatch",
+            "the human voice card survives the fast path: {out}"
+        );
+        assert_eq!(
+            card["lines"][0], "m1nd │ this graph does NOT cover your repo",
+            "line 1 IS the warning, verbatim: {out}"
+        );
+        let gaps = out["honest_gaps"].to_string();
+        assert!(
+            gaps.contains("does not cover your repo") && gaps.contains("WITHHELD"),
+            "the withheld orientation is explained honestly: {out}"
+        );
     }
 
     /// P1 — the medulla-only read fallback (TWO-TIER-BRAIN-PRD §9.5 · §10.4 rung 3

--- a/skills/m1nd-first/SKILL.md
+++ b/skills/m1nd-first/SKILL.md
@@ -72,7 +72,11 @@ this loop by default:
    a second round-trip (`code: false` gives the orientation-only packet). Heed
    `reception`: `reception.match == "caller_root_mismatch"` means the bound graph
    does NOT cover your current repo — do not trust retrieval for it; read
-   `reception.options[]`. Generic cross-root `ingest` remains withdrawn: never
+   `reception.options[]`. Under that mismatch north answers FAST and marks the
+   packet `proof_state: "reception_mismatch"` with `context: null`: it returns
+   the reception and the human-voice card WITHOUT orienting over a graph that is
+   not yours (a mismatch is a millisecond answer, not a spread-activation).
+   Generic cross-root `ingest` remains withdrawn: never
    add `project_root` or `allow_overlap`, and never treat the internal owner
    bootstrap as an executable repair. A brainless repo now has ONE real path —
    the HUMAN's one-time ceremony `m1nd init --birth <repo>`: OFFER that exact


### PR DESCRIPTION
**The PORTA half of the north-slow P0, ratified as portaria by Paco.** His probes measured a north from an uncovered root at **~47–55s** on the 21k served owner — the spread-activation is ~44s of it — only to return `this graph does not cover your repo`, a fact the reception computes from the `caller_root` header in microseconds. The newcomer, by definition, arrives with an uncovered root, so this is the first thing they feel at the door.

**Guard clause of operation order, not an engine change:** under a non-medulla `caller_root_mismatch`, north composes exactly `{reception, human_view}` and returns BEFORE `trust_selftest` and `orient/activate`. The `human_view` card carries no statistics under a mismatch (`compose_human_view` reads only the mismatch there — `trust_mode` is unread), so composing it early is free.

**Honest history, in the commit and here:** my first attempt at this dropped the `human_view` voice card and the served-medulla doctrine beat; the repo's own tests (`north_brainless_caller_serves_medulla_not_foreign_anchors`, `north_human_view_mismatch`) caught it and I reverted rather than ship an incomplete contract. This one preserves both — the served-medulla case is left to the full path on purpose (its cross-project doctrine feed is legitimate, and it already skips the orient so it never paid the activate cost).

**Proof:**
- `north_non_medulla_mismatch_takes_the_fast_path_with_the_voice_intact` — the fast path fires (`proof_state: reception_mismatch`, null context) with the voice card's warning line verbatim. Proven to bite: neutralize the guard and it reverts to `triaging`.
- `a_served_medulla_mismatch_keeps_its_full_beat_not_the_fast_path` — the served-medulla mismatch keeps `project_brain_absent` + human_view, NOT the bare fast path.
- two_tier 8/8 · north 34/34 · reception 10/10 · lightning green · fmt+clippy clean.

**Explicitly NOT here — the MOTOR half:** `activate`/`trust_selftest` are O(graph) and slow (~44s) even for a COVERED caller at 21k nodes — the mother verb being slow for its actual users. That is a core-engine scaling front (1.6.5, filed in the project inbox with the measurements), and touching it in a guard-clause PR would be exactly the blind engine surgery I declined. This PR makes the door fast and honest; the engine stays measured-and-named.