### PR TITLE
test(ui): freshness derives from the fixture's clock, not the wall clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,17 @@ jobs:
   rust-gates:
     name: Rust gates (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    # 120, not 90 (2026-08-02). `cargo test --workspace --all-targets` measured
+    # 62 min on the ubuntu 4-vCPU runner and up to 70 on windows, and under
+    # concurrent-PR runner contention it crossed the old 90-min ceiling and got
+    # cancelled — a timeout, not a test failure. The measured fix is more
+    # headroom for the runner the suite already fits on, NOT swapping to nextest,
+    # which the same gate-side measurement showed is SLOWER here (ubuntu 62→83
+    # min: the nested-Cargo I/O storm on a weak-I/O runner). nextest stays the
+    # local canonical runner and the shadow lane; the required legs stay on
+    # `cargo test` with room to finish. Revisit with a per-crate split if the
+    # wall keeps climbing.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/m1nd-ui/src/components/tree/tree-render.test.tsx
+++ b/m1nd-ui/src/components/tree/tree-render.test.tsx
@@ -11,11 +11,24 @@ import { dirname, join } from 'node:path';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import TreeRowView from './TreeRowView';
-import { buildTree, type TreeRow } from '../../lib/tree';
+import { buildTree, buildPostItIndex, type TreeRow } from '../../lib/tree';
 import type { GraphSnapshot } from '../../lib/snapshot';
 
 const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '__fixtures__');
 const snap = JSON.parse(readFileSync(join(FIX, 'snapshot.compact.json'), 'utf8')) as GraphSnapshot;
+
+// Freshness derives from the fixture's own newest claim, not the wall clock:
+// a frozen capture carries LAW, never WORLD, so the "fresh" post-it stays fresh
+// on any day (it silently aged past STALE_AFTER_MS once the fixture crossed 30
+// days, breaking this suite on main). See tree.test.ts.
+const FIXTURE_NOW =
+  Math.max(
+    ...snap.nodes
+      .flatMap((n) => n.tags ?? [])
+      .filter((t) => t.startsWith('light:created:'))
+      .map((t) => Number(t.slice('light:created:'.length)))
+      .filter((n) => Number.isFinite(n) && n > 0),
+  ) + 1000;
 
 function findRow(root: TreeRow, path: string): TreeRow | null {
   let found: TreeRow | null = null;
@@ -32,7 +45,7 @@ function findRow(root: TreeRow, path: string): TreeRow | null {
 const noop = () => {};
 
 test('a real file row with a memory renders its post-it chip and trust dot', () => {
-  const root = buildTree(snap);
+  const root = buildTree(snap, buildPostItIndex(snap, FIXTURE_NOW));
   const row = findRow(root, 'm1nd-mcp/src/http_server.rs');
   assert.ok(row, 'http_server.rs row exists in the assembled tree');
 

--- a/m1nd-ui/src/lib/tree.test.ts
+++ b/m1nd-ui/src/lib/tree.test.ts
@@ -15,8 +15,25 @@ import type { GraphSnapshot } from './snapshot';
 const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__');
 const snap = JSON.parse(readFileSync(join(FIX, 'snapshot.compact.json'), 'utf8')) as GraphSnapshot;
 
+// The "now" for freshness assertions is derived FROM the fixture, not from the
+// wall clock. A frozen capture carries LAW (which tags a memory has, which file
+// it anchors), never WORLD (what today's date is) — pinning `now` to
+// Date.now() made a "fresh" memory silently age into "aging" once the fixture's
+// light:created crossed STALE_AFTER_MS (30 days), which is exactly what broke
+// this suite on the main branch. Anchoring `now` a second after the newest
+// captured claim makes freshness a property of the fixture, reproducible on any
+// day. (Contract freezes LAW, never WORLD — the house rule this file forgot.)
+const FIXTURE_NOW =
+  Math.max(
+    ...snap.nodes
+      .flatMap((n) => n.tags ?? [])
+      .filter((t) => t.startsWith('light:created:'))
+      .map((t) => Number(t.slice('light:created:'.length)))
+      .filter((n) => Number.isFinite(n) && n > 0),
+  ) + 1000;
+
 test('post-it index anchors memories to the code node their grounded_in edge cites', () => {
-  const idx = buildPostItIndex(snap, Date.now());
+  const idx = buildPostItIndex(snap, FIXTURE_NOW);
   // The two real memories in the fixture cite http_server.rs and trust.rs.
   assert.ok(idx.has('m1nd-mcp/src/http_server.rs'), 'http_server.rs must carry a post-it');
   assert.ok(idx.has('m1nd-core/src/trust.rs'), 'trust.rs must carry a post-it');


### PR DESCRIPTION
**This is the flake blocking every open PR's merge — and it is a deterministic break on main, not a flake.**

Two post-it tests (`tree.test.ts`, `tree-render.test.tsx`) assert `data-postit-state="fresh"` while passing `Date.now()` as the age reference against a FROZEN snapshot fixture whose `light:created` timestamps are fixed. Measured: the fixture's newest memory was captured exactly **30 days** before `STALE_AFTER_MS` (= 30 days), so the day the capture crossed the threshold the computed state flipped `fresh → aging` and both tests began failing **on every push to main** — which is why the `UI unit` gate (and the aggregate `Test` check) has been red across #532/#533/#534/#535, none of which touch `m1nd-ui`.

**The house rule the file forgot:** a contract freezes LAW (which tags a memory carries, which file it anchors), never WORLD (what today's date is). The tests now derive `now` from the fixture itself — one second past the newest captured claim — so freshness is a property of the fixture, reproducible on any day. **No product code changed**: `STALE_AFTER_MS` and `postItState` are untouched; only the test's clock reference moved from the wall to the fixture.

Proven: `m1nd-ui` suite **656/656, 0 fail** (was 2 fail on main). This unblocks the four 1.6.4 gatehouse PRs, which were green on everything they own.

---
**Update 2026-08-02:** this PR now also carries the Rust-gate timeout bump (90→120 min) folded from #537, which is closed. The two were mutually blocking — see the `ci:` commit for the full reason. UI cure + timeout headroom ship together as the only green shape.