### PR TITLE
ci: give the Rust gate 120 minutes, the headroom the suite measured it needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,17 @@ jobs:
   rust-gates:
     name: Rust gates (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    # 120, not 90 (2026-08-02). `cargo test --workspace --all-targets` measured
+    # 62 min on the ubuntu 4-vCPU runner and up to 70 on windows, and under
+    # concurrent-PR runner contention it crossed the old 90-min ceiling and got
+    # cancelled — a timeout, not a test failure. The measured fix is more
+    # headroom for the runner the suite already fits on, NOT swapping to nextest,
+    # which the same gate-side measurement showed is SLOWER here (ubuntu 62→83
+    # min: the nested-Cargo I/O storm on a weak-I/O runner). nextest stays the
+    # local canonical runner and the shadow lane; the required legs stay on
+    # `cargo test` with room to finish. Revisit with a per-crate split if the
+    # wall keeps climbing.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**The measured fix for the cargo-test-timeout, ratified by Paco with the gate number on the table.**

`cargo test --workspace --all-targets` measured **~62 min on the ubuntu 4-vCPU runner** (up to ~70 on windows); under concurrent-PR runner contention it crossed the old **90-min** ceiling and the job was **cancelled** — a timeout, not a test failure. That is how #532/#533/#534/#535 kept showing a red Rust leg while being green in substance.

**Why headroom and not a runner swap:** the same gate-side measurement that keeps nextest in shadow showed nextest is **slower here** — ubuntu **62→83 min** (the nested-Cargo I/O storm on a weak-I/O runner). Promoting nextest to the required gate would trade a 62-min timeout for an 83-min one. So: nextest stays the local canonical runner and the shadow parity lane; the required legs stay on `cargo test` with room to finish. A per-crate split is the next lever if the wall keeps climbing.

One line of real change (`timeout-minutes: 90 → 120`) plus the rationale comment. This is the honest fix — the runner the suite already fits on, given room — chosen over the faster-looking dev-box number that measures worse on the gate (the same dev-box≠gate trap that became house law today).