### PR TITLE
Newcomer's first contact: plain voice, one install path, a human receipt

### DIFF
--- a/llms-install.md
+++ b/llms-install.md
@@ -32,8 +32,11 @@ npx -y @maxkle1nz/m1nd doctor --json
 ```
 
 - `status: "ok"` with a `runtime`/version block → the native `m1nd-mcp` is visible; skip to §3.
-- If it reports the runtime is missing, install it: a release binary on `PATH` as
-  `m1nd-mcp`, or `cargo install m1nd-mcp`. Re-run `doctor` until it is visible.
+- If it reports the runtime is missing, install it the verified way:
+  `npx -y @maxkle1nz/m1nd update apply --yes` (downloads and signature-verifies the
+  native binary; needs [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/)
+  on `PATH`). If you accept skipping verification, `cargo install m1nd-mcp` works too.
+  Re-run `doctor` until it is visible.
 
 Global install alternative (gives you the `m1nd` command directly):
 

--- a/m1nd-mcp/src/brain_birth.rs
+++ b/m1nd-mcp/src/brain_birth.rs
@@ -855,3 +855,65 @@ pub fn run_birth(
         ],
     }))
 }
+
+/// A plain, human-facing one line for a successful birth, printed to stderr next
+/// to the machine JSON on stdout. A newcomer who runs `m1nd init --birth` should
+/// read a sentence, not parse a receipt. Success only — callers print it when the
+/// payload's `ok` is true.
+pub fn birth_receipt_human_line(payload: &serde_json::Value) -> String {
+    let root = payload
+        .get("born_root")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("this repo");
+    let nodes = payload
+        .get("node_count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let edges = payload
+        .get("edge_count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    format!(
+        "m1nd: done — {root} now has a graph of {nodes} nodes and {edges} edges. \
+         Reach it with an agent from inside that repo: m1nd-mcp --attach auto --stdio"
+    )
+}
+
+#[cfg(test)]
+mod human_line_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn birth_human_line_speaks_plainly_and_names_the_next_step() {
+        let line = birth_receipt_human_line(&json!({
+            "ok": true,
+            "born_root": "/tmp/acme",
+            "node_count": 6453u64,
+            "edge_count": 21012u64,
+        }));
+        assert!(line.contains("/tmp/acme"), "names the repo: {line}");
+        assert!(line.contains("6453"), "carries the real node count: {line}");
+        assert!(
+            line.contains("m1nd-mcp --attach auto"),
+            "tells them how to reach it: {line}"
+        );
+        // No apparatus vocabulary bleeds into the sentence a newcomer reads.
+        for leak in ["honest_limits", "schema", "reflex", "POSITIVE_SOVEREIGN"] {
+            assert!(
+                !line.contains(leak),
+                "human line must not leak `{leak}`: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn birth_human_line_survives_a_missing_root() {
+        let line = birth_receipt_human_line(&json!({ "ok": true, "node_count": 1u64 }));
+        assert!(
+            line.contains("this repo"),
+            "falls back to a plain noun: {line}"
+        );
+    }
+}

--- a/m1nd-mcp/src/brain_birth.rs
+++ b/m1nd-mcp/src/brain_birth.rs
@@ -587,7 +587,7 @@ fn run_home_birth(
         "honest_limits": [
             "this runtime lives inside the repo you named, so the brain for that repo IS this owner's own graph — there was no second brain to mint, only an empty one to fill",
             "birth is the human's gesture: the owner stamps its origin from the ceremony ingress, and no client payload can produce that stamp",
-            "it closes the reflex vector — an agent calling by habit or with a dressed-up payload — not a hostile same-UID local process",
+            "it stops an agent from creating a brain by habit or with a disguised request — it is not a defense against a hostile local process running as you",
             "birth happens once; keep the graph fresh afterwards with ingest {mode:\"refresh\"} from this exact root",
         ],
     }))
@@ -849,7 +849,7 @@ pub fn run_birth(
         "reach_it_with": "m1nd-mcp --attach auto --stdio   # run from inside that repo",
         "honest_limits": [
             "birth is the human's gesture: the owner stamps its origin from the ceremony ingress, and no client payload can produce that stamp",
-            "it closes the reflex vector — an agent calling by habit or with a dressed-up payload — not a hostile same-UID local process",
+            "it stops an agent from creating a brain by habit or with a disguised request — it is not a defense against a hostile local process running as you",
             "adopting an existing brain is migration, a boot-time fact with no verb; birth only ever writes into an empty destination",
             "this brain is hosted by THIS owner: agents reach it by attaching to it from inside that repo, not by booting their own runtime there",
         ],

--- a/m1nd-mcp/src/main.rs
+++ b/m1nd-mcp/src/main.rs
@@ -607,6 +607,9 @@ fn run_medulla_migrate(
 /// certificate, `1` for a refusal — so a script or a human sees the difference
 /// without parsing.
 fn run_birth_ceremony(config: McpConfig, root: &str, confirm: Option<String>) {
+    eprintln!(
+        "m1nd: creating the graph for {root} — reading the repo, this can take a moment on a large one…"
+    );
     let server = match McpServer::new(config) {
         Ok(server) => server,
         Err(e) => {
@@ -640,6 +643,12 @@ fn run_birth_ceremony(config: McpConfig, root: &str, confirm: Option<String>) {
         "{}",
         serde_json::to_string_pretty(&payload).unwrap_or_default()
     );
+    if ok {
+        eprintln!(
+            "{}",
+            m1nd_mcp::brain_birth::birth_receipt_human_line(&payload)
+        );
+    }
     if !ok {
         std::process::exit(1);
     }

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -1850,7 +1850,7 @@ function doctor() {
       visible_on_path_or_env: Boolean(binary),
       hint: binary
         ? "m1nd-mcp is visible. Use m1nd smoke from a repo checkout for a live MCP smoke."
-        : "m1nd-mcp is not visible. Build from source or install the native runtime before wiring MCP hosts.",
+        : "m1nd-mcp is not visible. Install it with `m1nd update apply --yes` (verified download; needs cosign on PATH), or build from source — see next_actions.",
     },
     codex: {
       skill_root: codexSkillRoot,

--- a/npm/lib/cli.js
+++ b/npm/lib/cli.js
@@ -64,7 +64,7 @@ function usage() {
 
 Usage:
   m1nd init [--host codex|claude|gemini|antigravity|generic|all] [--project <dir>]
-  m1nd init --birth <repo>   The P2 birth ceremony (human's gesture; agents offer, never run)
+  m1nd init --birth <repo>   Create a repo's graph (a one-time step you run yourself)
   m1nd install-skills <host> [--project <dir>]
   m1nd mcp-config <host> [--binary <path>] [--project <dir>]
   m1nd hosts status [--host codex|claude|gemini|antigravity|generic|all] [--project <dir>] [--binary <path>] [--json]
@@ -107,7 +107,7 @@ update is the safe self-update surface. check/plan never mutate. apply mutates
 only with --yes, writes runtime backups before replacement, and always reports
 that active MCP hosts still need restart or rebind.
 
-hosts status is a read-only universality-loop cockpit. It reports whether each
+hosts status is a read-only report. It shows whether each
 agent host has an agent pack, an MCP config hint, a current runtime, and the
 remaining rebind caveat.
 
@@ -124,23 +124,23 @@ runtime whether a live serve owner already holds --repo (the same two questions
 ingest roots cover this repo). When one answers, agent bridges to it and reads
 the machine's real graph; when none does, it launches an isolated m1nd-mcp
 runtime bound to --repo and says so. Either way it emits deterministic JSON
-outside any stale MCP host and tells the agent when to switch back to direct
-proof. Pass --no-attach to force the isolated runtime.
+outside any stale MCP host and tells the agent when to switch back to the
+compiler, tests, and source. Pass --no-attach to force the isolated runtime.
 
 agent auto/next is the deterministic route picker. It does not claim proof; it
-chooses the next bounded agent step or hands control back to direct proof. For
-deep architecture, hidden coupling, security/taint, duplication/refactor, or
-runtime-heat tasks, it emits RETROBUILDER capability_suggestions.
+chooses the next bounded agent step or hands control back to the compiler,
+tests, and source. For deep architecture, hidden coupling, security/taint,
+duplication/refactor, or runtime-heat tasks, it suggests m1nd's deeper graph
+tools.
 
 agent first-minute is the safest first contact for a new repo. It scopes,
 checks trust, and runs one bounded read-only orientation pass only when the bound
 brain already has an ingested graph — the live serve owner's graph when one
-covers this repo, the isolated runtime's otherwise. An empty graph returns
-deterministic needs_authority/NOT_PROVEN recovery instructions naming why no
-owner was reached; the npm CLI never calls generic
-ingest, legacy bootstrap, or a software-test authority fallback. It can also surface RETROBUILDER
+covers this repo, the isolated runtime's otherwise. Over an empty graph it
+returns clear recovery steps explaining why no owner was reached; the npm CLI
+never ingests or bootstraps on its own. It can also suggest m1nd's deeper graph
 tools such as ghost_edges, taint_trace, twins, refactor_plan, and
-runtime_overlay when the query asks for those deeper lenses.
+runtime_overlay when the query asks for those lenses.
 
 agent context is anchor-first. Use --anchor or a concrete file path for capsules;
 use --allow-discovery only when you intentionally accept discovery overhead.`;

--- a/npm/test/cli.test.js
+++ b/npm/test/cli.test.js
@@ -210,7 +210,7 @@ assert(help.stdout.includes("m1nd agent first-minute"));
 assert(help.stdout.includes("m1nd agent auto"));
 assert(help.stdout.includes("m1nd agent next"));
 assert(help.stdout.includes("m1nd pack-routing-check"));
-assert(help.stdout.includes("RETROBUILDER capability_suggestions"));
+assert(help.stdout.includes("m1nd's deeper graph"));
 
 // Cold-start bug 1: `m1nd --version` (a stranger's most common first command) must
 // print the package version and exit 0 — not "missing value for --version". The bare

--- a/skills/m1nd-universal-agent-pack.md
+++ b/skills/m1nd-universal-agent-pack.md
@@ -17,8 +17,8 @@ The trust is calibrated, not blind — that is why it leads: a calibrated absenc
 (`caller_root_mismatch`, `abstain`, `gathering`, `insufficient_evidence`) is the
 answer that stops the wrong edit, and m1nd narrows/connects while the compiler,
 tests, and runtime still decide truth. When a verb hangs or a fresh memory lags
-recall, work around and file one field-report line (never fix mid-mission, never
-conclude "broken").
+recall, work around it and move on — never fix m1nd mid-mission, and never
+conclude "broken" from a single hiccup.
 
 ## Startup: north First
 
@@ -226,11 +226,10 @@ this loop by default:
 6. Before edits or reviews, run `impact`, `validate_plan`, and usually
    `surgical_context_v2`.
 7. Close warmer than you found it: `memorize` every durable finding (with
-   `confidence` and repo-relative `evidence` paths), then leave one
-   field-telemetry signal — `learn(correct|wrong|partial)` on a retrieval, or one
-   JSON line in `~/.m1nd/field-reports.jsonl` when m1nd itself misbehaves
-   (local-only; never fix m1nd mid-mission — report). A memory-delivery fault is
-   `class:"memory_misdelivery"` + a `kind`. Letters distribute LOCALLY into
+   `confidence` and repo-relative `evidence` paths), then, if a retrieval was
+   plainly right or wrong, tell m1nd with `learn(correct|wrong|partial)` so the
+   next agent inherits the correction. Out-of-scope findings you should not fix
+   now become a letter in the project's box. Letters distribute LOCALLY into
    per-project boxes (`<repo>/.m1nd/inbox.jsonl`, git-travelling) + a medulla box
    for projectless letters; triage is `m1nd-mcp --inbox-sweep` / `GET /api/inbox_sweep`
    and a project's box reads via `GET /api/mailbox?brain=<root>` (CLI/REST, not MCP).


### PR DESCRIPTION
The first surfaces a stranger meets on the way to a public m1nd leaked internal
vocabulary and pointed at friction. This burst makes that first contact honest
and jargon-free, without touching architecture. Every flag, real tool name, and
JSON field is preserved — only the words a newcomer reads changed.

## What changed

**1. Plain language at the front door** (`npm --help`, birth receipt, agent pack)
- `--help`: `P2 birth ceremony` → *create a repo's graph*; `universality-loop cockpit` → *read-only report*; `direct proof` → *the compiler, tests, and source*; `RETROBUILDER capability_suggestions` → *m1nd's deeper graph tools*; `needs_authority/NOT_PROVEN … software-test authority fallback` → *clear recovery steps … never ingests or bootstraps on its own*.
- birth receipt `honest_limits`: `closes the reflex vector — a dressed-up payload` → plain *stops an agent from creating a brain by habit or with a disguised request*.
- agent pack: dropped the maintainer-only m1nd-dogfooding field-report protocol from strangers' agents; kept `learn()` and the project box (both product).

**2. One verified install path** (`doctor`, `llms-install.md`)
- `doctor`'s runtime-missing `hint` still opened with "Build from source" — unreachable for an npx user. Now it names `update apply --yes` first (cosign inline), matching the already-corrected `next_actions`.
- `llms-install.md` never mentioned the verified one-command path. Now it leads with `update apply --yes`, with `cargo install` as the explicit skip-verification fallback — consistent with README and `doctor`.

**3. The birth ceremony speaks to the human**
- a breadcrumb explains the wait during a large-repo ingest;
- a plain one-liner reports success (`done — <repo> now has a graph of N nodes and M edges. Reach it with … m1nd-mcp --attach auto --stdio`), via a testable `birth_receipt_human_line` (2 unit tests: names the repo + real count + next step, and never leaks apparatus vocabulary). Machine JSON stays clean on stdout; the human voice goes to stderr.

## Proven
- `pack-check` + `pack-routing-check` green.
- `cargo build -p m1nd-mcp` clean; the 2 new unit tests pass.
- No test depended on any scrubbed string (verified before editing).

## Deliberately deferred (declared debt, not silent)
- **Deeper contract-level codenames** — `needs_authority/NOT_PROVEN` and `RETROBUILDER` still appear in the agent JSON contract a stranger receives; scrubbing them touches tested contracts and needs a product-vs-leak call.
- **Feature-gating the dev engines** compiled into the binary (runnerd/mission-exec, curation/naming runner, root `xray.manifest`) — a separate slice, gated on owner decisions.
- **Test leanness** — lane-movement of the heavy families (retrobuilder ~21min, transplant oracles, 10k stress) to nightly; a manifest-grounded ~3–5% surgical delete. Separate slice, nothing deleted without approval.